### PR TITLE
DOP-1219 Add leafygreen text input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,6 +3063,47 @@
         }
       }
     },
+    "@leafygreen-ui/text-input": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-2.0.0.tgz",
+      "integrity": "sha512-2xm2AjvJMZpvSqxOueSt2/Eu1k55gb/TdkDMcWIvgnC3xgVJ8z5Hv9nJU4QP6hIiVFH+1EiOa4NJMsmA+RQg+w==",
+      "requires": {
+        "@leafygreen-ui/icon": "^6.1.0",
+        "@leafygreen-ui/lib": "^4.3.1",
+        "@leafygreen-ui/palette": "^2.0.0"
+      },
+      "dependencies": {
+        "@leafygreen-ui/emotion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-2.0.1.tgz",
+          "integrity": "sha512-eswO+aWs6vbuiEDUpZz3tGjCBtgWr3hU4ndgrjFLNOQpWOsVOaW8zQzVu1XOMLHCjtfZy2/GDME7zQWVvcrVFg==",
+          "requires": {
+            "create-emotion": "^10.0.7",
+            "create-emotion-server": "10.0.27",
+            "emotion": "^10.0.7"
+          }
+        },
+        "@leafygreen-ui/icon": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-6.1.1.tgz",
+          "integrity": "sha512-4WDRpU8y3HGnEnxqqaofvB3gPIDaBN396nh6SHjxSqa7OgJZ4zOooPAyhxlUzycNH9JNZNh9J5Z8CnkHme+AxQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^4.4.1"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.5.0.tgz",
+          "integrity": "sha512-9MVBLWXGhHGmGD/yR6Kfp0CsgZOHyI+RTp4FhR9hnynqZOax66yIsP0JEoYuK/7TjAv9mmili/H8EHENCzFuTA==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^2.0.1",
+            "@testing-library/react": "^8.0.1",
+            "facepaint": "^1.2.1",
+            "polished": "^2.3.0"
+          }
+        }
+      }
+    },
     "@leafygreen-ui/theme": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/theme/-/theme-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@leafygreen-ui/leafygreen-provider": "^1.0.0",
     "@leafygreen-ui/modal": "^3.0.1",
     "@leafygreen-ui/palette": "^2.0.0",
+    "@leafygreen-ui/text-input": "^2.0.0",
     "@leafygreen-ui/tooltip": "^3.0.0",
     "@loadable/component": "^5.12.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
This PR simply adds the [Leafygreen Text Input](https://github.com/mongodb/leafygreen-ui/tree/master/packages/text-input) package as a dependency. It is not in use yet.