### PR TITLE
DOCSP-5382: Add npm scripts for running Gatsby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Front-end for Docs
+# MongoDB Docs Front-End
 
 Uses [Gatsby](https://www.gatsbyjs.org/) to build static site.
 
-## Installation:
+## Installation
 
 ```shell
 npm install
@@ -14,9 +14,11 @@ If this is your first time running the site you'll need the static directory:
 make static
 ```
 
-You'll need to set some ENV variables in two separate files at the root of this directory for separate production/development environments.
+### .env file setup
 
-`.env.production`
+You'll need to set some environment variables in two separate files at the root of this directory for separate production/development environments.
+
+#### `.env.production`
 ```
 NODE_ENV=production
 STITCH_ID=<STITCH_ID> 
@@ -25,7 +27,7 @@ DOCUMENTS=/<SITE/USER/BRANCH>
 GATSBY_PREFIX=/<SITE/USER/BRANCH>
 ```
 
-`.env.development`
+#### `.env.development`
 ```
 NODE_ENV=development
 STITCH_ID=<STITCH_ID> 
@@ -34,20 +36,20 @@ DOCUMENTS=/<SITE/USER/BRANCH>
 GATSBY_PREFIX=''
 ```
 
-## Running locally:
+## Running locally
 
 ```shell
-gatsby develop --prefix-paths
+npm run develop
 ```
 
 To build and serve the site, run the following commands:
 
 ```shell
-gatsby build --prefix-paths
-gatsby serve --prefix-paths
+$ npm run build
+$ npm run serve
 ```
 
-## Using mock test data:
+## Using mock test data
 
 Every time you run the application without the flag below, the data retrieved for the docs site is stored in `tests/unit/data/site/__testDataLatest.json`. There is also a reference data file in `tests/unit/data/site/__testData.json`. You can load either one of these into the Gatsby build with the flag:
 
@@ -62,7 +64,7 @@ Tests can be run using:
 npm test  # alias for npm run test
 ```
 
-### Unit Tests
+### Unit tests
 Unit tests are located in the `tests/unit/` directory. To run only unit tests, use:
 
 ```shell

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "snooty",
+  "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "snooty",
+  "version": "0.1.0",
+  "repository": "github:mongodb/snooty",
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
@@ -26,10 +29,11 @@
     "webpack-dev-server": ">=3.1.11"
   },
   "scripts": {
-    "start": "node server.js",
-    "dev": "webpack --mode development",
+    "build": "gatsby build --prefix-paths",
+    "develop": "gatsby develop --prefix-paths",
     "lint": "eslint src/ tests/",
     "lintfix": "prettier-eslint --write \"src/**/*.js\" \"tests/*.js\"",
+    "serve": "gatsby serve --prefix-paths",
     "test": "jest",
     "test-unit": "jest ./tests/unit/"
   },


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5382)]
- Add commands for `gatsby develop`, `build`, and `serve` to `package.json`'s `scripts` section
- Update README
- Remove some unused scripts from `package.json`
- Removes dependency on global installation of the Gatsby CLI

**Note:** While testing, the `npm run` process was sometimes killed randomly. This problem mostly seems to have gone away, but I'm not sure if it was due to my system config or a larger bug. Please pull this branch and run the commands a few times! If you run into problems, try running `gatsby clean` and see if they persist.