### PR TITLE
DOP-1017: Use PATH_PREFIX env variable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
       },
       setupFilesAfterEnv: ['<rootDir>/tests/testSetup.js', '<rootDir>/tests/emotionTestSetup.js'],
       snapshotSerializers: ['enzyme-to-json/serializer'],
-      testMatch: ['<rootDir>/tests/unit/*.test.js'],
+      testMatch: ['<rootDir>/tests/unit/*.test.js', '<rootDir>/tests/unit/utils/*.test.js'],
       transform: {
         '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
       },

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -1,6 +1,14 @@
 const normalizePath = path => path.replace(/\/+/g, `/`);
 
-const generatePathPrefix = ({ commitHash, parserBranch, patchId, project, snootyBranch, user }) => {
+const generatePathPrefix = ({ commitHash, parserBranch, patchId, pathPrefix, project, snootyBranch, user }) => {
+  // If user specified a PATH_PREFIX environment variable, ensure it begins with a prefix and use
+  if (pathPrefix) {
+    if (pathPrefix.startsWith('/')) {
+      return pathPrefix;
+    }
+    return `/${pathPrefix}`;
+  }
+
   let prefix = '';
   if (commitHash) prefix += `${commitHash}`;
   if (patchId) prefix += `/${patchId}`;

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -31,6 +31,7 @@ const siteMetadata = {
   parserBranch: process.env.GATSBY_PARSER_BRANCH,
   parserUser: process.env.GATSBY_PARSER_USER,
   patchId: process.env.PATCH_ID || '',
+  pathPrefix: process.env.PATH_PREFIX,
   project: process.env.GATSBY_SITE,
   snootyBranch: gitBranch,
   user: userInfo().username,

--- a/tests/unit/utils/generate-path-prefix.test.js
+++ b/tests/unit/utils/generate-path-prefix.test.js
@@ -1,0 +1,69 @@
+import { generatePathPrefix } from '../../../src/utils/generate-path-prefix';
+
+describe('path prefix testing', () => {
+  const commitHash = 'COMMIT_HASH';
+  const parserBranch = 'PARSER_BRANCH';
+  const patchId = 'PATCH_ID';
+  const project = 'PROJECT';
+  const snootyBranch = 'SNOOTY_BRANCH';
+  const user = 'USER';
+  const pathPrefix = 'PATH_PREFIX';
+  const pathPrefixSlash = '/PATH_PREFIX_SLASH';
+  const siteMetadata = {
+    parserBranch,
+    project,
+    snootyBranch,
+    user,
+  };
+
+  expect(process.env.GATSBY_SNOOTY_DEV).toBeUndefined();
+  let prefix;
+
+  it('should generate a prefix when none is provided', () => {
+    prefix = generatePathPrefix(siteMetadata);
+    expect(prefix).toBe(`/${project}/${user}/${parserBranch}`);
+  });
+
+  describe('when using developer mode', () => {
+    beforeAll(() => {
+      process.env.GATSBY_SNOOTY_DEV = true;
+    });
+
+    afterAll(() => {
+      delete process.env.GATSBY_SNOOTY_DEV;
+    });
+
+    it('should generate a different prefix if GATSBY_SNOOTY_DEV is enabled', () => {
+      expect(process.env.GATSBY_SNOOTY_DEV).toBe('true');
+      prefix = generatePathPrefix(siteMetadata);
+      expect(prefix).toBe(`/${parserBranch}/${project}/${user}/${snootyBranch}`);
+    });
+  });
+
+  it('should included the commit hash, if specified', () => {
+    expect(process.env.GATSBY_SNOOTY_DEV).toBeUndefined();
+    siteMetadata.commitHash = commitHash;
+    prefix = generatePathPrefix(siteMetadata);
+    expect(prefix).toBe(`/${commitHash}/${project}/${user}/${parserBranch}`);
+  });
+
+  it('should included the patch ID, if specified', () => {
+    siteMetadata.patchId = patchId;
+    prefix = generatePathPrefix(siteMetadata);
+    expect(prefix).toBe(`/${commitHash}/${patchId}/${project}/${user}/${parserBranch}`);
+  });
+
+  describe('when using a defined path prefix vairable', () => {
+    it('should prepend a slash if the variable does not include one', () => {
+      siteMetadata.pathPrefix = pathPrefix;
+      prefix = generatePathPrefix(siteMetadata);
+      expect(prefix).toBe(`/${pathPrefix}`);
+    });
+
+    it('should not prepend an additional slash', () => {
+      siteMetadata.pathPrefix = pathPrefixSlash;
+      prefix = generatePathPrefix(siteMetadata);
+      expect(prefix).toBe(pathPrefixSlash);
+    });
+  });
+});


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1017)] Accept `PATH_PREFIX` env variable and use as [Gatsby’s path prefix](https://www.gatsbyjs.org/docs/path-prefix/), if specified. Otherwise, generate path prefix using `/project/user/branch` as before.