### PR TITLE
DOCSP-7939: Populate includes in parser

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -137,11 +137,7 @@ exports.sourceNodes = async () => {
 
 exports.createPages = async ({ actions }) => {
   const { createPage } = actions;
-  const { parentPaths, slugToTitle, toctree, toctreeOrder } = await stitchClient.callFunction('fetchDocument', [
-    DB,
-    METADATA_COLLECTION,
-    { _id: ID_PREFIX },
-  ]);
+  const metadata = await stitchClient.callFunction('fetchDocument', [DB, METADATA_COLLECTION, { _id: ID_PREFIX }]);
 
   return new Promise((resolve, reject) => {
     PAGES.forEach(page => {
@@ -154,14 +150,11 @@ exports.createPages = async ({ actions }) => {
           path: slug,
           component: path.resolve(`./src/templates/${template}.js`),
           context: {
+            metadata,
             slug,
-            toctree,
-            toctreeOrder,
             snootyStitchId: SNOOTY_STITCH_ID,
             __refDocMapping: pageNodes,
             guidesMetadata: GUIDES_METADATA,
-            parentPaths: getNestedValue([page], parentPaths),
-            slugTitleMapping: slugToTitle,
           },
         });
       }

--- a/preview/preview-setup-cli.js
+++ b/preview/preview-setup-cli.js
@@ -4,7 +4,7 @@ const { validateEnvVariables } = require('../src/utils/setup/validate-env-variab
 const { getIncludeFile } = require('./get-include-file');
 const { getNestedValue } = require('../src/utils/get-nested-value');
 const { getTemplate } = require('../src/utils/get-template');
-const { getPageMetadata } = require('../src/utils/get-page-metadata');
+const { getGuideMetadata } = require('../src/utils/get-guide-metadata');
 const { getPageSlug } = require('../src/utils/get-page-slug');
 
 // Atlas DB config
@@ -16,7 +16,7 @@ const SNOOTY_STITCH_ID = 'snooty-koueq';
 // different types of references
 const PAGES = [];
 const INCLUDE_FILES = {};
-const PAGE_METADATA = {};
+const GUIDES_METADATA = {};
 
 // in-memory object with key/value = filename/document
 const RESOLVED_REF_DOC_MAPPING = {};
@@ -83,7 +83,7 @@ const sourceNodes = async () => {
       INCLUDE_FILES[key] = val;
     } else if (!key.includes('curl') && !key.includes('https://')) {
       PAGES.push(key);
-      PAGE_METADATA[key] = getPageMetadata(val);
+      GUIDES_METADATA[key] = getGuideMetadata(val);
     }
   });
 };
@@ -106,7 +106,7 @@ export const getPageData = async () => {
       context: {
         snootyStitchId: SNOOTY_STITCH_ID,
         __refDocMapping: pageNodes,
-        pageMetadata: PAGE_METADATA,
+        guidesMetadata: GUIDES_METADATA,
       },
     };
   }

--- a/preview/preview-setup-vscode.js
+++ b/preview/preview-setup-vscode.js
@@ -16,7 +16,7 @@ export const getPageData = async () => {
     context: {
       snootyStitchId: '',
       __refDocMapping: pageNodes,
-      pageMetadata: {},
+      guidesMetadata: {},
     },
   };
 };

--- a/src/components/LandingPage/Card.js
+++ b/src/components/LandingPage/Card.js
@@ -5,11 +5,11 @@ import { getNestedValue } from '../../utils/get-nested-value';
 
 const DEFAULT_COMPLETION_TIME = 15;
 
-const Card = ({ card, pageMetadata }) => {
-  const getCardTitle = cardSlug => getNestedValue([cardSlug, 'title'], pageMetadata);
+const Card = ({ card, guidesMetadata }) => {
+  const getCardTitle = cardSlug => getNestedValue([cardSlug, 'title'], guidesMetadata);
   const getCompletionTime = cardSlug =>
-    getNestedValue([cardSlug, 'completionTime'], pageMetadata) || DEFAULT_COMPLETION_TIME;
-  const getPills = cardSlug => getNestedValue([cardSlug, 'languages'], pageMetadata);
+    getNestedValue([cardSlug, 'completionTime'], guidesMetadata) || DEFAULT_COMPLETION_TIME;
+  const getPills = cardSlug => getNestedValue([cardSlug, 'languages'], guidesMetadata);
 
   const cardContent = () => {
     const cardSlug = getNestedValue(['argument', 0, 'value'], card);

--- a/src/components/LandingPage/LandingPageCards.js
+++ b/src/components/LandingPage/LandingPageCards.js
@@ -18,7 +18,7 @@ const CATEGORIES = [
   },
 ];
 
-const Category = ({ cards, category, pageMetadata }) => {
+const Category = ({ cards, category, guidesMetadata }) => {
   const columnSeparatedCards = [[], [], []];
   const lastRow = [];
 
@@ -58,7 +58,7 @@ const Category = ({ cards, category, pageMetadata }) => {
             return (
               <div className="guide-column" key={indexColumn}>
                 {cardColumn.map((card, index) => {
-                  return <Card card={card} key={index} pageMetadata={pageMetadata} />;
+                  return <Card card={card} key={index} guidesMetadata={guidesMetadata} />;
                 })}
               </div>
             );
@@ -69,7 +69,7 @@ const Category = ({ cards, category, pageMetadata }) => {
   );
 };
 
-const LandingPageCards = ({ guides, pageMetadata }) => {
+const LandingPageCards = ({ guides, guidesMetadata }) => {
   return CATEGORIES.map(category => (
     <Category
       cards={guides.filter(card => {
@@ -77,10 +77,10 @@ const LandingPageCards = ({ guides, pageMetadata }) => {
           card.name === 'card'
             ? getNestedValue(['argument', 0, 'value'], card)
             : getNestedValue(['children', 0, 'children', 0, 'children', 0, 'children', 0, 'value'], card);
-        return category.name === getNestedValue([cardSlug, 'category'], pageMetadata);
+        return category.name === getNestedValue([cardSlug, 'category'], guidesMetadata);
       })}
       category={category}
-      pageMetadata={pageMetadata}
+      guidesMetadata={guidesMetadata}
       key={category.iconSlug}
     />
   ));

--- a/src/components/Roles/Doc.js
+++ b/src/components/Roles/Doc.js
@@ -3,18 +3,8 @@ import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import { getNestedValue } from '../../utils/get-nested-value';
 
-const RoleDoc = ({ nodeData: { label, target }, pageMetadata }) => {
-  const getLinkText = labelText => {
-    const slug = labelText.startsWith('/') ? labelText.substr(1) : labelText;
-    let text = getNestedValue([slug, 'title'], pageMetadata);
-    if (!text) {
-      text = slug;
-      console.warn(`Role title for ${slug} could not be found.`);
-    }
-    return text;
-  };
-
-  const labelDisplay = label && label.value ? label.value : getLinkText(target);
+const RoleDoc = ({ nodeData: { label, target } }) => {
+  const labelDisplay = getNestedValue(['value'], label);
   return (
     // TODO: Replace <a> with <Link> when back button behavior is fixed for the component
     // GitHub issue: https://github.com/gatsbyjs/gatsby/issues/8357
@@ -31,7 +21,6 @@ RoleDoc.propTypes = {
     }),
     target: PropTypes.string.isRequired,
   }).isRequired,
-  pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
 };
 
 export default RoleDoc;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -13,7 +13,7 @@ const Document = props => {
   const {
     addPillstrip,
     footnotes,
-    pageContext: { pageMetadata, parentPaths, slug, slugTitleMapping, toctree, toctreeOrder, __refDocMapping },
+    pageContext: { guidesMetadata, parentPaths, slug, slugTitleMapping, toctree, toctreeOrder, __refDocMapping },
     pillstrips,
     substitutions,
   } = props;
@@ -44,7 +44,7 @@ const Document = props => {
                       key={index}
                       nodeData={child}
                       refDocMapping={__refDocMapping}
-                      pageMetadata={pageMetadata}
+                      guidesMetadata={guidesMetadata}
                       pillstrips={pillstrips}
                       substitutions={substitutions}
                     />
@@ -73,7 +73,7 @@ Document.propTypes = {
         children: PropTypes.array,
       }).isRequired,
     }).isRequired,
-    pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
+    guidesMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
     parentPaths: PropTypes.arrayOf(PropTypes.string),
     slug: PropTypes.string.isRequired,
     slugTitleMapping: PropTypes.shape({

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -13,7 +13,12 @@ const Document = props => {
   const {
     addPillstrip,
     footnotes,
-    pageContext: { guidesMetadata, parentPaths, slug, slugTitleMapping, toctree, toctreeOrder, __refDocMapping },
+    pageContext: {
+      guidesMetadata,
+      slug,
+      __refDocMapping,
+      metadata: { parentPaths, slugToTitle: slugTitleMapping, toctree, toctreeOrder },
+    },
     pillstrips,
     substitutions,
   } = props;
@@ -36,7 +41,7 @@ const Document = props => {
             <div className="documentwrapper">
               <div className="bodywrapper">
                 <div className="body">
-                  <Breadcrumbs parentPaths={parentPaths} slugTitleMapping={slugTitleMapping} />
+                  <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
                   {pageNodes.map((child, index) => (
                     <ComponentFactory
                       addPillstrip={addPillstrip}

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -120,11 +120,7 @@ export default class Guide extends Component {
     if (this.bodySections.length === 0) {
       return this.sections.map(section => {
         return (
-          <ComponentFactory
-            nodeData={section}
-            refDocMapping={getNestedValue(['__refDocMapping'], pageContext) || {}}
-            pageMetadata={pageContext.pageMetadata}
-          />
+          <ComponentFactory nodeData={section} refDocMapping={getNestedValue(['__refDocMapping'], pageContext) || {}} />
         );
       });
     }
@@ -139,7 +135,6 @@ export default class Guide extends Component {
           headingRef={this.sectionRefs[index]}
           refDocMapping={getNestedValue(['__refDocMapping'], pageContext) || {}}
           addTabset={this.addGuidesTabset}
-          pageMetadata={pageContext.pageMetadata}
           pillstrips={pillstrips}
         />
       );
@@ -169,7 +164,6 @@ export default class Guide extends Component {
                 cloud={cloud}
                 description={findKeyValuePair(this.sections, 'name', 'result_description')}
                 drivers={drivers}
-                pageMetadata={pageContext.pageMetadata}
                 refDocMapping={getNestedValue(['__refDocMapping'], pageContext) || {}}
                 time={findKeyValuePair(this.sections, 'name', 'time')}
                 title={findKeyValuePair(this.sections, 'type', 'heading')}
@@ -194,7 +188,6 @@ Guide.propTypes = {
       }).isRequired,
     }).isRequired,
     snootyStitchId: PropTypes.string.isRequired,
-    pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
   }).isRequired,
   path: PropTypes.string.isRequired,
   pillstrips: PropTypes.objectOf(PropTypes.object),

--- a/src/templates/guides-index.js
+++ b/src/templates/guides-index.js
@@ -5,7 +5,7 @@ import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { getNestedValue } from '../utils/get-nested-value';
 import Navbar from '../components/Navbar';
 
-const Index = ({ pageContext: { pageMetadata, __refDocMapping } }) => {
+const Index = ({ pageContext: { guidesMetadata, __refDocMapping } }) => {
   const guides = findKeyValuePair(getNestedValue(['ast', 'children'], __refDocMapping), 'name', 'guide-index') || [];
 
   return (
@@ -20,7 +20,7 @@ const Index = ({ pageContext: { pageMetadata, __refDocMapping } }) => {
                 ¶
               </a>
             </h1>
-            <LandingPageCards guides={guides.children} pageMetadata={pageMetadata} />
+            <LandingPageCards guides={guides.children} guidesMetadata={guidesMetadata} />
           </div>
         </div>
       </div>
@@ -30,7 +30,7 @@ const Index = ({ pageContext: { pageMetadata, __refDocMapping } }) => {
 
 Index.propTypes = {
   pageContext: PropTypes.shape({
-    pageMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
+    guidesMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
     __refDocMapping: PropTypes.shape({
       ast: PropTypes.shape({
         children: PropTypes.array,

--- a/src/utils/get-guide-metadata.js
+++ b/src/utils/get-guide-metadata.js
@@ -2,7 +2,7 @@ const { getNestedValue } = require('./get-nested-value');
 const { findKeyValuePair } = require('./find-key-value-pair');
 
 // Get various metadata for a given page
-const getPageMetadata = pageNode => {
+const getGuideMetadata = pageNode => {
   const children = getNestedValue(['ast', 'children'], pageNode);
   return {
     title: getNestedValue([0, 'children', 0, 'children', 0, 'value'], children),
@@ -12,4 +12,4 @@ const getPageMetadata = pageNode => {
   };
 };
 
-module.exports.getPageMetadata = getPageMetadata;
+module.exports.getGuideMetadata = getGuideMetadata;

--- a/tests/unit/Card.test.js
+++ b/tests/unit/Card.test.js
@@ -4,11 +4,11 @@ import Card from '../../src/components/LandingPage/Card';
 
 import cardData from './data/Card.test.json';
 import multiCardData from './data/MultiCard.test.json';
-import mockPageMetadata from './data/guidesPageMetadata.json';
+import mockGuidesMetadata from './data/guidesPageMetadata.json';
 
-const mountCard = ({ card }) => mount(<Card card={card} pageMetadata={mockPageMetadata} />);
+const mountCard = ({ card }) => mount(<Card card={card} guidesMetadata={mockGuidesMetadata} />);
 
-const shallowCard = ({ card }) => shallow(<Card card={card} pageMetadata={mockPageMetadata} />);
+const shallowCard = ({ card }) => shallow(<Card card={card} guidesMetadata={mockGuidesMetadata} />);
 
 describe('Card component', () => {
   describe('when a standard card is mounted', () => {

--- a/tests/unit/LandingPageCards.test.js
+++ b/tests/unit/LandingPageCards.test.js
@@ -2,15 +2,15 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import LandingPageCards from '../../src/components/LandingPage/LandingPageCards';
 
-import mockPageMetadata from './data/guidesPageMetadata.json';
-import mockPageMetadataMultiple from './data/guidesPageMetadataTwoCategories.json';
+import mockGuidesMetadata from './data/guidesPageMetadata.json';
+import mockGuidesMetadataMultiple from './data/guidesPageMetadataTwoCategories.json';
 import mockGuides from './data/LandingPageCards.test.json';
 
-const mountLandingPageCards = ({ guides, pageMetadata }) =>
-  mount(<LandingPageCards guides={guides} pageMetadata={pageMetadata} />);
+const mountLandingPageCards = ({ guides, guidesMetadata }) =>
+  mount(<LandingPageCards guides={guides} guidesMetadata={guidesMetadata} />);
 
-const shallowLandingPageCards = ({ guides, pageMetadata }) =>
-  shallow(<LandingPageCards guides={guides} pageMetadata={pageMetadata} />);
+const shallowLandingPageCards = ({ guides, guidesMetadata }) =>
+  shallow(<LandingPageCards guides={guides} guidesMetadata={guidesMetadata} />);
 
 describe('LandingPageCards component', () => {
   describe('when mounted with one type of guide', () => {
@@ -18,8 +18,8 @@ describe('LandingPageCards component', () => {
     let shallowWrapper;
 
     beforeAll(() => {
-      wrapper = mountLandingPageCards({ guides: mockGuides, pageMetadata: mockPageMetadata });
-      shallowWrapper = shallowLandingPageCards({ guides: mockGuides, pageMetadata: mockPageMetadata });
+      wrapper = mountLandingPageCards({ guides: mockGuides, guidesMetadata: mockGuidesMetadata });
+      shallowWrapper = shallowLandingPageCards({ guides: mockGuides, guidesMetadata: mockGuidesMetadata });
     });
 
     it('renders correctly', () => {
@@ -59,8 +59,8 @@ describe('LandingPageCards component', () => {
     let shallowWrapper;
 
     beforeAll(() => {
-      wrapper = mountLandingPageCards({ guides: mockGuides, pageMetadata: mockPageMetadataMultiple });
-      shallowWrapper = shallowLandingPageCards({ guides: mockGuides, pageMetadata: mockPageMetadataMultiple });
+      wrapper = mountLandingPageCards({ guides: mockGuides, guidesMetadata: mockGuidesMetadataMultiple });
+      shallowWrapper = shallowLandingPageCards({ guides: mockGuides, guidesMetadata: mockGuidesMetadataMultiple });
     });
 
     it('renders correctly', () => {

--- a/tests/unit/Role.test.js
+++ b/tests/unit/Role.test.js
@@ -15,15 +15,14 @@ import mockDataManual from './data/Role-manual.test.json';
 import mockDataProgram from './data/Role-program.test.json';
 import mockDataRef from './data/Role-ref.test.json';
 import mockDataTerm from './data/Role-term.test.json';
-import mockPageMetadata from './data/guidesPageMetadata.json';
 
 it('renders correctly role "doc"', () => {
-  const tree = render(<RoleDoc nodeData={mockDataDoc} pageMetadata={mockPageMetadata} />);
+  const tree = render(<RoleDoc nodeData={mockDataDoc} />);
   expect(tree).toMatchSnapshot();
 });
 
 it('renders correctly role "doc" when no link title is included', () => {
-  const tree = render(<RoleDoc nodeData={mockDataDocUnlabeled} pageMetadata={mockPageMetadata} />);
+  const tree = render(<RoleDoc nodeData={mockDataDocUnlabeled} />);
   expect(tree).toMatchSnapshot();
 });
 

--- a/tests/unit/__snapshots__/LandingPageCards.test.js.snap
+++ b/tests/unit/__snapshots__/LandingPageCards.test.js.snap
@@ -515,8 +515,7 @@ Array [
         "name": "Getting Started",
       }
     }
-    key="getting-started"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Getting Started",
@@ -2563,6 +2562,7 @@ Array [
         },
       }
     }
+    key="getting-started"
   />,
   <Category
     cards={Array []}
@@ -2572,8 +2572,7 @@ Array [
         "name": "Use Case",
       }
     }
-    key="use-case"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Getting Started",
@@ -4620,6 +4619,7 @@ Array [
         },
       }
     }
+    key="use-case"
   />,
   <Category
     cards={Array []}
@@ -4629,8 +4629,7 @@ Array [
         "name": "Deep Dive",
       }
     }
-    key="deep-dive"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Getting Started",
@@ -6677,6 +6676,7 @@ Array [
         },
       }
     }
+    key="deep-dive"
   />,
 ]
 `;
@@ -7105,8 +7105,7 @@ Array [
         "name": "Getting Started",
       }
     }
-    key="getting-started"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Use Case",
@@ -9153,6 +9152,7 @@ Array [
         },
       }
     }
+    key="getting-started"
   />,
   <Category
     cards={
@@ -9256,8 +9256,7 @@ Array [
         "name": "Use Case",
       }
     }
-    key="use-case"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Use Case",
@@ -11304,6 +11303,7 @@ Array [
         },
       }
     }
+    key="use-case"
   />,
   <Category
     cards={Array []}
@@ -11313,8 +11313,7 @@ Array [
         "name": "Deep Dive",
       }
     }
-    key="deep-dive"
-    pageMetadata={
+    guidesMetadata={
       Object {
         "cloud/atlas": Object {
           "category": "Use Case",
@@ -13361,6 +13360,7 @@ Array [
         },
       }
     }
+    key="deep-dive"
   />,
 ]
 `;

--- a/tests/unit/__snapshots__/Role.test.js.snap
+++ b/tests/unit/__snapshots__/Role.test.js.snap
@@ -21,9 +21,7 @@ exports[`renders correctly role "doc" when no link title is included 1`] = `
 <a
   class="reference internal"
   href="/server/drivers"
->
-  Connect to MongoDB
-</a>
+/>
 `;
 
 exports[`renders correctly role "manual" 1`] = `


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-7939)] [[Guides Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/ubuntu/DOCSP-7939/)]
- Stop populating includes as this is now done in the parser as of https://github.com/mongodb/snooty-parser/pull/74
- Replace `pageMetadata` with `guidesMetadata` to more accurately reflect usage
  - Only parse for guides metadata when building guides
  - Remove usage of `pageMetadata` in Roles, as this will be handled by the parser