### PR TITLE
Fix: Remove react-test-renderer and replace with enzyme

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -7864,11 +7864,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7881,15 +7883,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7992,7 +7997,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8002,6 +8008,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8014,17 +8021,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8041,6 +8051,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8113,7 +8124,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8123,6 +8135,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8228,6 +8241,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -21,7 +21,6 @@
     "prettier": "^1.16.3",
     "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1",
-    "react-test-renderer": "^16.7.0",
     "webpack": "^4.19.0",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": ">=3.1.11"

--- a/front-end/tests/Paragraph.test.js
+++ b/front-end/tests/Paragraph.test.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 import Paragraph from '../src/components/Paragraph';
 
 it('renders correctly', () => {
-  const tree = renderer
-    .create(<Paragraph nodeData={{ children: [{ type: 'text', value: 'hello world' }] }} />)
-    .toJSON();
+  const tree = shallow(<Paragraph nodeData={{ children: [{ type: 'text', value: 'hello world' }] }} />);
   expect(tree).toMatchSnapshot();
 });

--- a/front-end/tests/URIText.test.js
+++ b/front-end/tests/URIText.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 import URIText from '../src/components/URIText';
 
 describe('local MongoDB', () => {
@@ -21,7 +21,7 @@ describe('local MongoDB', () => {
   describe('when called without a placeholder', () => {
     it('returns the original string', () => {
       const value = 'This is the body text';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -29,7 +29,7 @@ describe('local MongoDB', () => {
   describe('when there is a <URISTRNG> placeholder', () => {
     it('replaces the placeholder', () => {
       const value = 'return MongoClient("<URISTRING>")';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -40,7 +40,7 @@ describe('local MongoDB', () => {
         username is <USERNAME>
         shell string (<URISTRING_SHELL>)
         without password (<URISTRING_SHELL_NOUSER>)`;
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -63,7 +63,7 @@ describe('local MongoDB with replica set', () => {
   describe('when called without a placeholder', () => {
     it('returns the original string', () => {
       const value = 'This is the body text';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -71,7 +71,7 @@ describe('local MongoDB with replica set', () => {
   describe('when there is a <URISTRNG> placeholder', () => {
     it('replaces the placeholder', () => {
       const value = 'return MongoClient("<URISTRING>")';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -82,7 +82,7 @@ describe('local MongoDB with replica set', () => {
         username is <USERNAME>
         shell string (<URISTRING_SHELL>)
         without password (<URISTRING_SHELL_NOUSER>)`;
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -105,7 +105,7 @@ describe('Cloud (unspecified version)', () => {
   describe('when called without a placeholder', () => {
     it('returns the original string', () => {
       const value = 'This is the body text';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -113,7 +113,7 @@ describe('Cloud (unspecified version)', () => {
   describe('when there is a <URISTRNG> placeholder', () => {
     it('replaces the placeholder', () => {
       const value = 'return MongoClient("<URISTRING>")';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -124,7 +124,7 @@ describe('Cloud (unspecified version)', () => {
         username is <USERNAME>
         shell string (<URISTRING_SHELL>)
         without password (<URISTRING_SHELL_NOUSER>)`;
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -149,7 +149,7 @@ describe('Cloud (MongoDB version 3.4)', () => {
   describe('when called without a placeholder', () => {
     it('returns the original string', () => {
       const value = 'This is the body text';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -157,7 +157,7 @@ describe('Cloud (MongoDB version 3.4)', () => {
   describe('when there is a <URISTRNG> placeholder', () => {
     it('replaces the placeholder', () => {
       const value = 'return MongoClient("<URISTRING>")';
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });
@@ -168,7 +168,7 @@ describe('Cloud (MongoDB version 3.4)', () => {
         username is <USERNAME>
         shell string (<URISTRING_SHELL>)
         without password (<URISTRING_SHELL_NOUSER>)`;
-      const tree = renderer.create(<URIText value={value} templateType={templateType} uri={uri} />).toJSON();
+      const tree = shallow(<URIText value={value} templateType={templateType} uri={uri} />);
       expect(tree).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
We have decided to go with [Enzyme](https://airbnb.io/enzyme/) for testing, so remove existing instances of `react-test-renderer` and replace with Enzyme.