### PR TITLE
Fix path prefix

### DIFF
--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -1,8 +1,9 @@
-const gatsby = jest.requireActual("gatsby")
+const gatsby = jest.requireActual('gatsby');
 
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
   StaticQuery: jest.fn(),
+  withPrefix: jest.fn().mockImplementation(str => str),
   useStaticQuery: jest.fn(),
-}
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
     },
     {
       displayName: 'unit',
+      globals: {
+        __PATH_PREFIX__: '',
+      },
       moduleNameMapper: {
         '^.+\\.(css)$': '<rootDir>/tests/unit/__mockStyles.js',
       },

--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
+import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import Lightbox from './Lightbox';
-import { getPathPrefix } from '../utils/get-path-prefix';
 
 export default class Figure extends Component {
   constructor(props) {
@@ -35,7 +35,7 @@ export default class Figure extends Component {
   render() {
     const { nodeData } = this.props;
     const { isLightboxSize } = this.state;
-    const imgSrc = `${getPathPrefix()}${nodeData.argument[0].value}`;
+    const imgSrc = nodeData.argument[0].value;
 
     if (isLightboxSize || (nodeData.options && nodeData.options.lightbox)) {
       return <Lightbox nodeData={nodeData} />;
@@ -48,7 +48,7 @@ export default class Figure extends Component {
         }}
       >
         <img
-          src={imgSrc}
+          src={withPrefix(imgSrc)}
           alt={nodeData.options.alt ? nodeData.options.alt : nodeData.argument[0].value}
           width="50%"
           onLoad={this.handleImageLoaded}

--- a/src/components/GuideBreadcrumbs.js
+++ b/src/components/GuideBreadcrumbs.js
@@ -1,13 +1,13 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { getPathPrefix } from '../utils/get-path-prefix';
 
 const GuideBreadcrumbs = () => {
   const { title } = useSiteMetadata();
   return (
     <ul className="breadcrumbs">
       <li className="breadcrumbs__bc">
-        <a href={`${getPathPrefix()}/`}>{title}</a> &gt;{' '}
+        <a href={withPrefix('/')}>{title}</a> &gt;{' '}
       </li>
     </ul>
   );

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { getPathPrefix } from '../utils/get-path-prefix';
+import { withPrefix } from 'gatsby';
 
 const CAPTION_TEXT = 'click to enlarge';
 const isSvg = imgSrc => /\.svg$/.test(imgSrc);
 
 const Lightbox = ({ nodeData }) => {
   const [showModal, setShowModal] = useState(false);
-  const imgSrc = `${getPathPrefix()}${nodeData.argument[0].value}`;
+  const imgSrc = nodeData.argument[0].value;
   const altText = nodeData.options.alt ? nodeData.options.alt : imgSrc;
 
   const toggleShowModal = () => {
@@ -21,7 +21,7 @@ const Lightbox = ({ nodeData }) => {
         style={{ width: nodeData.options && nodeData.options.figwidth ? nodeData.options.figwidth : 'auto' }}
       >
         <div className="lightbox__imageWrapper" onClick={toggleShowModal} role="button" tabIndex="-1">
-          <img src={imgSrc} alt={altText} width="50%" />
+          <img src={withPrefix(imgSrc)} alt={altText} width="50%" />
           <div className="lightbox__caption">{CAPTION_TEXT}</div>
         </div>
       </div>
@@ -33,7 +33,7 @@ const Lightbox = ({ nodeData }) => {
               'lightbox__content--activated',
               isSvg(imgSrc) ? 'lightbox__content--scalable' : null,
             ].join(' ')}
-            src={imgSrc}
+            src={withPrefix(imgSrc)}
             alt={`${altText} — Enlarged`}
           />
         </div>

--- a/src/components/Roles/Doc.js
+++ b/src/components/Roles/Doc.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import { findKeyValuePair } from '../../utils/find-key-value-pair';
-import { getPathPrefix } from '../../utils/get-path-prefix';
 
 const RoleDoc = ({ nodeData: { label, target }, refDocMapping }) => {
   const getLinkText = labelText => {
@@ -11,9 +11,9 @@ const RoleDoc = ({ nodeData: { label, target }, refDocMapping }) => {
 
   const labelDisplay = label && label.value ? label.value : getLinkText(target);
   return (
-    <a href={`${getPathPrefix()}${target}`} className="reference internal">
+    <Link to={target} className="reference internal">
       {labelDisplay}
-    </a>
+    </Link>
   );
 };
 

--- a/src/components/site-metadata.js
+++ b/src/components/site-metadata.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { withPrefix } from 'gatsby';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { getPathPrefix } from '../utils/get-path-prefix';
 
 const SiteMetadata = () => {
   const { branch, project, title } = useSiteMetadata();
@@ -50,10 +50,10 @@ const SiteMetadata = () => {
         title="MongoDB Help"
       />
 
-      <link rel="stylesheet" href={`${getPathPrefix()}/docs-tools/guides.css`} type="text/css" />
-      <link rel="stylesheet" href={`${getPathPrefix()}/docs-tools/css/navbar.min.css`} type="text/css" />
-      <script async src={`${getPathPrefix()}/scripts/segment.js`} />
-      <script async src={`${getPathPrefix()}/docs-tools/navbar.min.js`} />
+      <link rel="stylesheet" href={withPrefix('docs-tools/guides.css')} type="text/css" />
+      <link rel="stylesheet" href={withPrefix('docs-tools/css/navbar.min.css')} type="text/css" />
+      <script async src={withPrefix('scripts/segment.js')} />
+      <script async src={withPrefix('docs-tools/navbar.min.js')} />
     </Helmet>
   );
 };

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { withPrefix } from 'gatsby';
 import TOC from '../components/TOC';
 import GuideBreadcrumbs from '../components/GuideBreadcrumbs';
 import GuideSection from '../components/GuideSection';
@@ -8,7 +9,6 @@ import Widgets from '../components/Widgets/Widgets';
 import { LANGUAGES, DEPLOYMENTS, SECTION_NAME_MAPPING } from '../constants';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { findKeyValuePair } from '../utils/find-key-value-pair';
-import { getPathPrefix } from '../utils/get-path-prefix';
 import { throttle } from '../utils/throttle';
 import DefaultLayout from '../components/layout';
 
@@ -21,7 +21,7 @@ export default class Guide extends Component {
 
     // get correct lookup key based on whether running dev/prod
     if (process.env.NODE_ENV === 'production') {
-      const documentPrefix = getPathPrefix().substr(1);
+      const documentPrefix = withPrefix().slice(1, -1);
       guideKeyInMapping = guideKeyInMapping.replace(`${documentPrefix}/`, '');
     }
 
@@ -42,6 +42,9 @@ export default class Guide extends Component {
   }
 
   recalculate = () => {
+    if (this.sectionRefs.map(ref => ref.current).some(ref => ref === null)) {
+      return;
+    }
     const height = document.body.clientHeight - window.innerHeight;
     const headings = this.sectionRefs.map((ref, index) => [ref, this.bodySections[index].name]);
 

--- a/src/utils/__mocks__/get-path-prefix.js
+++ b/src/utils/__mocks__/get-path-prefix.js
@@ -1,3 +1,0 @@
-module.exports = {
-  getPathPrefix: jest.fn().mockReturnValue(''),
-};

--- a/src/utils/get-path-prefix.js
+++ b/src/utils/get-path-prefix.js
@@ -1,6 +1,0 @@
-import { useSiteMetadata } from '../hooks/use-site-metadata';
-
-export const getPathPrefix = () => {
-  const { branch, project, user } = useSiteMetadata();
-  return process.env.NODE_ENV === 'production' ? `/${project}/${user}/${branch}` : '';
-};

--- a/tests/unit/Figure.test.js
+++ b/tests/unit/Figure.test.js
@@ -6,8 +6,6 @@ import Figure from '../../src/components/Figure';
 import mockData from './data/Figure.test.json';
 import lightboxData from './data/FigureLightbox.test.json';
 
-jest.mock('../../src/utils/get-path-prefix');
-
 it('renders correctly', () => {
   const tree = shallow(<Figure nodeData={mockData} />);
   expect(tree).toMatchSnapshot();

--- a/tests/unit/Lightbox.test.js
+++ b/tests/unit/Lightbox.test.js
@@ -5,8 +5,6 @@ import Lightbox from '../../src/components/Lightbox';
 // data for this component
 import mockData from './data/Figure.test.json';
 
-jest.mock('../../src/utils/get-path-prefix');
-
 const mountLightbox = nodeData => mount(<Lightbox nodeData={nodeData} />);
 const shallowLightbox = nodeData => shallow(<Lightbox nodeData={nodeData} />);
 

--- a/tests/unit/Role.test.js
+++ b/tests/unit/Role.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
 
 import RoleCode from '../../src/components/Roles/Code';
 import RoleDoc from '../../src/components/Roles/Doc';
@@ -25,8 +25,6 @@ import mockDataTerm from './data/Role-term.test.json';
 import mockDataUpdate from './data/Role-update.test.json';
 import mockRefDocMapping from './data/index.test.json';
 
-jest.mock('../../src/utils/get-path-prefix');
-
 it('renders correctly a role "authrole"', () => {
   const tree = shallow(<RoleCode nodeData={mockDataAuthrole} />);
   expect(tree).toMatchSnapshot();
@@ -38,12 +36,12 @@ it('renders correctly role "binary"', () => {
 });
 
 it('renders correctly role "doc"', () => {
-  const tree = shallow(<RoleDoc nodeData={mockDataDoc} refDocMapping={mockRefDocMapping} />);
+  const tree = render(<RoleDoc nodeData={mockDataDoc} refDocMapping={mockRefDocMapping} />);
   expect(tree).toMatchSnapshot();
 });
 
 it('renders correctly role "doc" when no link title is included', () => {
-  const tree = shallow(<RoleDoc nodeData={mockDataDocUnlabeled} refDocMapping={mockRefDocMapping} />);
+  const tree = render(<RoleDoc nodeData={mockDataDocUnlabeled} refDocMapping={mockRefDocMapping} />);
   expect(tree).toMatchSnapshot();
 });
 

--- a/tests/unit/__snapshots__/Role.test.js.snap
+++ b/tests/unit/__snapshots__/Role.test.js.snap
@@ -95,7 +95,7 @@ exports[`renders correctly role "binary" 1`] = `
 
 exports[`renders correctly role "doc" 1`] = `
 <a
-  className="reference internal"
+  class="reference internal"
   href="/cloud/atlas"
 >
   Create an Atlas Account and Cluster
@@ -104,7 +104,7 @@ exports[`renders correctly role "doc" 1`] = `
 
 exports[`renders correctly role "doc" when no link title is included 1`] = `
 <a
-  className="reference internal"
+  class="reference internal"
   href="/server/drivers"
 >
   Connect to MongoDB


### PR DESCRIPTION
[[Staging](https://docs-mongodborg-staging.corp.mongodb.com/guides/sophstad/fix-get-path-prefix/)]
- Replace custom `getPathPrefix()` with Gatsby's (poorly documented) [`withPrefix()`](https://www.gatsbyjs.org/docs/gatsby-link/#add-the-path-prefix-to-paths-using-withprefix)
  - Remove relevant mocks
  - Update image src attributes and `<head>` links using this function
- Replace our one instance of an internal link with a Gatsby [`Link`](https://www.gatsbyjs.org/docs/gatsby-link/) component
- Fix tests