### PR TITLE
DOP-1165: adds support for the icon-fa5-brands, which was missed

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -70,6 +70,7 @@ export default class ComponentFactory extends Component {
       guilabel: RoleGUILabel,
       icon: RoleIcon,
       'icon-fa5': RoleIcon,
+      'icon-fa5-brands': RoleIcon,
       'icon-fa4': RoleIcon,
       'icon-mms': RoleIcon,
       'icon-charts': RoleIcon,

--- a/src/components/Roles/Icon.js
+++ b/src/components/Roles/Icon.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 const RoleIcon = ({ nodeData: { target, name } }) => {
   if ((name === 'icon') | (name === 'icon-fa5')) {
     return <i className={`fa-${target} fas`}></i>;
+  } else if (name === 'icon-fa5-brands') {
+    return <i className={`fab fa-${target}`}></i>;
   } else if (name === 'icon-fa4') {
     return <i className={`fa4-${target} fa4`}></i>;
   } else if (name === 'icon-charts') {


### PR DESCRIPTION
I missed one of the icon roles, so here's it is!

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/atlas-links/datalake/allison/icon-fa5-brands/tutorial/connect#add-the-mongo-shell-to-your-system-path