### PR TITLE
DOCSP-7708: Render TOC on all sites

### DIFF
--- a/src/components/TOCNode.js
+++ b/src/components/TOCNode.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
 import { formatTocTitleStyle } from '../utils/format-toc-title-style';
 import { isActiveTocNode } from '../utils/is-active-toc-node';
 import { isSelectedTocNode } from '../utils/is-selected-toc-node';
@@ -26,13 +27,17 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
   const toctreeSectionClasses = `toctree-l${level} ${isActive ? 'current' : ''} ${isSelected ? 'selected-item' : ''}`;
 
   const NodeLink = () => {
-    const formattedTitle = formatTocTitleStyle(title, options.styles);
+    // If title is a plaintext string, render as-is. Otherwise, iterate over the text nodes to properly format titles.
+    const formattedTitle =
+      typeof title === 'string'
+        ? formatTocTitleStyle(title, options.styles)
+        : title.map((e, index) => <ComponentFactory key={index} nodeData={e} />);
     const Tag = isExternalLink ? 'a' : Link;
     const tagProps = {};
     if (isExternalLink) {
       tagProps.href = target;
     } else {
-      tagProps.to = target;
+      tagProps.to = `/${target}`;
     }
     if (level === BASE_NODE_LEVEL) {
       const isDrawer = !!(options && options.drawer);
@@ -99,7 +104,7 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
 TOCNode.propTypes = {
   level: PropTypes.number,
   node: PropTypes.shape({
-    title: PropTypes.string.isRequired,
+    title: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.string]).isRequired,
     slug: PropTypes.string,
     url: PropTypes.string,
     children: PropTypes.array.isRequired,

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -65,7 +65,7 @@ Document.propTypes = {
       }).isRequired,
     }).isRequired,
     pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
-    toctree: PropTypes.objectOf(PropTypes.object),
+    toctree: PropTypes.object,
   }).isRequired,
   pillstrips: PropTypes.objectOf(PropTypes.object),
   substitutions: PropTypes.objectOf(PropTypes.array),

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -4,12 +4,13 @@ import ComponentFactory from '../components/ComponentFactory';
 import Footer from '../components/Footer';
 import { getNestedValue } from '../utils/get-nested-value';
 import Navbar from '../components/Navbar';
+import TOCSidebar from '../components/TOCSidebar';
 
 const Document = props => {
   const {
     addPillstrip,
     footnotes,
-    pageContext: { pageMetadata, __refDocMapping },
+    pageContext: { pageMetadata, toctree, __refDocMapping },
     pillstrips,
     substitutions,
   } = props;
@@ -19,6 +20,9 @@ const Document = props => {
     <React.Fragment>
       <Navbar />
       <div className="content">
+        <div id="left-column">
+          <TOCSidebar toctreeData={toctree} />
+        </div>
         <div id="main-column" className="main-column">
           <span className="showNav" id="showNav">
             Navigation
@@ -61,6 +65,7 @@ Document.propTypes = {
       }).isRequired,
     }).isRequired,
     pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
+    toctree: PropTypes.objectOf(PropTypes.object),
   }).isRequired,
   pillstrips: PropTypes.objectOf(PropTypes.object),
   substitutions: PropTypes.objectOf(PropTypes.array),

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -27,64 +27,64 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "children": Array [
             Object {
               "children": Array [],
-              "slug": "/drivers/c",
+              "slug": "drivers/c",
               "title": "C Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/cxx",
+              "slug": "drivers/cxx",
               "title": "C++ Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/csharp",
+              "slug": "drivers/csharp",
               "title": "C# and .NET Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/go",
+              "slug": "drivers/go",
               "title": "Go Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/java",
+              "slug": "drivers/java",
               "title": "Java Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/node",
+              "slug": "drivers/node",
               "title": "Node.js Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/perl",
+              "slug": "drivers/perl",
               "title": "Perl Driver",
             },
             Object {
               "children": Array [
                 Object {
                   "children": Array [],
-                  "slug": "/drivers/php-libraries",
+                  "slug": "drivers/php-libraries",
                   "title": "PHP Libraries, Frameworks, and Tools",
                 },
               ],
-              "slug": "/drivers/php",
+              "slug": "drivers/php",
               "title": "PHP Driver",
             },
             Object {
               "children": Array [
                 Object {
                   "children": Array [],
-                  "slug": "/drivers/pymongo",
+                  "slug": "drivers/pymongo",
                   "title": "PyMongo",
                 },
                 Object {
                   "children": Array [],
-                  "slug": "/drivers/motor",
+                  "slug": "drivers/motor",
                   "title": "Motor (Async Driver)",
                 },
               ],
-              "slug": "/drivers/python",
+              "slug": "drivers/python",
               "title": "Python Drivers",
             },
             Object {
@@ -99,26 +99,26 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/scala",
+              "slug": "drivers/scala",
               "title": "Scala Driver",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/community-supported-drivers",
+              "slug": "drivers/community-supported-drivers",
               "title": "Community Supported Drivers Reference",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/specs",
+              "slug": "drivers/specs",
               "title": "MongoDB Drivers Specs",
             },
             Object {
               "children": Array [],
-              "slug": "/drivers/driver-compatibility-reference",
+              "slug": "drivers/driver-compatibility-reference",
               "title": "Driver Compatibility",
             },
           ],
-          "slug": "/drivers",
+          "slug": "drivers",
           "title": "MongoDB Drivers and ODM",
         }
       }
@@ -141,11 +141,11 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
             },
             Object {
               "children": Array [],
-              "slug": "/tools/http-interfaces",
+              "slug": "tools/http-interfaces",
               "title": "HTTP Interface",
             },
           ],
-          "slug": "/tools",
+          "slug": "tools",
           "title": "MongoDB Integration and Tools",
         }
       }
@@ -158,22 +158,22 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "children": Array [
             Object {
               "children": Array [],
-              "slug": "/platforms/amazon-ec2",
+              "slug": "platforms/amazon-ec2",
               "title": "Amazon EC2",
             },
             Object {
               "children": Array [],
-              "slug": "/tutorial/backup-and-restore-mongodb-on-amazon-ec2",
+              "slug": "tutorial/backup-and-restore-mongodb-on-amazon-ec2",
               "title": "EC2 Backup and Restore",
             },
             Object {
               "children": Array [],
-              "slug": "/platforms/windows-azure",
+              "slug": "platforms/windows-azure",
               "title": "Microsoft Azure",
             },
             Object {
               "children": Array [],
-              "slug": "/platforms/windows",
+              "slug": "platforms/windows",
               "title": "Windows Quick Links and Reference Center",
             },
           ],
@@ -183,7 +183,7 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
               "code": "Platforms",
             },
           },
-          "slug": "/platforms",
+          "slug": "platforms",
           "title": "Platforms",
         }
       }
@@ -196,37 +196,37 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "children": Array [
             Object {
               "children": Array [],
-              "slug": "/use-cases/storing-log-data",
+              "slug": "use-cases/storing-log-data",
               "title": "Storing Log Data",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/hierarchical-aggregation",
+              "slug": "use-cases/hierarchical-aggregation",
               "title": "Hierarchical Aggregation",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/product-catalog",
+              "slug": "use-cases/product-catalog",
               "title": "Product Catalog",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/inventory-management",
+              "slug": "use-cases/inventory-management",
               "title": "Inventory Management",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/category-hierarchy",
+              "slug": "use-cases/category-hierarchy",
               "title": "Category Hierarchy",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/metadata-and-asset-management",
+              "slug": "use-cases/metadata-and-asset-management",
               "title": "Metadata and Asset Management",
             },
             Object {
               "children": Array [],
-              "slug": "/use-cases/storing-comments",
+              "slug": "use-cases/storing-comments",
               "title": "Storing Comments",
             },
           ],
@@ -236,7 +236,7 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
               "strong": "Use Cases",
             },
           },
-          "slug": "/use-cases",
+          "slug": "use-cases",
           "title": "Use Cases",
         }
       }

--- a/tests/unit/data/Table-Of-Contents.test.json
+++ b/tests/unit/data/Table-Of-Contents.test.json
@@ -4,66 +4,66 @@
   "children": [
     {
       "title": "MongoDB Drivers and ODM",
-      "slug": "/drivers",
+      "slug": "drivers",
       "children": [
         {
           "title": "C Driver",
-          "slug": "/drivers/c",
+          "slug": "drivers/c",
           "children": []
         },
         {
           "title": "C++ Driver",
-          "slug": "/drivers/cxx",
+          "slug": "drivers/cxx",
           "children": []
         },
         {
           "title": "C# and .NET Driver",
-          "slug": "/drivers/csharp",
+          "slug": "drivers/csharp",
           "children": []
         },
         {
           "title": "Go Driver",
-          "slug": "/drivers/go",
+          "slug": "drivers/go",
           "children": []
         },
         {
           "title": "Java Driver",
-          "slug": "/drivers/java",
+          "slug": "drivers/java",
           "children": []
         },
         {
           "title": "Node.js Driver",
-          "slug": "/drivers/node",
+          "slug": "drivers/node",
           "children": []
         },
         {
           "title": "Perl Driver",
-          "slug": "/drivers/perl",
+          "slug": "drivers/perl",
           "children": []
         },
         {
           "title": "PHP Driver",
-          "slug": "/drivers/php",
+          "slug": "drivers/php",
           "children": [
             {
               "title": "PHP Libraries, Frameworks, and Tools",
-              "slug": "/drivers/php-libraries",
+              "slug": "drivers/php-libraries",
               "children": []
             }
           ]
         },
         {
           "title": "Python Drivers",
-          "slug": "/drivers/python",
+          "slug": "drivers/python",
           "children": [
             {
               "title": "PyMongo",
-              "slug": "/drivers/pymongo",
+              "slug": "drivers/pymongo",
               "children": []
             },
             {
               "title": "Motor (Async Driver)",
-              "slug": "/drivers/motor",
+              "slug": "drivers/motor",
               "children": []
             }
           ]
@@ -80,29 +80,29 @@
         },
         {
           "title": "Scala Driver",
-          "slug": "/drivers/scala",
+          "slug": "drivers/scala",
           "children": []
         },
         {
           "title": "Community Supported Drivers Reference",
-          "slug": "/drivers/community-supported-drivers",
+          "slug": "drivers/community-supported-drivers",
           "children": []
         },
         {
           "title": "MongoDB Drivers Specs",
-          "slug": "/drivers/specs",
+          "slug": "drivers/specs",
           "children": []
         },
         {
           "title": "Driver Compatibility",
-          "slug": "/drivers/driver-compatibility-reference",
+          "slug": "drivers/driver-compatibility-reference",
           "children": []
         }
       ]
     },
     {
       "title": "MongoDB Integration and Tools",
-      "slug": "/tools",
+      "slug": "tools",
       "children": [
         {
           "title": "MongoDB Connector for Business Intelligence",
@@ -116,14 +116,14 @@
         },
         {
           "title": "HTTP Interface",
-          "slug": "/tools/http-interfaces",
+          "slug": "tools/http-interfaces",
           "children": []
         }
       ]
     },
     {
       "title": "Platforms",
-      "slug": "/platforms",
+      "slug": "platforms",
       "options": {
         "drawer": true,
         "styles": {
@@ -133,29 +133,29 @@
       "children": [
         {
           "title": "Amazon EC2",
-          "slug": "/platforms/amazon-ec2",
+          "slug": "platforms/amazon-ec2",
           "children": []
         },
         {
           "title": "EC2 Backup and Restore",
-          "slug": "/tutorial/backup-and-restore-mongodb-on-amazon-ec2",
+          "slug": "tutorial/backup-and-restore-mongodb-on-amazon-ec2",
           "children": []
         },
         {
           "title": "Microsoft Azure",
-          "slug": "/platforms/windows-azure",
+          "slug": "platforms/windows-azure",
           "children": []
         },
         {
           "title": "Windows Quick Links and Reference Center",
-          "slug": "/platforms/windows",
+          "slug": "platforms/windows",
           "children": []
         }
       ]
     },
     {
       "title": "Use Cases",
-      "slug": "/use-cases",
+      "slug": "use-cases",
       "options": {
         "drawer": true,
         "styles": {
@@ -165,37 +165,37 @@
       "children": [
         {
           "title": "Storing Log Data",
-          "slug": "/use-cases/storing-log-data",
+          "slug": "use-cases/storing-log-data",
           "children": []
         },
         {
           "title": "Hierarchical Aggregation",
-          "slug": "/use-cases/hierarchical-aggregation",
+          "slug": "use-cases/hierarchical-aggregation",
           "children": []
         },
         {
           "title": "Product Catalog",
-          "slug": "/use-cases/product-catalog",
+          "slug": "use-cases/product-catalog",
           "children": []
         },
         {
           "title": "Inventory Management",
-          "slug": "/use-cases/inventory-management",
+          "slug": "use-cases/inventory-management",
           "children": []
         },
         {
           "title": "Category Hierarchy",
-          "slug": "/use-cases/category-hierarchy",
+          "slug": "use-cases/category-hierarchy",
           "children": []
         },
         {
           "title": "Metadata and Asset Management",
-          "slug": "/use-cases/metadata-and-asset-management",
+          "slug": "use-cases/metadata-and-asset-management",
           "children": []
         },
         {
           "title": "Storing Comments",
-          "slug": "/use-cases/storing-comments",
+          "slug": "use-cases/storing-comments",
           "children": []
         }
       ]


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-7708)] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/manual/sophstad/DOCSP-7708/)]
- Snooty fetches toctree from Atlas in order to render TOC sidebar on all sites
- Update data JSON to match parser output

Known limitations:
- Formatted text doesn't render correctly in TOC sidebar