### PR TITLE
DOCSP-5772: Implement replace functionality

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -34,6 +34,9 @@ import RoleProgram from './Roles/Program';
 import RoleRef from './Roles/Ref';
 import RoleTerm from './Roles/Term';
 
+const IGNORED_NAMES = ['class', 'cssclass', 'default-domain'];
+const IGNORED_TYPES = ['class', 'comment', 'cssclass', 'substitution_definition', 'target'];
+
 export default class ComponentFactory extends Component {
   constructor() {
     super();
@@ -98,16 +101,7 @@ export default class ComponentFactory extends Component {
     }
 
     // do nothing with these nodes for now (cc. Andrew)
-    if (
-      type === 'target' ||
-      type === 'class' ||
-      type === 'cssclass' ||
-      name === 'cssclass' ||
-      name === 'class' ||
-      type === 'comment' ||
-      name === 'default-domain' ||
-      type === 'substitution_definition'
-    ) {
+    if (IGNORED_TYPES[type] !== undefined || IGNORED_NAMES[name] !== undefined) {
       return null;
     }
 

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -101,7 +101,7 @@ export default class ComponentFactory extends Component {
     }
 
     // do nothing with these nodes for now (cc. Andrew)
-    if (IGNORED_TYPES[type] !== undefined || IGNORED_NAMES[name] !== undefined) {
+    if (IGNORED_TYPES.includes(type) || IGNORED_NAMES.includes(name)) {
       return null;
     }
 

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -105,7 +105,8 @@ export default class ComponentFactory extends Component {
       name === 'cssclass' ||
       name === 'class' ||
       type === 'comment' ||
-      name === 'default-domain'
+      name === 'default-domain' ||
+      type === 'substitution_definition'
     ) {
       return null;
     }

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -85,8 +85,18 @@ export default class ComponentFactory extends Component {
   selectComponent() {
     const {
       nodeData: { children, name, type },
+      substitutions,
       ...rest
     } = this.props;
+
+    if (type === 'substitution_reference') {
+      if (!substitutions || !substitutions[name]) {
+        return null;
+      }
+
+      return substitutions[name].map((sub, index) => <ComponentFactory {...rest} nodeData={sub} key={index} />);
+    }
+
     // do nothing with these nodes for now (cc. Andrew)
     if (
       type === 'target' ||
@@ -141,4 +151,11 @@ ComponentFactory.propTypes = {
     name: PropTypes.string,
     type: PropTypes.string.isRequired,
   }).isRequired,
+  substitutions: PropTypes.shape({
+    [PropTypes.string]: PropTypes.arrayOf(PropTypes.object),
+  }),
+};
+
+ComponentFactory.defaultProps = {
+  substitutions: undefined,
 };

--- a/src/components/Include.js
+++ b/src/components/Include.js
@@ -1,33 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
+import { getIncludeFile } from '../utils/get-include-file';
 
-export default class Include extends Component {
-  constructor(props) {
-    super(props);
-
-    const { nodeData, refDocMapping, updateTotalStepCount } = this.props;
-
-    let key = getNestedValue(['argument', 0, 'value'], nodeData);
-    if (key.startsWith('/')) key = key.substr(1);
-    if (key.endsWith('.rst')) key = key.replace('.rst', '');
-    this.resolvedIncludeData = [];
-    // get document for include url
-    if (refDocMapping && Object.keys(refDocMapping).length > 0) {
-      this.resolvedIncludeData = refDocMapping[key].ast ? refDocMapping[key].ast.children : [];
-    }
-    if (updateTotalStepCount) {
-      updateTotalStepCount(this.resolvedIncludeData.length);
-    }
+const Include = ({ nodeData, refDocMapping, updateTotalStepCount, ...rest }) => {
+  const filename = getNestedValue(['argument', 0, 'value'], nodeData);
+  const resolvedIncludeData = getIncludeFile(refDocMapping, filename);
+  if (updateTotalStepCount) {
+    updateTotalStepCount(resolvedIncludeData.length);
   }
-
-  render() {
-    return this.resolvedIncludeData.map((includeObj, index) => (
-      <ComponentFactory {...this.props} nodeData={includeObj} key={index} stepNum={index} />
-    ));
-  }
-}
+  return resolvedIncludeData.map((includeObj, index) => (
+    <ComponentFactory {...rest} nodeData={includeObj} key={index} stepNum={index} />
+  ));
+};
 
 Include.propTypes = {
   nodeData: PropTypes.shape({
@@ -49,3 +35,5 @@ Include.defaultProps = {
   updateTotalStepCount: () => {},
   refDocMapping: undefined,
 };
+
+export default Include;

--- a/src/components/Include.js
+++ b/src/components/Include.js
@@ -1,19 +1,29 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
 import { getIncludeFile } from '../utils/get-include-file';
 
-const Include = ({ nodeData, refDocMapping, updateTotalStepCount, ...rest }) => {
-  const filename = getNestedValue(['argument', 0, 'value'], nodeData);
-  const resolvedIncludeData = getIncludeFile(refDocMapping, filename);
-  if (updateTotalStepCount) {
-    updateTotalStepCount(resolvedIncludeData.length);
+export default class Include extends Component {
+  constructor(props) {
+    super(props);
+
+    const { nodeData, refDocMapping, updateTotalStepCount } = this.props;
+
+    const filename = getNestedValue(['argument', 0, 'value'], nodeData);
+    this.resolvedIncludeData = getIncludeFile(refDocMapping, filename);
+
+    if (updateTotalStepCount) {
+      updateTotalStepCount(this.resolvedIncludeData.length);
+    }
   }
-  return resolvedIncludeData.map((includeObj, index) => (
-    <ComponentFactory {...rest} nodeData={includeObj} key={index} stepNum={index} />
-  ));
-};
+
+  render() {
+    return this.resolvedIncludeData.map((includeObj, index) => (
+      <ComponentFactory {...this.props} nodeData={includeObj} key={index} stepNum={index} />
+    ));
+  }
+}
 
 Include.propTypes = {
   nodeData: PropTypes.shape({
@@ -35,5 +45,3 @@ Include.defaultProps = {
   updateTotalStepCount: () => {},
   refDocMapping: undefined,
 };
-
-export default Include;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -14,16 +14,21 @@ const Document = props => {
   } = props;
   const pageNodes = getNestedValue([pageSlug || 'index', 'ast', 'children'], __refDocMapping) || [];
 
+  // Identify and save all substitutions as defined on this page and in its included files
   const getSubstitutions = () => {
-    const fileSubstitutions = findAllKeyValuePairs(pageNodes, 'type', 'substitution_definition');
+    // Find substitutions on page
+    const pageSubstitutions = findAllKeyValuePairs(pageNodes, 'type', 'substitution_definition');
 
+    // Find all include nodes on the page, get each include's contents, and find all substitutions in each include
     const includes = findAllKeyValuePairs(pageNodes, 'name', 'include');
     const includeContents = includes
       .map(include => getIncludeFile(__refDocMapping, getNestedValue(['argument', 0, 'value'], include)))
       .flat();
     const includeSubstitutions = findAllKeyValuePairs(includeContents, 'type', 'substitution_definition');
 
-    const substitutions = fileSubstitutions.concat(includeSubstitutions);
+    // Merge page and include substitutions.
+    // Create a map wherein each key is the word to be replaced, and each value is the nodes to replace it with.
+    const substitutions = pageSubstitutions.concat(includeSubstitutions);
     return substitutions.reduce((map, sub) => {
       map[sub.name] = sub.children; // eslint-disable-line no-param-reassign
       return map;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -4,6 +4,7 @@ import ComponentFactory from '../components/ComponentFactory';
 import DefaultLayout from '../components/layout';
 import Footer from '../components/Footer';
 import { getNestedValue } from '../utils/get-nested-value';
+import { findAllKeyValuePairs } from '../utils/find-all-key-value-pairs';
 
 const Document = props => {
   const {
@@ -11,6 +12,16 @@ const Document = props => {
     pageContext: { __refDocMapping },
   } = props;
   const pageNodes = getNestedValue([pageSlug || 'index', 'ast', 'children'], __refDocMapping) || [];
+
+  const getSubstitutions = () => {
+    const substitutions = findAllKeyValuePairs(pageNodes, 'type', 'substitution_definition');
+    const substitutionMap = {};
+    substitutions.forEach(sub => {
+      substitutionMap[sub.name] = sub.children;
+    });
+    return substitutionMap;
+  };
+
   return (
     <DefaultLayout>
       <div className="content">
@@ -23,7 +34,12 @@ const Document = props => {
               <div className="bodywrapper">
                 <div className="body">
                   {pageNodes.map((child, index) => (
-                    <ComponentFactory key={index} nodeData={child} refDocMapping={__refDocMapping} />
+                    <ComponentFactory
+                      key={index}
+                      nodeData={child}
+                      refDocMapping={__refDocMapping}
+                      substitutions={getSubstitutions()}
+                    />
                   ))}
                   <Footer />
                 </div>

--- a/src/utils/find-all-key-value-pairs.js
+++ b/src/utils/find-all-key-value-pairs.js
@@ -1,0 +1,17 @@
+/**
+ * Searches child nodes to find all instances of the specified key/value pair in the `nodes` object.
+ */
+export const findAllKeyValuePairs = (nodes, key, value) => {
+  const results = [];
+  const iter = node => {
+    if (node[key] === value) {
+      results.push(node);
+    }
+    if (node.children) {
+      return node.children.forEach(iter);
+    }
+    return null;
+  };
+  nodes.forEach(iter);
+  return results;
+};

--- a/src/utils/find-all-key-value-pairs.js
+++ b/src/utils/find-all-key-value-pairs.js
@@ -3,7 +3,7 @@
  */
 export const findAllKeyValuePairs = (nodes, key, value) => {
   const results = [];
-  const iter = node => {
+  const searchNode = node => {
     if (node[key] === value) {
       results.push(node);
     }
@@ -12,6 +12,6 @@ export const findAllKeyValuePairs = (nodes, key, value) => {
     }
     return null;
   };
-  nodes.forEach(iter);
+  nodes.forEach(searchNode);
   return results;
 };

--- a/src/utils/find-all-key-value-pairs.js
+++ b/src/utils/find-all-key-value-pairs.js
@@ -8,7 +8,7 @@ export const findAllKeyValuePairs = (nodes, key, value) => {
       results.push(node);
     }
     if (node.children) {
-      return node.children.forEach(iter);
+      return node.children.forEach(searchNode);
     }
     return null;
   };

--- a/src/utils/get-include-file.js
+++ b/src/utils/get-include-file.js
@@ -2,7 +2,12 @@ import { getNestedValue } from './get-nested-value';
 
 export const getIncludeFile = (refDocMapping, filename) => {
   let key = filename;
-  if (key.startsWith('/')) key = key.substr(1);
+  if (key.startsWith('/')) {
+    key = key.substr(1);
+  } else {
+    console.warn(`include file ${filename} does not begin with '/'`);
+  }
+
   if (key.endsWith('.rst')) key = key.replace('.rst', '');
 
   return getNestedValue([key, 'ast', 'children'], refDocMapping) || [];

--- a/src/utils/get-include-file.js
+++ b/src/utils/get-include-file.js
@@ -1,0 +1,9 @@
+import { getNestedValue } from './get-nested-value';
+
+export const getIncludeFile = (refDocMapping, filename) => {
+  let key = filename;
+  if (key.startsWith('/')) key = key.substr(1);
+  if (key.endsWith('.rst')) key = key.replace('.rst', '');
+
+  return getNestedValue([key, 'ast', 'children'], refDocMapping) || [];
+};


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5772)] [[Staging](https://docs-mongodborg-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5772/)] Improvements are visible on the [`/java/aggregation`](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-5772/java/aggregation) page.
- Parse page tree to find all `substitution_definition` nodes
- Parse all includes to find `substitution_definition` nodes
- Save these definitions in a `substitutions` map, which is passed as a prop to the `ComponentFactory`
- When the component factory encounters a `substitution_reference` node, replace it using the child nodes saved in the `substitutions` mapping
- Ignore `substitution_definition` nodes so they are not rendered on the page