### PR TITLE
DOCSP-6037: Dynamic heading hierarchy

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -4,7 +4,7 @@ import ComponentFactory from './ComponentFactory';
 
 const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const id = nodeData.id || '';
-  const HeadingTag = sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
+  const HeadingTag = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
   return (
     <HeadingTag id={id}>
       {nodeData.children.map((element, index) => {

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Heading = props => {
-  const { sectionDepth, nodeData } = props;
+const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const id = nodeData.id || '';
   const HeadingTag = sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
   return (
     <HeadingTag id={id}>
       {nodeData.children.map((element, index) => {
-        return <ComponentFactory {...props} nodeData={element} key={index} />;
+        return <ComponentFactory {...rest} nodeData={element} key={index} />;
       })}
       <a className="headerlink" href={`#${id}`} title="Permalink to this headline">
         ¶

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -3,24 +3,23 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
 const Heading = props => {
-  const { nodeData } = props;
+  const { sectionDepth, nodeData } = props;
   const id = nodeData.id || '';
+  const HeadingTag = sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
   return (
-    <h3 id={id}>
+    <HeadingTag id={id}>
       {nodeData.children.map((element, index) => {
-        if (element.type === 'text') {
-          return <React.Fragment key={index}>{element.value}</React.Fragment>;
-        }
         return <ComponentFactory {...props} nodeData={element} key={index} />;
       })}
       <a className="headerlink" href={`#${id}`} title="Permalink to this headline">
         ¶
       </a>
-    </h3>
+    </HeadingTag>
   );
 };
 
 Heading.propTypes = {
+  sectionDepth: PropTypes.number.isRequired,
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,26 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
-import { getNestedValue } from '../utils/get-nested-value';
 
 const Section = props => {
-  const { nodeData } = props;
+  const { sectionDepth, nodeData } = props;
   return (
     <section>
       {nodeData.children.map((child, index) => {
-        if (child.type === 'text') {
-          return <React.Fragment key={index}>{getNestedValue(['value'], child)}</React.Fragment>;
-        }
-        return <ComponentFactory {...props} nodeData={child} key={index} />;
+        return <ComponentFactory {...props} nodeData={child} key={index} sectionDepth={sectionDepth + 1} />;
       })}
     </section>
   );
 };
 
 Section.propTypes = {
+  sectionDepth: PropTypes.number,
   nodeData: PropTypes.shape({
     children: PropTypes.array.isRequired,
   }).isRequired,
+};
+
+Section.defaultProps = {
+  sectionDepth: 0,
 };
 
 export default Section;

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -2,12 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Section = props => {
-  const { sectionDepth, nodeData } = props;
+const Section = ({ sectionDepth, nodeData: { children }, ...rest }) => {
   return (
     <section>
-      {nodeData.children.map((child, index) => {
-        return <ComponentFactory {...props} nodeData={child} key={index} sectionDepth={sectionDepth + 1} />;
+      {children.map((child, index) => {
+        return <ComponentFactory {...rest} nodeData={child} key={index} sectionDepth={sectionDepth + 1} />;
       })}
     </section>
   );

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -45,6 +45,7 @@ const Document = props => {
             <div className="documentwrapper">
               <div className="bodywrapper">
                 <div className="body">
+                  <div className="bc" />
                   {pageNodes.map((child, index) => (
                     <ComponentFactory
                       key={index}

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -145,6 +145,7 @@ export default class Guide extends Component {
     return this.bodySections.map((section, index) => {
       return (
         <GuideSection
+          sectionDepth={2}
           guideSectionData={section}
           key={index}
           headingRef={this.sectionRefs[index]}

--- a/tests/unit/Heading.test.js
+++ b/tests/unit/Heading.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'enzyme';
 import Heading from '../../src/components/Heading';
 
 // data for this component
 import mockData from './data/Heading.test.json';
 
 it('renders correctly', () => {
-  const tree = shallow(<Heading nodeData={mockData} />);
+  const tree = render(<Heading nodeData={mockData} sectionDepth={3} />);
   expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
 >
   Create an administrative username and password
   <a
-    className="headerlink"
+    class="headerlink"
     href="#create-an-administrative-username-and-password"
     title="Permalink to this headline"
   >

--- a/tests/unit/__snapshots__/Include.test.js.snap
+++ b/tests/unit/__snapshots__/Include.test.js.snap
@@ -19,7 +19,7 @@ exports[`renders correctly 1`] = `
     class="section"
   >
     <section>
-      <h3
+      <h1
         id="access-to-an-atlas-supported-browser"
       >
         Access to an Atlas supported browser
@@ -30,7 +30,7 @@ exports[`renders correctly 1`] = `
         >
           ¶
         </a>
-      </h3>
+      </h1>
       <p
         class=""
         style="margin:"

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -25,6 +25,7 @@ exports[`renders correctly 1`] = `
         "type": "heading",
       }
     }
+    sectionDepth={1}
   />
   <ComponentFactory
     key="1"
@@ -61,6 +62,7 @@ exports[`renders correctly 1`] = `
         "type": "directive",
       }
     }
+    sectionDepth={1}
   />
   <ComponentFactory
     key="2"
@@ -97,6 +99,7 @@ exports[`renders correctly 1`] = `
         "type": "directive",
       }
     }
+    sectionDepth={1}
   />
 </section>
 `;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6037)] [[Guides Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/sophstad/DOCSP-6037/)] [[Spark Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/sophstad/DOCSP-6037)]
- Compute which level heading tag to use based on the section depth
- Add missing spacing `<div>` to document template so that page titles are properly formatted
- Update tests and snapshots