### PR TITLE
DOCSP-5910: Add definitionList

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -4,6 +4,7 @@ import { ADMONITIONS } from '../constants';
 import Step from './Step';
 import Paragraph from './Paragraph';
 import List from './List';
+import ListItem from './ListItem';
 import ListTable from './ListTable';
 import Emphasis from './Emphasis';
 import Include from './Include';
@@ -20,6 +21,8 @@ import Reference from './Reference';
 import Strong from './Strong';
 import URIWriter from './URIWriter/URIWriter';
 import TitleReference from './TitleReference';
+import DefinitionList from './DefinitionList';
+import DefinitionListItem from './DefinitionListItem';
 
 import RoleApi from './Roles/Api';
 import RoleClass from './Roles/Class';
@@ -57,11 +60,14 @@ export default class ComponentFactory extends Component {
       admonition: Admonition,
       block_quote: BlockQuote,
       code: Code,
+      definitionList: DefinitionList,
+      definitionListItem: DefinitionListItem,
       emphasis: Emphasis,
       figure: Figure,
       heading: Heading,
       include: Include,
       list: List,
+      listItem: ListItem,
       'list-table': ListTable,
       literal: Literal,
       literalinclude: LiteralInclude,

--- a/src/components/DefinitionList.js
+++ b/src/components/DefinitionList.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const DefinitionList = ({ nodeData, ...rest }) => {
+  return (
+    <dl className="first docutils">
+      {nodeData.children.map((definition, index) => (
+        <ComponentFactory {...rest} nodeData={definition} key={index} />
+      ))}
+    </dl>
+  );
+};
+
+DefinitionList.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.array.isRequired,
+  }).isRequired,
+};
+
+export default DefinitionList;

--- a/src/components/DefinitionListItem.js
+++ b/src/components/DefinitionListItem.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const DefinitionListItem = ({ nodeData: { children, term }, ...rest }) => (
+  <React.Fragment>
+    <dt>
+      {term.map(child => (
+        <ComponentFactory nodeData={child} />
+      ))}
+    </dt>
+    <dd>
+      {children.map((child, index) => (
+        <ComponentFactory {...rest} nodeData={child} key={index} />
+      ))}
+    </dd>
+  </React.Fragment>
+);
+
+DefinitionListItem.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.array.isRequired,
+    term: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default DefinitionListItem;

--- a/src/components/DefinitionListItem.js
+++ b/src/components/DefinitionListItem.js
@@ -5,13 +5,13 @@ import ComponentFactory from './ComponentFactory';
 const DefinitionListItem = ({ nodeData: { children, term }, ...rest }) => (
   <React.Fragment>
     <dt>
-      {term.map(child => (
-        <ComponentFactory nodeData={child} />
+      {term.map((child, index) => (
+        <ComponentFactory nodeData={child} key={`dt-${index}`} />
       ))}
     </dt>
     <dd>
       {children.map((child, index) => (
-        <ComponentFactory {...rest} nodeData={child} key={index} />
+        <ComponentFactory {...rest} nodeData={child} key={`dd-${index}`} />
       ))}
     </dd>
   </React.Fragment>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -6,12 +6,8 @@ const List = props => {
   const { nodeData } = props;
   return (
     <ul>
-      {nodeData.children.map((item, index) => (
-        <li key={index}>
-          {item.children.map((listItem, listItemIndex) => (
-            <ComponentFactory {...props} nodeData={listItem} key={listItemIndex} />
-          ))}
-        </li>
+      {nodeData.children.map((listChild, index) => (
+        <ComponentFactory {...props} nodeData={listChild} key={index} />
       ))}
     </ul>
   );

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const ListItem = ({ nodeData, ...rest }) => (
+  <li>
+    {nodeData.children.map((child, index) => (
+      <ComponentFactory {...rest} nodeData={child} key={index} parentNode="listItem" />
+    ))}
+  </li>
+);
+
+ListItem.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.array.isRequired,
+  }).isRequired,
+};
+
+export default ListItem;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -23,7 +23,7 @@ const Document = props => {
               <div className="bodywrapper">
                 <div className="body">
                   {pageNodes.map((child, index) => (
-                    <ComponentFactory {...props} key={index} nodeData={child} />
+                    <ComponentFactory key={index} nodeData={child} refDocMapping={__refDocMapping} />
                   ))}
                   <Footer />
                 </div>

--- a/tests/unit/DefinitionList.test.js
+++ b/tests/unit/DefinitionList.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'enzyme';
+import DefinitionList from '../../src/components/DefinitionList';
+import mockData from './data/DefinitionList.test.json';
+
+it('DefinitionList renders correctly', () => {
+  const tree = render(<DefinitionList nodeData={mockData} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/List.test.js
+++ b/tests/unit/List.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'enzyme';
 import List from '../../src/components/List';
 
 // data for this component
 import mockData from './data/List.test.json';
 
-it('renders correctly', () => {
-  const tree = shallow(<List nodeData={mockData} />);
+it('List renders correctly', () => {
+  const tree = render(<List nodeData={mockData} />);
   expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/DefinitionList.test.js.snap
+++ b/tests/unit/__snapshots__/DefinitionList.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefinitionList renders correctly 1`] = `
+<dl
+  class="first docutils"
+>
+  <dt>
+    <code
+      class="docutils literal notranslate"
+    >
+      <span
+        class="pre"
+      >
+        MongoDefaultPartitioner
+      </span>
+    </code>
+  </dt>
+  <dd>
+    <p
+      style="margin:"
+    >
+      <strong>
+        Default
+      </strong>
+      . Wraps the MongoSamplePartitioner and provides
+help for users of older versions of MongoDB.
+    </p>
+  </dd>
+</dl>
+`;

--- a/tests/unit/__snapshots__/List.test.js.snap
+++ b/tests/unit/__snapshots__/List.test.js.snap
@@ -1,90 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`List renders correctly 1`] = `
 <ul>
-  <li
-    key="0"
-  >
-    <ComponentFactory
-      key="0"
-      nodeData={
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 16,
-                },
-              },
-              "type": "text",
-              "value": "create a free account on Atlas, MongoDB's managed database solution in the cloud",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 16,
-            },
-          },
-          "type": "paragraph",
-        }
-      }
-    />
+  <li>
+    <p
+      style="margin:"
+    >
+      create a free account on Atlas, MongoDB's managed database solution in the cloud
+    </p>
   </li>
-  <li
-    key="1"
-  >
-    <ComponentFactory
-      key="0"
-      nodeData={
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 17,
-                },
-              },
-              "type": "text",
-              "value": "create a free MongoDB ",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 17,
-                    },
-                  },
-                  "type": "text",
-                  "value": "cluster",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 17,
-                },
-              },
-              "type": "emphasis",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 17,
-                },
-              },
-              "type": "text",
-              "value": ", or group of database instances.",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 17,
-            },
-          },
-          "type": "paragraph",
-        }
-      }
-    />
+  <li>
+    <p
+      style="margin:"
+    >
+      create a free MongoDB 
+      <em>
+        cluster
+      </em>
+      , or group of database instances.
+    </p>
   </li>
 </ul>
 `;

--- a/tests/unit/data/DefinitionList.test.json
+++ b/tests/unit/data/DefinitionList.test.json
@@ -1,0 +1,79 @@
+{
+  "type": "definitionList",
+  "position": {
+    "start": {
+      "line": 131
+    }
+  },
+  "children": [
+    {
+      "type": "definitionListItem",
+      "position": {
+        "start": {
+          "line": 133
+        }
+      },
+      "term": [
+        {
+          "type": "literal",
+          "position": {
+            "start": {
+              "line": 133
+            }
+          },
+          "children": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": 133
+                }
+              },
+              "value": "MongoDefaultPartitioner"
+            }
+          ]
+        }
+      ],
+      "children": [
+        {
+          "type": "paragraph",
+          "position": {
+            "start": {
+              "line": 132
+            }
+          },
+          "children": [
+            {
+              "type": "strong",
+              "position": {
+                "start": {
+                  "line": 132
+                }
+              },
+              "children": [
+                {
+                  "type": "text",
+                  "position": {
+                    "start": {
+                      "line": 132
+                    }
+                  },
+                  "value": "Default"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": 132
+                }
+              },
+              "value": ". Wraps the MongoSamplePartitioner and provides\nhelp for users of older versions of MongoDB."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5910)] [[Staging](https://docs-mongodborg-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5910/)] You can see an example of a definition list on the [/configuration](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5910/configuration) page.
- Add `DefinitionList` component
- Add tests
- Split lists into `List` and `ListItem` components
- Improves tests for lists so that raw HTML is rendered as snapshot