### PR TITLE
Fix failed PropType warning in DocumentBody

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -32,7 +32,7 @@ DocumentBody.propTypes = {
       children: PropTypes.array,
     }).isRequired,
   }).isRequired,
-  slugTitleMapping: PropTypes.objectOf(PropTypes.oneOf([PropTypes.array, PropTypes.string])),
+  slugTitleMapping: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.array, PropTypes.string])),
   substitutions: PropTypes.objectOf(PropTypes.array),
 };
 


### PR DESCRIPTION
Switches `PropTypes.oneOf` to `PropTypes.oneOfType`.

See https://jaketrent.com/post/react-oneof-vs-oneoftype/ for details

![image](https://user-images.githubusercontent.com/15657698/73703814-33348800-46bf-11ea-9415-d9899edc345d.png)
