### PR TITLE
DOCSP-5250: Add TitleReference component

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -18,6 +18,7 @@ import BlockQuote from './BlockQuote';
 import Reference from './Reference';
 import Strong from './Strong';
 import URIWriter from './URIWriter';
+import TitleReference from './TitleReference';
 
 // the different roles
 import RoleGUILabel from './Roles/GUILabel';
@@ -62,6 +63,7 @@ export default class ComponentFactory extends Component {
       step: Step,
       strong: Strong,
       tabs: Tabs,
+      title_reference: TitleReference,
       uriwriter: URIWriter,
     };
   }

--- a/src/components/TitleReference.js
+++ b/src/components/TitleReference.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TitleReference = ({
+  nodeData: {
+    children: [{ value }],
+  },
+}) => <cite>{value}</cite>;
+
+TitleReference.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+};
+
+export default TitleReference;

--- a/tests/unit/TitleReference.test.js
+++ b/tests/unit/TitleReference.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import TitleReference from '../../src/components/TitleReference';
+
+// data for this component
+import mockData from './data/TitleReference.test.json';
+
+it('renders correctly', () => {
+  const tree = shallow(<TitleReference nodeData={mockData} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/TitleReference.test.js.snap
+++ b/tests/unit/__snapshots__/TitleReference.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<cite>
+  admin
+</cite>
+`;

--- a/tests/unit/data/TitleReference.test.json
+++ b/tests/unit/data/TitleReference.test.json
@@ -1,0 +1,19 @@
+{
+  "type": "title_reference",
+  "position": {
+    "start": {
+      "line": 0
+    }
+  },
+  "children": [
+    {
+      "type": "text",
+      "position": {
+	"start": {
+	  "line": 0
+	}
+      },
+      "value": "admin"
+    }
+  ]
+}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5250)] Adds `TitleReference` component, which places `<cite>` tags around text enclosed by backticks (`) in rST files.