### PR TITLE
UP 2657 (Part 2) Toggling the TOC Sidebar

### DIFF
--- a/src/components/TOCSidebar.js
+++ b/src/components/TOCSidebar.js
@@ -1,14 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import TableOfContents from './TableOfContents';
+import { TOCContext } from './toc-context';
 
-const TOCSidebar = props => (
-  <aside className="sidebar" id="sidebar">
-    <div className="sphinxsidebar" id="sphinxsidebar">
-      <div id="sphinxsidebarwrapper" className="sphinxsidebarwrapper">
-        <TableOfContents {...props} />
+const TOCSidebar = props => {
+  const { toggleSidebar } = useContext(TOCContext);
+  return (
+    <aside className="sidebar" id="sidebar">
+      <div className="sphinxsidebar" id="sphinxsidebar">
+        <div id="sphinxsidebarwrapper" className="sphinxsidebarwrapper">
+          <a href="javascript:void(0)" className="closeNav" id="closeNav" onClick={toggleSidebar}>
+            Close ×
+          </a>
+          <TableOfContents {...props} />
+        </div>
       </div>
-    </div>
-  </aside>
-);
+    </aside>
+  );
+};
 
 export default TOCSidebar;

--- a/src/components/TOCSidebar.js
+++ b/src/components/TOCSidebar.js
@@ -8,7 +8,12 @@ const TOCSidebar = props => {
     <aside className="sidebar" id="sidebar">
       <div className="sphinxsidebar" id="sphinxsidebar">
         <div id="sphinxsidebarwrapper" className="sphinxsidebarwrapper">
-          <a href="javascript:void(0)" className="closeNav" id="closeNav" onClick={toggleSidebar}>
+          <a // eslint-disable-line jsx-a11y/anchor-is-valid, jsx-a11y/interactive-supports-focus, no-script-url
+            className="closeNav"
+            id="closeNav"
+            onClick={toggleSidebar}
+            role="button"
+          >
             Close ×
           </a>
           <TableOfContents {...props} />

--- a/src/components/toc-context.js
+++ b/src/components/toc-context.js
@@ -3,4 +3,5 @@ import React from 'react';
 export const TOCContext = React.createContext({
   activeSection: undefined,
   toggleDrawer: () => {},
+  toggleSidebar: () => {},
 });

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from '../components/ComponentFactory';
 import Footer from '../components/Footer';
 import TOCSidebar from '../components/TOCSidebar';
 import { getNestedValue } from '../utils/get-nested-value';
 import Navbar from '../components/Navbar';
+import { TOCContext } from '../components/toc-context';
 import TEST_DATA from '../../tests/unit/data/Table-Of-Contents.test.json';
 
 const Document = props => {
@@ -16,42 +17,51 @@ const Document = props => {
     substitutions,
   } = props;
   const pageNodes = getNestedValue(['ast', 'children'], __refDocMapping) || [];
-
+  const [sidebarVisible, setSidebarVisible] = useState(true);
+  const toggleSidebar = () => setSidebarVisible(!sidebarVisible);
   return (
     <React.Fragment>
       <Navbar />
-      <div className="content">
-        <div id="left-column">
-          <TOCSidebar toctreeData={TEST_DATA} />
-        </div>
-        <div id="main-column" className="main-column">
-          <span className="showNav" id="showNav">
-            Navigation
-          </span>
-          <div className="document">
-            <div className="documentwrapper">
-              <div className="bodywrapper">
-                <div className="body">
-                  <div className="bc" />
-                  {pageNodes.map((child, index) => (
-                    <ComponentFactory
-                      addPillstrip={addPillstrip}
-                      footnotes={footnotes}
-                      key={index}
-                      nodeData={child}
-                      refDocMapping={__refDocMapping}
-                      pageMetadata={pageMetadata}
-                      pillstrips={pillstrips}
-                      substitutions={substitutions}
-                    />
-                  ))}
-                  <Footer />
+      <TOCContext.Provider value={{ toggleSidebar }}>
+        <div className="content">
+          <div id="left-column" style={{ display: sidebarVisible ? 'flex' : 'none' }}>
+            <TOCSidebar toctreeData={TEST_DATA} />
+          </div>
+          <div id="main-column" className="main-column">
+            <span
+              className="showNav"
+              id="showNav"
+              style={{ display: sidebarVisible ? 'none' : 'flex' }}
+              onClick={toggleSidebar}
+              role="button"
+            >
+              Navigation
+            </span>
+            <div className="document">
+              <div className="documentwrapper">
+                <div className="bodywrapper">
+                  <div className="body">
+                    <div className="bc" />
+                    {pageNodes.map((child, index) => (
+                      <ComponentFactory
+                        addPillstrip={addPillstrip}
+                        footnotes={footnotes}
+                        key={index}
+                        nodeData={child}
+                        refDocMapping={__refDocMapping}
+                        pageMetadata={pageMetadata}
+                        pillstrips={pillstrips}
+                        substitutions={substitutions}
+                      />
+                    ))}
+                    <Footer />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </TOCContext.Provider>
     </React.Fragment>
   );
 };

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -19,21 +19,25 @@ const Document = props => {
   const pageNodes = getNestedValue(['ast', 'children'], __refDocMapping) || [];
   const [sidebarVisible, setSidebarVisible] = useState(true);
   const toggleSidebar = () => setSidebarVisible(!sidebarVisible);
+  const sidebarStyle = { display: sidebarVisible ? 'flex' : 'none' };
+  const collapsedSidebarButtonStyle = { display: sidebarVisible ? 'none' : 'flex' };
   return (
     <React.Fragment>
       <Navbar />
       <TOCContext.Provider value={{ toggleSidebar }}>
         <div className="content">
-          <div id="left-column" style={{ display: sidebarVisible ? 'flex' : 'none' }}>
+          <div id="left-column" style={sidebarStyle} aria-expanded={sidebarVisible}>
             <TOCSidebar toctreeData={TEST_DATA} />
           </div>
           <div id="main-column" className="main-column">
             <span
-              className="showNav"
               id="showNav"
-              style={{ display: sidebarVisible ? 'none' : 'flex' }}
+              className="showNav"
+              style={collapsedSidebarButtonStyle}
               onClick={toggleSidebar}
               role="button"
+              tabIndex="0"
+              aria-expanded={sidebarVisible}
             >
               Navigation
             </span>


### PR DESCRIPTION
This PR adds functionality to toggle the TOC sidebar open and closed just as it works at docs.mongodb.com.

_It seems as if some the content disappears under about 1150px. Going to look a bit into this._