### PR TITLE
Add text components, update storybook styling

### DIFF
--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -8,6 +8,15 @@ const globalStyles = css`
   body {
     background: ${colorMap.devBlack};
     color: ${colorMap.devWhite};
+    font-family: 'Fira Mono Bold', 'Space Mono Bold', 'Source Code Pro';
+  }
+  /* Need overrides for guides.css styles */
+  h1,
+  h2,
+  h3,
+  h4 {
+    border: none;
+    font-family: 'Fira Mono Bold', 'Space Mono Bold', 'Source Code Pro';
   }
 `;
 
@@ -49,6 +58,22 @@ const ContentWrapper = styled('main')`
   flex: 1;
   margin: ${size.large} 0;
 `;
+
+export const StorybookLayout = ({ children }) => {
+  const storybookStyles = css`
+    ${globalStyles};
+    body {
+      background: ${colorMap.devWhite};
+      color: ${colorMap.devBlack};
+    }
+  `;
+  return (
+    <GlobalWrapper>
+      <Global styles={storybookStyles} />
+      <ContentWrapper>{children}</ContentWrapper>
+    </GlobalWrapper>
+  );
+};
 
 export default ({ children }) => (
   <GlobalWrapper>

--- a/src/components/dev-hub/text/index.js
+++ b/src/components/dev-hub/text/index.js
@@ -1,0 +1,3 @@
+import { H1, H2, H3, H4, P } from './text';
+
+export { H1, H2, H3, H4, P };

--- a/src/components/dev-hub/text/text.js
+++ b/src/components/dev-hub/text/text.js
@@ -1,0 +1,45 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { fontSize, size } from '../theme';
+
+/**
+ *
+ * @param {Object.string} param
+ *  @param {string} italic should be italic style
+ *  @param {string} bold should be bold weight
+ */
+const variants = ({ bold, collapse }) =>
+  css`
+    font-weight: ${bold ? 'bold' : 'normal'};
+    margin: ${collapse && 0};
+  `;
+
+const bottomMargin = css`
+  margin: 0 0 ${size.default} 0;
+`;
+
+export const H1 = styled('h1')`
+  ${bottomMargin};
+  font-size: ${fontSize.h1};
+  ${variants};
+`;
+export const H2 = styled('h2')`
+  ${bottomMargin};
+  font-size: ${fontSize.h2};
+  ${variants};
+`;
+export const H3 = styled('h3')`
+  ${bottomMargin};
+  font-size: ${fontSize.h3};
+  ${variants};
+`;
+export const H4 = styled('h4')`
+  ${bottomMargin};
+  font-size: ${fontSize.h4};
+  ${variants};
+`;
+
+export const P = styled('p')`
+  ${bottomMargin};
+  ${variants};
+`;

--- a/src/pages/dev-hub/community.js
+++ b/src/pages/dev-hub/community.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import Layout from '../../components/dev-hub/layout';
+import { H1 } from '../../components/dev-hub/text';
 
 export default ({ ...data }) => {
   return (
     <Layout>
-      <h1>Community</h1>
+      <H1>Community</H1>
     </Layout>
   );
 };

--- a/src/pages/dev-hub/index.js
+++ b/src/pages/dev-hub/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Layout from '../../components/dev-hub/layout';
+import { H1, H2, P } from '../../components/dev-hub/text';
 import { colorMap, size } from '../../components/dev-hub/theme';
 
 const LiveStream = styled('div')`
@@ -68,10 +69,8 @@ export default ({ ...data }) => {
     <Layout>
       <LiveStream>Live now</LiveStream>
       <Hero>
-        <h1>
-          <pre>sample code</pre>
-        </h1>
-        <p>description text</p>
+        <H1>sample code</H1>
+        <P>description text</P>
         <div>
           <a>primary link</a>
           <a>secondary link</a>
@@ -90,8 +89,8 @@ export default ({ ...data }) => {
       </ArticleGallery>
       <FeatureSection>
         <header>
-          <h2>Developer Inspo</h2>
-          <p>description text</p>
+          <H2>Developer Inspo</H2>
+          <P>description text</P>
           <div>
             <a>primary link</a>
             <a>tertiary link</a>
@@ -102,8 +101,8 @@ export default ({ ...data }) => {
       <FeatureSection>
         <FeatureSectionVideo>Video</FeatureSectionVideo>
         <header>
-          <h2>Let's do it live</h2>
-          <p>description text</p>
+          <H2>Let's do it live</H2>
+          <P>description text</P>
           <div>
             <a>primary link</a>
           </div>
@@ -111,8 +110,8 @@ export default ({ ...data }) => {
       </FeatureSection>
       <FeatureSection>
         <header>
-          <h2>Get Involved</h2>
-          <p>description text</p>
+          <H2>Get Involved</H2>
+          <P>description text</P>
           <div>
             <a>primary link</a>
             <a>tertiary link</a>

--- a/src/pages/dev-hub/learn.js
+++ b/src/pages/dev-hub/learn.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import Layout from '../../components/dev-hub/layout';
+import { H1 } from '../../components/dev-hub/text';
 
 export default ({ ...data }) => {
   return (
     <Layout>
-      <h1>Learn</h1>
+      <H1>Learn</H1>
     </Layout>
   );
 };

--- a/src/pages/dev-hub/storybook.js
+++ b/src/pages/dev-hub/storybook.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { StorybookLayout } from '../../components/dev-hub/layout';
+import { H1, H2, H3, H4, P } from '../../components/dev-hub/text';
 import { colorMap, size } from '../../components/dev-hub/theme';
 
 const StorybookContainer = styled('div')`
@@ -13,14 +15,28 @@ const Swatch = styled('div')`
   margin: ${size.tiny};
 `;
 
+const SectionHeader = styled(H2)`
+  text-decoration: underline;
+`;
+
 export default () => (
-  <StorybookContainer>
-    <h1>DevHub Component "Storybook"</h1>
-    <p>Colors</p>
-    {Object.keys(colorMap).map(colorName => (
-      <Swatch key={colorName} colorName={colorName} colorValue={colorMap[colorName]}>
-        {colorMap[colorName]} - {colorName}
-      </Swatch>
-    ))}
-  </StorybookContainer>
+  <StorybookLayout>
+    <StorybookContainer>
+      <H1>DevHub Component "Storybook"</H1>
+      <SectionHeader>Text</SectionHeader>
+      <H1 collapse>Heading 1</H1>
+      <H2>Heading 2</H2>
+      <H3>Heading 3</H3>
+      <H4>Heading 4</H4>
+      <P>Paragraph</P>
+      <SectionHeader>Colors</SectionHeader>
+      {Object.keys(colorMap).map(colorName => (
+        <Swatch key={colorName} colorName={colorName} colorValue={colorMap[colorName]}>
+          <P collapse>
+            {colorMap[colorName]} - {colorName}
+          </P>
+        </Swatch>
+      ))}
+    </StorybookContainer>
+  </StorybookLayout>
 );


### PR DESCRIPTION
This PR:

- Adds text components (H1, etc) and adds fonts from mockup to global styles in layouts
- Uses ^ on existing layout pages
- Updates storybook styling and adds text components to it

![Screen Shot 2020-02-03 at 10 54 20 AM](https://user-images.githubusercontent.com/9064401/73668467-e1b2db80-4673-11ea-8ae2-4512537d8b0e.png)
![Screen Shot 2020-02-03 at 10 54 41 AM](https://user-images.githubusercontent.com/9064401/73668474-e4adcc00-4673-11ea-8030-1350b286935f.png)
