### PR TITLE
Bugfix: properly fetch guides for landing page

### DIFF
--- a/front-end/src/templates/index.js
+++ b/front-end/src/templates/index.js
@@ -8,13 +8,41 @@ export default class Index extends Component {
     this.state = {
       name: 'Guides',
       description: 'Getting Started',
-      guides: this.props.pageContext.__refDocMapping.index.ast.children[3].children
+      guides: [],
     };
     console.log(11, this.props.pageContext.__refDocMapping);
+  }
+  
+  componentDidMount() {
+    this.findGuideIndex(this.props.pageContext.__refDocMapping.index.ast);
+  }
+
+  findGuideIndex(node) {
+    if (node.name === 'guide-index') {
+      this.setState({ guides: node.children });
+      return node.children;
+    }
+
+    if (node.children) {
+      node.children.forEach((child, index) => {
+        let result = this.findGuideIndex(child);
+
+        if (result !== false) {
+          return result;
+        }
+      });
+    }
+
+    return false;
   }
 
   render() {
     console.log(22, this.state.guides);
+
+    if (this.state.guides.length === 0) {
+      return null;
+    }
+
     const allCards = this.state.guides.map((card, index) => {
       return (
         <Card 


### PR DESCRIPTION
A restructuring of the AST caused guides to not be properly parsed for the landing page. This PR properly renders the homepage, and finds guides by searching through `children` arrays of the AST rather than querying a specific index.