### PR TITLE
DOP-1165: add front-end support for font awesome and mms/charts-specific icons

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -55,6 +55,7 @@ import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
 import RoleFile from './Roles/File';
 import RoleGUILabel from './Roles/GUILabel';
+import RoleIcon from './Roles/Icon';
 
 const IGNORED_NAMES = ['default-domain', 'raw', 'toctree'];
 const IGNORED_TYPES = ['comment', 'substitution_definition', 'inline_target'];
@@ -67,6 +68,11 @@ export default class ComponentFactory extends Component {
       class: RoleClass,
       file: RoleFile,
       guilabel: RoleGUILabel,
+      icon: RoleIcon,
+      'icon-fa5': RoleIcon,
+      'icon-fa4': RoleIcon,
+      'icon-mms': RoleIcon,
+      'icon-charts': RoleIcon,
     };
     this.componentMap = {
       admonition: Admonition,

--- a/src/components/Roles/Icon.js
+++ b/src/components/Roles/Icon.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RoleIcon = ({ nodeData: { target, name } }) => {
+  if ((name === 'icon') | (name === 'icon-fa5')) {
+    return <i class={`fa-${target} fas`}></i>;
+  } else if (name === 'icon-fa4') {
+    return <i class={`fa4-${target} fa4`}></i>;
+  } else if (name === 'icon-charts') {
+    return <i class={`charts-icon-${target} charts-icon`}></i>;
+  } else if (name === 'icon-mms') {
+    return <i class={`mms-icon-${target} mms-icon`}></i>;
+  }
+};
+
+RoleIcon.propTypes = {
+  nodeData: PropTypes.shape({
+    target: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default RoleIcon;

--- a/src/components/Roles/Icon.js
+++ b/src/components/Roles/Icon.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 
 const RoleIcon = ({ nodeData: { target, name } }) => {
   if ((name === 'icon') | (name === 'icon-fa5')) {
-    return <i class={`fa-${target} fas`}></i>;
+    return <i className={`fa-${target} fas`}></i>;
   } else if (name === 'icon-fa4') {
-    return <i class={`fa4-${target} fa4`}></i>;
+    return <i className={`fa4-${target} fa4`}></i>;
   } else if (name === 'icon-charts') {
-    return <i class={`charts-icon-${target} charts-icon`}></i>;
+    return <i className={`charts-icon-${target} charts-icon`}></i>;
   } else if (name === 'icon-mms') {
-    return <i class={`mms-icon-${target} mms-icon`}></i>;
+    return <i className={`mms-icon-${target} mms-icon`}></i>;
   }
 };
 


### PR DESCRIPTION
Allison's first React PR. Oooh, aaah. And it seems to work!

~~For reasons that confound me, some pages seem to be having trouble remaining rendered -- for example, https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/charts/allison/icons/data-source-permissions seems to navigate itself away as soon as you click on it. There content is there, it's just hiding? I have no idea why. It doesn't appear to be specific to icons, because https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/charts/allison/icons/embedded-chart-options is doing it as well and there are no icons on that page.~~ Claire has sorted that out! Yay!


Staging (Charts): https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/charts/allison/icons/view-export-chart-data

Hopefully we'll be able to replace this with the leafygreen component once all of the CET teams have migrated to using those.
