### PR TITLE
DOCSP-5911: Refactor listTable and Paragraph components

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -20,6 +20,7 @@ import Reference from './Reference';
 import Strong from './Strong';
 import URIWriter from './URIWriter/URIWriter';
 import TitleReference from './TitleReference';
+import Text from './Text';
 
 import RoleApi from './Roles/Api';
 import RoleClass from './Roles/Class';
@@ -71,6 +72,7 @@ export default class ComponentFactory extends Component {
       step: Step,
       strong: Strong,
       tabs: Tabs,
+      text: Text,
       title_reference: TitleReference,
       uriwriter: URIWriter,
     };

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
 
 const ListTable = ({ nodeData: { children, options } }) => {
@@ -16,7 +17,7 @@ const ListTable = ({ nodeData: { children, options } }) => {
   }
 
   return (
-    <table className={['docutils', options.class, widths, customAlign].join(' ')} style={{ width: customWidth }}>
+    <table className={['docutils', options.class || '', widths, customAlign].join(' ')} style={{ width: customWidth }}>
       {widths === 'colwidths-given' && <ColGroup widths={options.widths.split(/[ ,]+/)} />}
       <ListTableHeader rows={headerRows} stubColumnCount={stubColumnCount} />
       <ListTableBody rows={bodyRows} headerRowCount={headerRowCount} stubColumnCount={stubColumnCount} />
@@ -57,7 +58,7 @@ const ListTableHeaderRow = ({ row, rowIndex, stubColumnCount }) => (
   <tr className={rowIndex % 2 === 0 ? 'row-odd' : 'row-even'}>
     {row.map((column, colIndex) => (
       <th className={`head ${colIndex <= stubColumnCount - 1 && 'stub'}`} key={colIndex}>
-        {getNestedValue(['children', 0, 'children', 0, 'value'], column)}
+        <ComponentFactory nodeData={getNestedValue(['children', 0], column)} parentNode="listTable" />
       </th>
     ))}
   </tr>
@@ -107,8 +108,17 @@ ListTableBody.propTypes = {
 const ListTableBodyRow = ({ row, rowIndex, stubColumnCount }) => (
   <tr className={rowIndex % 2 === 0 ? 'row-odd' : 'row-even'}>
     {row.map((column, colIndex) => (
-      <td className={`${colIndex <= stubColumnCount - 1 && 'stub'}`} key={colIndex}>
-        {getNestedValue(['children', 0, 'children', 0, 'value'], column)}
+      <td className={`${colIndex <= stubColumnCount - 1 ? 'stub' : ''}`} key={colIndex}>
+        {column.children.length === 1 ? (
+          <ComponentFactory nodeData={getNestedValue(['children', 0], column)} parentNode="listTable" />
+        ) : (
+          column.children.map((element, index) => {
+            let position = '';
+            if (index === 0) position = 'first';
+            if (index === column.children.length - 1) position = 'last';
+            return <ComponentFactory key={index} nodeData={element} position={position} />;
+          })
+        )}
       </td>
     ))}
   </tr>

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -2,16 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Paragraph = props => {
-  const { admonition, nodeData } = props;
+const Paragraph = ({ admonition, nodeData, parentNode, position, ...rest }) => {
+  if (parentNode === 'listItem' || parentNode === 'listTable') {
+    return nodeData.children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
+  }
   return (
-    <p style={{ margin: admonition ? '0 0 12.5px' : '' }}>
-      {nodeData.children.map((element, index) => {
-        if (element.type === 'text') {
-          return <React.Fragment key={index}>{element.value}</React.Fragment>;
-        }
-        return <ComponentFactory {...props} nodeData={element} key={index} />;
-      })}
+    <p style={{ margin: admonition ? '0 0 12.5px' : '' }} className={position}>
+      {nodeData.children.map((element, index) => (
+        <ComponentFactory {...rest} nodeData={element} key={index} />
+      ))}
     </p>
   );
 };
@@ -26,10 +25,14 @@ Paragraph.propTypes = {
       })
     ).isRequired,
   }).isRequired,
+  parentNode: PropTypes.string,
+  position: PropTypes.string,
 };
 
 Paragraph.defaultProps = {
   admonition: false,
+  parentNode: undefined,
+  position: '',
 };
 
 export default Paragraph;

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
 const Paragraph = ({ admonition, nodeData, parentNode, position, ...rest }) => {
+  // For paragraph nodes that appear inside certain containers, skip <p> tags and just render their contents
   if (parentNode === 'listItem' || parentNode === 'listTable') {
     return nodeData.children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
   }

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Text = ({ nodeData: { value } }) => <React.Fragment>{value}</React.Fragment>;
+
+Text.propTypes = {
+  nodeData: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default Text;

--- a/tests/unit/ListTable.test.js
+++ b/tests/unit/ListTable.test.js
@@ -1,25 +1,25 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount, render } from 'enzyme';
 import ListTable from '../../src/components/ListTable';
 
 import mockData from './data/ListTable.test.json';
 import mockDataFixedWidths from './data/ListTableFixedWidths.test.json';
 
 const mountListTable = data => mount(<ListTable nodeData={data} />);
-const shallowListTable = data => shallow(<ListTable nodeData={data} />);
+const renderListTable = data => render(<ListTable nodeData={data} />);
 
 describe('when rendering a list-table directive', () => {
   let wrapper;
-  let shallowWrapper;
+  let rendered;
   const data = mockData;
 
   beforeAll(() => {
     wrapper = mountListTable(data);
-    shallowWrapper = shallowListTable(data);
+    rendered = renderListTable(data);
   });
 
   it('renders correctly', () => {
-    expect(shallowWrapper).toMatchSnapshot();
+    expect(rendered).toMatchSnapshot();
   });
 
   it('displays one header row', () => {
@@ -78,16 +78,16 @@ describe('when rendering a list-table directive', () => {
 
 describe('when rendering a list table with fixed widths', () => {
   let wrapper;
-  let shallowWrapper;
+  let rendered;
   const data = mockDataFixedWidths;
 
   beforeAll(() => {
     wrapper = mountListTable(data);
-    shallowWrapper = shallowListTable(data);
+    rendered = renderListTable(data);
   });
 
   it('renders correctly', () => {
-    expect(shallowWrapper).toMatchSnapshot();
+    expect(rendered).toMatchSnapshot();
   });
 
   it('displays no header row', () => {

--- a/tests/unit/__snapshots__/DefinitionList.test.js.snap
+++ b/tests/unit/__snapshots__/DefinitionList.test.js.snap
@@ -17,6 +17,7 @@ exports[`DefinitionList renders correctly 1`] = `
   </dt>
   <dd>
     <p
+      class=""
       style="margin:"
     >
       <strong>

--- a/tests/unit/__snapshots__/List.test.js.snap
+++ b/tests/unit/__snapshots__/List.test.js.snap
@@ -3,22 +3,14 @@
 exports[`List renders correctly 1`] = `
 <ul>
   <li>
-    <p
-      style="margin:"
-    >
-      create a free account on Atlas, MongoDB's managed database solution in the cloud
-    </p>
+    create a free account on Atlas, MongoDB's managed database solution in the cloud
   </li>
   <li>
-    <p
-      style="margin:"
-    >
-      create a free MongoDB 
-      <em>
-        cluster
-      </em>
-      , or group of database instances.
-    </p>
+    create a free MongoDB 
+    <em>
+      cluster
+    </em>
+    , or group of database instances.
   </li>
 </ul>
 `;

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -2,1414 +2,277 @@
 
 exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 <table
-  className="docutils guide-tablenate-odd colwidths-given "
-  style={
-    Object {
-      "width": "auto",
-    }
-  }
+  class="docutils guide-tablenate-odd colwidths-given "
+  style="width:auto"
 >
-  <ColGroup
-    widths={
-      Array [
-        "20",
-        "80",
-      ]
-    }
+  <colgroup>
+    <col
+      width="20%"
+    />
+    <col
+      width="80%"
+    />
+  </colgroup>
+  <thead
+    valign="bottom"
   />
-  <ListTableHeader
-    rows={Array []}
-    stubColumnCount={0}
-  />
-  <ListTableBody
-    headerRowCount={0}
-    rows={
-      Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 33,
-                            },
-                          },
-                          "type": "text",
-                          "value": "notebook",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 33,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 34,
-                            },
-                          },
-                          "type": "text",
-                          "value": "50",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 34,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 35,
-                            },
-                          },
-                          "type": "text",
-                          "value": "8.5x11,in",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 35,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 36,
-                            },
-                          },
-                          "type": "text",
-                          "value": "A",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 36,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 37,
-                            },
-                          },
-                          "type": "text",
-                          "value": "college-ruled,perforated",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 37,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 38,
-                            },
-                          },
-                          "type": "text",
-                          "value": "8",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 38,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 33,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 33,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 26,
-            },
-          },
-          "type": "listItem",
-        },
-      ]
-    }
-    stubColumnCount={0}
-  />
+  <tbody
+    valign="top"
+  >
+    <tr
+      class="row-odd"
+    >
+      <td
+        class=""
+      >
+        notebook
+      </td>
+      <td
+        class=""
+      >
+        50
+      </td>
+      <td
+        class=""
+      >
+        8.5x11,in
+      </td>
+      <td
+        class=""
+      >
+        A
+      </td>
+      <td
+        class=""
+      >
+        college-ruled,perforated
+      </td>
+      <td
+        class=""
+      >
+        8
+      </td>
+    </tr>
+  </tbody>
 </table>
 `;
 
 exports[`when rendering a list-table directive renders correctly 1`] = `
 <table
-  className="docutils guide-tablenate colwidths-auto "
-  style={
-    Object {
-      "width": "auto",
-    }
-  }
+  class="docutils guide-tablenate colwidths-auto "
+  style="width:auto"
 >
-  <ListTableHeader
-    rows={
-      Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 14,
-                        },
-                      },
-                      "type": "text",
-                      "value": "name",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 14,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 15,
-                        },
-                      },
-                      "type": "text",
-                      "value": "quantity",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 15,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 16,
-                        },
-                      },
-                      "type": "text",
-                      "value": "size",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 16,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 17,
-                        },
-                      },
-                      "type": "text",
-                      "value": "status",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 17,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 18,
-                        },
-                      },
-                      "type": "text",
-                      "value": "tags",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 18,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 19,
-                        },
-                      },
-                      "type": "text",
-                      "value": "rating",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 19,
-                    },
-                  },
-                  "type": "paragraph",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 14,
-                },
-              },
-              "type": "listItem",
-            },
-          ],
-          "ordered": false,
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "list",
-        },
-      ]
-    }
-    stubColumnCount={1}
-  />
-  <ListTableBody
-    headerRowCount={1}
-    rows={
-      Array [
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 21,
-                            },
-                          },
-                          "type": "text",
-                          "value": "journal",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 21,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 22,
-                            },
-                          },
-                          "type": "text",
-                          "value": "25",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 22,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 23,
-                            },
-                          },
-                          "type": "text",
-                          "value": "14x21,cm",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 23,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 24,
-                            },
-                          },
-                          "type": "text",
-                          "value": "A",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 24,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 25,
-                            },
-                          },
-                          "type": "text",
-                          "value": "brown, lined",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 25,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 26,
-                            },
-                          },
-                          "type": "text",
-                          "value": "9",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 26,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 21,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 21,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 28,
-                            },
-                          },
-                          "type": "text",
-                          "value": "notebook",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 28,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 29,
-                            },
-                          },
-                          "type": "text",
-                          "value": "50",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 29,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 30,
-                            },
-                          },
-                          "type": "text",
-                          "value": "8.5x11,in",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 30,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 31,
-                            },
-                          },
-                          "type": "text",
-                          "value": "A",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 31,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 32,
-                            },
-                          },
-                          "type": "text",
-                          "value": "college-ruled,perforated",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 32,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 33,
-                            },
-                          },
-                          "type": "text",
-                          "value": "8",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 33,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 28,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 28,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 35,
-                            },
-                          },
-                          "type": "text",
-                          "value": "paper",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 35,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 36,
-                            },
-                          },
-                          "type": "text",
-                          "value": "100",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 36,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 37,
-                            },
-                          },
-                          "type": "text",
-                          "value": "8.5x11,in",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 37,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 38,
-                            },
-                          },
-                          "type": "text",
-                          "value": "D",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 38,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 39,
-                            },
-                          },
-                          "type": "text",
-                          "value": "watercolor",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 39,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 40,
-                            },
-                          },
-                          "type": "text",
-                          "value": "10",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 40,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 35,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 35,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 42,
-                            },
-                          },
-                          "type": "text",
-                          "value": "planner",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 42,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 43,
-                            },
-                          },
-                          "type": "text",
-                          "value": "75",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 43,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 44,
-                            },
-                          },
-                          "type": "text",
-                          "value": "22.85x30,cm",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 44,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 45,
-                            },
-                          },
-                          "type": "text",
-                          "value": "D",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 45,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 46,
-                            },
-                          },
-                          "type": "text",
-                          "value": "2019",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 46,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 47,
-                            },
-                          },
-                          "type": "text",
-                          "value": "10",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 47,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 42,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 42,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "listItem",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 49,
-                            },
-                          },
-                          "type": "text",
-                          "value": "postcard",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 49,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 50,
-                            },
-                          },
-                          "type": "text",
-                          "value": "45",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 50,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 51,
-                            },
-                          },
-                          "type": "text",
-                          "value": "10x,cm",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 51,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "D",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 53,
-                            },
-                          },
-                          "type": "text",
-                          "value": "double-sided,white",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 53,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 54,
-                            },
-                          },
-                          "type": "text",
-                          "value": "2",
-                        },
-                      ],
-                      "position": Object {
-                        "start": Object {
-                          "line": 54,
-                        },
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 49,
-                    },
-                  },
-                  "type": "listItem",
-                },
-              ],
-              "ordered": false,
-              "position": Object {
-                "start": Object {
-                  "line": 49,
-                },
-              },
-              "type": "list",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 14,
-            },
-          },
-          "type": "listItem",
-        },
-      ]
-    }
-    stubColumnCount={1}
-  />
+  <thead
+    valign="bottom"
+  >
+    <tr
+      class="row-odd"
+    >
+      <th
+        class="head stub"
+      >
+        name
+      </th>
+      <th
+        class="head false"
+      >
+        quantity
+      </th>
+      <th
+        class="head false"
+      >
+        size
+      </th>
+      <th
+        class="head false"
+      >
+        status
+      </th>
+      <th
+        class="head false"
+      >
+        tags
+      </th>
+      <th
+        class="head false"
+      >
+        rating
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    valign="top"
+  >
+    <tr
+      class="row-even"
+    >
+      <td
+        class="stub"
+      >
+        journal
+      </td>
+      <td
+        class=""
+      >
+        25
+      </td>
+      <td
+        class=""
+      >
+        14x21,cm
+      </td>
+      <td
+        class=""
+      >
+        A
+      </td>
+      <td
+        class=""
+      >
+        brown, lined
+      </td>
+      <td
+        class=""
+      >
+        9
+      </td>
+    </tr>
+    <tr
+      class="row-odd"
+    >
+      <td
+        class="stub"
+      >
+        notebook
+      </td>
+      <td
+        class=""
+      >
+        50
+      </td>
+      <td
+        class=""
+      >
+        8.5x11,in
+      </td>
+      <td
+        class=""
+      >
+        A
+      </td>
+      <td
+        class=""
+      >
+        college-ruled,perforated
+      </td>
+      <td
+        class=""
+      >
+        8
+      </td>
+    </tr>
+    <tr
+      class="row-even"
+    >
+      <td
+        class="stub"
+      >
+        paper
+      </td>
+      <td
+        class=""
+      >
+        100
+      </td>
+      <td
+        class=""
+      >
+        8.5x11,in
+      </td>
+      <td
+        class=""
+      >
+        D
+      </td>
+      <td
+        class=""
+      >
+        watercolor
+      </td>
+      <td
+        class=""
+      >
+        10
+      </td>
+    </tr>
+    <tr
+      class="row-odd"
+    >
+      <td
+        class="stub"
+      >
+        planner
+      </td>
+      <td
+        class=""
+      >
+        75
+      </td>
+      <td
+        class=""
+      >
+        22.85x30,cm
+      </td>
+      <td
+        class=""
+      >
+        D
+      </td>
+      <td
+        class=""
+      >
+        2019
+      </td>
+      <td
+        class=""
+      >
+        10
+      </td>
+    </tr>
+    <tr
+      class="row-even"
+    >
+      <td
+        class="stub"
+      >
+        postcard
+      </td>
+      <td
+        class=""
+      >
+        45
+      </td>
+      <td
+        class=""
+      >
+        10x,cm
+      </td>
+      <td
+        class=""
+      >
+        D
+      </td>
+      <td
+        class=""
+      >
+        double-sided,white
+      </td>
+      <td
+        class=""
+      >
+        2
+      </td>
+    </tr>
+  </tbody>
 </table>
 `;

--- a/tests/unit/__snapshots__/Paragraph.test.js.snap
+++ b/tests/unit/__snapshots__/Paragraph.test.js.snap
@@ -2,13 +2,27 @@
 
 exports[`renders correctly 1`] = `
 <p
+  className=""
   style={
     Object {
       "margin": "",
     }
   }
 >
-  Verify that MongoDB has started successfully by
-checking the process output for the following line:
+  <ComponentFactory
+    key="0"
+    nodeData={
+      Object {
+        "position": Object {
+          "start": Object {
+            "line": 0,
+          },
+        },
+        "type": "text",
+        "value": "Verify that MongoDB has started successfully by
+checking the process output for the following line:",
+      }
+    }
+  />
 </p>
 `;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5911)] [[Staging](https://docs-mongodborg-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5911/)]
- Add `Text` component
  - Restructure `Paragraph` component so that it passes its children to the component factory
- Pass `ListItem` children to component factory
- Conditionally display text in `<p>` tag
  - Don't use `<p>` tags in tables (unless there are multiple paragraphs)
- Improve tests so that list table outputs raw HTML