### PR TITLE
DOP-1227: Add subscript and superscript support

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -74,6 +74,10 @@ export default class ComponentFactory extends Component {
       'icon-fa4': RoleIcon,
       'icon-mms': RoleIcon,
       'icon-charts': RoleIcon,
+      sub: Subscript,
+      subscript: Subscript,
+      sup: Superscript,
+      superscript: Superscript,
     };
     this.componentMap = {
       admonition: Admonition,
@@ -113,9 +117,7 @@ export default class ComponentFactory extends Component {
       section: Section,
       step: Step,
       strong: Strong,
-      subscript: Subscript,
       substitution_reference: SubstitutionReference,
-      superscript: Superscript,
       tabs: Tabs,
       'tabs-pillstrip': TabsPillstrip,
       target: Target,


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1227)] [[MongoCLI Staging](https://docs.mongodb.com/mongocli/stable/reference/atlas/cluster-create/#output)] Adds support for the `:sub:` and `:sup:` aliases of `:subscript:` and `:superscript:`.