### PR TITLE
upgrade html-screen-capture-js to 1.0.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11819,9 +11819,9 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-screen-capture-js": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/html-screen-capture-js/-/html-screen-capture-js-1.0.32.tgz",
-      "integrity": "sha512-By+qC5U3c34H0SK8gSZOlkFxtncCO+Ly9Vr14FcOzENfmCmlyJyxeflMi6ZH/Ul1zs26CxX4p+A47KPQOSHJYQ=="
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/html-screen-capture-js/-/html-screen-capture-js-1.0.43.tgz",
+      "integrity": "sha512-DdHRya4U4wu7S9pj/yasgy/dxeQztLuehNyCBoSpo6nBPQJ31QLHjMBlsZf/4kY4cFFwi5azhs1VtoEP443JWg=="
     },
     "html-tokenize": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11819,9 +11819,9 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-screen-capture-js": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/html-screen-capture-js/-/html-screen-capture-js-1.0.43.tgz",
-      "integrity": "sha512-DdHRya4U4wu7S9pj/yasgy/dxeQztLuehNyCBoSpo6nBPQJ31QLHjMBlsZf/4kY4cFFwi5azhs1VtoEP443JWg=="
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/html-screen-capture-js/-/html-screen-capture-js-1.0.44.tgz",
+      "integrity": "sha512-oz5oRhAnRdDweQ9UyM2YQ5+MHvyzbazJnmnIzLlwz2fQbdt46LXZezU2KeVfJQmzGms+np5MsAMW6T3d63Z3pg=="
     },
     "html-tokenize": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gatsby-plugin-emotion": "^4.1.22",
     "gatsby-plugin-react-helmet": "^3.1.14",
     "highlight.js": "^9.16.2",
-    "html-screen-capture-js": "^1.0.43",
+    "html-screen-capture-js": "^1.0.44",
     "mongodb-stitch-browser-sdk": "^4.8.0",
     "mongodb-stitch-server-sdk": "^4.7.1",
     "no-scroll": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gatsby-plugin-emotion": "^4.1.22",
     "gatsby-plugin-react-helmet": "^3.1.14",
     "highlight.js": "^9.16.2",
-    "html-screen-capture-js": "^1.0.31",
+    "html-screen-capture-js": "^1.0.43",
     "mongodb-stitch-browser-sdk": "^4.8.0",
     "mongodb-stitch-server-sdk": "^4.7.1",
     "no-scroll": "^2.1.1",


### PR DESCRIPTION
Since html-screen-capture-js@1.0.31 (the version currently used by Snooty), we added support for more types of inputs (e.g. checkboxes, textareas, etc.), handled resized images, and fixed some minor defects. I don't have Snooty working locally, so I'm unable to test this, but html-screen-capture-js doesn't break compatibility between versions, so hopefully, this should go smoothly. It would be great if some Mongo Ninja can test and merge this upgrade.