### PR TITLE
DOP-1012: Change <td> to <th> for stub columns

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -107,24 +107,29 @@ ListTableBody.propTypes = {
 
 const ListTableBodyRow = ({ row, rowIndex, stubColumnCount, ...rest }) => (
   <tr className={rowIndex % 2 === 0 ? 'row-odd' : 'row-even'}>
-    {row.map((column, colIndex) => (
-      <td className={`${colIndex <= stubColumnCount - 1 ? 'stub' : ''}`} key={colIndex}>
-        {column.children.map((element, index) => {
-          let colClass = [];
-          if (index === 0) {
-            colClass.push('first');
-          }
-          if (index === column.children.length - 1) {
-            colClass.push('last');
-          }
-          return (
-            <CSSWrapper className={colClass.join(' ')} key={index}>
-              <ComponentFactory {...rest} key={index} nodeData={element} parentNode="listTable" />
-            </CSSWrapper>
-          );
-        })}
-      </td>
-    ))}
+    {row.map((column, colIndex) => {
+      let isStub = colIndex <= stubColumnCount - 1;
+      const CellTag = isStub ? 'th' : 'td';
+      let cellClass = isStub ? 'stub' : '';
+      return (
+        <CellTag className={cellClass} key={colIndex}>
+          {column.children.map((element, index) => {
+            let colChildClass = [];
+            if (index === 0) {
+              colChildClass.push('first');
+            }
+            if (index === column.children.length - 1) {
+              colChildClass.push('last');
+            }
+            return (
+              <CSSWrapper className={colChildClass.join(' ')} key={index}>
+                <ComponentFactory {...rest} key={index} nodeData={element} parentNode="listTable" />
+              </CSSWrapper>
+            );
+          })}
+        </CellTag>
+      );
+    })}
   </tr>
 );
 

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -109,29 +109,20 @@ const ListTableBodyRow = ({ row, rowIndex, stubColumnCount, ...rest }) => (
   <tr className={rowIndex % 2 === 0 ? 'row-odd' : 'row-even'}>
     {row.map((column, colIndex) => (
       <td className={`${colIndex <= stubColumnCount - 1 ? 'stub' : ''}`} key={colIndex}>
-        {column.children.length === 1 ? (
-          <CSSWrapper className={['first', 'last'].join(' ')}>
-            <ComponentFactory {...rest} nodeData={getNestedValue(['children', 0], column)} parentNode="listTable" />
-          </CSSWrapper>
-        ) : (
-          column.children.map((element, index) => {
-            if (index === 0) {
-              return (
-                <CSSWrapper key={index} className="first">
-                  <ComponentFactory {...rest} nodeData={element} />
-                </CSSWrapper>
-              );
-            }
-            if (index === column.children.length - 1) {
-              return (
-                <CSSWrapper key={index} className="last">
-                  <ComponentFactory {...rest} nodeData={element} />
-                </CSSWrapper>
-              );
-            }
-            return <ComponentFactory {...rest} key={index} nodeData={element} />;
-          })
-        )}
+        {column.children.map((element, index) => {
+          let colClass = [];
+          if (index === 0) {
+            colClass.push('first');
+          }
+          if (index === column.children.length - 1) {
+            colClass.push('last');
+          }
+          return (
+            <CSSWrapper className={colClass.join(' ')} key={index}>
+              <ComponentFactory {...rest} key={index} nodeData={element} parentNode="listTable" />
+            </CSSWrapper>
+          );
+        })}
       </td>
     ))}
   </tr>

--- a/tests/unit/ListTable.test.js
+++ b/tests/unit/ListTable.test.js
@@ -51,7 +51,7 @@ describe('when rendering a list-table directive', () => {
     ).toHaveLength(5);
   });
 
-  it('displays six body columns', () => {
+  it('displays five body columns', () => {
     expect(
       wrapper
         .find('tbody')
@@ -60,7 +60,19 @@ describe('when rendering a list-table directive', () => {
         .first()
         .children()
         .find('td')
-    ).toHaveLength(6);
+    ).toHaveLength(5);
+  });
+
+  it('displays one stub column', () => {
+    expect(
+      wrapper
+        .find('tbody')
+        .children()
+        .find('tr')
+        .first()
+        .children()
+        .find('th')
+    ).toHaveLength(1);
   });
 
   it('applies the class passed in as an option', () => {

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -106,11 +106,11 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
     <tr
       class="row-even"
     >
-      <td
+      <th
         class="stub"
       >
         journal
-      </td>
+      </th>
       <td
         class=""
       >
@@ -140,11 +140,11 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
     <tr
       class="row-odd"
     >
-      <td
+      <th
         class="stub"
       >
         notebook
-      </td>
+      </th>
       <td
         class=""
       >
@@ -174,11 +174,11 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
     <tr
       class="row-even"
     >
-      <td
+      <th
         class="stub"
       >
         paper
-      </td>
+      </th>
       <td
         class=""
       >
@@ -208,11 +208,11 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
     <tr
       class="row-odd"
     >
-      <td
+      <th
         class="stub"
       >
         planner
-      </td>
+      </th>
       <td
         class=""
       >
@@ -242,11 +242,11 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
     <tr
       class="row-even"
     >
-      <td
+      <th
         class="stub"
       >
         postcard
-      </td>
+      </th>
       <td
         class=""
       >


### PR DESCRIPTION
[[DOP-1012]](https://jira.mongodb.org/browse/DOP-1012) [[BI-Connector]](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/claire/DOP-1012/reference/drdl)

### Notes

- Add a `CellTag` variable to dynamically tag stub columns
- Add a corresponding test
- Simplify `CSSWrapper` code