### PR TITLE
DOCSP-8882: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         run: |
           npm install --production
           zip -9r snooty.zip . -x "*.git*" "*.cache*" public/\* docs-tools/\*
+      - name: Get environment
+        id: environment
+        run: |
+          echo "::set-output name=date::$(date +%Y-%m-%d)"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -23,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: "Release: [${{ github.ref }}] - ${{ steps.environment.outputs.date }}"
           draft: true
           prerelease: true
       - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build project
+      - name: Build package
+        id: build_package
         run: |
           npm install --production
-          zip -9r snooty.zip . -x "*.git*" "*.cache*" public/\* docs-tools/\*
+          make static
+          make package-preview
       - name: Get environment
         id: environment
         run: |
@@ -37,6 +39,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./snooty.zip
-          asset_name: snooty.zip
+          asset_path: ./${{ steps.build_package.outputs.package_filename }}
+          asset_name: ${{ steps.build_package.outputs.package_filename }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    tags:
+    - 'v*'
+
+name: Create Release
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          npm install --production
+          zip -9r snooty.zip . -x "*.git*" "*.cache*" public/\* docs-tools/\*
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./snooty.zip
+          asset_name: snooty.zip
+          asset_content_type: application/zip

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,6 @@ static:
 	-rm -r ./docs-tools/
 	git submodule add --force https://github.com/mongodb/docs-tools
 	-mkdir -p ./static/images
-	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
+	-mkdir -p ./static/docs-tools
+	cp -a ./docs-tools/themes/mongodb/static/. ./static/docs-tools/
+	cp ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/images/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 STAGING_BUCKET=docs-mongodb-org-staging
-include .env.production
+PLATFORM=$(shell printf '%s_%s' "$$(uname -s | tr '[:upper:]' '[:lower:]')" "$$(uname -m)")
+PACKAGE_NAME=snooty-preview-${VERSION}-${PLATFORM}.zip
+VERSION=$(shell git describe --tags)
+-include .env.production
 
 .PHONY: stage static
 
@@ -16,6 +19,9 @@ else
 PREFIX = $(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
 endif
 
+package-preview:
+	zip -9r ${PACKAGE_NAME} src node_modules preview preview-start.js static webpack.config.js index.html package.json package-lock.json
+	echo "::set-output name=package_filename::${PACKAGE_NAME}"
 
 stage: prefix
 	@if [ -z "${GATSBY_SNOOTY_DEV}" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PREFIX = $(GATSBY_PARSER_BRANCH)/$(GATSBY_SITE)
 endif
 
 package-preview:
-	zip -9r ${PACKAGE_NAME} src node_modules preview preview-start.js static webpack.config.js index.html package.json package-lock.json
+	zip -9r --symlinks ${PACKAGE_NAME} src node_modules preview preview-start.js static webpack.config.js index.html package.json package-lock.json
 	echo "::set-output name=package_filename::${PACKAGE_NAME}"
 
 stage: prefix

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,7 @@ static:
 	git submodule add --force https://github.com/mongodb/docs-tools
 	-mkdir -p ./static/images
 	-mkdir -p ./static/docs-tools
-	cp -a ./docs-tools/themes/mongodb/static/. ./static/docs-tools/
+	cp ./docs-tools/themes/mongodb/static/guides.css ./static/docs-tools/
+	cp ./docs-tools/themes/mongodb/static/mongodb-docs.css ./static/docs-tools/
+	cp ./docs-tools/themes/mongodb/static/css/navbar.min.css ./static/docs-tools/
 	cp ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/images/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ static:
 	git submodule add --force https://github.com/mongodb/docs-tools
 	-mkdir -p ./static/images
 	-mkdir -p ./static/docs-tools
+	cp -a ./docs-tools/themes/mongodb/static/fonts ./static/docs-tools/
 	cp ./docs-tools/themes/mongodb/static/guides.css ./static/docs-tools/
 	cp ./docs-tools/themes/mongodb/static/mongodb-docs.css ./static/docs-tools/
+	cp ./docs-tools/themes/mongodb/static/navbar.min.js ./static/docs-tools/
 	cp ./docs-tools/themes/mongodb/static/css/navbar.min.css ./static/docs-tools/
 	cp ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/images/

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,18 +1,12 @@
-const { execSync } = require('child_process');
 const userInfo = require('os').userInfo;
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
+const { getGitBranch } = require('./src/utils/get-git-branch');
 
 const runningEnv = process.env.NODE_ENV || 'production';
 
 require('dotenv').config({
   path: `.env.${runningEnv}`,
 });
-
-const getGitBranch = () => {
-  return execSync('git rev-parse --abbrev-ref HEAD')
-    .toString('utf8')
-    .replace(/[\n\r\s]+$/, '');
-};
 
 const metadata = {
   parserBranch: process.env.GATSBY_PARSER_BRANCH,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,9 +1960,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",
@@ -17574,9 +17574,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "true-case-path": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3269,6 +3269,48 @@
       "integrity": "sha512-v0A231a/lfOo6kxQtmEkdBfTApvC21aJYukA8pkKnoTvVqh3Wmm7/Rwy4GBCHTTHVoLVA5qsBDDvf1XY1nIV2g==",
       "optional": true
     },
+    "auto-changelog": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.16.2.tgz",
+      "integrity": "sha512-QL7zKH5FBBHz6tECO8CjZ8LpdevVSJoDskDzzPeoB9Bfe6LyXmRzXUoTIFKJXXdVaX8ydMpDO9Oa8ihZ4Au+CA==",
+      "dev": true,
+      "requires": {
+        "commander": "^3.0.1",
+        "core-js": "^3.2.1",
+        "handlebars": "^4.1.2",
+        "lodash.uniqby": "^4.7.0",
+        "node-fetch": "^2.6.0",
+        "parse-github-url": "^1.0.2",
+        "regenerator-runtime": "^0.13.3",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "autoprefixer": {
       "version": "9.7.3",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
@@ -12554,6 +12596,12 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -13935,6 +13983,12 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "dev": true
     },
     "parse-json": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snooty",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:unit": "jest unit",
     "preversion": "npm run ensure-master && npm run format && npm run lint && npm run test:unit",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
-    "postversion": "git push --follow-tags"
+    "postversion": "git push"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "repository": "github:mongodb/snooty",
   "devDependencies": {
+    "auto-changelog": "^1.16.2",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-preset-gatsby": "^0.2.23",
@@ -23,6 +24,7 @@
     "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
+    "ensure-master": "node scripts/ensure-master.js",
     "format": "npm run prettier -- --check",
     "format:fix": "npm run prettier -- --write",
     "lint": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ignore-pattern 'docs-tools/*' --ignore-pattern 'preview/*' --ext .js,.jsx .",
@@ -32,7 +34,10 @@
     "serve": "gatsby serve --prefix-paths",
     "test": "jest",
     "test:regression": "jest regression",
-    "test:unit": "jest unit"
+    "test:unit": "jest unit",
+    "preversion": "npm run ensure-master && npm run format && npm run lint && npm run test:unit",
+    "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
+    "postversion": "git push --follow-tags"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snooty",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": "github:mongodb/snooty",
   "devDependencies": {
     "auto-changelog": "^1.16.2",
@@ -37,7 +37,7 @@
     "test:unit": "jest unit",
     "preversion": "npm run ensure-master && npm run format && npm run lint && npm run test:unit",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
-    "postversion": "git push"
+    "postversion": "git push origin v$npm_package_version"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "devDependencies": {
     "auto-changelog": "^1.16.2",
     "babel-jest": "^24.9.0",
-    "babel-loader": "^8.0.6",
     "babel-preset-gatsby": "^0.2.23",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
@@ -47,6 +46,7 @@
     ]
   },
   "dependencies": {
+    "babel-loader": "^8.0.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.3",

--- a/scripts/ensure-master.js
+++ b/scripts/ensure-master.js
@@ -1,0 +1,18 @@
+const { getGitBranch } = require('../src/utils/get-git-branch');
+
+const ensureMaster = () => getGitBranch() === 'master';
+
+const main = () => {
+  let warned = false;
+
+  if (!ensureMaster()) {
+    warned = true;
+    console.error('Can only release on master');
+  }
+
+  if (warned) {
+    process.exit(1);
+  }
+};
+
+main();

--- a/src/html.js
+++ b/src/html.js
@@ -34,7 +34,7 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
       ) : (
         <link rel="stylesheet" href={withPrefix('docs-tools/mongodb-docs.css')} type="text/css" />
       )}
-      <link rel="stylesheet" href={withPrefix('docs-tools/css/navbar.min.css')} type="text/css" />
+      <link rel="stylesheet" href={withPrefix('docs-tools/navbar.min.css')} type="text/css" />
       {headComponents}
     </head>
     <body {...bodyAttributes}>

--- a/src/utils/get-git-branch.js
+++ b/src/utils/get-git-branch.js
@@ -1,0 +1,9 @@
+const { execSync } = require('child_process');
+
+const getGitBranch = () => {
+  return execSync('git rev-parse --abbrev-ref HEAD')
+    .toString('utf8')
+    .replace(/[\n\r\s]+$/, '');
+};
+
+module.exports.getGitBranch = getGitBranch;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8882)] General release workflow:
1. Call `npm version <major/minor/patch>` to kick off [`npm-version`](https://docs.npmjs.com/cli/version). Three scripts are then called:
    1. `preversion`: ensures master branch, runs standard lint/format/unit tests
    2. `version`: auto-generates changelog using git history and [`auto-changelog`](https://www.npmjs.com/package/auto-changelog). `npm-version` then adds a commit here.
    3. `postversion`: push with tags
2. GitHub Action invoked: release is created, then an artifact is built and attached to said release.

I also did some simplification of our git submodule. Right now `snooty.zip` is around 58M. So close! Also, do let me know if you know of any approach for testing the GitHub Action. Thanks!