### PR TITLE
DOP-1256: Implement Rubric directive

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -49,6 +49,7 @@ import Image from './Image';
 import RefRole from './RefRole';
 import Target from './Target';
 import Glossary from './Glossary';
+import Rubric from './Rubric';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -112,6 +113,7 @@ const componentMap = {
   paragraph: Paragraph,
   ref_role: RefRole,
   reference: Reference,
+  rubric: Rubric,
   section: Section,
   step: Step,
   strong: Strong,

--- a/src/components/Roles/Abbr.js
+++ b/src/components/Roles/Abbr.js
@@ -10,9 +10,11 @@ const Abbr = ({
     return null;
   }
 
-  // Abbreviations appear as "ABBR (Full Name Here)", so separate this into `abbr` and `expansion`
+  // Abbreviations are written as as "ABBR (Full Name Here)", so separate this into `abbr` and `expansion`
   let [abbr, expansion] = value.split('(');
-  expansion = expansion.split(')')[0];
+  if (expansion) {
+    expansion = expansion.split(')')[0];
+  }
   return <abbr title={expansion}>{abbr}</abbr>;
 };
 

--- a/src/components/Rubric.js
+++ b/src/components/Rubric.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const Rubric = ({ nodeData: { argument }, ...rest }) => (
+  <p className="rubric">
+    {argument.map((node, i) => (
+      <ComponentFactory {...rest} key={i} nodeData={node} />
+    ))}
+  </p>
+);
+
+Rubric.propTypes = {
+  nodeData: PropTypes.shape({
+    argument: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default Rubric;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1256)] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/DOP-1256/reference/api/apiKeys-orgs-get-one)] <— [source](https://github.com/schmalliso/cloud-docs/blob/snooty-setup/source/includes/api/base-api-uri.rst)
- Support `rubric` directive
- Bonus: add error handling to `:abbr:` role component