### PR TITLE
DOCSP-5425: Add missing roles

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -20,9 +20,11 @@ import Strong from './Strong';
 import URIWriter from './URIWriter';
 import TitleReference from './TitleReference';
 
+import RoleClass from './Roles/Class';
 import RoleCode from './Roles/Code';
 import RoleDoc from './Roles/Doc';
 import RoleGUILabel from './Roles/GUILabel';
+import RoleApi from './Roles/Api';
 import RoleManual from './Roles/Manual';
 import RoleProgram from './Roles/Program';
 import RoleRef from './Roles/Ref';
@@ -34,9 +36,12 @@ export default class ComponentFactory extends Component {
     this.roles = {
       authrole: RoleCode,
       binary: RoleCode,
+      class: RoleClass,
+      'csharp-api': RoleApi,
       dbcommand: RoleCode,
       doc: RoleDoc,
       guilabel: RoleGUILabel,
+      'java-sync-api': RoleApi,
       manual: RoleManual,
       method: RoleCode,
       option: RoleCode,
@@ -76,7 +81,14 @@ export default class ComponentFactory extends Component {
       nodeData: { name, type },
     } = this.props;
     // do nothing with these nodes for now (cc. Andrew)
-    if (type === 'target' || type === 'class' || type === 'cssclass' || name === 'cssclass' || name === 'class') {
+    if (
+      type === 'target' ||
+      type === 'class' ||
+      type === 'cssclass' ||
+      name === 'cssclass' ||
+      name === 'class' ||
+      type === 'comment'
+    ) {
       return null;
     }
     const lookup = type === 'directive' ? name : type;

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -20,11 +20,11 @@ import Strong from './Strong';
 import URIWriter from './URIWriter';
 import TitleReference from './TitleReference';
 
+import RoleApi from './Roles/Api';
 import RoleClass from './Roles/Class';
 import RoleCode from './Roles/Code';
 import RoleDoc from './Roles/Doc';
 import RoleGUILabel from './Roles/GUILabel';
-import RoleApi from './Roles/Api';
 import RoleManual from './Roles/Manual';
 import RoleProgram from './Roles/Program';
 import RoleRef from './Roles/Ref';

--- a/src/components/Roles/Api.js
+++ b/src/components/Roles/Api.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RoleJavaSyncApi = ({
+  nodeData: {
+    label: { value },
+    name,
+    target,
+  },
+}) => {
+  let href;
+  console.log(name);
+  if (name === 'java-sync-api') {
+    href = `http://mongodb.github.io/mongo-java-driver/3.7/javadoc/${target}`;
+  } else if (name === 'csharp-api') {
+    href = `https://mongodb.github.io/mongo-csharp-driver/2.5/apidocs/html/${target}.htm`;
+  }
+
+  return (
+    <a href={href} className="reference external">
+      {value}
+    </a>
+  );
+};
+
+RoleJavaSyncApi.propTypes = {
+  nodeData: PropTypes.shape({
+    label: PropTypes.shape({
+      value: PropTypes.string.isRequired,
+    }).isRequired,
+    name: PropTypes.oneOf(['java-sync-api', 'csharp-api']).isRequired,
+    target: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default RoleJavaSyncApi;

--- a/src/components/Roles/Api.js
+++ b/src/components/Roles/Api.js
@@ -9,7 +9,6 @@ const RoleJavaSyncApi = ({
   },
 }) => {
   let href;
-  console.log(name);
   if (name === 'java-sync-api') {
     href = `http://mongodb.github.io/mongo-java-driver/3.7/javadoc/${target}`;
   } else if (name === 'csharp-api') {

--- a/src/components/Roles/Api.js
+++ b/src/components/Roles/Api.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const RoleJavaSyncApi = ({
+const RoleApi = ({
   nodeData: {
     label: { value },
     name,
@@ -22,7 +22,7 @@ const RoleJavaSyncApi = ({
   );
 };
 
-RoleJavaSyncApi.propTypes = {
+RoleApi.propTypes = {
   nodeData: PropTypes.shape({
     label: PropTypes.shape({
       value: PropTypes.string.isRequired,
@@ -32,4 +32,4 @@ RoleJavaSyncApi.propTypes = {
   }).isRequired,
 };
 
-export default RoleJavaSyncApi;
+export default RoleApi;

--- a/src/components/Roles/Class.js
+++ b/src/components/Roles/Class.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const baseUrl = 'https://api.mongodb.com/python/current/api/pymongo/results.html#';
+const RoleClass = ({ nodeData: { label, target } }) => {
+  return (
+    <a href={`${baseUrl}${target}`} className="reference external">
+      <code className="xref py py-class docutils literal notranslate">
+        <span className="pre">{label}</span>
+      </code>
+    </a>
+  );
+};
+
+RoleClass.propTypes = {
+  nodeData: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    target: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default RoleClass;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5425)] Add 3 missing roles:
- `java-sync-api`
- `csharp-api`
- `py:class`

Bonus fix: catches nodes of type `comment` and returns nothing.