### PR TITLE
DOP-1220 Search Results Part 1: Generic Pagination

### DIFF
--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -5,27 +5,15 @@ import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 
-const BUTTON_HEIGHT = theme.size.medium;
 const BUTTON_WIDTH = '14px';
 const ENABLED_COLOR = uiColors.gray.dark2;
 const DISABLED_COLOR = uiColors.gray.light1;
 
 const PaginationButton = styled(IconButton)`
   background-color: #fff;
-  height: ${BUTTON_HEIGHT};
   padding: 0;
   width: ${BUTTON_WIDTH};
   z-index: 1;
-  /* Below removes default hover effects from button */
-  background-image: none;
-  border: none;
-  box-shadow: none;
-  :before {
-    display: none;
-  }
-  :after {
-    display: none;
-  }
 `;
 
 const PaginationContainer = styled('div')`

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from '@emotion/styled';
-import Button from '@leafygreen-ui/button';
+import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
@@ -10,7 +10,7 @@ const BUTTON_WIDTH = '14px';
 const ENABLED_COLOR = uiColors.gray.dark2;
 const DISABLED_COLOR = uiColors.gray.light1;
 
-const PaginationButton = styled(Button)`
+const PaginationButton = styled(IconButton)`
   background-color: #fff;
   height: ${BUTTON_HEIGHT};
   padding: 0;
@@ -28,14 +28,6 @@ const PaginationButton = styled(Button)`
   }
 `;
 
-const PaginationButtonIcon = styled(Icon)`
-  height: ${BUTTON_HEIGHT};
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: ${BUTTON_WIDTH};
-`;
-
 const PaginationContainer = styled('div')`
   align-items: center;
   display: flex;
@@ -47,31 +39,32 @@ const PaginationText = styled('p')`
 `;
 
 const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
-  const decrementPage = useCallback(() => setCurrentPage(currentPage - 1), [currentPage, setCurrentPage]);
-  const incrementPage = useCallback(() => setCurrentPage(currentPage + 1), [currentPage, setCurrentPage]);
+  const decrementPage = useCallback(() => {
+    if (currentPage !== 1) setCurrentPage(currentPage - 1);
+  }, [currentPage, setCurrentPage]);
+  const incrementPage = useCallback(() => {
+    if (currentPage !== totalPages) setCurrentPage(currentPage + 1);
+  }, [currentPage, setCurrentPage, totalPages]);
   const canDecrementPage = useMemo(() => currentPage !== 1, [currentPage]);
   const canIncrementPage = useMemo(() => currentPage < totalPages, [currentPage, totalPages]);
   return (
     <PaginationContainer>
-      <PaginationButton
-        aria-label="Back Page"
-        disabled={!canDecrementPage}
-        glyph={<PaginationButtonIcon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
-        onClick={decrementPage}
-        title="Back Page"
-      />
+      <PaginationButton ariaLabel="Back Page" disabled={!canDecrementPage} onClick={decrementPage} title="Back Page">
+        <Icon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
+      </PaginationButton>
       <PaginationText>
         <strong>
           {currentPage}/{totalPages}
         </strong>
       </PaginationText>
       <PaginationButton
-        aria-label="Forward Page"
+        ariaLabel="Forward Page"
         disabled={!canIncrementPage}
-        glyph={<PaginationButtonIcon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
         onClick={incrementPage}
         title="Forward Page"
-      />
+      >
+        <Icon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
+      </PaginationButton>
     </PaginationContainer>
   );
 };

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -56,13 +56,8 @@ const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
       <PaginationButton
         aria-label="Back Page"
         disabled={!canDecrementPage}
-        glyph={
-          <PaginationButtonIcon
-            glyph="ChevronLeft"
-            fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR}
-            onClick={decrementPage}
-          />
-        }
+        glyph={<PaginationButtonIcon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
+        onClick={decrementPage}
         title="Back Page"
       />
       <PaginationText>
@@ -73,13 +68,8 @@ const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
       <PaginationButton
         aria-label="Forward Page"
         disabled={!canIncrementPage}
-        glyph={
-          <PaginationButtonIcon
-            glyph="ChevronRight"
-            fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR}
-            onClick={incrementPage}
-          />
-        }
+        glyph={<PaginationButtonIcon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
+        onClick={incrementPage}
         title="Forward Page"
       />
     </PaginationContainer>

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -38,12 +38,13 @@ const PaginationButtonIcon = styled(Icon)`
 `;
 
 const PaginationContainer = styled('div')`
+  align-items: center;
   display: flex;
 `;
 
 const PaginationText = styled('p')`
+  font-size: ${theme.size.default};
   margin: 0 ${theme.size.tiny};
-  line-height: 22px;
 `;
 
 const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -13,7 +13,6 @@ const DISABLED_COLOR = uiColors.gray.light1;
 const PaginationButton = styled(Button)`
   background-color: #fff;
   height: ${BUTTON_HEIGHT};
-  /* button is 24 px and entire container is 36px so 6px top gives equal spacing */
   padding: 0;
   width: ${BUTTON_WIDTH};
   z-index: 1;

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -1,0 +1,89 @@
+import React, { useCallback, useMemo } from 'react';
+import styled from '@emotion/styled';
+import Button from '@leafygreen-ui/button';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import { theme } from '../../theme/docsTheme';
+
+const BUTTON_HEIGHT = theme.size.medium;
+const BUTTON_WIDTH = '14px';
+const ENABLED_COLOR = uiColors.gray.dark2;
+const DISABLED_COLOR = uiColors.gray.light1;
+
+const PaginationButton = styled(Button)`
+  background-color: #fff;
+  height: ${BUTTON_HEIGHT};
+  /* button is 24 px and entire container is 36px so 6px top gives equal spacing */
+  padding: 0;
+  width: ${BUTTON_WIDTH};
+  z-index: 1;
+  /* Below removes default hover effects from button */
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
+const PaginationButtonIcon = styled(Icon)`
+  height: ${BUTTON_HEIGHT};
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: ${BUTTON_WIDTH};
+`;
+
+const PaginationContainer = styled('div')`
+  display: flex;
+`;
+
+const PaginationText = styled('p')`
+  margin: 0 ${theme.size.tiny};
+  line-height: 22px;
+`;
+
+const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
+  const decrementPage = useCallback(() => setCurrentPage(currentPage - 1), [currentPage, setCurrentPage]);
+  const incrementPage = useCallback(() => setCurrentPage(currentPage + 1), [currentPage, setCurrentPage]);
+  const canDecrementPage = useMemo(() => currentPage !== 1, [currentPage]);
+  const canIncrementPage = useMemo(() => currentPage < totalPages, [currentPage, totalPages]);
+  return (
+    <PaginationContainer>
+      <PaginationButton
+        aria-label="Back Page"
+        disabled={!canDecrementPage}
+        glyph={
+          <PaginationButtonIcon
+            glyph="ChevronLeft"
+            fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR}
+            onClick={decrementPage}
+          />
+        }
+        title="Back Page"
+      />
+      <PaginationText>
+        <strong>
+          {currentPage}/{totalPages}
+        </strong>
+      </PaginationText>
+      <PaginationButton
+        aria-label="Forward Page"
+        disabled={!canIncrementPage}
+        glyph={
+          <PaginationButtonIcon
+            glyph="ChevronRight"
+            fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR}
+            onClick={incrementPage}
+          />
+        }
+        title="Forward Page"
+      />
+    </PaginationContainer>
+  );
+};
+
+export default Pagination;

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css, keyframes } from '@emotion/core';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
+import Pagination from './Pagination';
 
 const SEARCHBAR_HEIGHT = 36;
 const SEARCH_RESULTS_DESKTOP_HEIGHT = 368;
@@ -56,20 +57,31 @@ const SearchResultsContainer = styled('div')`
 `;
 
 const SearchFooter = styled('div')`
+  align-items: center;
   box-shadow: 0 0 ${theme.size.tiny} 0 rgba(184, 196, 194, 0.64);
+  display: flex;
   height: ${SEARCH_FOOTER_DESKTOP_HEIGHT};
+  justify-content: flex-end;
   position: relative;
+  padding-left: ${theme.size.default};
+  padding-right: ${theme.size.default};
   width: 100%;
   @media ${theme.screenSize.upToXSmall} {
     display: none;
   }
 `;
 
-const SearchDropdown = () => (
-  <SearchResultsContainer>
-    <SearchResults />
-    <SearchFooter />
-  </SearchResultsContainer>
-);
+const SearchDropdown = ({ results = [] }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = results ? results.length : 0;
+  return (
+    <SearchResultsContainer>
+      <SearchResults />
+      <SearchFooter>
+        <Pagination currentPage={currentPage} setCurrentPage={setCurrentPage} totalPages={totalPages} />
+      </SearchFooter>
+    </SearchResultsContainer>
+  );
+};
 
 export default SearchDropdown;

--- a/tests/unit/Pagination.test.js
+++ b/tests/unit/Pagination.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Pagination from '../../src/components/Searchbar/Pagination';
+
+it('renders pagination correctly', () => {
+  const tree = shallow(<Pagination currentPage={1} totalPages={10} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/Pagination.test.js
+++ b/tests/unit/Pagination.test.js
@@ -1,8 +1,61 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import React, { useState } from 'react';
+import { shallow, mount } from 'enzyme';
 import Pagination from '../../src/components/Searchbar/Pagination';
 
-it('renders pagination correctly', () => {
-  const tree = shallow(<Pagination currentPage={1} totalPages={10} />);
-  expect(tree).toMatchSnapshot();
+// Simple wrapper to add state control around the Pagination component
+const PaginationController = ({ startPage, totalPages }) => {
+  const [page, setPage] = useState(startPage);
+  return <Pagination currentPage={page} totalPages={totalPages} setCurrentPage={setPage} />;
+};
+
+describe('Pagination', () => {
+  it('renders pagination correctly', () => {
+    const wrapper = shallow(<Pagination currentPage={1} totalPages={10} setCurrentPage={jest.fn} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not allow page 1 to be decremented', () => {
+    const wrapper = shallow(<Pagination currentPage={1} totalPages={10} setCurrentPage={jest.fn} />);
+    let paginationText = wrapper.find('PaginationText').text();
+    expect(paginationText).toBe('1/10');
+    const decrementButton = wrapper.find('PaginationButton').at(0);
+    expect(decrementButton.props().disabled).toBeTruthy();
+    decrementButton.simulate('click');
+    paginationText = wrapper.find('PaginationText').text();
+    // Should not allow for 1 to be decremented
+    expect(paginationText).toBe('1/10');
+  });
+
+  it('should allow pages > 1 to be decremented', () => {
+    const paginationWithController = mount(<PaginationController startPage={2} totalPages={5} />);
+    let paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('2/5');
+    const decrementButton = paginationWithController.find('PaginationButton').at(0);
+    expect(decrementButton.props().disabled).toBeFalsy();
+    decrementButton.simulate('click');
+    paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('1/5');
+  });
+
+  it('should allow pages < total pages to be incremented', () => {
+    const paginationWithController = mount(<PaginationController startPage={2} totalPages={5} />);
+    let paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('2/5');
+    const incrementButton = paginationWithController.find('PaginationButton').at(1);
+    expect(incrementButton.props().disabled).toBeFalsy();
+    incrementButton.simulate('click');
+    paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('3/5');
+  });
+
+  it('should not allow the last page to be incremented', () => {
+    const paginationWithController = mount(<PaginationController startPage={5} totalPages={5} />);
+    let paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('5/5');
+    const incrementButton = paginationWithController.find('PaginationButton').at(1);
+    expect(incrementButton.props().disabled).toBeTruthy();
+    incrementButton.simulate('click');
+    paginationText = paginationWithController.find('PaginationText').text();
+    expect(paginationText).toBe('5/5');
+  });
 });

--- a/tests/unit/__snapshots__/Pagination.test.js.snap
+++ b/tests/unit/__snapshots__/Pagination.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders pagination correctly 1`] = `
+<PaginationContainer>
+  <PaginationButton
+    aria-label="Back Page"
+    disabled={true}
+    glyph={
+      <ForwardRef(render)
+        fill="#B8C4C2"
+        glyph="ChevronLeft"
+        onClick={[Function]}
+      />
+    }
+    title="Back Page"
+  />
+  <PaginationText>
+    <strong>
+      1
+      /
+      10
+    </strong>
+  </PaginationText>
+  <PaginationButton
+    aria-label="Forward Page"
+    disabled={false}
+    glyph={
+      <ForwardRef(render)
+        fill="#3D4F58"
+        glyph="ChevronRight"
+        onClick={[Function]}
+      />
+    }
+    title="Forward Page"
+  />
+</PaginationContainer>
+`;

--- a/tests/unit/__snapshots__/Pagination.test.js.snap
+++ b/tests/unit/__snapshots__/Pagination.test.js.snap
@@ -3,17 +3,16 @@
 exports[`Pagination renders pagination correctly 1`] = `
 <PaginationContainer>
   <PaginationButton
-    aria-label="Back Page"
+    ariaLabel="Back Page"
     disabled={true}
-    glyph={
-      <ForwardRef(render)
-        fill="#B8C4C2"
-        glyph="ChevronLeft"
-      />
-    }
     onClick={[Function]}
     title="Back Page"
-  />
+  >
+    <Icon
+      fill="#B8C4C2"
+      glyph="ChevronLeft"
+    />
+  </PaginationButton>
   <PaginationText>
     <strong>
       1
@@ -22,16 +21,15 @@ exports[`Pagination renders pagination correctly 1`] = `
     </strong>
   </PaginationText>
   <PaginationButton
-    aria-label="Forward Page"
+    ariaLabel="Forward Page"
     disabled={false}
-    glyph={
-      <ForwardRef(render)
-        fill="#3D4F58"
-        glyph="ChevronRight"
-      />
-    }
     onClick={[Function]}
     title="Forward Page"
-  />
+  >
+    <Icon
+      fill="#3D4F58"
+      glyph="ChevronRight"
+    />
+  </PaginationButton>
 </PaginationContainer>
 `;

--- a/tests/unit/__snapshots__/Pagination.test.js.snap
+++ b/tests/unit/__snapshots__/Pagination.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders pagination correctly 1`] = `
+exports[`Pagination renders pagination correctly 1`] = `
 <PaginationContainer>
   <PaginationButton
     aria-label="Back Page"
@@ -9,9 +9,9 @@ exports[`renders pagination correctly 1`] = `
       <ForwardRef(render)
         fill="#B8C4C2"
         glyph="ChevronLeft"
-        onClick={[Function]}
       />
     }
+    onClick={[Function]}
     title="Back Page"
   />
   <PaginationText>
@@ -28,9 +28,9 @@ exports[`renders pagination correctly 1`] = `
       <ForwardRef(render)
         fill="#3D4F58"
         glyph="ChevronRight"
-        onClick={[Function]}
       />
     }
+    onClick={[Function]}
     title="Forward Page"
   />
 </PaginationContainer>


### PR DESCRIPTION
[Staging Guides](https://docs-mongodbcom-staging.corp.mongodb.com/master/guides/jordanstapinski/pagination-component/)
[Staging Ecosystem](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/pagination-component/)
^ For these I just left the dropdown open for easier inspection. That is not a change made in this PR.

This PR adds a generic `Pagination` component to be used with search results. I also added interaction and snapshot testing for it. This component lets a parent component control the current page and enables/disables actions accordingly.

![Screen Shot 2020-07-21 at 1 43 07 PM](https://user-images.githubusercontent.com/9064401/88088268-236b0c00-cb58-11ea-8c62-2625b0045a47.png)
