### PR TITLE
DOCSP-5133: Sort named tabsets

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
-import { stringifyTab } from '../constants';
+import { PLATFORMS, stringifyTab } from '../constants';
 
 export default class Tabs extends Component {
   constructor(props) {
@@ -28,15 +28,27 @@ export default class Tabs extends Component {
       .join('/');
   };
 
+  sortTabset = (nodeData, referenceArray) => {
+    return nodeData.children.sort(
+      (a, b) =>
+        referenceArray.indexOf(a.argument[0].value.toLowerCase()) -
+        referenceArray.indexOf(b.argument[0].value.toLowerCase())
+    );
+  };
+
   render() {
     const { tabsetName } = this.state;
     const { nodeData, activeTabs, setActiveTab } = this.props;
     const isHeaderTabset = tabsetName === 'drivers' || tabsetName === 'cloud';
+    const tabs =
+      tabsetName === 'platforms' || tabsetName === 'linux/macos/windows'
+        ? this.sortTabset(nodeData, PLATFORMS)
+        : nodeData.children;
     return (
       <React.Fragment>
         {isHeaderTabset || (
           <ul className="tab-strip tab-strip--singleton" role="tablist">
-            {nodeData.children.map((tab, index) => {
+            {tabs.map((tab, index) => {
               const tabName = tab.argument[0].value.toLowerCase();
               return (
                 <li
@@ -55,7 +67,7 @@ export default class Tabs extends Component {
             })}
           </ul>
         )}
-        {nodeData.children.map((tab, index) => {
+        {tabs.map((tab, index) => {
           const tabName = tab.argument[0].value.toLowerCase();
           return (
             activeTabs[tabsetName] === tabName && (

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -41,7 +41,7 @@ export default class Tabs extends Component {
     const { nodeData, activeTabs, setActiveTab } = this.props;
     const isHeaderTabset = tabsetName === 'drivers' || tabsetName === 'cloud';
     const tabs =
-      tabsetName === 'platforms' || tabsetName === 'linux/macos/windows'
+      tabsetName === 'platforms' || PLATFORMS.some(p => tabsetName.includes(p))
         ? this.sortTabset(nodeData, PLATFORMS)
         : nodeData.children;
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -44,6 +44,7 @@ export default class Tabs extends Component {
       tabsetName === 'platforms' || tabsetName === 'linux/macos/windows'
         ? this.sortTabset(nodeData, PLATFORMS)
         : nodeData.children;
+
     return (
       <React.Fragment>
         {isHeaderTabset || (

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ const LANGUAGES = [
   'perl',
   'ruby',
   'scala',
+  'go',
 ];
 
 const DEPLOYMENTS = ['cloud', 'local'];
@@ -34,6 +35,7 @@ const SLUG_TO_STRING = {
   perl: 'Perl',
   ruby: 'Ruby',
   scala: 'Scala',
+  go: 'Go',
   cloud: 'Cloud',
   local: 'Local',
   macos: 'macOS',

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -31,17 +31,19 @@ export default class Guide extends Component {
     let tabs = tabData.map(tab => tab.argument[0].value);
     if (tabsetName === 'cloud') {
       tabs = DEPLOYMENTS.filter(tab => tabs.includes(tab));
-      this.setNamedTabData(tabsetName, tabs);
+      this.setNamedTabData(tabsetName, tabs, DEPLOYMENTS);
     } else if (tabsetName === 'drivers') {
       tabs = LANGUAGES.filter(tab => tabs.includes(tab));
-      this.setNamedTabData(tabsetName, tabs);
+      this.setNamedTabData(tabsetName, tabs, LANGUAGES);
     }
     this.setActiveTab(getLocalValue(tabsetName) || tabs[0], tabsetName);
   };
 
-  setNamedTabData = (tabsetName, tabs) => {
+  matchArraySorting = (tabs, referenceArray) => referenceArray.filter(t => tabs.includes(t));
+
+  setNamedTabData = (tabsetName, tabs, constants) => {
     this.setState(prevState => ({
-      [tabsetName]: Array.from(new Set([...(prevState[tabsetName] || []), ...tabs])),
+      [tabsetName]: this.matchArraySorting(Array.from(new Set([...(prevState[tabsetName] || []), ...tabs])), constants),
     }));
   };
 


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5133)] This PR correctly sorts named tab/pillsets to match the order defined in `src/constants.js` (this order is based roughly on popularity).

There is a common case where an _anonymous_ tabset is used to create tabs for Windows/macOS/Linux rather than a `platforms` tabset. We will now sort these tabs to match the order defined by the `platforms` tabset.

This PR also adds Go as a language option.