### PR TITLE
DOP-1078: Correctly write intersphinx inventory

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -86,7 +86,7 @@ exports.createPages = async ({ actions }) => {
 
   // Save files in the static_files field of metadata document, including intersphinx inventories
   if (metadata.static_files) {
-    saveStaticFiles(metadata.static_files);
+    await saveStaticFiles(metadata.static_files);
   }
 
   return new Promise((resolve, reject) => {

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -15,26 +15,18 @@ const saveFile = async (file, data) => {
 // Write all assets to static directory
 const saveAssetFiles = async (assets, stitchClient) => {
   if (assets.length) {
-    const promises = [];
     const assetQuery = { _id: { $in: assets } };
     const assetDataDocuments = await stitchClient.callFunction('fetchDocuments', [
       database,
       ASSETS_COLLECTION,
       assetQuery,
     ]);
-    assetDataDocuments.forEach(({ filename, data: { buffer } }) => {
-      promises.push(saveFile(filename, buffer));
-    });
-    await Promise.all(promises);
+    await Promise.all(assetDataDocuments.map(({ filename, data: { buffer } }) => saveFile(filename, buffer)));
   }
 };
 
 const saveStaticFiles = async staticFiles => {
-  const promises = [];
-  Object.entries(staticFiles).forEach(([file, data]) => {
-    promises.push(saveFile(file, data.buffer));
-  });
-  await Promise.all(promises);
+  await Promise.all(Object.entries(staticFiles).map(([file, data]) => saveFile(file, data.buffer)));
 };
 
 module.exports = { saveAssetFiles, saveStaticFiles };

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -30,7 +30,11 @@ const saveAssetFiles = async (assets, stitchClient) => {
 };
 
 const saveStaticFiles = async staticFiles => {
-  Object.entries(staticFiles).forEach(([file, data]) => saveFile(file, data));
+  const promises = [];
+  Object.entries(staticFiles).forEach(([file, data]) => {
+    promises.push(saveFile(file, data.buffer));
+  });
+  await Promise.all(promises);
 };
 
 module.exports = { saveAssetFiles, saveStaticFiles };


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1078)] [[Drivers Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/drivers/sophstad/DOP-1078/)]
- Write `buffer` field of the binary data to fix intersphinx inventories.
- Fix async/await implementation.