### PR TITLE
[DOP-1219] Searchbar Part 3: Testing

### DIFF
--- a/tests/testSetup.js
+++ b/tests/testSetup.js
@@ -30,4 +30,5 @@ Object.defineProperty(global.self, 'crypto', {
   },
 });
 
+window.matchMedia = () => ({ addListener: () => {}, removeListener: () => {} });
 window.scrollTo = () => {};

--- a/tests/unit/Searchbar.test.js
+++ b/tests/unit/Searchbar.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Searchbar from '../../src/components/Searchbar';
+
+it('renders correctly without browser', () => {
+  const condensedTree = shallow(<Searchbar isExpanded={false} />);
+  expect(condensedTree).toMatchSnapshot();
+  const expandedTree = shallow(<Searchbar isExpanded />);
+  expect(expandedTree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/Navbar.test.js.snap
+++ b/tests/unit/__snapshots__/Navbar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly without browser 1`] = `
 <Fragment>
-  <div
+  <NavbarContainer
     className="navbar"
     data-navprops="{\\"links\\": [
         {\\"url\\": \\"https://docs.mongodb.com/manual/\\",\\"text\\": \\"Server\\", \\"active\\": false},
@@ -12,8 +12,13 @@ exports[`renders correctly without browser 1`] = `
         {\\"url\\": \\"https://docs.mongodb.com/guides/\\",\\"text\\": \\"Guides\\", \\"active\\": false}
       ]}"
     id="navbar"
+    isExpanded={false}
+    shouldOpaqueWhenExpanded={true}
     tabIndex="0"
   />
-  <Searchbar />
+  <Searchbar
+    isExpanded={false}
+    setIsExpanded={[Function]}
+  />
 </Fragment>
 `;

--- a/tests/unit/__snapshots__/Searchbar.test.js.snap
+++ b/tests/unit/__snapshots__/Searchbar.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly without browser 1`] = `
+<SearchbarContainer
+  isExpanded={false}
+  onBlur={[Function]}
+  onFocus={[Function]}
+>
+  <ExpandButton
+    aria-label="Open MongoDB Docs Search"
+    onClick={[Function]}
+  >
+    <ExpandMagnifyingGlass
+      fill="#89989B"
+      glyph="MagnifyingGlass"
+    />
+  </ExpandButton>
+</SearchbarContainer>
+`;
+
+exports[`renders correctly without browser 2`] = `
+<SearchbarContainer
+  isExpanded={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+>
+  <MagnifyingGlass
+    glyph="MagnifyingGlass"
+  />
+  <StyledTextInput
+    autoFocus={true}
+    isSearching={false}
+    label="Search Docs"
+    onChange={[Function]}
+    placeholder="Search Documentation"
+    tabIndex="0"
+    value=""
+  />
+</SearchbarContainer>
+`;


### PR DESCRIPTION
This PR adds some simple unit snapshot tests for the Searchbar (closed vs open state) and augment the existing Navbar snapshot based on where #228 is going. For the `useMedia` hook I had to create a simple mock for it in `testSetup`.