### PR TITLE
DOCSP-6185: Change lint script to run from local node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop --prefix-paths",
-    "lint": "eslint src/ tests/",
+    "lint": "./node_modules/.bin/eslint src/ tests/",
     "lintfix": "prettier-eslint --write \"src/**/*.js\" \"tests/**/*.js\"",
     "serve": "gatsby serve --prefix-paths",
     "test": "jest",


### PR DESCRIPTION
Changed script in `package.json` to run `./node_modules/.bin/eslint src/ tests/`.