### PR TITLE
DOP-1046: Hide feedback widget heading container for non-title headings

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -7,6 +7,8 @@ import useScreenSize from '../hooks/useScreenSize';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
+const ConditionalWrapper = ({ condition, wrapper, children }) => (condition ? wrapper(children) : children);
+
 const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const id = nodeData.id || '';
   const HeadingTag = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
@@ -16,7 +18,15 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const shouldShowStarRating = isPageTitle && isTabletOrMobile;
 
   return (
-    <HeadingContainer className={`heading-container-h${sectionDepth}`} stackVertically={isSmallScreen}>
+    <ConditionalWrapper
+      condition={shouldShowStarRating}
+      wrapper={children => (
+        <HeadingContainer className={`heading-container-h${sectionDepth}`} stackVertically={isSmallScreen}>
+          {children}
+          <FeedbackHeading isStacked={isSmallScreen} />
+        </HeadingContainer>
+      )}
+    >
       <HeadingTag id={id}>
         {nodeData.children.map((element, index) => {
           return <ComponentFactory {...rest} nodeData={element} key={index} />;
@@ -25,8 +35,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
           ¶
         </a>
       </HeadingTag>
-      <FeedbackHeading isVisible={shouldShowStarRating} isStacked={isSmallScreen} />
-    </HeadingContainer>
+    </ConditionalWrapper>
   );
 };
 

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -114,8 +114,7 @@ describe('FeedbackWidget', () => {
   describe('FeedbackHeading', () => {
     it('is hidden on large/desktop screens', async () => {
       wrapper = await mountFormWithFeedbackState({}, withScreenSize('desktop'));
-      expect(wrapper.exists('FeedbackHeading')).toBe(true);
-      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(0);
+      expect(wrapper.exists('FeedbackHeading')).toBe(false);
     });
 
     it('is visible on medium/tablet screens', async () => {

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -1,34 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-.emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-<div
-  class="heading-container-h3 emotion-0 emotion-1"
+<h3
+  id="create-an-administrative-username-and-password"
 >
-  <h3
-    id="create-an-administrative-username-and-password"
+  Create an administrative username and password
+  <a
+    class="headerlink"
+    href="#create-an-administrative-username-and-password"
+    title="Permalink to this headline"
   >
-    Create an administrative username and password
-    <a
-      class="headerlink"
-      href="#create-an-administrative-username-and-password"
-      title="Permalink to this headline"
-    >
-      ¶
-    </a>
-  </h3>
-</div>
+    ¶
+  </a>
+</h3>
 `;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1046)] [[Homepage Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/sophstad/DOP-1046/)] [[Charts Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/charts/sophstad/DOP-1046/)] Expected behavior:
- Feedback widget stars render on mobile: `<h1>` tags are surrounded by heading container `<div>`
  - Homepage does _not_ render star widget, by design
- All other `<hN>` tags are _not_ surrounded by heading container `<div>` (mobile and desktop)