### PR TITLE
DOCSP-6887: Image component can use vscode resources as a source

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "develop": "gatsby develop --prefix-paths",
     "lint": "./node_modules/.bin/eslint src/ tests/ preview/",
     "lintfix": "prettier-eslint --write \"src/**/*.js\" \"tests/**/*.js\" \"preview/**/*.js\"",
-    "preview": "webpack-dev-server --open --config ./webpack.config.js --env.PREVIEW_CLI='true'",
+    "preview": "webpack-dev-server --open --config ./webpack.config.js --env.PREVIEW_MODE='cli'",
     "serve": "gatsby serve --prefix-paths",
     "test": "jest",
     "test:regression": "jest regression",

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -7,7 +7,7 @@ import { getNestedValue } from '../utils/get-nested-value';
 const CAPTION_TEXT = 'click to enlarge';
 const isSvg = imgSrc => /\.svg$/.test(imgSrc);
 
-const Lightbox = ({ nodeData, base64Uri, ...rest }) => {
+const Lightbox = ({ nodeData, ...rest }) => {
   const [showModal, setShowModal] = useState(false);
   const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
   const modal = useRef(null);
@@ -72,11 +72,6 @@ Lightbox.propTypes = {
       alt: PropTypes.string,
     }).isRequired,
   }).isRequired,
-  base64Uri: PropTypes.string,
-};
-
-Lightbox.defaultProps = {
-  base64Uri: null,
 };
 
 export default Lightbox;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 // Obtain the process.env variables to pass into preview-start-cli.js
-const getCliVariables = (page) => {
+const getCliVariables = (previewMode, page) => {
   // eslint-disable-next-line global-require
   const dotenv = require('dotenv').config({
     path: `.env.development`,
@@ -12,24 +12,26 @@ const getCliVariables = (page) => {
     'process.env.GATSBY_SITE': JSON.stringify(dotenv.parsed.GATSBY_SITE),
     'process.env.GATSBY_PARSER_USER': JSON.stringify(dotenv.parsed.GATSBY_PARSER_USER),
     'process.env.GATSBY_PARSER_BRANCH': JSON.stringify(dotenv.parsed.GATSBY_PARSER_BRANCH),
-    'process.env.PREVIEW_PAGE': JSON.stringify(`${page}`),
-  };
-}
-
-// Obtain the process.env variables to pass into preview-start-vscode.js
-const getVsCodeVariables = (site, page) => {
-  return {
-    'process.env.GATSBY_SITE': JSON.stringify(site),
+    'process.env.PREVIEW_MODE': JSON.stringify(previewMode),
     'process.env.PREVIEW_PAGE': JSON.stringify(page),
   };
-}
+};
+
+// Obtain the process.env variables to pass into preview-start-vscode.js
+const getVsCodeVariables = (previewMode, site, page) => {
+  return {
+    'process.env.GATSBY_SITE': JSON.stringify(site),
+    'process.env.PREVIEW_MODE': JSON.stringify(previewMode),
+    'process.env.PREVIEW_PAGE': JSON.stringify(page),
+  };
+};
 
 module.exports = env => {
   const noopPath = path.resolve(__dirname, 'preview/noop.js');
-  const previewSetupPath = env.PREVIEW_CLI ? 'cli' : 'vscode';
-  const envVariables = env.PREVIEW_CLI
-    ? getCliVariables(env.PREVIEW_PAGE)
-    : getVsCodeVariables(env.PROJECT_NAME, env.PREVIEW_PAGE);
+  const envVariables =
+    env.PREVIEW_MODE === 'cli'
+      ? getCliVariables(env.PREVIEW_MODE, env.PREVIEW_PAGE)
+      : getVsCodeVariables(env.PREVIEW_MODE, env.PROJECT_NAME, env.PREVIEW_PAGE);
 
   return {
     mode: 'development',
@@ -60,7 +62,7 @@ module.exports = env => {
     resolve: {
       alias: {
         gatsby: noopPath,
-        previewSetup: path.resolve(__dirname, 'preview', `preview-setup-${previewSetupPath}.js`),
+        previewSetup: path.resolve(__dirname, 'preview', `preview-setup-${env.PREVIEW_MODE}.js`),
         useSiteMetadata: noopPath,
       },
       extensions: ['*', '.js', '.css'],


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-6887)
[Compass Staging](https://docs-mongodbcom-staging.corp.mongodb.com/compass/raymundrodriguez/DOCSP-6887/)

This PR introduces the use of full paths for images when running Snooty Preview on VS Code. Images still rely on base64 data pulled from Stitch when using Snooty Preview on CLI. Images still use `withPrefix()` on Gatsby.

This PR must be merged before the VS Code PR for [DOCSP-6887](https://github.com/mongodb/snooty-vscode/pull/8). Update the snooty-frontend submodule on VS Code after merging this.