### PR TITLE
DOCSP-5912: Add transition component

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -23,6 +23,7 @@ import URIWriter from './URIWriter/URIWriter';
 import TitleReference from './TitleReference';
 import DefinitionList from './DefinitionList';
 import DefinitionListItem from './DefinitionListItem';
+import Transition from './Transition';
 
 import RoleApi from './Roles/Api';
 import RoleClass from './Roles/Class';
@@ -78,6 +79,7 @@ export default class ComponentFactory extends Component {
       strong: Strong,
       tabs: Tabs,
       title_reference: TitleReference,
+      transition: Transition,
       uriwriter: URIWriter,
     };
   }

--- a/src/components/Transition.js
+++ b/src/components/Transition.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Transition = () => <hr className="docutils" />;
+
+export default Transition;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5912)] [[Staging](https://docs-mongodborg-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5912/)] Adds `Transition` component, which is a horizontal rule (`<hr/>`). It's visible on the index page.