### PR TITLE
DOCSP-8973: Add production build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "gatsby build --prefix-paths",
+    "build:prod": "gatsby build",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
     "ensure-master": "node scripts/ensure-master.js",
@@ -31,6 +32,7 @@
     "prettier": "prettier \"**/*.{js,jsx,json,md}\"",
     "preview": "webpack-dev-server --open --config ./webpack.config.js --env.PREVIEW_MODE='cli'",
     "serve": "gatsby serve --prefix-paths",
+    "serve:prod": "gatsby serve",
     "test": "jest",
     "test:regression": "jest regression",
     "test:unit": "jest unit",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:unit": "jest unit",
     "preversion": "npm run ensure-master && npm run format && npm run lint && npm run test:unit",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
-    "postversion": "git push origin v$npm_package_version"
+    "postversion": "git push origin v$npm_package_version && git push origin master"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8973)]
- Adds production build target that does not prefix paths
- Bonus: Adds small improvement to automatic versioning workflow

I can't exactly provide a staging link since `mut` prefixes the site with `user` and `branch` 😂 but I successfully tested `npm run build:prod && npm run serve:prod` on an EC2 instance!