### PR TITLE
Support configuration to hide feedback widget header

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import styled from '@emotion/styled';
-import { FeedbackHeading } from './Widgets/FeedbackWidget';
+import Loadable from '@loadable/component';
 import useScreenSize from '../hooks/useScreenSize';
+
+const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
 const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const id = nodeData.id || '';
@@ -14,7 +16,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const shouldShowStarRating = isPageTitle && isTabletOrMobile;
 
   return (
-    <HeadingContainer stackVertically={isSmallScreen}>
+    <HeadingContainer className={`heading-container-h${sectionDepth}`} stackVertically={isSmallScreen}>
       <HeadingTag id={id}>
         {nodeData.children.map((element, index) => {
           return <ComponentFactory {...rest} nodeData={element} key={index} />;

--- a/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
@@ -2,10 +2,13 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import StarRating, { StarRatingLabel } from './components/StarRating';
+import { useFeedbackState } from './context';
 
 export default function FeedbackHeading({ isVisible = true, isStacked = false }) {
+  const { hideHeader } = useFeedbackState();
   return (
-    isVisible && (
+    isVisible &&
+    !hideHeader && (
       <StarRatingContainer isStacked={isStacked}>
         <StarRating size="lg" />
         <StarRatingLabel>Give Feedback</StarRatingLabel>

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -12,7 +12,7 @@ import { getViewport } from '../../../hooks/useViewport';
 
 const FeedbackContext = React.createContext();
 
-export function FeedbackProvider({ page, test = {}, ...props }) {
+export function FeedbackProvider({ page, hideHeader = false, test = {}, ...props }) {
   const [feedback, setFeedback] = React.useState((test.feedback !== {} && test.feedback) || null);
   const [isSupportRequest, setIsSupportRequest] = React.useState(test.isSupportRequest || false);
   const [view, setView] = React.useState(test.view || 'waiting');
@@ -161,6 +161,7 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
     submitSupport,
     submitAllFeedback,
     abandon,
+    hideHeader,
   };
 
   return <FeedbackContext.Provider value={value}>{props.children}</FeedbackContext.Provider>;

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { FeedbackProvider, FeedbackForm, FeedbackTab, useFeedbackData } from './FeedbackWidget';
 import { isBrowser } from '../../utils/is-browser';
 
-const Widgets = ({ children, location, pageTitle, publishedBranches, slug }) => {
+const Widgets = ({ children, location, pageOptions, pageTitle, publishedBranches, slug }) => {
   const url = isBrowser ? window.location.href : null;
+  const hideFeedbackHeader = pageOptions.hidefeedback === 'header';
   const feedbackData = useFeedbackData({
     slug,
     url,
@@ -13,7 +14,7 @@ const Widgets = ({ children, location, pageTitle, publishedBranches, slug }) => 
   });
 
   return (
-    <FeedbackProvider page={feedbackData}>
+    <FeedbackProvider page={feedbackData} hideHeader={hideFeedbackHeader}>
       {children}
       <FeedbackTab />
       <FeedbackForm />
@@ -26,9 +27,16 @@ Widgets.propTypes = {
   location: PropTypes.shape({
     href: PropTypes.string.isRequired,
   }).isRequired,
+  pageOptions: PropTypes.shape({
+    hideFeedback: PropTypes.string,
+  }),
   pageTitle: PropTypes.string.isRequired,
   publishedBranches: PropTypes.object.isRequired,
   slug: PropTypes.string.isRequired,
+};
+
+Widgets.defaultProps = {
+  pageOptions: {},
 };
 
 export default Widgets;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -132,8 +132,9 @@ export default class DefaultLayout extends Component {
   render() {
     const {
       children,
-      pageContext: { location, metadata, slug },
+      pageContext: { location, metadata, slug, __refDocMapping },
     } = this.props;
+
     const { pillstrips } = this.state;
     const lookup = slug === '/' ? 'index' : slug;
     const siteTitle = getNestedValue(['title'], metadata) || '';
@@ -142,6 +143,7 @@ export default class DefaultLayout extends Component {
       <TabContext.Provider value={{ ...this.state, setActiveTab: this.setActiveTab }}>
         <Widgets
           location={location}
+          pageOptions={getNestedValue(['ast', 'options'], __refDocMapping)}
           pageTitle={pageTitle}
           publishedBranches={getNestedValue(['publishedBranches'], metadata)}
           slug={slug}

--- a/src/utils/get-nested-value.js
+++ b/src/utils/get-nested-value.js
@@ -1,12 +1,12 @@
 /*
- * Safely return a deeply nested value from an object. If the property is not found, return null.
+ * Safely return a deeply nested value from an object. If the property is not found, return undefined.
  * Arguments:
  * - p: an array containing the path to the desired return value
  * - o: the object to be searched
  */
 const getNestedValue = (p, o) => {
-  if (!o) return null;
-  return p.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), o);
+  if (!o) return undefined;
+  return p.reduce((xs, x) => (xs && xs[x] ? xs[x] : undefined), o);
 };
 
 // TODO: switch to ES6 export syntax if Gatsby implements support for ES6 module imports

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -4,7 +4,6 @@ import {
   FeedbackProvider,
   FeedbackForm,
   FeedbackTab,
-  FeedbackHeading,
   FeedbackFooter,
 } from '../../src/components/Widgets/FeedbackWidget';
 import { BSON } from 'mongodb-stitch-server-sdk';
@@ -17,9 +16,11 @@ import {
   mockStitchFunctions,
   clearMockStitchFunctions,
 } from '../utils/feedbackWidgetStitchFunctions';
+import Heading from '../../src/components/Heading';
+import headingData from './data/Heading.test.json';
 
 async function mountFormWithFeedbackState(feedbackState = {}, options = {}) {
-  const { view, isSupportRequest, ...feedback } = feedbackState;
+  const { view, isSupportRequest, hideHeader, ...feedback } = feedbackState;
   const wrapper = mount(
     <FeedbackProvider
       test={{
@@ -33,11 +34,12 @@ async function mountFormWithFeedbackState(feedbackState = {}, options = {}) {
         url: 'https://docs.mongodb.com/test',
         docs_property: 'test',
       }}
+      hideHeader={hideHeader}
     >
       <FeedbackForm />
       <div>
         <FeedbackTab />
-        <FeedbackHeading />
+        <Heading nodeData={headingData} sectionDepth={1} />
         <FeedbackFooter />
       </div>
     </FeedbackProvider>,
@@ -106,6 +108,32 @@ describe('FeedbackWidget', () => {
       wrapper = await mountFormWithFeedbackState({}, withScreenSize('iphone-x'));
       expect(wrapper.exists('FeedbackTab')).toBe(true);
       expect(wrapper.find('FeedbackTab').children()).toHaveLength(0);
+    });
+  });
+
+  describe('FeedbackHeading', () => {
+    it('is hidden on large/desktop screens', async () => {
+      wrapper = await mountFormWithFeedbackState({}, withScreenSize('desktop'));
+      expect(wrapper.exists('FeedbackHeading')).toBe(true);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(0);
+    });
+
+    it('is visible on medium/tablet screens', async () => {
+      wrapper = await mountFormWithFeedbackState({}, withScreenSize('ipad-pro'));
+      expect(wrapper.exists('FeedbackHeading')).toBe(true);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(1);
+    });
+
+    it('is visible on small/mobile screens', async () => {
+      wrapper = await mountFormWithFeedbackState({}, withScreenSize('iphone-x'));
+      expect(wrapper.exists('FeedbackHeading')).toBe(true);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(1);
+    });
+
+    it('is hidden on small/mobile screens when configured with page option', async () => {
+      wrapper = await mountFormWithFeedbackState({ hideHeader: true }, withScreenSize('iphone-x'));
+      expect(wrapper.exists('FeedbackHeading')).toBe(true);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(0);
     });
   });
 

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders correctly 1`] = `
 }
 
 <div
-  class="emotion-0 emotion-1"
+  class="heading-container-h3 emotion-0 emotion-1"
 >
   <h3
     id="create-an-administrative-username-and-password"


### PR DESCRIPTION
[[Drivers Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/hide-feedback-header/)] When this line is included in a file's page options, hide the feedback widget's star header component on mobile:
```
:hidefeedback: header
```

On the staging link, you can see that the star rating appears at the bottom of the page, but not in the header title. On other pages, the stars appear in the header.
<img width="427" alt="image" src="https://user-images.githubusercontent.com/9298431/83668236-a1218b00-a59d-11ea-9f17-c35500ca2c58.png">
<img width="419" alt="image" src="https://user-images.githubusercontent.com/9298431/83668247-a54da880-a59d-11ea-97f9-3052930dd497.png">
