### PR TITLE
Fix: Remove required value property

### DIFF
--- a/src/components/Roles/Class.js
+++ b/src/components/Roles/Class.js
@@ -2,24 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const baseUrl = 'https://api.mongodb.com/python/current/api/pymongo/results.html#';
-const RoleClass = ({
-  nodeData: {
-    label: { value },
-    target,
-  },
-}) => (
-  <a href={`${baseUrl}${target}`} className="reference external">
-    <code className="xref py py-class docutils literal notranslate">
-      <span className="pre">{value}</span>
-    </code>
-  </a>
-);
+const RoleClass = ({ nodeData: { label, target } }) => {
+  const labelDisplay = label && label.value ? label.value : target;
+  return (
+    <a href={`${baseUrl}${target}`} className="reference external">
+      <code className="xref py py-class docutils literal notranslate">
+        <span className="pre">{labelDisplay}</span>
+      </code>
+    </a>
+  );
+};
 
 RoleClass.propTypes = {
   nodeData: PropTypes.shape({
     label: PropTypes.shape({
-      value: PropTypes.string.isRequired,
-    }).isRequired,
+      value: PropTypes.string,
+    }),
     target: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/components/Roles/Doc.js
+++ b/src/components/Roles/Doc.js
@@ -19,7 +19,7 @@ const RoleDoc = ({ nodeData: { label, target }, refDocMapping }) => {
 RoleDoc.propTypes = {
   nodeData: PropTypes.shape({
     label: PropTypes.shape({
-      value: PropTypes.string.isRequired,
+      value: PropTypes.string,
     }),
     target: PropTypes.string.isRequired,
   }).isRequired,


### PR DESCRIPTION
The `Class` role (updated in DOCSP-5425) does not require a `label.value` property, which was previously marked as required and lead to page render failure. If `label.value` is not specified, use the role's `target` property as the link text.