### PR TITLE
Fix: Env Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make static
 You'll need to set some environment variables in two separate files at the root of this directory for separate production/development environments.
 
 #### `.env.production`
-Running Snooty's `build` and `serve` stages use the `production` environment. Your `.env.production` file should be as follows:
+Snooty's `build` and `serve` stages use the `production` environment. Your `.env.production` file should be as follows:
 ```
 NAMESPACE=<DB>/<COLLECTION> 
 GATSBY_STITCH_ID=<STITCH_ID> 
@@ -37,7 +37,7 @@ GATSBY_PREFIX=/<descriptive-slug>
 If `GATSBY_PREFIX` is not set, a prefix will automatically be generated in the form of `/SITE/USER/BRANCH`.
 
 #### `.env.development`
-Running Snooty's `develop` stage uses the `development` environment. Your `.env.development` file should be as follows:
+Snooty's `develop` stage uses the `development` environment. Your `.env.development` file should be as follows:
 ```
 NAMESPACE=<DB>/<COLLECTION> 
 GATSBY_STITCH_ID=<STITCH_ID> 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,31 @@ make static
 You'll need to set some environment variables in two separate files at the root of this directory for separate production/development environments.
 
 #### `.env.production`
+Running Snooty's `build` and `serve` stages use the `production` environment. Your `.env.production` file should be as follows:
 ```
-NODE_ENV=production
-STITCH_ID=<STITCH_ID> 
-NAMESPACE=<DB/COLLECTION> 
-DOCUMENTS=/<SITE/USER/BRANCH>
-GATSBY_PREFIX=/<SITE/USER/BRANCH>
+NAMESPACE=<DB>/<COLLECTION> 
+GATSBY_STITCH_ID=<STITCH_ID> 
+GATSBY_SITE=<SITE>
+GATSBY_USER=<USER>
+GATSBY_BRANCH=<BRANCH>
 ```
 
-#### `.env.development`
+##### Path prefixing
+When setting up a staging environment, you may wish to include a descriptive path prefix (e.g. `ops-manager-update`). To do so, set the `GATSBY_PREFIX` variable in your production .env file *with a preceding slash*:
 ```
-NODE_ENV=development
-STITCH_ID=<STITCH_ID> 
-NAMESPACE=<DB/COLLECTION> 
-DOCUMENTS=/<SITE/USER/BRANCH>
-GATSBY_PREFIX=''
+GATSBY_PREFIX=/<descriptive-slug>
+```
+
+If `GATSBY_PREFIX` is not set, a prefix will automatically be generated in the form of `/SITE/USER/BRANCH`.
+
+#### `.env.development`
+Running Snooty's `develop` stage uses the `development` environment. Your `.env.development` file should be as follows:
+```
+NAMESPACE=<DB>/<COLLECTION> 
+GATSBY_STITCH_ID=<STITCH_ID> 
+GATSBY_SITE=<SITE>
+GATSBY_USER=<USER>
+GATSBY_BRANCH=<BRANCH>
 ```
 
 ## Running locally

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,12 @@ require('dotenv').config({
   path: `.env.${runningEnv}`,
 });
 
+const getPathPrefix = () =>
+  process.env.GATSBY_PREFIX ||
+  (runningEnv === 'production'
+    ? `/${process.env.GATSBY_SITE}/${process.env.GATSBY_USER}/${process.env.GATSBY_BRANCH}`
+    : '/');
+
 module.exports = {
-  pathPrefix: process.env.GATSBY_PREFIX !== '' ? process.env.GATSBY_PREFIX : '/'
-}
+  pathPrefix: getPathPrefix(),
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,9 +49,9 @@ const validateEnvVariables = () => {
   ) {
     return {
       error: true,
-      message: `ERROR with .env.${
+      message: `${
         process.env.NODE_ENV
-      } file: parameters required are NAMESPACE, GATSBY_STITCH_ID, GATSBY_SITE, GATSBY_USER, and GATSBY_BRANCH`,
+      } requires the variables NAMESPACE, GATSBY_STITCH_ID, GATSBY_SITE, GATSBY_USER, and GATSBY_BRANCH`,
     };
   }
   // make sure formats are correct
@@ -62,9 +62,9 @@ const validateEnvVariables = () => {
   ) {
     return {
       error: true,
-      message: `ERROR with .env.${
+      message: `within .env.${
         process.env.NODE_ENV
-      } file: GATSBY_PREFIX must start with a slash: GATSBY_PREFIX=/<PREFIX_NAME>`,
+      }, GATSBY_PREFIX must start with a slash: GATSBY_PREFIX=/<PREFIX_NAME>`,
     };
   }
   // create split prefix for use in stitch function
@@ -119,7 +119,7 @@ exports.sourceNodes = async ({ actions }) => {
 
     // resolve references/urls to documents
     RESOLVED_REF_DOC_MAPPING = await stitchClient.callFunction('resolveReferences', [
-      DOCUMENTS,
+      DOCUMENTS.split('/'),
       process.env.NAMESPACE,
       documents,
       RESOLVED_REF_DOC_MAPPING,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,5 @@
 const path = require('path');
 const fs = require('fs');
-const crypto = require('crypto');
-const uuidv1 = require('uuid/v1');
 const { Stitch, AnonymousCredential } = require('mongodb-stitch-server-sdk');
 
 // where assets and documents are referenced
@@ -16,7 +14,6 @@ const LATEST_TEST_DATA_FILE = '__testDataLatest.json';
 // different types of references
 const PAGES = [];
 const INCLUDE_FILES = [];
-const GITHUB_CODE_EXAMPLES = [];
 const ASSETS = [];
 
 // in-memory object with key/value = filename/document
@@ -27,9 +24,8 @@ let stitchClient;
 
 const setupStitch = () => {
   return new Promise((resolve, reject) => {
-    stitchClient = Stitch.hasAppClient(process.env.STITCH_ID)
-      ? Stitch.getAppClient(process.env.STITCH_ID)
-      : Stitch.initializeAppClient(process.env.STITCH_ID);
+    const stitchId = process.env.GATSBY_STITCH_ID;
+    stitchClient = Stitch.hasAppClient(stitchId) ? Stitch.getAppClient(stitchId) : Stitch.initializeAppClient(stitchId);
     stitchClient.auth
       .loginWithCredential(new AnonymousCredential())
       .then(user => {
@@ -44,30 +40,38 @@ const setupStitch = () => {
 // https://www.gatsbyjs.org/docs/environment-variables/#defining-environment-variables
 const validateEnvVariables = () => {
   // make sure necessary env vars exist
-  if (!process.env.NAMESPACE || !process.env.STITCH_ID || !process.env.DOCUMENTS || process.env.GATSBY_PREFIX === undefined) {
-    return { 
-      error: true, 
-      message: 'ERROR with .env.* file: parameters required are GATSBY_PREFIX, DOCUMENTS, NAMESPACE, and STITCH_ID' 
+  if (
+    !process.env.NAMESPACE ||
+    !process.env.GATSBY_STITCH_ID ||
+    !process.env.GATSBY_SITE ||
+    !process.env.GATSBY_USER ||
+    !process.env.GATSBY_BRANCH
+  ) {
+    return {
+      error: true,
+      message: `ERROR with .env.${
+        process.env.NODE_ENV
+      } file: parameters required are NAMESPACE, GATSBY_STITCH_ID, GATSBY_SITE, GATSBY_USER, and GATSBY_BRANCH`,
     };
   }
   // make sure formats are correct
-  if (process.env.NODE_ENV === 'production' && !process.env.GATSBY_PREFIX.startsWith('/')) {
-    return { 
-      error: true, 
-      message: 'ERROR with .env.* file: GATSBY_PREFIX must be in format /<site>/<user>/<branch>' 
-    };
-  } 
-  if (!process.env.DOCUMENTS.startsWith('/')) {
-    return { 
-      error: true, 
-      message: 'ERROR with .env.* file: DOCUMENTS must be in format /<site>/<user>/<branch>' 
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.GATSBY_PREFIX &&
+    !process.env.GATSBY_PREFIX.startsWith('/')
+  ) {
+    return {
+      error: true,
+      message: `ERROR with .env.${
+        process.env.NODE_ENV
+      } file: GATSBY_PREFIX must start with a slash: GATSBY_PREFIX=/<PREFIX_NAME>`,
     };
   }
   // create split prefix for use in stitch function
-  DOCUMENTS = process.env.DOCUMENTS.substr(1).split('/');
+  DOCUMENTS = `${process.env.GATSBY_SITE}/${process.env.GATSBY_USER}/${process.env.GATSBY_BRANCH}`;
   NAMESPACE_ASSETS = `${process.env.NAMESPACE.split('/')[0]}/assets`;
   return {
-    error: false
+    error: false,
   };
 };
 
@@ -89,7 +93,7 @@ exports.sourceNodes = async ({ actions }) => {
 
   if (envResults.error) {
     throw Error(envResults.message);
-  } 
+  }
 
   // wait to connect to stitch
   await setupStitch();
@@ -107,7 +111,7 @@ exports.sourceNodes = async ({ actions }) => {
     }
   } else {
     // start from index document
-    const query = { _id: `${DOCUMENTS.join('/')}/index` };
+    const query = { _id: `${DOCUMENTS}/index` };
     const documents = await stitchClient.callFunction('fetchDocuments', [process.env.NAMESPACE, query]);
 
     // set data for index page
@@ -126,20 +130,11 @@ exports.sourceNodes = async ({ actions }) => {
   for (const ref of Object.keys(RESOLVED_REF_DOC_MAPPING)) {
     if (ref.includes('includes/')) {
       INCLUDE_FILES.push(ref);
-    } else if (ref.includes('https://github.com')) {
-      GITHUB_CODE_EXAMPLES.push(ref);
     } else if (ref.includes('#')) {
       ASSETS.push(ref);
     } else if (!ref.includes('curl') && !ref.includes('https://')) {
       PAGES.push(ref);
     }
-  }
-
-  // get code examples for all github urls
-  for (const url of GITHUB_CODE_EXAMPLES) {
-    const githubRawUrl = url.replace('https://github.com', 'https://raw.githubusercontent.com').replace('blob/', '');
-    const codeFile = await stitchClient.callFunction('fetchReferenceUrlContent', [githubRawUrl]);
-    RESOLVED_REF_DOC_MAPPING[url] = codeFile;
   }
 
   // create images directory
@@ -154,7 +149,6 @@ exports.sourceNodes = async ({ actions }) => {
 
   console.log(11, PAGES);
   console.log(22, INCLUDE_FILES);
-  console.log(33, GITHUB_CODE_EXAMPLES);
   console.log(44, ASSETS);
   //console.log(RESOLVED_REF_DOC_MAPPING);
 
@@ -181,7 +175,6 @@ exports.createPages = ({ graphql, actions }) => {
           component: path.resolve(`./src/templates/${template}.js`),
           context: {
             __refDocMapping: RESOLVED_REF_DOC_MAPPING,
-            __stitchID: process.env.STITCH_ID,
           },
         });
       }

--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Lightbox from './Lightbox';
+import { getPrefix } from '../util';
 
 const Figure = ({ nodeData }) => {
   const imgRef = React.createRef();
   const [isLightboxSize, setIsLightboxSize] = useState(false);
-  const imgSrc = (process.env.GATSBY_PREFIX || '') + nodeData.argument[0].value;
+  const imgSrc = `${getPrefix()}${nodeData.argument[0].value}`;
 
   const imgShouldHaveLightbox = () => {
     const naturalArea = imgRef.current.naturalWidth * imgRef.current.naturalHeight;

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { getPrefix } from '../util';
 
 const CAPTION_TEXT = 'click to enlarge';
 const isSvg = imgSrc => /\.svg$/.test(imgSrc);
 
 const Lightbox = ({ nodeData }) => {
   const [showModal, setShowModal] = useState(false);
-  const imgSrc = (process.env.GATSBY_PREFIX || '') + nodeData.argument[0].value;
+  const imgSrc = `${getPrefix()}${nodeData.argument[0].value}`;
   const altText = nodeData.options.alt ? nodeData.options.alt : imgSrc;
 
   const toggleShowModal = () => {

--- a/src/html.js
+++ b/src/html.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getPrefix } from './util';
 
 const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyComponents, postBodyComponents }) => (
   <html lang="en" {...htmlAttributes}>
@@ -21,9 +22,9 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
         property="og:image:secure_url"
         content="https://webassets.mongodb.com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
       />
-      <link rel="stylesheet" href={`${process.env.GATSBY_PREFIX}/static/guides.css`} type="text/css" />
-      <link rel="stylesheet" href={`${process.env.GATSBY_PREFIX}/static/pygments.css`} type="text/css" />
-      <link rel="stylesheet" href={`${process.env.GATSBY_PREFIX}/static/css/navbar.min.css`} type="text/css" />
+      <link rel="stylesheet" href={`${getPrefix()}/static/guides.css`} type="text/css" />
+      <link rel="stylesheet" href={`${getPrefix()}/static/pygments.css`} type="text/css" />
+      <link rel="stylesheet" href={`${getPrefix()}/static/css/navbar.min.css`} type="text/css" />
       <link
         rel="search"
         type="application/opensearchdescription+xml"
@@ -43,16 +44,16 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
         id="navbar"
         data-navprops='{"links": [{"url": "https://docs.mongodb.com/manual/","text": "Server"},{"url": "https://docs.mongodb.com/ecosystem/drivers/","text": "Drivers"},{"url": "https://docs.mongodb.com/cloud/","text": "Cloud"},{"url": "https://docs.mongodb.com/tools/","text": "Tools"},{"url": "https://docs.mongodb.com/guides/","text": "Guides","active": true}]}'
       />
-      <script async src={`${process.env.GATSBY_PREFIX}/static/navbar.min.js`} />
+      <script async src={`${getPrefix()}/static/navbar.min.js`} />
       {preBodyComponents}
       <div
         key="body"
         id="___gatsby"
         dangerouslySetInnerHTML={{ __html: body }} // eslint-disable-line react/no-danger
       />
-      <script type="text/javascript" src={`${process.env.GATSBY_PREFIX}/static/lib/jquery.min.js`} />
-      <script type="text/javascript" src={`${process.env.GATSBY_PREFIX}/static/lib/bootstrap.js`} />
-      <script type="text/javascript" src={`${process.env.GATSBY_PREFIX}/static/controller.js`} />
+      <script type="text/javascript" src={`${getPrefix()}/static/lib/jquery.min.js`} />
+      <script type="text/javascript" src={`${getPrefix()}/static/lib/bootstrap.js`} />
+      <script type="text/javascript" src={`${getPrefix()}/static/controller.js`} />
       {postBodyComponents}
     </body>
   </html>

--- a/src/html.js
+++ b/src/html.js
@@ -35,9 +35,9 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
     </head>
     <body
       {...bodyAttributes}
-      data-project="guides"
+      data-project={process.env.GATSBY_SITE}
       data-project-title="MongoDB Guides"
-      data-branch="DOCSP-3279"
+      data-branch={process.env.GATSBY_BRANCH}
       data-enable-marian="1"
     >
       <div

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -5,6 +5,7 @@ import GuideSection from '../components/GuideSection';
 import GuideHeading from '../components/GuideHeading';
 import { LANGUAGES, DEPLOYMENTS } from '../constants';
 import { getLocalValue, setLocalValue } from '../localStorage';
+import { getPrefix } from '../util';
 
 export default class Guide extends Component {
   constructor(propsFromServer) {
@@ -14,8 +15,8 @@ export default class Guide extends Component {
     let guideKeyInMapping = this.props['*']; // eslint-disable-line react/destructuring-assignment
 
     // get correct lookup key based on whether running dev/prod
-    if (process.env.GATSBY_PREFIX !== '') {
-      const documentPrefix = process.env.GATSBY_PREFIX.substr(1);
+    if (process.env.NODE_ENV === 'production') {
+      const documentPrefix = getPrefix().substr(1);
       guideKeyInMapping = guideKeyInMapping.replace(`${documentPrefix}/`, '');
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -16,7 +16,6 @@ export const findKeyValuePair = (nodes, key, value) => {
   return result;
 };
 
-// export const getPrefix = () => process.env.GATSBY_PREFIX || ''
 export const getPrefix = () =>
   process.env.GATSBY_PREFIX ||
   (process.env.NODE_ENV === 'production'

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,6 @@ export const findKeyValuePair = (nodes, key, value) => {
 // export const getPrefix = () => process.env.GATSBY_PREFIX || ''
 export const getPrefix = () =>
   process.env.GATSBY_PREFIX ||
-  (process.env.NODE_ENV === 'development'
-    ? ''
-    : `/${process.env.GATSBY_SITE}/${process.env.GATSBY_USER}/${process.env.GATSBY_BRANCH}`);
+  (process.env.NODE_ENV === 'production'
+    ? `/${process.env.GATSBY_SITE}/${process.env.GATSBY_USER}/${process.env.GATSBY_BRANCH}`
+    : '');

--- a/src/util.js
+++ b/src/util.js
@@ -2,7 +2,7 @@
  * Recursively searches child nodes to find the specified key/value pair.
  * Prevents us from having to rely on a fixed depth for properties in the AST.
  */
-const findKeyValuePair = (nodes, key, value) => {
+export const findKeyValuePair = (nodes, key, value) => {
   let result;
   const iter = node => {
     if (node[key] === value) {
@@ -16,4 +16,9 @@ const findKeyValuePair = (nodes, key, value) => {
   return result;
 };
 
-export { findKeyValuePair }; // eslint-disable-line import/prefer-default-export
+// export const getPrefix = () => process.env.GATSBY_PREFIX || ''
+export const getPrefix = () =>
+  process.env.GATSBY_PREFIX ||
+  (process.env.NODE_ENV === 'development'
+    ? ''
+    : `/${process.env.GATSBY_SITE}/${process.env.GATSBY_USER}/${process.env.GATSBY_BRANCH}`);


### PR DESCRIPTION
- Modify env vars so that we can use `SITE`, `USER`, and `BRANCH` variables independently within the front end.
- `STITCH_ID` renamed to `GATSBY_STITCH_ID` to expose it to the front end.
- `GATSBY_PREFIX` no longer required.
  - It will be used if specified.
  - If not, `production` environments will default to `/SITE/USER/BRANCH` and `development` environments will default to `/`.
- No longer set `NODE_ENV` in .env files, as this is a [reserved environment variable](https://www.gatsbyjs.org/docs/environment-variables/#reserved-environment-variables).
- Remove some deprecated GitHub fetch code.