### PR TITLE
DOCSP-5702: Dynamic page title

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
         __PATH_PREFIX__: '',
       },
       moduleNameMapper: {
-        '^.+\\.(css)$': '<rootDir>/tests/unit/__mockStyles.js',
+        '^.+\\.(css)$': 'identity-obj-proxy',
       },
       setupFilesAfterEnv: ['<rootDir>/src/testSetup.js'],
       snapshotSerializers: ['enzyme-to-json/serializer'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8757,6 +8757,11 @@
         }
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9345,6 +9350,14 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gatsby-plugin-react-helmet": "^3.0.12",
     "highlight.js": "^9.15.8",
     "html-webpack-plugin": "^3.2.0",
+    "identity-obj-proxy": "^3.0.0",
     "mongodb-stitch-browser-sdk": "^4.4.0",
     "mongodb-stitch-server-sdk": "^4.4.0",
     "prop-types": "^15.7.1",

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Highlight from 'react-highlight';
 import { reportAnalytics } from '../utils/report-analytics';
 import 'highlight.js/styles/a11y-light.css';
+import codeStyle from '../styles/code.module.css';
 import URIText from './URIWriter/URIText';
 import {
   URI_PLACEHOLDER,
@@ -98,7 +99,7 @@ export default class Code extends Component {
         </div>
         <div className={`copyable-code-block notranslate highlight-${lang}`}>
           <div className="highlight">
-            <Highlight className={lang}>{code}</Highlight>
+            <Highlight className={`${lang} ${codeStyle.hljs}`}>{code}</Highlight>
           </div>
         </div>
       </div>

--- a/src/components/GuideHeading.js
+++ b/src/components/GuideHeading.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
 import ComponentFactory from './ComponentFactory';
 import Pills from './Pills';
 import { stringifyTab } from '../constants';
@@ -13,6 +14,9 @@ const GuideHeading = ({ activeTabs, author, cloud, description, drivers, setActi
   const displayTitle = title.children[0].value;
   return (
     <div className="section">
+      <Helmet>
+        <title>{displayTitle}</title>
+      </Helmet>
       <h1 id={title.id}>
         {displayTitle}
         <a className="headerlink" href={`#${title.id}`} title="Permalink to this headline">

--- a/src/components/site-metadata.js
+++ b/src/components/site-metadata.js
@@ -34,15 +34,6 @@ const SiteMetadata = () => {
         property="og:image:secure_url"
         content="https://webassets.mongodb.com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
       />
-      <style type="text/css">
-        {`
-          .hljs {
-            background: none !important;
-            padding: 0px !important;
-            display: inline !important;
-          }
-        `}
-      </style>
       <link
         rel="search"
         type="application/opensearchdescription+xml"

--- a/src/styles/code.module.css
+++ b/src/styles/code.module.css
@@ -1,0 +1,5 @@
+.hljs {
+  background: none;
+  padding: 0px;
+  display: inline;
+}

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -27,7 +27,7 @@ exports[`renders correctly 1`] = `
       className="highlight"
     >
       <Highlight
-        className="javascript"
+        className="javascript hljs"
         element={null}
         innerHTML={false}
       >

--- a/tests/unit/__snapshots__/Pills.test.js.snap
+++ b/tests/unit/__snapshots__/Pills.test.js.snap
@@ -10,7 +10,7 @@ exports[`Pills component renders correctly 1`] = `
     key="0"
   >
     <span
-      className="guide__pill   "
+      className="guide__pill   guide__pill"
       onClick={[Function]}
       role="button"
       tabIndex={0}
@@ -23,7 +23,7 @@ exports[`Pills component renders correctly 1`] = `
     key="1"
   >
     <span
-      className="guide__pill   "
+      className="guide__pill   guide__pill"
       onClick={[Function]}
       role="button"
       tabIndex={1}
@@ -36,7 +36,7 @@ exports[`Pills component renders correctly 1`] = `
     key="2"
   >
     <span
-      className="guide__pill   "
+      className="guide__pill   guide__pill"
       onClick={[Function]}
       role="button"
       tabIndex={2}
@@ -49,7 +49,7 @@ exports[`Pills component renders correctly 1`] = `
     key="3"
   >
     <span
-      className="guide__pill   "
+      className="guide__pill   guide__pill"
       onClick={[Function]}
       role="button"
       tabIndex={3}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5702)] [[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/sophstad/DOCSP-5702/)]
- Dynamically set a page's `<title>` tag according to the `<h1>` title of the page
- Improve style override of our `Code` component by moving it out of the `<head>` and into a CSS module