### PR TITLE
Bugfix: add fallback branch to version dropdown

### DIFF
--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -28,7 +28,10 @@ const VersionDropdown = ({
 
   const prefixVersion = version => {
     // Display as "Version X" on menu if numeric version
-    const isNumeric = version => !isNaN(version.split()[0]);
+    const isNumeric = (version = '') => {
+      const [firstWord] = version.split();
+      return !isNaN(firstWord);
+    };
     return `${isNumeric(version) ? 'Version ' : ''}${version}`;
   };
 
@@ -52,7 +55,7 @@ const VersionDropdown = ({
 
   // Zip two sections of data to map git branches to their "pretty" names
   const gitNamedMapping = zip(gitBranches, published);
-  const currentBranch = gitNamedMapping[parserBranch];
+  const currentBranch = gitNamedMapping[parserBranch] || parserBranch;
 
   const wrapperRef = useRef(null);
   useOutsideHandler(wrapperRef);


### PR DESCRIPTION
[[Node Staging](https://docs-mongodbcom-staging.corp.mongodb.com/27a5b68/dop919/node/sophstad/bugfix-version-dropdown/)] Fixes bug where sites were failing to build if the content branch was not specified in the repo's `published-branches.yaml`. This should not be the case: users must be able to build branches in development and _then_ merge them into a branch specified in the YAML file.

As such, add a fallback to the component so that users can build development branches using Snooty.