### PR TITLE
DOCSP-5648: Fix breadcrumb link

### DIFF
--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -138,7 +138,7 @@ export default class Guide extends Component {
           <div className="body" data-pagename={pageSlug}>
             <ul className="breadcrumbs">
               <li className="breadcrumbs__bc">
-                <a href="/">MongoDB Guides</a> &gt;{' '}
+                <a href={`${getPrefix()}/`}>MongoDB Guides</a> &gt;{' '}
               </li>
             </ul>
             <GuideHeading


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5648)] [[Staging](https://docs-mongodborg-staging.corp.mongodb.com/guides/sophstad/DOCSP-5648/)] Fix "MongoDB Guides" breadcrumb link at the top of each guide. Tested in both `develop` and staging environments.