### PR TITLE
DOCSP-7862: Ignore toctree directive

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -71,7 +71,7 @@ export default class ComponentFactory extends Component {
     };
     this.componentMap = {
       admonition: Admonition,
-      block_quote: BlockQuote,
+      blockquote: BlockQuote,
       'card-group': CardGroup,
       class: CSSClass,
       code: Code,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -55,7 +55,7 @@ import RoleProgram from './Roles/Program';
 import RoleRef from './Roles/Ref';
 import RoleTerm from './Roles/Term';
 
-const IGNORED_NAMES = ['default-domain'];
+const IGNORED_NAMES = ['default-domain', 'toctree'];
 const IGNORED_TYPES = ['comment', 'substitution_definition', 'target'];
 
 export default class ComponentFactory extends Component {

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -1,6 +1,6 @@
 const generatePathPrefix = ({ parserBranch, project, snootyBranch, user }) => {
   const base = `/${project}/${user}/${parserBranch}`;
-  return process.env.SNOOTY_DEV ? `/${parserBranch}/${project}/${user}/${snootyBranch}` : base;
+  return process.env.GATSBY_SNOOTY_DEV ? `/${parserBranch}/${project}/${user}/${snootyBranch}` : base;
 };
 
 // TODO: switch to ES6 export syntax if Gatsby implements support for ES6 module imports


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-7862)] [[Node Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/node/ubuntu/DOCSP-7862/)] [[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/ubuntu/DOCSP-7862/)]
- Ignore `toctree` directive in AST in order to suppress error message `==Not implemented:directive,toctree ==`.
- Fixes bug in path prefix caused by using an incorrectly named environment variable.
- Fixes block quote mapping in component factory