### PR TITLE
Upgrade Leafy Text Input to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,9 +3064,9 @@
       }
     },
     "@leafygreen-ui/text-input": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-3.0.0.tgz",
-      "integrity": "sha512-tLC/pXJenY5/mz6SfvUlHSMMhARhjDjAknv9xl05/NaSnv08EN0S088aT8/nhQ3NeKw89leGf5y0kqIYg5Q00Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-3.0.1.tgz",
+      "integrity": "sha512-BAy0d4ufdCOpRexCGO7ORvJHDcFhA7tKaaRSvB+jFS+NCu4RL8QMl4NK4UXxALilORA8oW60W3GGX+ZdiGfI7g==",
       "requires": {
         "@leafygreen-ui/icon": "^6.1.0",
         "@leafygreen-ui/lib": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@leafygreen-ui/leafygreen-provider": "^1.0.0",
     "@leafygreen-ui/modal": "^3.0.1",
     "@leafygreen-ui/palette": "^2.0.0",
-    "@leafygreen-ui/text-input": "^3.0.0",
+    "@leafygreen-ui/text-input": "^3.0.1",
     "@leafygreen-ui/tooltip": "^3.0.0",
     "@loadable/component": "^5.12.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
[Changelog](https://github.com/mongodb/leafygreen-ui/blob/master/packages/text-input/CHANGELOG.md)

Fixes the aria-labelledby casing on the TextInput (which I also was noticing in the console). Didn't think this one needed to be staged :)