### PR TITLE
DOCSP-5272: Support hidden tabsets

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -40,6 +40,7 @@ export default class Tabs extends Component {
     const { tabsetName } = this.state;
     const { nodeData, activeTabs, setActiveTab } = this.props;
     const isHeaderTabset = tabsetName === 'drivers' || tabsetName === 'cloud';
+    const isHidden = nodeData.options && nodeData.options.hidden;
     const tabs =
       tabsetName === 'platforms' || PLATFORMS.some(p => tabsetName.includes(p))
         ? this.sortTabset(nodeData, PLATFORMS)
@@ -47,7 +48,7 @@ export default class Tabs extends Component {
 
     return (
       <React.Fragment>
-        {isHeaderTabset || (
+        {isHeaderTabset || isHidden || (
           <ul className="tab-strip tab-strip--singleton" role="tablist">
             {tabs.map((tab, index) => {
               const tabName = tab.argument[0].value.toLowerCase();

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -6,6 +6,7 @@ import Tabs from '../../src/components/Tabs';
 // data for this component
 import mockDataPlatforms from './data/Tabs-platform.test.json';
 import mockDataLanguages from './data/Tabs-languages.test.json';
+import mockDataHidden from './data/Tabs-hidden.test.json';
 
 const mountTabs = ({ mockData, mockSetActiveTab, mockAddTabset, activeTabs }) =>
   mount(<Tabs nodeData={mockData} setActiveTab={mockSetActiveTab} addTabset={mockAddTabset} activeTabs={activeTabs} />);
@@ -17,11 +18,17 @@ describe('Tabs testing', () => {
     const mockAddTabset = jest.fn();
 
     beforeAll(() => {
-      wrapper = mountTabs({ mockData: mockDataPlatforms, mockSetActiveTab, mockAddTabset, activeTabs: { platforms: PLATFORMS[0] } });
+      wrapper = mountTabs({
+        mockData: mockDataPlatforms,
+        mockSetActiveTab,
+        mockAddTabset,
+        activeTabs: { platforms: PLATFORMS[0] },
+      });
     });
 
     it('tabs container exists with correct number of children', () => {
       const tabCount = wrapper.props().nodeData.children.length;
+      expect(wrapper.find('.tab-strip')).toHaveLength(1);
       expect(wrapper.find('.tab-strip__element').exists()).toEqual(true);
       expect(wrapper.find('.tab-strip__element')).toHaveLength(tabCount);
     });
@@ -55,11 +62,35 @@ describe('Tabs testing', () => {
     const mockAddTabset = jest.fn();
 
     beforeAll(() => {
-      wrapper = mountTabs({ mockData: mockDataLanguages, mockSetActiveTab, mockAddTabset, activeTabs: { drivers: LANGUAGES[0] } });
+      wrapper = mountTabs({
+        mockData: mockDataLanguages,
+        mockSetActiveTab,
+        mockAddTabset,
+        activeTabs: { drivers: LANGUAGES[0] },
+      });
     });
 
     it('tabset should not be created for drivers/language pills', () => {
-      expect(wrapper.find('.tab-strip__element').exists()).toEqual(false)
+      expect(wrapper.find('.tab-strip__element').exists()).toEqual(false);
+    });
+  });
+
+  describe('when a hidden tabset is passed in', () => {
+    let wrapper;
+    const mockSetActiveTab = jest.fn();
+    const mockAddTabset = jest.fn();
+
+    beforeAll(() => {
+      wrapper = mountTabs({
+        mockData: mockDataHidden,
+        mockSetActiveTab,
+        mockAddTabset,
+        activeTabs: {},
+      });
+    });
+
+    it('does not render a tabset', () => {
+      expect(wrapper.find('.tab-strip')).toHaveLength(0);
     });
   });
 });

--- a/tests/unit/data/Tabs-hidden.test.json
+++ b/tests/unit/data/Tabs-hidden.test.json
@@ -1,0 +1,436 @@
+{
+  "type": "directive",
+  "position": {
+    "start": {
+      "line": 2
+    }
+  },
+  "name": "tabs",
+  "argument": [],
+  "options": {
+    "hidden": true,
+    "tabset": "cloud"
+  },
+  "children": [
+    {
+      "type": "directive",
+      "position": {
+	"start": {
+	  "line": 6
+	}
+      },
+      "name": "tab",
+      "argument": [
+	{
+	  "type": "text",
+	  "position": {
+	    "start": {
+	      "line": 6
+	    }
+	  },
+	  "value": "cloud"
+	}
+      ],
+      "children": [
+	{
+	  "type": "paragraph",
+	  "position": {
+	    "start": {
+	      "line": 0
+	    }
+	  },
+	  "children": [
+	    {
+	      "type": "text",
+	      "position": {
+		"start": {
+		  "line": 0
+		}
+	      },
+	      "value": "Check that you have an Atlas account and have deployed a MongoDB database\ncluster. See "
+	    },
+	    {
+	      "type": "role",
+	      "position": {
+		"start": {
+		  "line": 0
+		}
+	      },
+	      "name": "doc",
+	      "label": "/cloud/atlas",
+	      "target": "/cloud/atlas",
+	      "raw": "/cloud/atlas",
+	      "children": []
+	    },
+	    {
+	      "type": "text",
+	      "position": {
+		"start": {
+		  "line": 0
+		}
+	      },
+	      "value": " for information on how to\nlogin and create a cluster in Atlas."
+	    }
+	  ]
+	}
+      ]
+    },
+    {
+      "type": "directive",
+      "position": {
+	"start": {
+	  "line": 13
+	}
+      },
+      "name": "tab",
+      "argument": [
+	{
+	  "type": "text",
+	  "position": {
+	    "start": {
+	      "line": 13
+	    }
+	  },
+	  "value": "local"
+	}
+      ],
+      "children": [
+	{
+	  "type": "directive",
+	  "position": {
+	    "start": {
+	      "line": 0
+	    }
+	  },
+	  "name": "tabs",
+	  "argument": [],
+	  "options": {
+	    "tabset": "platforms"
+	  },
+	  "children": [
+	    {
+	      "type": "directive",
+	      "position": {
+		"start": {
+		  "line": 74
+		}
+	      },
+	      "name": "tab",
+	      "argument": [
+		{
+		  "type": "text",
+		  "position": {
+		    "start": {
+		      "line": 74
+		    }
+		  },
+		  "value": "windows"
+		}
+	      ],
+	      "children": [
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 0
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 0
+			}
+		      },
+		      "value": "To make sure that your MongoDB instance is running on Windows,\nrun the following command from the Windows command prompt:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 3
+		    }
+		  },
+		  "lang": "bat",
+		  "copyable": true,
+		  "value": "tasklist /FI \"IMAGENAME eq mongod.exe\""
+		},
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 7
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": "If a "
+		    },
+		    {
+		      "type": "role",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "name": "binary",
+		      "label": {
+			"type": "text",
+			"value": "mongod.exe",
+			"position": {
+			  "start": {
+			    "line": 63
+			  }
+			}
+		      },
+		      "target": "bin.mongod.exe",
+		      "raw": "mongod.exe <bin.mongod.exe>",
+		      "children": []
+		    },
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": " instance is running, you will\nsee something like:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 10
+		    }
+		  },
+		  "lang": "bat",
+		  "copyable": true,
+		  "value": "Image Name                     PID Session Name        Session#    Mem Usage\n========================= ======== ================ =========== ============\nmongod.exe                    8716 Console                    1      9,508 K"
+		}
+	      ]
+	    },
+	    {
+	      "type": "directive",
+	      "position": {
+		"start": {
+		  "line": 92
+		}
+	      },
+	      "name": "tab",
+	      "argument": [
+		{
+		  "type": "text",
+		  "position": {
+		    "start": {
+		      "line": 92
+		    }
+		  },
+		  "value": "linux"
+		}
+	      ],
+	      "children": [
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 0
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 0
+			}
+		      },
+		      "value": "To make sure your MongoDB instance is running on Linux, run the\nfollowing command from your terminal:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 3
+		    }
+		  },
+		  "lang": "sh",
+		  "copyable": true,
+		  "value": "ps -e| grep 'mongod'"
+		},
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 7
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": "If a "
+		    },
+		    {
+		      "type": "role",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "name": "binary",
+		      "label": "~bin.mongod",
+		      "target": "~bin.mongod",
+		      "raw": "~bin.mongod",
+		      "children": []
+		    },
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": " instance is running, you will see\nsomething like:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 10
+		    }
+		  },
+		  "lang": "sh",
+		  "copyable": true,
+		  "value": "89780 ttys026    0:53.48 ./mongod"
+		}
+	      ]
+	    },
+	    {
+	      "type": "directive",
+	      "position": {
+		"start": {
+		  "line": 109
+		}
+	      },
+	      "name": "tab",
+	      "argument": [
+		{
+		  "type": "text",
+		  "position": {
+		    "start": {
+		      "line": 109
+		    }
+		  },
+		  "value": "macos"
+		}
+	      ],
+	      "children": [
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 0
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 0
+			}
+		      },
+		      "value": "To make sure your MongoDB instance is running on Mac, run the\nfollowing command from your terminal:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 3
+		    }
+		  },
+		  "lang": "sh",
+		  "copyable": true,
+		  "value": "ps -e | grep 'mongod'"
+		},
+		{
+		  "type": "paragraph",
+		  "position": {
+		    "start": {
+		      "line": 7
+		    }
+		  },
+		  "children": [
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": "If a "
+		    },
+		    {
+		      "type": "role",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "name": "binary",
+		      "label": "~bin.mongod",
+		      "target": "~bin.mongod",
+		      "raw": "~bin.mongod",
+		      "children": []
+		    },
+		    {
+		      "type": "text",
+		      "position": {
+			"start": {
+			  "line": 7
+			}
+		      },
+		      "value": " instance is running, you will see\nsomething like:"
+		    }
+		  ]
+		},
+		{
+		  "type": "code",
+		  "position": {
+		    "start": {
+		      "line": 10
+		    }
+		  },
+		  "lang": "sh",
+		  "copyable": true,
+		  "value": "89780 ttys026    0:53.48 ./mongod"
+		}
+	      ]
+	    }
+	  ]
+	}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5272)] Hides tabsets when rST file includes the `:hidden:` option. Content is still rendered conditionally using the active tab selected elsewhere on the page.