### PR TITLE
FeedbackCard should display behind tooltips

### DIFF
--- a/src/components/FeedbackWidget/FeedbackCard.js
+++ b/src/components/FeedbackWidget/FeedbackCard.js
@@ -26,7 +26,6 @@ const Floating = styled.div`
   position: fixed;
   top: 256px;
   right: 40px;
-  z-index: 80;
 `;
 const Card = styled(LeafygreenCard)`
   width: 320px;


### PR DESCRIPTION
- Removes the unnecessary `z-index` on `<FeedbackCard />` that made `<StarRating />` tooltips display behind the card

[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/master/node/nlarew/feedback-fix/)