### PR TITLE
DOCSP-8385: Render commit-based builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v0.2] - 2020-01-23
+
+### Added
+
+- Support commit-based builds
+
+## [v0.1] - 2020-01-23
+
+### Added
+
+- Initial release

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,27 @@ include .env.production
 
 .PHONY: stage static
 
-stage:
+# To stage a specific build, include the commit hash/patch ID as environment variables when staging
+# 	example: COMMIT_HASH=123456 make stage
+# Here, generate path prefix according to environment variables
+prefix:
+ifdef PATCH_ID
+PREFIX = $(COMMIT_HASH)/$(PATCH_ID)/$(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
+else
+ifdef COMMIT_HASH
+PREFIX = $(COMMIT_HASH)/$(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
+else
+PREFIX = $(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
+endif
+endif
+
+
+stage: prefix
 	@if [ -z "${GATSBY_SNOOTY_DEV}" ]; then \
 		echo "To stage changes to the Snooty frontend, ensure that GATSBY_SNOOTY_DEV=true in your production environment."; exit 1; \
 	else \
-		mut-publish public ${STAGING_BUCKET} --prefix=${GATSBY_PARSER_BRANCH}/${GATSBY_SITE} --stage ${ARGS}; \
-		echo "Hosted at ${STAGING_URL}/${GATSBY_PARSER_BRANCH}/${GATSBY_SITE}/${USER}/${GIT_BRANCH}/"; \
+		mut-publish public ${STAGING_BUCKET} --prefix=${PREFIX} --stage ${ARGS}; \
+		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
 
 static:

--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,14 @@ include .env.production
 
 .PHONY: stage static
 
-# To stage a specific build, include the commit hash/patch ID as environment variables when staging
+# To stage a specific build, include the commit hash as environment variable when staging
 # 	example: COMMIT_HASH=123456 make stage
 # Here, generate path prefix according to environment variables
 prefix:
-ifdef PATCH_ID
-PREFIX = $(COMMIT_HASH)/$(PATCH_ID)/$(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
-else
 ifdef COMMIT_HASH
 PREFIX = $(COMMIT_HASH)/$(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
 else
 PREFIX = $(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
-endif
 endif
 
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,7 +81,6 @@ const saveAssetFiles = async assets => {
 const constructDbFilter = () => ({
   page_id: { $regex: new RegExp(`^${PAGE_ID_PREFIX}/*`) },
   commit_hash: process.env.COMMIT_HASH || { $exists: false },
-  patch_id: process.env.PATCH_ID || { $exists: false },
 });
 
 exports.sourceNodes = async () => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -112,6 +112,11 @@ exports.sourceNodes = async () => {
     const query = constructDbFilter();
     const documents = await stitchClient.callFunction('fetchDocuments', [DB, DOCUMENTS_COLLECTION, query]);
 
+    if (documents.length === 0) {
+      console.error('No documents matched your query.');
+      process.exit(1);
+    }
+
     documents.forEach(doc => {
       const { page_id, ...rest } = doc;
       RESOLVED_REF_DOC_MAPPING[page_id.replace(`${PAGE_ID_PREFIX}/`, '')] = rest;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "develop": "gatsby develop",
     "format": "npm run prettier -- --check",
     "format:fix": "npm run prettier -- --write",
-    "lint": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ignore-pattern 'docs-tools/*' --ext .js,.jsx .",
+    "lint": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ignore-pattern 'docs-tools/*' --ignore-pattern 'preview/*' --ext .js,.jsx .",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "prettier \"**/*.{js,jsx,json,md}\"",
     "preview": "webpack-dev-server --open --config ./webpack.config.js --env.PREVIEW_MODE='cli'",

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -2,16 +2,18 @@ const normalizePath = path => path.replace(/\/+/g, `/`);
 
 const generatePathPrefix = ({ parserBranch, project, snootyBranch, user }) => {
   let prefix = '';
-  if (process.env.COMMIT_HASH) {
-    prefix = `/${process.env.COMMIT_HASH}`;
-  }
-  if (process.env.PATCH_ID) {
-    prefix = `${prefix}/${process.env.PATCH_ID}`;
-  }
-  const base = `/${project}/${user}/${parserBranch}`;
-  const path = process.env.SNOOTY_DEV
-    ? `${prefix}/${parserBranch}/${project}/${user}/${snootyBranch}`
-    : `${prefix}/${base}`;
+  if (process.env.COMMIT_HASH) prefix = `${process.env.COMMIT_HASH}`;
+  if (process.env.PATCH_ID) prefix = `${prefix}/${process.env.PATCH_ID}`;
+
+  // Include the Snooty branch in pathPrefix for Snooty developers. mut automatically
+  // includes the git branch of the repo where it is called, so this parameter must
+  // be present in the URL's path prefix in order to be mut-compatible.
+  //
+  // TODO: Simplify this logic when Snooty development is staged in integration environment
+  const base = `${project}/${user}`;
+  const path = process.env.GATSBY_SNOOTY_DEV
+    ? `/${prefix}/${parserBranch}/${base}/${snootyBranch}`
+    : `/${prefix}/${base}/${parserBranch}`;
   return normalizePath(path);
 };
 

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -3,7 +3,6 @@ const normalizePath = path => path.replace(/\/+/g, `/`);
 const generatePathPrefix = ({ parserBranch, project, snootyBranch, user }) => {
   let prefix = '';
   if (process.env.COMMIT_HASH) prefix = `${process.env.COMMIT_HASH}`;
-  if (process.env.PATCH_ID) prefix = `${prefix}/${process.env.PATCH_ID}`;
 
   // Include the Snooty branch in pathPrefix for Snooty developers. mut automatically
   // includes the git branch of the repo where it is called, so this parameter must

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -1,6 +1,18 @@
+const normalizePath = path => path.replace(/\/+/g, `/`);
+
 const generatePathPrefix = ({ parserBranch, project, snootyBranch, user }) => {
+  let prefix = '';
+  if (process.env.COMMIT_HASH) {
+    prefix = `/${process.env.COMMIT_HASH}`;
+  }
+  if (process.env.PATCH_ID) {
+    prefix = `${prefix}/${process.env.PATCH_ID}`;
+  }
   const base = `/${project}/${user}/${parserBranch}`;
-  return process.env.SNOOTY_DEV ? `/${parserBranch}/${project}/${user}/${snootyBranch}` : base;
+  const path = process.env.SNOOTY_DEV
+    ? `${prefix}/${parserBranch}/${project}/${user}/${snootyBranch}`
+    : `${prefix}/${base}`;
+  return normalizePath(path);
 };
 
 // TODO: switch to ES6 export syntax if Gatsby implements support for ES6 module imports


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8385)] [[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/123/master/ecosystem/ubuntu/DOCSP-8385/)]
- Query for documents based on `COMMIT_HASH` and `PATCH_ID` environment variables
- Prepend `pathPrefix` with commit hash/patch ID, if specified
- Edit Makefile to allow for Snooty developers to easily stage sites