### PR TITLE
DOCSP-5647: adjust padding of clickable element in pills

### DIFF
--- a/src/components/Pills.js
+++ b/src/components/Pills.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { stringifyTab } from '../constants';
 import { reportAnalytics } from '../utils/report-analytics';
+import pillStyles from '../styles/pills.module.css';
 
 const Pills = ({
   activeClass,
@@ -17,12 +18,11 @@ const Pills = ({
   return (
     <ul className={`guide__pills ${ulClass}`} role="tablist" data-tab-preference={dataTabPreference}>
       {pills.map((pill, index) => (
-        <li
-          className={['guide__pill', activePill === pill ? activeClass : '', liClass].join(' ')}
-          data-tabid={pill}
-          key={index}
-        >
+        <li data-tabid={pill} key={index}>
           <span
+            className={['guide__pill', activePill === pill ? activeClass : '', liClass, pillStyles.guide__pill].join(
+              ' '
+            )}
             onClick={() => {
               handleClick(pill);
               reportAnalytics('Pill Selected', {

--- a/src/styles/pills.module.css
+++ b/src/styles/pills.module.css
@@ -1,0 +1,3 @@
+.guide__pill {
+  display: inline-block;
+}

--- a/tests/unit/LandingPageCards.test.js
+++ b/tests/unit/LandingPageCards.test.js
@@ -50,7 +50,7 @@ describe('LandingPageCards component', () => {
     });
 
     it('shows 5 pills (4 languages + 1 See More button)', () => {
-      expect(wrapper.find('li.guide__pill')).toHaveLength(5);
+      expect(wrapper.find('.guide__pill')).toHaveLength(5);
     });
   });
 

--- a/tests/unit/Pills.test.js
+++ b/tests/unit/Pills.test.js
@@ -23,9 +23,8 @@ describe('Pills component', () => {
 
   it('clicking a pill calls the event handler', () => {
     wrapper
-      .find('li.guide__pill')
+      .find('.guide__pill')
       .first()
-      .childAt(0)
       .simulate('click');
     expect(wrapper.props().handleClick).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/__snapshots__/Pills.test.js.snap
+++ b/tests/unit/__snapshots__/Pills.test.js.snap
@@ -6,11 +6,11 @@ exports[`Pills component renders correctly 1`] = `
   role="tablist"
 >
   <li
-    className="guide__pill  "
     data-tabid="python"
     key="0"
   >
     <span
+      className="guide__pill   "
       onClick={[Function]}
       role="button"
       tabIndex={0}
@@ -19,11 +19,11 @@ exports[`Pills component renders correctly 1`] = `
     </span>
   </li>
   <li
-    className="guide__pill  "
     data-tabid="compass"
     key="1"
   >
     <span
+      className="guide__pill   "
       onClick={[Function]}
       role="button"
       tabIndex={1}
@@ -32,11 +32,11 @@ exports[`Pills component renders correctly 1`] = `
     </span>
   </li>
   <li
-    className="guide__pill  "
     data-tabid="motor"
     key="2"
   >
     <span
+      className="guide__pill   "
       onClick={[Function]}
       role="button"
       tabIndex={2}
@@ -45,11 +45,11 @@ exports[`Pills component renders correctly 1`] = `
     </span>
   </li>
   <li
-    className="guide__pill  "
     data-tabid="go"
     key="3"
   >
     <span
+      className="guide__pill   "
       onClick={[Function]}
       role="button"
       tabIndex={3}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5647)] [[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/sophstad/DOCSP-5647/)]
- Adjust pills so that the entire pill is clickable, not just the text.
- Makes use of Gatsby's [CSS Modules](https://www.gatsbyjs.org/tutorial/part-two/#using-component-scoped-css) for component-scoped CSS.