### PR TITLE
UP-2657 (Add Gatsby Link)

### DIFF
--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -1,3 +1,5 @@
+const React = require('react');
+
 const gatsby = jest.requireActual('gatsby');
 
 module.exports = {
@@ -6,4 +8,13 @@ module.exports = {
   StaticQuery: jest.fn(),
   withPrefix: jest.fn().mockImplementation(str => str),
   useStaticQuery: jest.fn(),
+  // https://www.gatsbyjs.org/docs/unit-testing/
+  Link: jest.fn().mockImplementation(
+    // these props are invalid for an `a` tag
+    ({ activeClassName, activeStyle, getProps, innerRef, partiallyActive, ref, replace, to, ...rest }) =>
+      React.createElement('a', {
+        ...rest,
+        href: to,
+      })
+  ),
 };

--- a/src/components/TOCNode.js
+++ b/src/components/TOCNode.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import { formatTocTitleStyle } from '../utils/format-toc-title-style';
 import { isActiveTocNode } from '../utils/is-active-toc-node';
@@ -26,6 +27,13 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
 
   const NodeLink = () => {
     const formattedTitle = formatTocTitleStyle(title, options.styles);
+    const Tag = isExternalLink ? 'a' : Link;
+    const tagProps = {};
+    if (isExternalLink) {
+      tagProps.href = target;
+    } else {
+      tagProps.to = target;
+    }
     if (level === BASE_NODE_LEVEL) {
       const isDrawer = !!(options && options.drawer);
       if (isDrawer) {
@@ -49,18 +57,18 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
         );
       }
       return (
-        <a href={target} aria-expanded={hasChildren ? isActive : undefined} className={anchorTagClassNames}>
+        <Tag {...tagProps} aria-expanded={hasChildren ? isActive : undefined} className={anchorTagClassNames}>
           {formattedTitle}
-        </a>
+        </Tag>
       );
     }
 
     // In this case, we have a node which should be rendered with the 'expand-icon'
     return (
-      <a href={target} className={anchorTagClassNames} aria-expanded={hasChildren ? isActive : undefined}>
+      <Tag {...tagProps} className={anchorTagClassNames} aria-expanded={hasChildren ? isActive : undefined}>
         <span className={hasChildren ? 'expand-icon docs-expand-arrow' : 'expand-icon'} />
         {formattedTitle}
-      </a>
+      </Tag>
     );
   };
   return (

--- a/src/components/TOCNode.js
+++ b/src/components/TOCNode.js
@@ -57,7 +57,12 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
         );
       }
       return (
-        <Tag {...tagProps} aria-expanded={hasChildren ? isActive : undefined} className={anchorTagClassNames}>
+        <Tag
+          {...tagProps}
+          aria-expanded={hasChildren ? isActive : undefined}
+          className={anchorTagClassNames}
+          onClick={() => toggleDrawer(slug)}
+        >
           {formattedTitle}
         </Tag>
       );

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import TOCNode from './TOCNode';
 import { TOCContext } from './toc-context';
@@ -15,6 +16,14 @@ const TableOfContents = ({ toctreeData }) => {
   }
   const { title, slug, url, children } = toctreeData;
   const target = url || slug;
+  const isExternalLink = !!url;
+  const LinkComponent = isExternalLink ? 'a' : Link;
+  const linkProps = {};
+  if (isExternalLink) {
+    linkProps.href = target;
+  } else {
+    linkProps.to = target;
+  }
   const [activeSection, setActiveSection] = useState(currentPage);
   const toggleDrawer = newSlug => {
     if (activeSection === newSlug) {
@@ -27,7 +36,7 @@ const TableOfContents = ({ toctreeData }) => {
   return (
     <TOCContext.Provider value={{ activeSection, toggleDrawer }}>
       <h3>
-        <a href={target}>{title}</a>
+        <LinkComponent {...linkProps}>{title}</LinkComponent>
       </h3>
       <ul className="current">
         {children.map(c => (

--- a/tests/unit/TableOfContents.test.js
+++ b/tests/unit/TableOfContents.test.js
@@ -57,12 +57,9 @@ describe('Table of Contents testing', () => {
     describe('TOC navigation should render and work as expected', () => {
       it('TOC slugs work as expected', () => {
         expect(window.location.pathname).toBe('/');
-        const testTOCLink = testComponent
-          .find('ul li.toctree-l1')
-          .first()
-          .find('.reference');
+        const testTOCLink = testComponent.find('ul li.toctree-l1 .reference').first();
         expect(testTOCLink.hasClass('internal')).toBe(true);
-        expect(testTOCLink.prop('href')).toBe('/drivers');
+        expect(testTOCLink.prop('to')).toBe('/drivers');
         expect(testComponent.find('.toctree-l2')).toHaveLength(0);
         updatePageLocation('Drivers', '/drivers');
         expect(window.location.pathname).toBe('/drivers');
@@ -77,6 +74,7 @@ describe('Table of Contents testing', () => {
           .first()
           .find('.reference');
         expect(biConnectorLink.hasClass('external')).toBe(true);
+        expect(biConnectorLink.prop('href')).toBe('https://docs.mongodb.com/bi-connector/current/');
       });
     });
 

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -10,11 +10,11 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
   }
 >
   <h3>
-    <a
-      href="/"
+    <mockConstructor
+      to="/"
     >
       MongoDB Ecosystem
-    </a>
+    </mockConstructor>
   </h3>
   <ul
     className="current"


### PR DESCRIPTION
_The base branch for this is the TOC component main branch_

This PR adds `Gatsby Link` to the TOC to improve performance for Nodes with a `slug`. Unit tests were also augmented to mock the `Link`.

If Gatsby is being removed, the logic for these components can remain the same, and instead of importing `Link` from `gatsby`, you can import `Link` from the new navigational framework (like `react-router`)