### PR TITLE
DOCSP-5132: Add lightbox and tests

### DIFF
--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -1,13 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import Lightbox from './Lightbox';
 
-const Figure = ({ nodeData }) => (
-  <img
-    src={nodeData.argument[0].value}
-    alt={nodeData.options.alt ? nodeData.options.alt : nodeData.argument[0].value}
-    width="50%"
-  />
-);
+const Figure = ({ nodeData }) => {
+  const imgRef = React.createRef();
+  const [isLightboxSize, setIsLightboxSize] = useState(false);
+
+  const imgShouldHaveLightbox = () => {
+    const naturalArea = imgRef.current.naturalWidth * imgRef.current.naturalHeight;
+    const clientArea = imgRef.current.clientWidth * imgRef.current.clientHeight;
+    return clientArea < naturalArea * 0.9;
+  };
+
+  const handleImageLoaded = () => {
+    setIsLightboxSize(imgShouldHaveLightbox());
+  };
+
+  if (isLightboxSize || (nodeData.options && nodeData.options.lightbox)) {
+    return <Lightbox nodeData={nodeData} />;
+  }
+
+  return (
+    <div
+      className="figure"
+      style={{
+        width: nodeData.options && nodeData.options.figwidth ? nodeData.options.figwidth : 'auto',
+      }}
+    >
+      <img
+        src={nodeData.argument[0].value}
+        alt={nodeData.options.alt ? nodeData.options.alt : nodeData.argument[0].value}
+        width="50%"
+        onLoad={handleImageLoaded}
+        ref={imgRef}
+      />
+    </div>
+  );
+};
 
 Figure.propTypes = {
   nodeData: PropTypes.shape({
@@ -18,6 +47,7 @@ Figure.propTypes = {
     ).isRequired,
     options: PropTypes.shape({
       alt: PropTypes.string,
+      lightbox: PropTypes.bool,
     }).isRequired,
   }).isRequired,
 };

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const CAPTION_TEXT = 'click to enlarge';
+const isSvg = imgSrc => /\.svg$/.test(imgSrc);
+
+const Lightbox = ({ nodeData }) => {
+  const [showModal, setShowModal] = useState(false);
+  const imgSrc = nodeData.argument[0].value;
+  const altText = nodeData.options.alt ? nodeData.options.alt : imgSrc;
+
+  const toggleShowModal = () => {
+    setShowModal(prevShowState => !prevShowState);
+  };
+
+  return (
+    <React.Fragment>
+      <div
+        className="figure lightbox"
+        style={{ width: nodeData.options && nodeData.options.figwidth ? nodeData.options.figwidth : 'auto' }}
+      >
+        <div className="lightbox__imageWrapper" onClick={toggleShowModal} role="button" tabIndex="-1">
+          <img src={imgSrc} alt={altText} width="50%" />
+          <div className="lightbox__caption">{CAPTION_TEXT}</div>
+        </div>
+      </div>
+      {showModal && (
+        <div className="lightbox__modal" title="click to close" onClick={toggleShowModal} role="button" tabIndex="-1">
+          <img
+            className={[
+              'lightbox__content',
+              'lightbox__content--activated',
+              isSvg(imgSrc) ? 'lightbox__content--scalable' : null,
+            ].join(' ')}
+            src={imgSrc}
+            alt={`${altText} — Enlarged`}
+          />
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+Lightbox.propTypes = {
+  nodeData: PropTypes.shape({
+    argument: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    options: PropTypes.shape({
+      alt: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default Lightbox;

--- a/tests/unit/Figure.test.js
+++ b/tests/unit/Figure.test.js
@@ -4,8 +4,14 @@ import Figure from '../../src/components/Figure';
 
 // data for this component
 import mockData from './data/Figure.test.json';
+import lightboxData from './data/FigureLightbox.test.json';
 
 it('renders correctly', () => {
   const tree = shallow(<Figure nodeData={mockData} />);
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders lightbox correctly when specified as an option', () => {
+  const tree = shallow(<Figure nodeData={lightboxData} />);
   expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/Lightbox.test.js
+++ b/tests/unit/Lightbox.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import Lightbox from '../../src/components/Lightbox';
+
+// data for this component
+import mockData from './data/Figure.test.json';
+
+const mountLightbox = nodeData => mount(<Lightbox nodeData={nodeData} />);
+const shallowLightbox = nodeData => shallow(<Lightbox nodeData={nodeData} />);
+
+describe('Lightbox', () => {
+  let wrapper;
+  let shallowWrapper;
+
+  beforeAll(() => {
+      wrapper = mountLightbox(mockData);
+      shallowWrapper = shallowLightbox(mockData);
+    });
+
+  it('renders correctly', () => {
+      expect(shallowWrapper).toMatchSnapshot();
+    });
+
+  it('displays lightbox classes', () => {
+      expect(wrapper.find('.lightbox')).toHaveLength(1);
+      expect(wrapper.find('.lightbox__imageWrapper')).toHaveLength(1);
+    });
+
+  it('does not display the modal', () => {
+      expect(wrapper.find('.lightbox__modal')).toHaveLength(0);
+    });
+
+  it('shows a caption', () => {
+      expect(wrapper.find('.lightbox__caption')).toHaveLength(1);
+      expect(wrapper.find('.lightbox__caption').text()).toEqual('click to enlarge');
+    });
+
+  it('clicking the photo', () => {
+      const modalOpener = wrapper.find('.lightbox__imageWrapper');
+      modalOpener.simulate('click');
+    });
+
+  it('displays the modal', () => {
+      expect(wrapper.find('.lightbox__modal')).toHaveLength(1);
+    });
+
+  it('clicking anywhere on the modal', () => {
+      const modalOpener = wrapper.find('.lightbox__modal');
+      modalOpener.simulate('click');
+    });
+
+  it('closes the modal', () => {
+      expect(wrapper.find('.lightbox__modal')).toHaveLength(0);
+    });
+});

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -1,9 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<img
-  alt="/images/firstcluster.png"
-  src="/images/firstcluster.png"
-  width="50%"
+<div
+  className="figure"
+  style={
+    Object {
+      "width": "700px",
+    }
+  }
+>
+  <img
+    alt="/images/firstcluster.png"
+    onLoad={[Function]}
+    src="/images/firstcluster.png"
+    width="50%"
+  />
+</div>
+`;
+
+exports[`renders lightbox correctly when specified as an option 1`] = `
+<Lightbox
+  nodeData={
+    Object {
+      "argument": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 13,
+            },
+          },
+          "type": "text",
+          "value": "/images/firstcluster.png",
+        },
+      ],
+      "children": Array [],
+      "name": "figure",
+      "options": Object {
+        "checksum": "968654cd30e0b15d8b835ff39a066d3e4555aeef2bc77707908d6f990a643706",
+        "figwidth": "700px",
+        "lightbox": true,
+      },
+      "position": Object {
+        "start": Object {
+          "line": 13,
+        },
+      },
+      "type": "directive",
+    }
+  }
 />
 `;

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Lightbox renders correctly 1`] = `
+<Fragment>
+  <div
+    className="figure lightbox"
+    style={
+      Object {
+        "width": "700px",
+      }
+    }
+  >
+    <div
+      className="lightbox__imageWrapper"
+      onClick={[Function]}
+      role="button"
+      tabIndex="-1"
+    >
+      <img
+        alt="/images/firstcluster.png"
+        src="/images/firstcluster.png"
+        width="50%"
+      />
+      <div
+        className="lightbox__caption"
+      >
+        click to enlarge
+      </div>
+    </div>
+  </div>
+</Fragment>
+`;

--- a/tests/unit/data/FigureLightbox.test.json
+++ b/tests/unit/data/FigureLightbox.test.json
@@ -1,0 +1,26 @@
+{
+  "type": "directive",
+  "position": {
+      "start": {
+            "line": 13
+          }
+    },
+  "name": "figure",
+  "argument": [
+      {
+            "type": "text",
+            "position": {
+                    "start": {
+                              "line": 13
+                            }
+                  },
+            "value": "/images/firstcluster.png"
+          }
+    ],
+  "options": {
+      "figwidth": "700px",
+      "checksum": "968654cd30e0b15d8b835ff39a066d3e4555aeef2bc77707908d6f990a643706",
+      "lightbox": true
+    },
+  "children": []
+}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5132)] This PR adds a Lightbox to images that either:
- Specify `:lightbox:` as one of their options
- Are 10% larger than their container ([as is done currently](https://github.com/mongodb/docs-tools/blob/f6f48fb3876f4ed7b5131d00119755a25a09de7d/themes/mongodb/src/js/componentLightbox.js#L57))

<img width="1552" alt="Screen Shot 2019-04-12 at 4 36 16 PM" src="https://user-images.githubusercontent.com/9298431/56064836-2b2ae680-5d41-11e9-8daa-afdd148e0f2b.png">
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/56064787-0df61800-5d41-11e9-8b91-7621b4567b72.png">
