### PR TITLE
Bugfix: Only render .txt files as pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -134,6 +134,7 @@ exports.sourceNodes = async () => {
   const assets = [];
   Object.entries(RESOLVED_REF_DOC_MAPPING).forEach(([key, val]) => {
     const pageNode = getNestedValue(['ast', 'children'], val);
+    const filename = getNestedValue(['filename'], val) || '';
     if (pageNode) {
       assets.push(...val.static_assets);
     }
@@ -141,7 +142,7 @@ exports.sourceNodes = async () => {
       INCLUDE_FILES[key] = val;
     } else if (key.includes('images/')) {
       IMAGE_FILES[key] = val;
-    } else if (!key.includes('curl') && !key.includes('https://')) {
+    } else if (filename.endsWith('.txt')) {
       PAGES.push(key);
       PAGE_METADATA[key] = getPageMetadata(val);
     }

--- a/src/utils/format-text.js
+++ b/src/utils/format-text.js
@@ -4,5 +4,7 @@ import ComponentFactory from '../components/ComponentFactory';
 /*
  * Given either a string or an array of Snooty text nodes, return the appropriate text output.
  */
-export const formatText = text =>
-  typeof text === 'string' ? text : text.map((e, index) => <ComponentFactory key={index} nodeData={e} />);
+export const formatText = text => {
+  if (!text) return '';
+  return typeof text === 'string' ? text : text.map((e, index) => <ComponentFactory key={index} nodeData={e} />);
+};


### PR DESCRIPTION
Only files with the extension `.txt` should be rendered as pages. Fix this oversight.

Additionally, improve safety of a string modification utility function.