### PR TITLE
DOCSP-5701: Support new parser ID implementation

### DIFF
--- a/src/components/GuideHeading.js
+++ b/src/components/GuideHeading.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import Pills from './Pills';
 import { stringifyTab } from '../constants';
-import { slugifyTitle } from '../util';
 
 // TODO: Improve validation of template content
 const GuideHeading = ({ activeTabs, author, cloud, description, drivers, setActiveTab, time, title, ...rest }) => {
@@ -13,10 +12,10 @@ const GuideHeading = ({ activeTabs, author, cloud, description, drivers, setActi
 
   const displayTitle = title.children[0].value;
   return (
-    <div className="section" id={slugifyTitle(displayTitle)}>
-      <h1>
+    <div className="section">
+      <h1 id={title.id}>
         {displayTitle}
-        <a className="headerlink" href={`#${slugifyTitle(displayTitle)}`} title="Permalink to this headline">
+        <a className="headerlink" href={`#${title.id}`} title="Permalink to this headline">
           ¶
         </a>
       </h1>

--- a/src/components/GuideSection.js
+++ b/src/components/GuideSection.js
@@ -4,7 +4,6 @@ import ComponentFactory from './ComponentFactory';
 import Stepper from './Stepper';
 import { setLocalValue } from '../browserStorage';
 import { SECTION_NAME_MAPPING } from '../constants';
-import { slugifyTitle } from '../util';
 
 export default class GuideSection extends Component {
   constructor() {
@@ -62,16 +61,13 @@ export default class GuideSection extends Component {
       headingRef,
     } = this.props;
     const { showAllSteps, showAllStepsText, showStepIndex, showStepper, totalStepsInProcedure, uri } = this.state;
+    const section = SECTION_NAME_MAPPING[name];
 
     return (
-      <div className="section" id={`${slugifyTitle(SECTION_NAME_MAPPING[name])}`}>
-        <h2 ref={headingRef}>
-          {SECTION_NAME_MAPPING[name]}
-          <a
-            className="headerlink"
-            href={`#${slugifyTitle(SECTION_NAME_MAPPING[name])}`}
-            title="Permalink to this headline"
-          >
+      <div className="section">
+        <h2 ref={headingRef} id={section.id}>
+          {section.title}
+          <a className="headerlink" href={`#${section.id}`} title="Permalink to this headline">
             ¶
           </a>
         </h2>
@@ -102,9 +98,12 @@ export default class GuideSection extends Component {
 }
 
 GuideSection.propTypes = {
-  headingRef: PropTypes.shape({ current: PropTypes.element }).isRequired,
+  headingRef: PropTypes.shape({
+    // for server-side rendering, replace Element with an empty function
+    current: PropTypes.instanceOf(typeof Element === 'undefined' ? () => {} : Element),
+  }).isRequired,
   guideSectionData: PropTypes.shape({
     children: PropTypes.array.isRequired,
-    name: PropTypes.string.isRequired,
+    name: PropTypes.oneOf(Object.keys(SECTION_NAME_MAPPING)),
   }).isRequired,
 };

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
 const Heading = props => {
-  const { id, nodeData } = props;
+  const { nodeData } = props;
+  const id = nodeData.id || '';
   return (
-    <h3>
+    <h3 id={id}>
       {nodeData.children.map((element, index) => {
         if (element.type === 'text') {
           return <React.Fragment key={index}>{element.value}</React.Fragment>;
@@ -20,18 +21,14 @@ const Heading = props => {
 };
 
 Heading.propTypes = {
-  id: PropTypes.string,
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(
       PropTypes.shape({
         value: PropTypes.string,
       })
     ).isRequired,
+    id: PropTypes.string.isRequired,
   }).isRequired,
-};
-
-Heading.defaultProps = {
-  id: '',
 };
 
 export default Heading;

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -1,23 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
-import { findKeyValuePair, slugifyTitle } from '../util';
 
 const Step = props => {
   const { nodeData, showAllSteps, showStepIndex, stepNum } = props;
-  const getHeadingText = (node, stringArr) => {
-    if (node.value) {
-      stringArr.push(node.value);
-    } else if (node.children) {
-      node.children.forEach(child => {
-        stringArr = getHeadingText(child, stringArr); // eslint-disable-line no-param-reassign
-      });
-    }
-    return stringArr;
-  };
-
-  const headingNode = findKeyValuePair(nodeData.children, 'type', 'heading');
-  const headingId = slugifyTitle(getHeadingText(headingNode, []).join(''));
 
   return (
     <div
@@ -29,9 +15,9 @@ const Step = props => {
       <div className="bullet-block" style={{ display: !showAllSteps && 'none' }}>
         <div className="sequence-step">{stepNum + 1}</div>
       </div>
-      <div className="section" id={headingId}>
+      <div className="section">
         {nodeData.children.map((child, index) => (
-          <ComponentFactory {...props} nodeData={child} key={index} id={headingId} />
+          <ComponentFactory {...props} nodeData={child} key={index} />
         ))}
       </div>
     </div>

--- a/src/components/TOC.js
+++ b/src/components/TOC.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SECTION_NAME_MAPPING } from '../constants';
-import { slugifyTitle } from '../util';
 
 const TOC = ({ activeSection, sectionKeys }) => (
   <aside className="left-toc hide-first-toc-level">
@@ -11,8 +10,8 @@ const TOC = ({ activeSection, sectionKeys }) => (
         <ul>
           {sectionKeys.map((section, index) => (
             <li className={section === activeSection ? 'active' : ''} key={index}>
-              <a className="reference internal" href={`#${slugifyTitle(SECTION_NAME_MAPPING[section])}`}>
-                {SECTION_NAME_MAPPING[section]}
+              <a className="reference internal" href={`#${SECTION_NAME_MAPPING[section].id}`}>
+                {SECTION_NAME_MAPPING[section].title}
               </a>
             </li>
           ))}

--- a/src/constants.js
+++ b/src/constants.js
@@ -78,12 +78,27 @@ export const REF_LABELS = {
 };
 
 export const SECTION_NAME_MAPPING = {
-  prerequisites: 'What You’ll Need',
-  check_your_environment: 'Check Your Environment',
-  procedure: 'Procedure',
-  summary: 'Summary',
-  whats_next: 'What’s Next',
-  seealso: 'See Also',
+  prerequisites: {
+    id: 'what-you-ll-need',
+    title: 'What You’ll Need',
+  },
+  check_your_environment: {
+    id: 'check-your-environment',
+    title: 'Check Your Environment',
+  },
+  procedure: {
+    id: 'procedure',
+    title: 'Procedure',
+  },
+  summary: { id: 'summary', title: 'Summary' },
+  whats_next: {
+    id: 'what-s-next',
+    title: 'What’s Next',
+  },
+  seealso: {
+    id: 'see-also',
+    title: 'See Also',
+  },
 };
 
 export const ADMONITIONS = ['admonition', 'note', 'tip', 'important', 'warning'];

--- a/src/util.js
+++ b/src/util.js
@@ -80,5 +80,3 @@ export const throttle = (func, wait) => {
     return result;
   };
 };
-
-export const slugifyTitle = title => title.toLowerCase().replace(/\W+/g, '-');

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -1,11 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<h3>
+<h3
+  id="create-an-administrative-username-and-password"
+>
   Create an administrative username and password
   <a
     className="headerlink"
-    href="#"
+    href="#create-an-administrative-username-and-password"
     title="Permalink to this headline"
   >
     ¶

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -25,10 +25,8 @@ exports[`renders correctly 1`] = `
   </div>
   <div
     className="section"
-    id="connect-to-your-mongodb-instance"
   >
     <ComponentFactory
-      id="connect-to-your-mongodb-instance"
       key="0"
       nodeData={
         Object {

--- a/tests/unit/data/Heading.test.json
+++ b/tests/unit/data/Heading.test.json
@@ -15,5 +15,6 @@
       },
       "value": "Create an administrative username and password"
     }
-  ]
+  ],
+  "id": "create-an-administrative-username-and-password"
 }


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5701)] [[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/sophstad/DOCSP-5701/cloud/migrate-from-aws-to-atlas#validate-your-aws-credentials-with-atlas-live-migration-service)]
- Use parser-generated IDs as `id` attributes and target links
- Stop generating `id` fields in front-end
- Statically define guide section ids, as they are not provided by the parser
- Update tests
- Remove invalid `PropTypes` check in `GuideSection` component