### PR TITLE
DOCSP-7109: Update Snooty Preview files to work within VS Code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,14 @@
 {
-  presets: [ 
+  "presets": [ 
     [
       "@babel/env", 
       {
-        loose: true,
-        useBuiltIns: "usage",
-        shippedProposals: true,
-        targets: {
-          browsers: [">0.25%", "not dead", "ie >= 11"],
-        },
+        "loose": true,
+        "useBuiltIns": "usage",
+        "shippedProposals": true,
+        "targets": {
+          "browsers": [">0.25%", "not dead", "ie >= 11"],
+        }
       }
     ],
     [
@@ -16,11 +16,11 @@
       {}
     ]
   ],
-  plugins: [
+  "plugins": [
     [
       "@babel/plugin-proposal-class-properties",
       {
-        loose: true,
+        "loose": true,
       },
     ],
     "@babel/plugin-syntax-dynamic-import",
@@ -28,8 +28,8 @@
     [
       "@babel/plugin-transform-runtime",
       {
-        helpers: true,
-        regenerator: true,
+        "helpers": true,
+        "regenerator": true,
       },
     ],
     ["@babel/plugin-transform-react-jsx"],

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,6 @@
-# Local Preview
+# Snooty Preview
 
-Snooty can support locally rendering a single page without the use of `Gatsby.js`. 
+Snooty can support rendering a single page without the use of `Gatsby.js`. 
 This utilizes `webpack` directly. Preview mode relies on the following files:
 
 * `webpack.config.js` - Webpack configuration files.
@@ -15,20 +15,13 @@ The following files are additional files that serve as workarounds for `gatsby`:
 
 ## Usage
 
-To use local preview, `.env.development` must be set up with the intended information that 
-would be used when using `gatsby develop`.
+Note: This assumes that the Snooty Frontend has already been added as a submodule in Snooty VS Code.
 
-**On your command line:**
-```
-npm run preview -- --env.PREVIEW_PAGE="<page-name-here>"
-```
+Snooty Preview is intended to be used along with the Snooty extension on VS Code.
 
-**Example to get to the landing page:**
-```
-npm run preview -- --env.PREVIEW_PAGE="index"
-```
+To run on VS Code:
+1. `cmd + shift + p`
+2. Run `Snooty Preview`
+The Snooty extension generates `page-ast.json` when running Snooty Preview, allowing the file to be used by `preview-setup.js`.
 
-**Example to get to https://docs.mongodb.com/guides/server/drivers/ :**
-```
-npm run preview -- --env.PREVIEW_PAGE="server/drivers"
-```
+This generates `bundle.js` to be used by Snooty VS Code's webview implementation.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,7 +1,6 @@
 # Snooty Preview
 
-Snooty can support rendering a single page without the use of `Gatsby.js`. 
-This utilizes `webpack` directly. Preview mode relies on the following files:
+Snooty can support rendering a single page without the use of `Gatsby.js` by utilizing `webpack` directly. Preview mode relies on the following files:
 
 * `webpack.config.js` - Webpack configuration files.
 * `preview-start.js` - Entry point for preview mode.
@@ -15,13 +14,21 @@ The following files are additional files that serve as workarounds for `gatsby`:
 
 ## Usage
 
-Note: This assumes that the Snooty Frontend has already been added as a submodule in Snooty VS Code.
+Note: This assumes that the Snooty Frontend has already been added as a submodule in [Snooty VS Code](https://github.com/mongodb/snooty-vscode).
 
 Snooty Preview is intended to be used along with the Snooty extension on VS Code.
 
 To run on VS Code:
-1. `cmd + shift + p`
-2. Run `Snooty Preview`
-The Snooty extension generates `page-ast.json` when running Snooty Preview, allowing the file to be used by `preview-setup.js`.
+1. Go to a `.txt` file that corresponds to its own page.
+2. `cmd + shift + p` to open up a list of possible commands.
+3. Run `Snooty Preview` to open a webview panel to preview the page for the current `.txt` file.
 
-This generates `bundle.js` to be used by Snooty VS Code's webview implementation.
+## Key Processes
+
+`Snooty Preview` can be broken down into three key processes:
+1. Obtaining the page AST.
+The current page's AST is obtained from the [Snooty Parser's](https://github.com/mongodb/snooty-parser) RPC method [`textDocument/get_page_ast`](https://github.com/mongodb/snooty-parser/blob/DOCSP-6544/RPC-methods.md#textdocumentget_page_ast). The page AST is saved as `page-ast.json` within the Snooty frontend submodule's `preview` directory.
+2. Generating `bundle.js`.
+The Snooty extension runs a task to initiate webpack within the Snooty frontend submodule. This creates a bundle file that is stored within the submodule's `preview` directory.
+3. Starting the webview panel.
+The Snooty extension handles previewing the single page by starting a webview panel within VS Code. The `bundle.js` is used as a script within the webview's html.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -211,6 +211,8 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   actions.setWebpackConfig({
     resolve: {
       alias: {
+        // Use noop file to prevent any preview-setup errors
+        previewSetup: path.resolve(__dirname, 'preview/noop.js'),
         useSiteMetadata: path.resolve(__dirname, 'src/hooks/use-site-metadata.js'),
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,17 +972,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "develop": "gatsby develop --prefix-paths",
     "lint": "./node_modules/.bin/eslint src/ tests/",
     "lintfix": "prettier-eslint --write \"src/**/*.js\" \"tests/**/*.js\"",
-    "preview": "webpack-dev-server --config ./webpack.config.js",
     "serve": "gatsby serve --prefix-paths",
     "test": "jest",
     "test:regression": "jest regression",

--- a/preview-start.js
+++ b/preview-start.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Helmet } from 'react-helmet';
-import { getPageData } from './preview/preview-setup';
+// eslint-disable-next-line import/no-unresolved
+import { getPageData } from 'previewSetup'; // Alias found in gatsby-node and webpack.config.js
 // Layouts
 import DefaultLayout from './src/components/layout';
 import Document from './src/templates/document';
@@ -22,7 +23,7 @@ class Preview extends React.Component {
   }
 
   componentDidMount() {
-    getPageData(process.env.PREVIEW_PAGE).then(pageData => {
+    getPageData().then(pageData => {
       const Template = this.templates[pageData.template] ? this.templates[pageData.template] : Document;
       this.setState({
         pageData,
@@ -37,10 +38,11 @@ class Preview extends React.Component {
     return (
       <React.Fragment>
         <Helmet>
+          {/* See TODO in webpack.config.js */}
           {process.env.GATSBY_SITE === 'guides' ? (
-            <link rel="stylesheet" href="./static/docs-tools/guides.css" type="text/css" />
+            <link rel="stylesheet" href="./docs-tools/themes/mongodb/static/guides.css" type="text/css" />
           ) : (
-            <link rel="stylesheet" href="./static/docs-tools/mongodb-docs.css" type="text/css" />
+            <link rel="stylesheet" href="./docs-tools/themes/mongodb/static/mongodb-docs.css" type="text/css" />
           )}
         </Helmet>
         {pageData && (

--- a/preview-start.js
+++ b/preview-start.js
@@ -40,9 +40,9 @@ class Preview extends React.Component {
         <Helmet>
           {/* See TODO in webpack.config.js */}
           {process.env.GATSBY_SITE === 'guides' ? (
-            <link rel="stylesheet" href="./docs-tools/themes/mongodb/static/guides.css" type="text/css" />
+            <link rel="stylesheet" href="./static/docs-tools/guides.css" type="text/css" />
           ) : (
-            <link rel="stylesheet" href="./docs-tools/themes/mongodb/static/mongodb-docs.css" type="text/css" />
+            <link rel="stylesheet" href="./static/docs-tools/mongodb-docs.css" type="text/css" />
           )}
         </Helmet>
         {pageData && (

--- a/preview/preview-setup.js
+++ b/preview/preview-setup.js
@@ -1,151 +1,19 @@
-// TODO: Optimize this file along with gatsby-node. To make things reusable
-const { Stitch, AnonymousCredential } = require('mongodb-stitch-browser-sdk');
-const { validateEnvVariables } = require('../src/utils/setup/validate-env-variables');
-const { getIncludeFile } = require('./get-include-file');
-const { getNestedValue } = require('../src/utils/get-nested-value');
-const { findAllKeyValuePairs } = require('../src/utils/find-all-key-value-pairs');
-const { findKeyValuePair } = require('../src/utils/find-key-value-pair');
+// eslint-disable-next-line import/no-unresolved
+const pageAST = require('./page-ast.json'); // File created by Snooty extension on VS Code
 
-// Atlas DB config
-const DB = 'snooty';
-const DOCUMENTS_COLLECTION = 'documents';
-const ASSETS_COLLECTION = 'assets';
-const SNOOTY_STITCH_ID = 'snooty-koueq';
-
-// different types of references
-const PAGES = [];
-const INCLUDE_FILES = {};
-const PAGE_TITLE_MAP = {};
-
-// in-memory object with key/value = filename/document
-let RESOLVED_REF_DOC_MAPPING = {};
-
-// stich client connection
-let stitchClient;
-
-const setupStitch = () => {
-  return new Promise((resolve, reject) => {
-    stitchClient = Stitch.hasAppClient(SNOOTY_STITCH_ID)
-      ? Stitch.getAppClient(SNOOTY_STITCH_ID)
-      : Stitch.initializeAppClient(SNOOTY_STITCH_ID);
-    stitchClient.auth
-      .loginWithCredential(new AnonymousCredential())
-      .then(user => {
-        console.log('logged into stitch');
-        resolve();
-      })
-      .catch(console.error);
-  });
-};
-
-// Parse a page's AST to find all figure nodes and return a map of image checksums and filenames
-const getImagesInPage = page => {
-  const imageNodes = findAllKeyValuePairs(page, 'name', 'figure');
-  return imageNodes.reduce((obj, node) => {
-    const name = getNestedValue(['argument', 0, 'value'], node);
-    const checksum = getNestedValue(['options', 'checksum'], node);
-    obj[checksum] = name;
-    return obj;
-  }, {});
-};
-
-// For each include node found in a page, set its 'children' property to be the array of include contents
-const populateIncludeNodes = nodes => {
-  const replaceInclude = node => {
-    if (node.name === 'include') {
-      const includeFilename = getNestedValue(['argument', 0, 'value'], node);
-      const includeNode = getIncludeFile(INCLUDE_FILES, includeFilename);
-      // Perform the same operation on include nodes inside this include file
-      const replacedInclude = includeNode.map(replaceInclude);
-      node.children = replacedInclude;
-    } else if (node.children) {
-      node.children.forEach(replaceInclude);
-    }
-    return node;
+// Returns bare minimum data needed by a single page
+export const getPageData = async () => {
+  const pageNodes = {
+    ast: pageAST,
   };
-  return nodes.map(replaceInclude);
-};
 
-const sourceNodes = async () => {
-  // setup env variables
-  const envResults = validateEnvVariables();
-
-  if (envResults.error) {
-    throw Error(envResults.message);
-  }
-
-  // wait to connect to stitch
-  await setupStitch();
-
-  // start from index document
-  const idPrefix = `${process.env.GATSBY_SITE}/${process.env.GATSBY_PARSER_USER}/${process.env.GATSBY_PARSER_BRANCH}`;
-  const query = { _id: { $regex: new RegExp(`${idPrefix}/*`) } };
-  const documents = await stitchClient.callFunction('fetchDocuments', [DB, DOCUMENTS_COLLECTION, query]);
-  documents.forEach(doc => {
-    const { _id, ...rest } = doc;
-    RESOLVED_REF_DOC_MAPPING[_id.replace(`${idPrefix}/`, '')] = rest;
-  });
-
-  // Identify page documents and parse each document for images
-  let assets = {};
-  Object.entries(RESOLVED_REF_DOC_MAPPING).forEach(([key, val]) => {
-    const pageNode = getNestedValue(['ast', 'children'], val);
-    if (pageNode) {
-      assets = { ...assets, ...getImagesInPage(pageNode) };
-    }
-    if (key.includes('includes/')) {
-      INCLUDE_FILES[key] = val;
-    } else if (!key.includes('curl') && !key.includes('https://')) {
-      PAGES.push(key);
-      PAGE_TITLE_MAP[key] = {
-        title: getNestedValue(['ast', 'children', 0, 'children', 0, 'children', 0, 'value'], val),
-        category: getNestedValue(
-          ['argument', 0, 'value'],
-          findKeyValuePair(getNestedValue(['ast', 'children'], val), 'name', 'category')
-        ),
-        completionTime: getNestedValue(
-          ['argument', 0, 'value'],
-          findKeyValuePair(getNestedValue(['ast', 'children'], val), 'name', 'time')
-        ),
-        languages: findKeyValuePair(getNestedValue(['ast', 'children'], val), 'name', 'languages'),
-      };
-    }
-  });
-};
-
-// Similar to gatsby-node's createPage(). Return the data needed by a single page
-export const getPageData = async page => {
-  await sourceNodes();
-  const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
-
-  pageNodes.ast.children = populateIncludeNodes(getNestedValue(['ast', 'children'], pageNodes));
-
-  let template = 'document';
-  if (process.env.GATSBY_SITE === 'guides') {
-    template = page === 'index' ? 'guides-index' : 'guide';
-  }
-  const pageUrl = page === 'index' ? '/' : page;
-  if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {
-    return {
-      path: pageUrl,
-      template,
-      context: {
-        snootyStitchId: SNOOTY_STITCH_ID,
-        __refDocMapping: pageNodes,
-        pageMetadata: PAGE_TITLE_MAP,
-      },
-    };
-  }
-  return null;
-};
-
-// Use checksum from a Figure component to return base64 data of image
-export const getBase64Uri = async checksum => {
-  const query = { _id: { $eq: checksum } };
-  const [assetData] = await stitchClient.callFunction('fetchDocuments', [DB, ASSETS_COLLECTION, query]);
-
-  const base64 = assetData.data.buffer.toString('base64');
-  const fileFormat = assetData.filename.split('.')[-1];
-  const prefix = `data:image/${fileFormat};base64,`;
-  return prefix.concat(base64);
+  return {
+    path: '',
+    template: 'guide',
+    context: {
+      snootyStitchId: '',
+      __refDocMapping: pageNodes,
+      pageMetadata: {},
+    },
+  };
 };

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -20,12 +20,14 @@ export default class Image extends Component {
     this._isMounted = true;
 
     // Get base64 image data
+    // TODO: Receive images some other way when preview for VS Code is up and running (DOCSP-6886)
     if (process.env.PREVIEW_PAGE) {
       const { nodeData } = this.props;
       const checksum = getNestedValue(['options', 'checksum'], nodeData);
 
       // Get base64 data of image using checksum
-      import('../../preview/preview-setup')
+      // eslint-disable-next-line import/no-unresolved
+      import('previewSetup')
         .then(module => {
           return module.getBase64Uri(checksum);
         })

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -186,7 +186,7 @@ export default class Guide extends Component {
 }
 
 Guide.propTypes = {
-  addPillstrip: PropTypes.func.isRequired,
+  addPillstrip: PropTypes.func,
   pageContext: PropTypes.shape({
     __refDocMapping: PropTypes.shape({
       ast: PropTypes.shape({
@@ -197,7 +197,12 @@ Guide.propTypes = {
     pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
   }).isRequired,
   path: PropTypes.string.isRequired,
-  pillstrips: PropTypes.objectOf(PropTypes.object).isRequired,
+  pillstrips: PropTypes.objectOf(PropTypes.object),
+};
+
+Guide.defaultProps = {
+  addPillstrip: () => {},
+  pillstrips: {},
 };
 
 Guide.contextType = TabContext;

--- a/src/utils/browser-storage.js
+++ b/src/utils/browser-storage.js
@@ -1,14 +1,14 @@
 import { isBrowser } from './is-browser';
 
 export const setLocalValue = (key, value) => {
-  if (isBrowser()) {
+  if (!process.env.PREVIEW_PAGE && isBrowser()) {
     const prevState = JSON.parse(window.localStorage.getItem('mongodb-docs'));
     localStorage.setItem('mongodb-docs', JSON.stringify({ ...prevState, [key]: value }));
   }
 };
 
 export const getLocalValue = key => {
-  if (isBrowser() && JSON.parse(window.localStorage.getItem('mongodb-docs'))) {
+  if (!process.env.PREVIEW_PAGE && isBrowser() && JSON.parse(window.localStorage.getItem('mongodb-docs'))) {
     const docsObj = JSON.parse(window.localStorage.getItem('mongodb-docs'));
     if (docsObj) {
       return docsObj[key];
@@ -18,14 +18,14 @@ export const getLocalValue = key => {
 };
 
 export const setSessionValue = (key, value) => {
-  if (isBrowser()) {
+  if (!process.env.PREVIEW_PAGE && isBrowser()) {
     const prevState = JSON.parse(window.sessionStorage.getItem('mongodb-docs'));
     sessionStorage.setItem('mongodb-docs', JSON.stringify({ ...prevState, [key]: value }));
   }
 };
 
 export const getSessionValue = key => {
-  if (isBrowser() && JSON.parse(window.sessionStorage.getItem('mongodb-docs'))) {
+  if (!process.env.PREVIEW_PAGE && isBrowser() && JSON.parse(window.sessionStorage.getItem('mongodb-docs'))) {
     const docsObj = JSON.parse(window.sessionStorage.getItem('mongodb-docs'));
     if (docsObj) {
       return docsObj[key];

--- a/src/utils/browser-storage.js
+++ b/src/utils/browser-storage.js
@@ -1,14 +1,16 @@
 import { isBrowser } from './is-browser';
 
+const isValidStorage = !process.env.PREVIEW_PAGE && isBrowser();
+
 export const setLocalValue = (key, value) => {
-  if (!process.env.PREVIEW_PAGE && isBrowser()) {
+  if (isValidStorage) {
     const prevState = JSON.parse(window.localStorage.getItem('mongodb-docs'));
     localStorage.setItem('mongodb-docs', JSON.stringify({ ...prevState, [key]: value }));
   }
 };
 
 export const getLocalValue = key => {
-  if (!process.env.PREVIEW_PAGE && isBrowser() && JSON.parse(window.localStorage.getItem('mongodb-docs'))) {
+  if (isValidStorage && JSON.parse(window.localStorage.getItem('mongodb-docs'))) {
     const docsObj = JSON.parse(window.localStorage.getItem('mongodb-docs'));
     if (docsObj) {
       return docsObj[key];
@@ -18,14 +20,14 @@ export const getLocalValue = key => {
 };
 
 export const setSessionValue = (key, value) => {
-  if (!process.env.PREVIEW_PAGE && isBrowser()) {
+  if (isValidStorage) {
     const prevState = JSON.parse(window.sessionStorage.getItem('mongodb-docs'));
     sessionStorage.setItem('mongodb-docs', JSON.stringify({ ...prevState, [key]: value }));
   }
 };
 
 export const getSessionValue = key => {
-  if (!process.env.PREVIEW_PAGE && isBrowser() && JSON.parse(window.sessionStorage.getItem('mongodb-docs'))) {
+  if (isValidStorage && JSON.parse(window.sessionStorage.getItem('mongodb-docs'))) {
     const docsObj = JSON.parse(window.sessionStorage.getItem('mongodb-docs'));
     if (docsObj) {
       return docsObj[key];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,54 +1,61 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const dotenv = require('dotenv').config({
-    path: `.env.development`,
-});
+module.exports = env => {
+  const noopPath = path.resolve(__dirname, 'preview/noop.js');
 
-module.exports = (env) => {
-    return {
-        mode: "development",
-        entry: './preview-start.js',
-        module: {
-            rules: [
-                {
-                    test: /\.js$/,
-                    use: {
-                        loader: 'babel-loader'
-                    }
-                },
-                {
-                    test: /\.css$/, 
-                    use: ['style-loader', 'css-loader']
-                }
-            ]
-        },
-        resolve: {
-            alias: {
-                gatsby: path.resolve(__dirname, 'preview/noop.js'),
-                useSiteMetadata: path.resolve(__dirname, "preview/noop.js")
+  return {
+    mode: 'development',
+    entry: path.resolve(__dirname, 'preview-start.js'),
+    resolveLoader: {
+      modules: [path.resolve(__dirname, 'node_modules')],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              babelrc: true,
+              babelrcRoots: [path.resolve(__dirname)],
             },
-            extensions: ['*', '.js', '.css']
+          },
+          // Including this results in a babel-loader error within VS Code
+          exclude: /node_modules\/react-highlight/,
         },
-        output: {
-            filename: 'bundle.js',
-            path: path.resolve(__dirname, 'preview'),
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
         },
-        devServer: {
-            contentBase: './',
-            open: true
-        },
-        // fs won't work properly with default webpack configurations https://stackoverflow.com/a/51669301
-        node: {
-            fs: 'empty'
-        },
-        plugins: [
-            new webpack.DefinePlugin({
-                'process.env.GATSBY_SITE': JSON.stringify(dotenv.parsed.GATSBY_SITE),
-                'process.env.GATSBY_PARSER_USER': JSON.stringify(dotenv.parsed.GATSBY_PARSER_USER),
-                'process.env.GATSBY_PARSER_BRANCH': JSON.stringify(dotenv.parsed.GATSBY_PARSER_BRANCH),
-                'process.env.PREVIEW_PAGE': JSON.stringify(`${env.PREVIEW_PAGE}`)
-            })
-        ]
-    }
-}
+      ],
+    },
+    resolve: {
+      alias: {
+        gatsby: noopPath,
+        previewSetup: path.resolve(__dirname, 'preview-setup'),
+        useSiteMetadata: noopPath,
+      },
+      extensions: ['*', '.js', '.css'],
+    },
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, 'preview'),
+    },
+    // Config for webpack-dev-server
+    devServer: {
+      contentBase: path.resolve(__dirname),
+    },
+    // fs won't work properly with default webpack configurations https://stackoverflow.com/a/51669301
+    // We're using the bundle file in a browser but fs is local to Node
+    node: {
+      fs: 'empty',
+    },
+    plugins: [
+      // TODO: Pass in an environment variable for process.env.GATSBY_SITE
+      new webpack.DefinePlugin({
+        'process.env.PREVIEW_PAGE': JSON.stringify(`${env.PREVIEW_PAGE}`),
+      }),
+    ],
+  };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = env => {
     resolve: {
       alias: {
         gatsby: noopPath,
-        previewSetup: path.resolve(__dirname, 'preview-setup'),
+        previewSetup: path.resolve(__dirname, 'preview', 'preview-setup'),
         useSiteMetadata: noopPath,
       },
       extensions: ['*', '.js', '.css'],


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-7109)
[Guides staging link](https://docs-mongodbcom-staging.corp.mongodb.com/guides/raymundrodriguez/DOCSP-7109/)

To prepare the snooty frontend to be used as a submodule for the snooty extension to create the bundle file, some of the original preview files had to be updated.

Things to note about this PR:
* `npm run preview` is no longer available as its own script.
* `page-ast.json` is a file generated by Snooty on VS Code. (Submodule will be added to snooty-vscode when [DOCSP-6886](https://jira.mongodb.org/browse/DOCSP-6886) is pushed)