### PR TITLE
DOCSP-4432: Add front-end tests to Drone file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,18 @@
 ---
 pipeline:
 
+  build:
+    image: node:10.10.0
+    commands:
+      - cd front-end/
+      - npm install
+
+  test:
+    image: node:10.10.0
+    commands:
+      - cd front-end/
+      - npm test
+
   publish:
     image: plugins/ecr
     secrets: [ ecr_access_key, ecr_secret_key]


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-4432)] Integrate Jest front-end testing with Drone. This PR adds two tasks to the `.drone.yml` file:

- `build`: build the front-end using npm
- `test`: execute `npm test` as specified in `package.json`