### PR TITLE
DOP-1212: Correctly generate version URLs for production deploys

### DIFF
--- a/src/components/CSSWrapper.js
+++ b/src/components/CSSWrapper.js
@@ -13,7 +13,7 @@ export default class CSSWrapper extends React.Component {
      * GitHub issue: https://github.com/yannickcr/eslint-plugin-react/issues/678
      */
     const childNode = findDOMNode(this); // eslint-disable-line react/no-find-dom-node
-    if (childNode && childNode.classList) {
+    if (childNode && childNode.classList && className) {
       // classList.add() can only handle strings that do not contain spaces, so convert strings to an array of space-free
       // strings and iterate over this array in order to add multiple classes
       const classes = typeof className === 'string' ? className.split(' ') : className;

--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -23,7 +23,7 @@ const VersionDropdown = ({
   slug,
 }) => {
   const siteMetadata = useSiteMetadata();
-  const { parserBranch } = siteMetadata;
+  const { parserBranch, pathPrefix, project, snootyEnv } = siteMetadata;
   const [hidden, setHidden] = useState(true);
 
   const prefixVersion = version => {
@@ -79,6 +79,23 @@ const VersionDropdown = ({
     return null;
   }
 
+  const generatePrefix = version => {
+    // Manual is a special case because it does not use a path prefix (found at root of docs.mongodb.com)
+    const isManualProduction = project === 'manual' && snootyEnv === 'production';
+    if (isManualProduction) {
+      return `/${version}`;
+    }
+
+    // For production builds, append version after project name
+    if (pathPrefix) {
+      const [project] = pathPrefix.split('/');
+      return `/${project}/${version}`;
+    }
+
+    // For staging, replace current version in dynamically generated path prefix
+    return generatePathPrefix({ ...siteMetadata, parserBranch: version });
+  };
+
   return (
     <div ref={wrapperRef} className="btn-group version-sidebar">
       <Button
@@ -94,7 +111,7 @@ const VersionDropdown = ({
       {!hidden && (
         <ul className={['dropdown-menu', dropdownStyles.menu].join(' ')} role="menu">
           {active.map(version => {
-            const url = normalizePath(`${generatePathPrefix({ ...siteMetadata, parserBranch: version })}/${slug}`);
+            const url = normalizePath(`${generatePrefix(version)}/${slug}`);
             return (
               <li className={currentBranch === version ? 'active' : ''} key={version}>
                 <a className="version-selector" href={url}>

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -11,6 +11,7 @@ export const useSiteMetadata = () => {
             parserBranch
             parserUser
             patchId
+            pathPrefix
             project
             snootyBranch
             user

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -31,9 +31,10 @@ const siteMetadata = {
   parserBranch: process.env.GATSBY_PARSER_BRANCH,
   parserUser: process.env.GATSBY_PARSER_USER,
   patchId: process.env.PATCH_ID || '',
-  pathPrefix: process.env.PATH_PREFIX,
+  pathPrefix: process.env.PATH_PREFIX || '',
   project: process.env.GATSBY_SITE,
   snootyBranch: gitBranch,
+  snootyEnv: process.env.SNOOTY_ENV || 'development',
   user: userInfo().username,
 };
 


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1212)] I wasn't able to generate a staging link demonstrating this functionality because mut “places each stage under a unique namespace computed from an arbitrary username and branch” ([source](https://github.com/mongodb/mut/blob/master/mut/stage.py#L567-L568)). However, you can test this by building on your machine:

1. Configure your `.env.production` file:
```
GATSBY_SITE=bi-connector
GATSBY_PARSER_USER=sophstad
GATSBY_PARSER_BRANCH=master
GATSBY_SNOOTY_DEV=true
PATH_PREFIX=bi-connector/v2.13
```
2. `npm run build && npm run serve`
3. Inspect the URLs present in the version selector dropdown. They should include the prefix and the new version to navigate to.

Note that I also included a small bug fix in the `CSSWrapper` component.