### PR TITLE
DOCSP-5882: Configure regression tests for Spark Connector

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       displayName: 'regression',
       preset: 'jest-puppeteer',
+      setupFilesAfterEnv: ['<rootDir>/src/regressionTestSetup.js'],
       testMatch: ['<rootDir>/tests/regression/*.test.js'],
     },
     {

--- a/tests/regression/guides.test.js
+++ b/tests/regression/guides.test.js
@@ -1,6 +1,6 @@
 import { DEPLOYMENTS, PLATFORMS, stringifyTab } from '../../src/constants';
 import { slugArray } from '../../src/regressionTestSetup';
-import { cleanString, localUrl, getLinksFromUrl, getTextFromUrl, getTOCFromUrl } from './util';
+import { cleanString, getClassText, getPageLinks, getPageText, localUrl } from './util';
 
 require('dotenv').config({ path: './.env.production' });
 
@@ -91,7 +91,7 @@ const runComparisons = async (slug, storageObj = defaultStorageObj) => {
   const key = Object.keys(storageObj)[0];
   const val = Object.values(storageObj)[0];
   return Promise.all([
-    getTextFromUrl(
+    getPageText(
       prodUrl,
       slug,
       {
@@ -101,7 +101,7 @@ const runComparisons = async (slug, storageObj = defaultStorageObj) => {
       getTargetClass,
       clickPills
     ),
-    getTextFromUrl(
+    getPageText(
       localUrl,
       slug,
       {
@@ -135,16 +135,16 @@ describe('with default tabs', () => {
     it(`table of contents labels are the same`, async () => {
       const tocClass = '.left-toc';
       const [oldTOC, newTOC] = await Promise.all([
-        await getTOCFromUrl(prodUrl, slug, tocClass),
-        await getTOCFromUrl(localUrl, slug, tocClass),
+        await getClassText(prodUrl, slug, tocClass),
+        await getClassText(localUrl, slug, tocClass),
       ]);
       expect(newTOC).toEqual(cleanOldTOC(oldTOC));
     });
 
     it(`links are the same`, async () => {
       const [oldLinks, newLinks] = await Promise.all([
-        await getLinksFromUrl(prodUrl, slug, defaultStorageObj, clickPills, removeEnableAuthLink),
-        await getLinksFromUrl(localUrl, slug, defaultStorageObj, clickPills),
+        await getPageLinks(prodUrl, slug, defaultStorageObj, clickPills, removeEnableAuthLink),
+        await getPageLinks(localUrl, slug, defaultStorageObj, clickPills),
       ]);
       expect(newLinks).toEqual(oldLinks);
     });
@@ -163,8 +163,8 @@ describe('with local storage', () => {
 
       it(`deployment links are the same`, async () => {
         const [oldLinks, newLinks] = await Promise.all([
-          await getLinksFromUrl(prodUrl, slug, defaultStorageObj),
-          await getLinksFromUrl(localUrl, slug, defaultStorageObj),
+          await getPageLinks(prodUrl, slug, defaultStorageObj),
+          await getPageLinks(localUrl, slug, defaultStorageObj),
         ]);
         expect(newLinks).toEqual(oldLinks);
       });
@@ -180,8 +180,8 @@ describe('with local storage', () => {
 
       it(`language links are the same`, async () => {
         const [oldLinks, newLinks] = await Promise.all([
-          await getLinksFromUrl(prodUrl, slug, defaultStorageObj),
-          await getLinksFromUrl(localUrl, slug, defaultStorageObj),
+          await getPageLinks(prodUrl, slug, defaultStorageObj),
+          await getPageLinks(localUrl, slug, defaultStorageObj),
         ]);
         expect(newLinks).toEqual(oldLinks);
       });
@@ -197,8 +197,8 @@ describe('with local storage', () => {
 
       it(`platform links are the same`, async () => {
         const [oldLinks, newLinks] = await Promise.all([
-          await getLinksFromUrl(prodUrl, slug, defaultStorageObj),
-          await getLinksFromUrl(localUrl, slug, defaultStorageObj),
+          await getPageLinks(prodUrl, slug, defaultStorageObj),
+          await getPageLinks(localUrl, slug, defaultStorageObj),
         ]);
         expect(newLinks).toEqual(oldLinks);
       });

--- a/tests/regression/spark-connector.test.js
+++ b/tests/regression/spark-connector.test.js
@@ -1,11 +1,11 @@
 import { slugArray } from '../../src/regressionTestSetup';
-import { cleanString, getTextFromUrl, localUrl, prodUrl } from './util';
+import { cleanString, getPageText, localUrl, prodUrl } from './util';
 
 describe('landing page', () => {
   it(`page text is the same`, async () => {
     const [legacyText, snootyText] = await Promise.all([
-      await getTextFromUrl(prodUrl, ''),
-      await getTextFromUrl(localUrl, ''),
+      await getPageText(prodUrl, ''),
+      await getPageText(localUrl, ''),
     ]);
     expect(cleanString(snootyText)).toEqual(cleanString(legacyText));
   });
@@ -14,8 +14,8 @@ describe('landing page', () => {
 describe.each(slugArray)('%p', slug => {
   it(`page text is the same`, async () => {
     const [legacyText, snootyText] = await Promise.all([
-      await getTextFromUrl(prodUrl, slug),
-      await getTextFromUrl(localUrl, slug),
+      await getPageText(prodUrl, slug),
+      await getPageText(localUrl, slug),
     ]);
     expect(cleanString(snootyText)).toEqual(cleanString(legacyText));
   });

--- a/tests/regression/spark-connector.test.js
+++ b/tests/regression/spark-connector.test.js
@@ -1,0 +1,22 @@
+import { slugArray } from '../../src/regressionTestSetup';
+import { cleanString, getTextFromUrl, localUrl, prodUrl } from './util';
+
+describe('landing page', () => {
+  it(`page text is the same`, async () => {
+    const [legacyText, snootyText] = await Promise.all([
+      await getTextFromUrl(prodUrl, ''),
+      await getTextFromUrl(localUrl, ''),
+    ]);
+    expect(cleanString(snootyText)).toEqual(cleanString(legacyText));
+  });
+});
+
+describe.each(slugArray)('%p', slug => {
+  it(`page text is the same`, async () => {
+    const [legacyText, snootyText] = await Promise.all([
+      await getTextFromUrl(prodUrl, slug),
+      await getTextFromUrl(localUrl, slug),
+    ]);
+    expect(cleanString(snootyText)).toEqual(cleanString(legacyText));
+  });
+});

--- a/tests/regression/util.js
+++ b/tests/regression/util.js
@@ -47,14 +47,14 @@ const setUpPage = async (baseUrl, slug, storageObj, interactWithPage = undefined
   return page;
 };
 
-export const getTextFromUrl = async (baseUrl, slug, storageObj, getTargetClass, interactWithPage = undefined) => {
+export const getPageText = async (baseUrl, slug, storageObj, getTargetClass, interactWithPage = undefined) => {
   const page = await setUpPage(baseUrl, slug, storageObj, interactWithPage);
   const className = getTargetClass && typeof getTargetClass === 'function' ? getTargetClass(slug) : '.body';
   const bodyElement = await page.$(className);
   return page.evaluate(element => Promise.resolve(element.innerText), bodyElement);
 };
 
-export const getLinksFromUrl = async (
+export const getPageLinks = async (
   baseUrl,
   slug,
   storageObj,
@@ -91,7 +91,7 @@ export const getLinksFromUrl = async (
  * Return the text that is displayed in a table of contents.
  * The class surrounding the TOC must be passed as an argument.
  */
-export const getTOCFromUrl = async (baseUrl, slug, tocClass) => {
+export const getClassText = async (baseUrl, slug, tocClass) => {
   const page = await browser.newPage();
   await page.goto(`${baseUrl}/${slug}`);
   const tocElement = await page.$(tocClass);

--- a/tests/regression/util.js
+++ b/tests/regression/util.js
@@ -1,0 +1,99 @@
+require('dotenv').config({ path: './.env.production' });
+
+const { execSync } = require('child_process');
+const userInfo = require('os').userInfo;
+
+const getGitBranch = () => {
+  return execSync('git rev-parse --abbrev-ref HEAD')
+    .toString('utf8')
+    .replace(/[\n\r\s]+$/, '');
+};
+
+const gatsbyPrefix = `${process.env.SITE}/${userInfo().username}/${getGitBranch()}`;
+export const prodUrl = `https://docs.mongodb.com/${process.env.SITE}/${process.env.PARSER_BRANCH}`;
+export const localUrl = `http://127.0.0.1:9000/${gatsbyPrefix}`;
+
+/*
+ * Replace characters to standardize between the two builders.
+ * - Trim whitespace from beginning and end of each line (mostly affects codeblocks)
+ * - Replace curly single quotes with straight single quotes
+ * - Replace curly double quotes with straight double quotes
+ * - Replace en dashes with double hyphens
+ * - Replace ellipses with 3 periods
+ * - Remove blank lines/whitespace
+ * - Normalize versions of macOS downloads to 1.0
+ */
+export const cleanString = str => {
+  const trimmedStrs = str
+    .split('\n')
+    .map(line => line.trim())
+    .join('\n');
+  return trimmedStrs
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace('–', '--')
+    .replace(/\u2026/g, '...')
+    .replace(/^\s*[\r\n]/gm, '')
+    .replace(/tar -zxvf mongodb-macos-x86_64-([0-9]+).([0-9]+).tgz\n+/, 'tar -zxvf mongodb-macos-x86_64-1.0.tgz');
+};
+
+const setUpPage = async (baseUrl, slug, storageObj, interactWithPage = undefined) => {
+  const page = await browser.newPage();
+  await page.goto(`${baseUrl}/${slug}`);
+
+  if (interactWithPage && typeof interactWithPage === 'function') {
+    await interactWithPage(page, slug, storageObj);
+  }
+  return page;
+};
+
+export const getTextFromUrl = async (baseUrl, slug, storageObj, getTargetClass, interactWithPage = undefined) => {
+  const page = await setUpPage(baseUrl, slug, storageObj, interactWithPage);
+  const className = getTargetClass && typeof getTargetClass === 'function' ? getTargetClass(slug) : '.body';
+  const bodyElement = await page.$(className);
+  return page.evaluate(element => Promise.resolve(element.innerText), bodyElement);
+};
+
+export const getLinksFromUrl = async (
+  baseUrl,
+  slug,
+  storageObj,
+  interactWithPage = undefined,
+  filterLinks = undefined
+) => {
+  const page = await setUpPage(baseUrl, slug, storageObj, interactWithPage);
+  let hrefs = await page.$$eval(
+    '.body a',
+    (as, url) => {
+      return as.reduce((acc, a) => {
+        if (a.className === 'headerlink' || a.offsetWidth > 0 || a.offsetHeight > 0) {
+          acc[a.text.trim()] = a.href
+            .replace(url.replace('https://', 'http://'), '')
+            .replace(url, '')
+            .replace('https://', 'http://')
+            .replace('/#', '#')
+            .replace(/\/$/, '');
+        }
+        return acc;
+      }, {});
+    },
+    baseUrl
+  );
+
+  if (filterLinks && typeof filterLinks === 'function') {
+    hrefs = filterLinks(hrefs, baseUrl, storageObj, slug);
+  }
+
+  return hrefs;
+};
+
+/*
+ * Return the text that is displayed in a table of contents.
+ * The class surrounding the TOC must be passed as an argument.
+ */
+export const getTOCFromUrl = async (baseUrl, slug, tocClass) => {
+  const page = await browser.newPage();
+  await page.goto(`${baseUrl}/${slug}`);
+  const tocElement = await page.$(tocClass);
+  return page.evaluate(element => Promise.resolve(element.innerText), tocElement);
+};


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5882)]
- Move regression test helper functions into `tests/regression/util.js`
- Add tests for Spark Connector