### PR TITLE
DOCSP-7186: Update preview files to support all templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ coverage/
 .coverage
 .env.*
 tests/unit/data/site/__testDataLatest.json
+preview/page-ast.json
+preview/bundle.js

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -174,7 +174,7 @@ exports.createPages = ({ actions }) => {
     PAGES.forEach(page => {
       const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
       pageNodes.ast.children = populateIncludeNodes(getNestedValue(['ast', 'children'], pageNodes));
-      const template = getTemplate(page);
+      const template = getTemplate(page, process.env.GATSBY_SITE);
       const pageUrl = page === 'index' ? '/' : page;
       if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {
         createPage({

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,6 +6,7 @@ const { validateEnvVariables } = require('./src/utils/setup/validate-env-variabl
 const { getIncludeFile } = require('./src/utils/get-include-file');
 const { getNestedValue } = require('./src/utils/get-nested-value');
 const { findKeyValuePair } = require('./src/utils/find-key-value-pair');
+const { getTemplate } = require('./src/utils/get-template');
 
 // Atlas DB config
 const DB = 'snooty';
@@ -173,10 +174,7 @@ exports.createPages = ({ actions }) => {
     PAGES.forEach(page => {
       const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
       pageNodes.ast.children = populateIncludeNodes(getNestedValue(['ast', 'children'], pageNodes));
-      let template = 'document';
-      if (process.env.GATSBY_SITE === 'guides') {
-        template = page === 'index' ? 'guides-index' : 'guide';
-      }
+      const template = getTemplate(page);
       const pageUrl = page === 'index' ? '/' : page;
       if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {
         createPage({

--- a/package-lock.json
+++ b/package-lock.json
@@ -7343,25 +7343,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -7371,13 +7371,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
@@ -7387,31 +7387,31 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
@@ -7426,25 +7426,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -7453,13 +7453,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -7475,7 +7475,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
@@ -7489,13 +7489,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -7504,7 +7504,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -7513,7 +7513,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -7523,19 +7523,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
@@ -7544,13 +7544,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
@@ -7559,13 +7559,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "optional": true,
           "requires": {
@@ -7575,7 +7575,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
@@ -7584,7 +7584,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "optional": true,
           "requires": {
@@ -7628,7 +7628,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -7654,7 +7654,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -7666,19 +7666,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
@@ -7687,19 +7687,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -7709,19 +7709,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -7733,7 +7733,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -7741,7 +7741,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -7756,7 +7756,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
@@ -7765,19 +7765,19 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
@@ -7789,19 +7789,19 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
@@ -7812,7 +7812,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -7821,7 +7821,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -7830,13 +7830,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
@@ -7851,13 +7851,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -7866,13 +7866,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "optional": true
         }

--- a/preview-start.js
+++ b/preview-start.js
@@ -38,7 +38,6 @@ class Preview extends React.Component {
     return (
       <React.Fragment>
         <Helmet>
-          {/* See TODO in webpack.config.js */}
           {process.env.GATSBY_SITE === 'guides' ? (
             <link rel="stylesheet" href="./static/docs-tools/guides.css" type="text/css" />
           ) : (

--- a/preview/preview-setup.js
+++ b/preview/preview-setup.js
@@ -3,13 +3,20 @@ const pageAST = require('./page-ast.json'); // File created by Snooty extension 
 
 // Returns bare minimum data needed by a single page
 export const getPageData = async () => {
+  const fileId = process.env.PREVIEW_PAGE;
   const pageNodes = {
     ast: pageAST,
   };
 
+  // Pick which template to use
+  let template = 'document';
+  if (process.env.GATSBY_SITE === 'guides') {
+    template = fileId === 'index' ? 'guides-index' : 'guide';
+  }
+
   return {
     path: '',
-    template: 'guide',
+    template,
     context: {
       snootyStitchId: '',
       __refDocMapping: pageNodes,

--- a/preview/preview-setup.js
+++ b/preview/preview-setup.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 const pageAST = require('./page-ast.json'); // File created by Snooty extension on VS Code
+const { getTemplate } = require('../src/utils/get-template');
 
 // Returns bare minimum data needed by a single page
 export const getPageData = async () => {
@@ -7,12 +8,7 @@ export const getPageData = async () => {
   const pageNodes = {
     ast: pageAST,
   };
-
-  // Pick which template to use
-  let template = 'document';
-  if (process.env.GATSBY_SITE === 'guides') {
-    template = fileId === 'index' ? 'guides-index' : 'guide';
-  }
+  const template = getTemplate(fileId);
 
   return {
     path: '',

--- a/preview/preview-setup.js
+++ b/preview/preview-setup.js
@@ -8,7 +8,7 @@ export const getPageData = async () => {
   const pageNodes = {
     ast: pageAST,
   };
-  const template = getTemplate(fileId);
+  const template = getTemplate(fileId, process.env.GATSBY_SITE);
 
   return {
     path: '',

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -1,0 +1,10 @@
+// Returns the name of the template to be used based on the site and page name.
+const getTemplate = page => {
+  let template = 'document';
+  if (process.env.GATSBY_SITE === 'guides') {
+    template = page === 'index' ? 'guides-index' : 'guide';
+  }
+  return template;
+};
+
+module.exports.getTemplate = getTemplate;

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -1,7 +1,7 @@
 // Returns the name of the template to be used based on the site and page name.
-const getTemplate = page => {
+const getTemplate = (page, site) => {
   let template = 'document';
-  if (process.env.GATSBY_SITE === 'guides') {
+  if (site === 'guides') {
     template = page === 'index' ? 'guides-index' : 'guide';
   }
   return template;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,6 @@ module.exports = env => {
       fs: 'empty',
     },
     plugins: [
-      // TODO: Pass in an environment variable for process.env.GATSBY_SITE
       new webpack.DefinePlugin({
         'process.env.PREVIEW_PAGE': JSON.stringify(`${env.PREVIEW_PAGE}`),
         'process.env.GATSBY_SITE': JSON.stringify(`${env.PROJECT_NAME}`),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = env => {
       // TODO: Pass in an environment variable for process.env.GATSBY_SITE
       new webpack.DefinePlugin({
         'process.env.PREVIEW_PAGE': JSON.stringify(`${env.PREVIEW_PAGE}`),
+        'process.env.GATSBY_SITE': JSON.stringify(`${env.PROJECT_NAME}`),
       }),
     ],
   };


### PR DESCRIPTION
[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-7186)
[Compass Staging](https://docs-mongodborg-staging.corp.mongodb.com/compass/raymundrodriguez/DOCSP-7186/)

This PR introduces changes to the preview files on the frontend. These changes will allow the VS Code extension to preview pages that use templates other than just `Guide`.

`process.env.GATSBY_SITE` is reimplemented into the webpack config but instead of obtaining it from `.env.development`, it is passed as a variable from within the Snooty extension.

Note: Since the VS Code extension requires these frontend changes to present in the submodule, this PR needs to be pushed before changes to the extension are pushed. (Extension's branch can be found [here](https://github.com/mongodb/snooty-vscode/tree/DOCSP-7186))