### PR TITLE
DOCSP-8134: Fix tabset rendering in ecosystem

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -82,8 +82,10 @@ export default class Tabs extends Component {
     const { tabsetName } = this.state;
     const { nodeData, pillstrips } = this.props;
     const { activeTabs, setActiveTab } = this.context;
+    // Certain tabsets are rendered at the top of the page, rather than inline, in Guides
     const isHeaderTabset =
-      tabsetName === 'drivers' || tabsetName === 'cloud' || Object.keys(pillstrips).includes(tabsetName);
+      process.env.GATSBY_SITE === 'guides' &&
+      (tabsetName === 'drivers' || tabsetName === 'cloud' || Object.keys(pillstrips).includes(tabsetName));
     const isHidden = nodeData.options && nodeData.options.hidden;
     const tabs =
       tabsetName === 'platforms' || PLATFORMS.some(p => tabsetName.includes(p))

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -68,12 +68,13 @@ describe('Tabs testing', () => {
     });
   });
 
-  describe('Drivers unit tests', () => {
+  describe('Guides unit tests', () => {
     let wrapper;
     const mockSetActiveTab = jest.fn();
     const mockAddTabset = jest.fn();
 
     beforeAll(() => {
+      process.env = Object.assign(process.env, { GATSBY_SITE: 'guides' });
       wrapper = mountTabs({
         activeTabs: {},
         mockData: mockDataLanguages,
@@ -84,6 +85,26 @@ describe('Tabs testing', () => {
 
     it('tabset should not be created for drivers/language pills', () => {
       expect(wrapper.find('.tab-strip__element').exists()).toEqual(false);
+    });
+  });
+
+  describe('Ecosystem unit tests', () => {
+    let wrapper;
+    const mockSetActiveTab = jest.fn();
+    const mockAddTabset = jest.fn();
+
+    beforeAll(() => {
+      process.env = Object.assign(process.env, { GATSBY_SITE: 'ecosystem' });
+      wrapper = mountTabs({
+        activeTabs: {},
+        mockData: mockDataLanguages,
+        mockAddTabset,
+        mockSetActiveTab,
+      });
+    });
+
+    it('tabset should be created for drivers/language pills', () => {
+      expect(wrapper.find('.tab-strip__element').exists()).toEqual(true);
     });
   });
 


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8134)] [[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/ubuntu/master/use-cases/client-side-field-level-encryption-guide)] [[Guides Staging](https://docs-mongodbcom-staging.corp.mongodb.com/guides/ubuntu/master/)] Fixed bug where `drivers` tabsets were not rendering in Ecosystem docs.

In Guides, certain tabsets are rendered as pills at the top of the page, not inline. This PR adds a check of which site is being built to determine whether to render tabs or pills.

Eventually, we will add better directives for defining pillsets.