### PR TITLE
DOP-958: landing template

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -128,7 +128,11 @@ exports.createPages = async ({ actions }) => {
     PAGES.forEach(page => {
       const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
 
-      const template = getTemplate(page, process.env.GATSBY_SITE);
+      const template = getTemplate(
+        process.env.GATSBY_SITE,
+        page,
+        getNestedValue(['ast', 'options', 'template'], pageNodes)
+      );
       const slug = getPageSlug(page);
       if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {
         createPage({

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -4,6 +4,7 @@ import SiteMetadata from './site-metadata';
 import { TabContext } from './tab-context';
 import { findAllKeyValuePairs } from '../utils/find-all-key-value-pairs';
 import { getNestedValue } from '../utils/get-nested-value';
+import { getPlaintext } from '../utils/get-plaintext';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 
 export default class DefaultLayout extends Component {
@@ -128,12 +129,17 @@ export default class DefaultLayout extends Component {
   };
 
   render() {
-    const { children, pageContext } = this.props;
+    const {
+      children,
+      pageContext: { metadata, slug },
+    } = this.props;
     const { pillstrips } = this.state;
-    const title = getNestedValue(['metadata', 'title'], pageContext) || '';
+    const lookup = slug === '/' ? 'index' : slug;
+    const siteTitle = getNestedValue(['title'], metadata) || '';
+    const pageTitle = getPlaintext(getNestedValue(['slugToTitle', lookup], metadata));
     return (
       <TabContext.Provider value={{ ...this.state, setActiveTab: this.setActiveTab }}>
-        <SiteMetadata title={title} />
+        <SiteMetadata siteTitle={siteTitle} pageTitle={pageTitle} />
         {React.cloneElement(children, {
           pillstrips,
           addPillstrip: this.addPillstrip,
@@ -153,6 +159,7 @@ DefaultLayout.propTypes = {
       }).isRequired,
     }).isRequired,
     metadata: PropTypes.shape({
+      slugToTitle: PropTypes.object,
       title: PropTypes.string,
     }).isRequired,
   }).isRequired,

--- a/src/components/site-metadata.js
+++ b/src/components/site-metadata.js
@@ -4,16 +4,15 @@ import { Helmet } from 'react-helmet';
 // eslint-disable-next-line import/no-unresolved
 import { useSiteMetadata } from 'useSiteMetadata'; // Alias in webpack.config
 
-const SiteMetadata = props => {
+const SiteMetadata = ({ pageTitle, siteTitle }) => {
   const { branch, project } = useSiteMetadata();
-  const { title } = props;
   return (
     <Helmet
-      titleTemplate={`%s — ${title}`}
-      defaultTitle={title}
+      defaultTitle="MongoDB Documentation"
+      title={`${pageTitle} — ${siteTitle}`}
       bodyAttributes={{
         'data-project': project,
-        'data-project-title': title,
+        'data-project-title': siteTitle,
         'data-branch': branch,
         'data-enable-marian': 1,
       }}
@@ -22,7 +21,8 @@ const SiteMetadata = props => {
 };
 
 SiteMetadata.propTypes = {
-  title: PropTypes.string,
+  pageTitle: PropTypes.string.isRequired,
+  siteTitle: PropTypes.string.isRequired,
 };
 
 export default SiteMetadata;

--- a/src/styles/landing.module.css
+++ b/src/styles/landing.module.css
@@ -1,0 +1,7 @@
+.fullWidth {
+  margin: 40px auto !important;
+}
+
+.document {
+  margin: 28px 15px 0 15px;
+}

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -7,8 +7,6 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import InternalPageNav from '../components/InternalPageNav';
 import Sidebar from '../components/Sidebar';
 import DocumentBody from '../components/DocumentBody';
-import { Helmet } from 'react-helmet';
-import { getPlaintextTitle } from '../utils/get-plaintext-title.js';
 import { useWindowSize } from '../hooks/use-window-size.js';
 import style from '../styles/navigation.module.css';
 import { isBrowser } from '../utils/is-browser.js';
@@ -23,8 +21,6 @@ const Document = props => {
     ...rest
   } = props;
 
-  const title = getPlaintextTitle(getNestedValue([slug], slugTitleMapping));
-
   const windowSize = useWindowSize();
   const minWindowWidth = 1093; /* Specific value from docs-tools/themes/mongodb/src/css/mongodb-base.css */
 
@@ -38,9 +34,6 @@ const Document = props => {
 
   return (
     <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
       <Navbar />
       <div className="content">
         <div>
@@ -66,12 +59,7 @@ const Document = props => {
               <div className="bodywrapper">
                 <div className="body">
                   <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
-                  <DocumentBody
-                    refDocMapping={__refDocMapping}
-                    slug={slug}
-                    slugTitleMapping={slugTitleMapping}
-                    {...rest}
-                  />
+                  <DocumentBody refDocMapping={__refDocMapping} slug={slug} {...rest} />
                   <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />
                   <Footer />
                 </div>

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -1,77 +1,42 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Footer from '../components/Footer';
-import { getNestedValue } from '../utils/get-nested-value';
 import Navbar from '../components/Navbar';
-import { Helmet } from 'react-helmet';
-import { getPlaintextTitle } from '../utils/get-plaintext-title.js';
 import EcosystemHomepageStyles from '../styles/ecosystem-homepage.module.css';
 import EcosystemHomepageTiles from '../components/EcosystemHomepageTiles';
 
-const EcosystemIndex = props => {
-  const {
-    pageContext: {
-      slug,
-      metadata: { slugToTitle: slugTitleMapping },
-    },
-  } = props;
-
-  const title = getPlaintextTitle(getNestedValue([slug], slugTitleMapping));
-
-  return (
-    <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
-      <Navbar />
-      <div className="content">
-        <div className={[EcosystemHomepageStyles.fullWidth, 'main-column'].join(' ')} id="main-column">
-          <div className={[EcosystemHomepageStyles.document, 'document'].join(' ')}>
-            <div className="documentwrapper">
-              <div className="bodywrapper">
-                <div className="body">
-                  <section className={EcosystemHomepageStyles.mainContentPadding}>
-                    <h1>Start Developing with MongoDB</h1>
-                    <p>Connect your application to your database with one of our official libraries.</p>
-                    <p>
-                      The following libraries are officially supported by MongoDB. They are actively maintained, support
-                      new MongoDB features, and receive bug fixes, performance enhancements, and security patches.
-                    </p>
-                    <EcosystemHomepageTiles />
-                    <p>
-                      Don’t see your desired language? Browse a list of{' '}
-                      <a href="https://docs.mongodb.com/ecosystem/drivers/community-supported-drivers/">
-                        community supported libraries
-                      </a>
-                      .
-                    </p>
-                  </section>
-                  <Footer />
-                </div>
+const EcosystemIndex = props => (
+  <React.Fragment>
+    <Navbar />
+    <div className="content">
+      <div className={[EcosystemHomepageStyles.fullWidth, 'main-column'].join(' ')} id="main-column">
+        <div className={[EcosystemHomepageStyles.document, 'document'].join(' ')}>
+          <div className="documentwrapper">
+            <div className="bodywrapper">
+              <div className="body">
+                <section className={EcosystemHomepageStyles.mainContentPadding}>
+                  <h1>Start Developing with MongoDB</h1>
+                  <p>Connect your application to your database with one of our official libraries.</p>
+                  <p>
+                    The following libraries are officially supported by MongoDB. They are actively maintained, support
+                    new MongoDB features, and receive bug fixes, performance enhancements, and security patches.
+                  </p>
+                  <EcosystemHomepageTiles />
+                  <p>
+                    Don’t see your desired language? Browse a list of{' '}
+                    <a href="https://docs.mongodb.com/ecosystem/drivers/community-supported-drivers/">
+                      community supported libraries
+                    </a>
+                    .
+                  </p>
+                </section>
+                <Footer />
               </div>
             </div>
           </div>
         </div>
       </div>
-    </React.Fragment>
-  );
-};
-
-EcosystemIndex.propTypes = {
-  pageContext: PropTypes.shape({
-    __refDocMapping: PropTypes.shape({
-      ast: PropTypes.shape({
-        children: PropTypes.array,
-      }).isRequired,
-    }).isRequired,
-    parentPaths: PropTypes.arrayOf(PropTypes.string),
-    slug: PropTypes.string.isRequired,
-    slugTitleMapping: PropTypes.shape({
-      [PropTypes.string]: PropTypes.string,
-    }),
-    toctree: PropTypes.object,
-    toctreeOrder: PropTypes.arrayOf(PropTypes.string),
-  }).isRequired,
-};
+    </div>
+  </React.Fragment>
+);
 
 export default EcosystemIndex;

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -116,14 +116,7 @@ export default class Guide extends Component {
   };
 
   createSections() {
-    const {
-      addPillstrip,
-      pageContext,
-      pillstrips,
-      pageContext: {
-        metadata: { slugToTitle },
-      },
-    } = this.props;
+    const { addPillstrip, pageContext, pillstrips } = this.props;
     if (this.bodySections.length === 0) {
       return this.sections.map(section => {
         return (
@@ -143,7 +136,6 @@ export default class Guide extends Component {
           refDocMapping={getNestedValue(['__refDocMapping'], pageContext) || {}}
           addTabset={this.addGuidesTabset}
           pillstrips={pillstrips}
-          slugTitleMapping={slugToTitle}
         />
       );
     });
@@ -195,9 +187,6 @@ Guide.propTypes = {
         children: PropTypes.array,
       }).isRequired,
     }).isRequired,
-    slugTitleMapping: PropTypes.shape({
-      [PropTypes.string]: PropTypes.string,
-    }),
     snootyStitchId: PropTypes.string.isRequired,
   }).isRequired,
   path: PropTypes.string.isRequired,

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Footer from '../components/Footer';
+import Navbar from '../components/Navbar';
+import DocumentBody from '../components/DocumentBody';
+import landingStyles from '../styles/landing.module.css';
+
+const Landing = ({ pageContext: { slug, __refDocMapping }, ...rest }) => (
+  <React.Fragment>
+    <Navbar />
+    <div className="content">
+      <div className={`main-column ${landingStyles.fullWidth}`} id="main-column">
+        <div className={landingStyles.document}>
+          <div className="body">
+            <DocumentBody refDocMapping={__refDocMapping} slug={slug} {...rest} />
+            <Footer />
+          </div>
+        </div>
+      </div>
+    </div>
+  </React.Fragment>
+);
+
+Landing.propTypes = {
+  pageContext: PropTypes.shape({
+    __refDocMapping: PropTypes.object.isRequired,
+    slug: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default Landing;

--- a/src/utils/get-plaintext.js
+++ b/src/utils/get-plaintext.js
@@ -1,9 +1,9 @@
 /*
- * Given an array of text nodes with formatting (from get-page-title.js), retrieve the title.
+ * Given an array of text nodes with formatting, retrieve the string.
  * Returns plaintext string indicating the nested title.
  */
 
-export const getPlaintextTitle = nodeArray => {
+export const getPlaintext = nodeArray => {
   const extractText = (title, node) => {
     if (node.type === 'text') {
       return title + node.value;

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -1,12 +1,17 @@
 // Returns the name of the template to be used based on the site and page name.
-const getTemplate = (page, site) => {
-  switch (site) {
-    case 'guides':
-      return page === 'index' ? 'guides-index' : 'guide';
-    case 'drivers':
-      return page === 'index' ? 'ecosystem-index' : 'document';
+const getTemplate = (site, page, template) => {
+  switch (template) {
+    case 'landing':
+      return 'landing';
     default:
-      return 'document';
+      switch (site) {
+        case 'guides':
+          return page === 'index' ? 'guides-index' : 'guide';
+        case 'drivers':
+          return page === 'index' ? 'ecosystem-index' : 'document';
+        default:
+          return 'document';
+      }
   }
 };
 


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-958)] [[Drivers Staging](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-958/drivers/sophstad/DOP-958/)]
- Change `getTemplate()` function to use `template` field specified in page rST
- Add landing template
- Handle page title in `Layout` component to avoid duplicate code
  - Set title in `SiteMetadata`
  - Remove former title implementation