### PR TITLE
DOP-1220 Search Results Part 2: Desktop Search Results

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,6 +3,7 @@ import useMedia from '../hooks/use-media';
 import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import { isBrowser } from '../utils/is-browser';
+import { searchParamsToURL } from '../utils/search-params-to-url';
 import { URL_SLUGS } from '../constants';
 import Searchbar from './Searchbar';
 
@@ -91,7 +92,11 @@ const Navbar = () => {
         className="navbar"
         data-navprops={navprops}
       />
-      <Searchbar isExpanded={isSearchbarExpanded} setIsExpanded={onSearchbarExpand} />
+      <Searchbar
+        isExpanded={isSearchbarExpanded}
+        setIsExpanded={onSearchbarExpand}
+        searchParamsToURL={searchParamsToURL}
+      />
     </>
   );
 };

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -1,19 +1,39 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from '@emotion/styled';
-import IconButton from '@leafygreen-ui/icon-button';
+import Button from '@leafygreen-ui/button';
 import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 
+const BUTTON_HEIGHT = theme.size.medium;
 const BUTTON_WIDTH = '14px';
 const ENABLED_COLOR = uiColors.gray.dark2;
 const DISABLED_COLOR = uiColors.gray.light1;
 
-const PaginationButton = styled(IconButton)`
+const PaginationButton = styled(Button)`
   background-color: #fff;
+  height: ${BUTTON_HEIGHT};
   padding: 0;
   width: ${BUTTON_WIDTH};
   z-index: 1;
+  /* Below removes default hover effects from button */
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
+const PaginationButtonIcon = styled(Icon)`
+  height: ${BUTTON_HEIGHT};
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: ${BUTTON_WIDTH};
 `;
 
 const PaginationContainer = styled('div')`
@@ -27,32 +47,31 @@ const PaginationText = styled('p')`
 `;
 
 const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
-  const decrementPage = useCallback(() => {
-    if (currentPage !== 1) setCurrentPage(currentPage - 1);
-  }, [currentPage, setCurrentPage]);
-  const incrementPage = useCallback(() => {
-    if (currentPage !== totalPages) setCurrentPage(currentPage + 1);
-  }, [currentPage, setCurrentPage, totalPages]);
+  const decrementPage = useCallback(() => setCurrentPage(currentPage - 1), [currentPage, setCurrentPage]);
+  const incrementPage = useCallback(() => setCurrentPage(currentPage + 1), [currentPage, setCurrentPage]);
   const canDecrementPage = useMemo(() => currentPage !== 1, [currentPage]);
   const canIncrementPage = useMemo(() => currentPage < totalPages, [currentPage, totalPages]);
   return (
     <PaginationContainer>
-      <PaginationButton ariaLabel="Back Page" disabled={!canDecrementPage} onClick={decrementPage} title="Back Page">
-        <Icon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
-      </PaginationButton>
+      <PaginationButton
+        aria-label="Back Page"
+        disabled={!canDecrementPage}
+        glyph={<PaginationButtonIcon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
+        onClick={decrementPage}
+        title="Back Page"
+      />
       <PaginationText>
         <strong>
           {currentPage}/{totalPages}
         </strong>
       </PaginationText>
       <PaginationButton
-        ariaLabel="Forward Page"
+        aria-label="Forward Page"
         disabled={!canIncrementPage}
+        glyph={<PaginationButtonIcon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
         onClick={incrementPage}
         title="Forward Page"
-      >
-        <Icon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
-      </PaginationButton>
+      />
     </PaginationContainer>
   );
 };

--- a/src/components/Searchbar/Pagination.js
+++ b/src/components/Searchbar/Pagination.js
@@ -1,39 +1,19 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from '@emotion/styled';
-import Button from '@leafygreen-ui/button';
+import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 
-const BUTTON_HEIGHT = theme.size.medium;
-const BUTTON_WIDTH = '14px';
+const BUTTON_WIDTH = theme.size.default;
 const ENABLED_COLOR = uiColors.gray.dark2;
 const DISABLED_COLOR = uiColors.gray.light1;
 
-const PaginationButton = styled(Button)`
+const PaginationButton = styled(IconButton)`
   background-color: #fff;
-  height: ${BUTTON_HEIGHT};
   padding: 0;
   width: ${BUTTON_WIDTH};
   z-index: 1;
-  /* Below removes default hover effects from button */
-  background-image: none;
-  border: none;
-  box-shadow: none;
-  :before {
-    display: none;
-  }
-  :after {
-    display: none;
-  }
-`;
-
-const PaginationButtonIcon = styled(Icon)`
-  height: ${BUTTON_HEIGHT};
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: ${BUTTON_WIDTH};
 `;
 
 const PaginationContainer = styled('div')`
@@ -47,31 +27,32 @@ const PaginationText = styled('p')`
 `;
 
 const Pagination = ({ currentPage, setCurrentPage, totalPages }) => {
-  const decrementPage = useCallback(() => setCurrentPage(currentPage - 1), [currentPage, setCurrentPage]);
-  const incrementPage = useCallback(() => setCurrentPage(currentPage + 1), [currentPage, setCurrentPage]);
+  const decrementPage = useCallback(() => {
+    if (currentPage !== 1) setCurrentPage(currentPage - 1);
+  }, [currentPage, setCurrentPage]);
+  const incrementPage = useCallback(() => {
+    if (currentPage !== totalPages) setCurrentPage(currentPage + 1);
+  }, [currentPage, setCurrentPage, totalPages]);
   const canDecrementPage = useMemo(() => currentPage !== 1, [currentPage]);
   const canIncrementPage = useMemo(() => currentPage < totalPages, [currentPage, totalPages]);
   return (
     <PaginationContainer>
-      <PaginationButton
-        aria-label="Back Page"
-        disabled={!canDecrementPage}
-        glyph={<PaginationButtonIcon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
-        onClick={decrementPage}
-        title="Back Page"
-      />
+      <PaginationButton ariaLabel="Back Page" disabled={!canDecrementPage} onClick={decrementPage} title="Back Page">
+        <Icon glyph="ChevronLeft" fill={canDecrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
+      </PaginationButton>
       <PaginationText>
         <strong>
           {currentPage}/{totalPages}
         </strong>
       </PaginationText>
       <PaginationButton
-        aria-label="Forward Page"
+        ariaLabel="Forward Page"
         disabled={!canIncrementPage}
-        glyph={<PaginationButtonIcon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />}
         onClick={incrementPage}
         title="Forward Page"
-      />
+      >
+        <Icon glyph="ChevronRight" fill={canIncrementPage ? ENABLED_COLOR : DISABLED_COLOR} />
+      </PaginationButton>
     </PaginationContainer>
   );
 };

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css, keyframes } from '@emotion/core';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 import Pagination from './Pagination';
+import SearchResults from './SearchResults';
 
-const SEARCHBAR_HEIGHT = 36;
-const SEARCH_RESULTS_DESKTOP_HEIGHT = 368;
+const RESULTS_PER_PAGE = 3;
 const SEARCH_FOOTER_DESKTOP_HEIGHT = theme.size.xlarge;
 
 const animationKeyframe = startingOpacity => keyframes`
@@ -23,21 +23,6 @@ const fadeInAnimation = (startingOpacity, seconds) => css`
   animation-iteration-count: 1;
   animation-timing-function: ease-in;
   animation-duration: ${seconds};
-`;
-
-const SearchResults = styled('div')`
-  box-shadow: 0 0 ${theme.size.tiny} 0 rgba(184, 196, 194, 0.48);
-  height: ${SEARCH_RESULTS_DESKTOP_HEIGHT}px;
-  position: relative;
-  /* Give top padding on desktop to offset this extending into the searchbar */
-  padding-top: ${theme.size.default};
-  width: 100%;
-  @media ${theme.screenSize.upToXSmall} {
-    box-shadow: none;
-    /* On mobile, let the dropdown take the available height */
-    height: calc(100% - ${SEARCH_FOOTER_DESKTOP_HEIGHT} - ${SEARCHBAR_HEIGHT}px);
-    padding-top: 0;
-  }
 `;
 
 const SearchResultsContainer = styled('div')`
@@ -72,11 +57,17 @@ const SearchFooter = styled('div')`
 `;
 
 const SearchDropdown = ({ results = [] }) => {
+  const [visibleResults, setVisibleResults] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = results ? results.length : 0;
+  const totalPages = results ? Math.ceil(results.length / RESULTS_PER_PAGE) : 0;
+  useEffect(() => {
+    const start = (currentPage - 1) * RESULTS_PER_PAGE;
+    const end = currentPage * RESULTS_PER_PAGE;
+    setVisibleResults(results.slice(start, end));
+  }, [currentPage, results]);
   return (
     <SearchResultsContainer>
-      <SearchResults />
+      <SearchResults totalResultsCount={results.length} visibleResults={visibleResults} />
       <SearchFooter>
         <Pagination currentPage={currentPage} setCurrentPage={setCurrentPage} totalPages={totalPages} />
       </SearchFooter>

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -15,6 +15,7 @@ const truncate = maxLines => css`
 `;
 
 const SearchResultContainer = styled('div')`
+  height: 100%;
   :hover,
   :focus {
     background-color: ${RESULT_HOVER_COLOR};

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { theme } from '../../theme/docsTheme';
+
+const LINK_COLOR = '#494747';
+const RESULT_HOVER_COLOR = '#d8d8d8';
+
+// Truncates text to a maximum number of lines
+const truncate = maxLines => css`
+  display: -webkit-box;
+  -webkit-line-clamp: ${maxLines}; /* supported cross browser */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const SearchResultContainer = styled('div')`
+  :hover,
+  :focus {
+    background-color: ${RESULT_HOVER_COLOR};
+    transition: background-color 150ms ease-in;
+  }
+`;
+
+const SearchResultLink = styled('a')`
+  color: ${LINK_COLOR};
+  height: 100%;
+  text-decoration: none;
+  :hover,
+  :focus {
+    color: ${LINK_COLOR};
+    text-decoration: none;
+  }
+`;
+
+const StyledPreviewText = styled('p')`
+  font-family: Akzidenz;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  line-height: 20px;
+  margin-bottom: 0;
+  margin-top: 0;
+  ${({ maxLines }) => truncate(maxLines)};
+`;
+
+const StyledResultTitle = styled('p')`
+  font-family: Akzidenz;
+  font-size: 14px;
+  line-height: ${theme.size.medium};
+  letter-spacing: 0.5px;
+  height: ${theme.size.medium};
+  margin-bottom: 6px;
+  margin-top: 0;
+  ${truncate(1)};
+`;
+
+const SearchResult = React.memo(({ maxLines = 2, preview, title, url, ...props }) => (
+  <SearchResultLink href={url}>
+    <SearchResultContainer {...props}>
+      <StyledResultTitle>
+        <strong>{title}</strong>
+      </StyledResultTitle>
+      <StyledPreviewText maxLines={maxLines}>{preview}</StyledPreviewText>
+    </SearchResultContainer>
+  </SearchResultLink>
+));
+
+export default SearchResult;

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import { theme } from '../../theme/docsTheme';
 
 const LINK_COLOR = '#494747';
-const RESULT_HOVER_COLOR = '#d8d8d8';
 
 // Truncates text to a maximum number of lines
 const truncate = maxLines => css`
@@ -16,11 +15,6 @@ const truncate = maxLines => css`
 
 const SearchResultContainer = styled('div')`
   height: 100%;
-  :hover,
-  :focus {
-    background-color: ${RESULT_HOVER_COLOR};
-    transition: background-color 150ms ease-in;
-  }
 `;
 
 const SearchResultLink = styled('a')`
@@ -30,6 +24,10 @@ const SearchResultLink = styled('a')`
   :focus {
     color: ${LINK_COLOR};
     text-decoration: none;
+    ${SearchResultContainer} {
+      background-color: rgba(231, 238, 236, 0.4);
+      transition: background-color 150ms ease-in;
+    }
   }
 `;
 

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -24,7 +24,6 @@ const SearchResultContainer = styled('div')`
 
 const SearchResultLink = styled('a')`
   color: ${LINK_COLOR};
-  height: 100%;
   text-decoration: none;
   :hover,
   :focus {
@@ -55,8 +54,8 @@ const StyledResultTitle = styled('p')`
 `;
 
 const SearchResult = React.memo(({ maxLines = 2, preview, title, url, ...props }) => (
-  <SearchResultLink href={url}>
-    <SearchResultContainer {...props}>
+  <SearchResultLink href={url} {...props}>
+    <SearchResultContainer>
       <StyledResultTitle>
         <strong>{title}</strong>
       </StyledResultTitle>

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -34,7 +34,7 @@ const SearchResultLink = styled('a')`
 `;
 
 const StyledPreviewText = styled('p')`
-  font-family: Akzidenz;
+  font-family: 'Akzidenz Grotesk BQ Light';
   font-size: 14px;
   letter-spacing: 0.5px;
   line-height: 20px;
@@ -57,9 +57,7 @@ const StyledResultTitle = styled('p')`
 const SearchResult = React.memo(({ maxLines = 2, preview, title, url, ...props }) => (
   <SearchResultLink href={url} {...props}>
     <SearchResultContainer>
-      <StyledResultTitle>
-        <strong>{title}</strong>
-      </StyledResultTitle>
+      <StyledResultTitle>{title}</StyledResultTitle>
       <StyledPreviewText maxLines={maxLines}>{preview}</StyledPreviewText>
     </SearchResultContainer>
   </SearchResultLink>

--- a/src/components/Searchbar/SearchResults.js
+++ b/src/components/Searchbar/SearchResults.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { theme } from '../../theme/docsTheme';
+import SearchResult from './SearchResult';
+
+const SEARCHBAR_HEIGHT = '36px';
+const SEARCH_RESULTS_DESKTOP_HEIGHT = '368px';
+const SEARCH_RESULT_HEIGHT = '102px';
+
+const StyledResultText = styled('p')`
+  font-family: Akzidenz;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  margin: 0;
+  padding-left: ${theme.size.medium};
+`;
+
+const SearchResultsContainer = styled('div')`
+  align-items: center;
+  box-shadow: 0 0 ${theme.size.tiny} 0 rgba(184, 196, 194, 0.48);
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: ${theme.size.medium} ${SEARCH_RESULT_HEIGHT} ${SEARCH_RESULT_HEIGHT} ${SEARCH_RESULT_HEIGHT};
+  height: ${SEARCH_RESULTS_DESKTOP_HEIGHT};
+  position: relative;
+  /* Give top padding on desktop to offset this extending into the searchbar */
+  padding-top: 38px;
+  width: 100%;
+  @media ${theme.screenSize.upToXSmall} {
+    box-shadow: none;
+    /* On mobile, let the dropdown take the available height */
+    height: calc(100% - ${SEARCHBAR_HEIGHT});
+    padding-top: 0;
+  }
+`;
+
+const StyledSearchResult = styled(SearchResult)`
+  max-height: 100%;
+  height: 100%;
+  padding: ${theme.size.default} ${theme.size.medium};
+`;
+
+const SearchResults = ({ totalResultsCount, visibleResults }) => (
+  <SearchResultsContainer>
+    <StyledResultText>
+      <strong>Most Relevant Results ({totalResultsCount})</strong>
+    </StyledResultText>
+    {visibleResults.map(({ title, preview, url }) => (
+      <StyledSearchResult key={url} title={title} preview={preview} url={url} />
+    ))}
+  </SearchResultsContainer>
+);
+
+export default SearchResults;

--- a/src/components/Searchbar/SearchResults.js
+++ b/src/components/Searchbar/SearchResults.js
@@ -37,7 +37,9 @@ const SearchResultsContainer = styled('div')`
 const StyledSearchResult = styled(SearchResult)`
   max-height: 100%;
   height: 100%;
-  padding: ${theme.size.default} ${theme.size.medium};
+  > div {
+    padding: ${theme.size.default} ${theme.size.medium};
+  }
 `;
 
 const SearchResults = ({ totalResultsCount, visibleResults }) => (

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -12,6 +12,7 @@ import SearchDropdown from './SearchDropdown';
 const BUTTON_SIZE = theme.size.medium;
 const GO_BUTTON_COLOR = uiColors.green.light3;
 const GO_BUTTON_SIZE = '20px';
+const SEARCH_DELAY_TIME = 200;
 const SEARCHBAR_DESKTOP_WIDTH = 372;
 const SEARCHBAR_HEIGHT = 36;
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
@@ -196,11 +197,12 @@ const SearchbarContainer = styled('div')`
   }
 `;
 
-const Searchbar = ({ isExpanded, setIsExpanded }) => {
+const Searchbar = ({ isExpanded, setIsExpanded, searchParamsToURL }) => {
   const [value, setValue] = useState('');
-  const onChange = useCallback(e => setValue(e.target.value), []);
   const { isMobile } = useScreenSize();
   const [blurEvent, setBlurEvent] = useState(null);
+  const [searchEvent, setSearchEvent] = useState(null);
+  const [searchResults, setSearchResults] = useState([]);
   const [isFocused, setIsFocused] = useState(false);
 
   // A user is searching if the text input is focused and it is not empty
@@ -211,15 +213,32 @@ const Searchbar = ({ isExpanded, setIsExpanded }) => {
     setIsFocused(true);
   }, [blurEvent]);
   // The React onBlur event fires when tabbing between child elements
-  const onBlur = useCallback(
-    () =>
-      setBlurEvent(
-        setTimeout(() => {
-          setIsFocused(false);
-          setIsExpanded(!!value);
-        }, 0)
-      ),
-    [setIsExpanded, value]
+  const onBlur = useCallback(() => {
+    setBlurEvent(
+      setTimeout(() => {
+        setIsFocused(false);
+        setIsExpanded(!!value);
+      }, 0)
+    );
+  }, [setIsExpanded, value]);
+  const onSearchChange = useCallback(
+    e => {
+      const value = e.target.value;
+      setValue(e.target.value);
+      // Debounce any queued search event since the query has changed
+      clearTimeout(searchEvent);
+      if (value) {
+        // Set a timeout to trigger the search to avoid over-requesting
+        setSearchEvent(
+          setTimeout(async () => {
+            const result = await fetch(searchParamsToURL(value, {}));
+            const resultJson = await result.json();
+            setSearchResults(resultJson.results);
+          }, SEARCH_DELAY_TIME)
+        );
+      }
+    },
+    [searchEvent, searchParamsToURL]
   );
   return (
     <SearchbarContainer isExpanded={isExpanded} onBlur={onBlur} onFocus={onFocus}>
@@ -230,7 +249,7 @@ const Searchbar = ({ isExpanded, setIsExpanded }) => {
             autoFocus
             label="Search Docs"
             isSearching={isSearching}
-            onChange={onChange}
+            onChange={onSearchChange}
             placeholder="Search Documentation"
             tabIndex="0"
             value={value}
@@ -245,7 +264,7 @@ const Searchbar = ({ isExpanded, setIsExpanded }) => {
               glyph={<TextActionIcon glyph="X" fill={uiColors.gray.base} />}
             />
           )}
-          {isSearching && <SearchDropdown />}
+          {isSearching && <SearchDropdown results={searchResults} />}
         </>
       ) : (
         <ExpandButton aria-label="Open MongoDB Docs Search" onClick={() => setIsExpanded(true)}>

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -223,15 +223,15 @@ const Searchbar = ({ isExpanded, setIsExpanded, searchParamsToURL }) => {
   }, [setIsExpanded, value]);
   const onSearchChange = useCallback(
     e => {
-      const value = e.target.value;
-      setValue(e.target.value);
+      const enteredValue = e.target.value;
+      setValue(enteredValue);
       // Debounce any queued search event since the query has changed
       clearTimeout(searchEvent);
-      if (value) {
+      if (enteredValue) {
         // Set a timeout to trigger the search to avoid over-requesting
         setSearchEvent(
           setTimeout(async () => {
-            const result = await fetch(searchParamsToURL(value, {}));
+            const result = await fetch(searchParamsToURL(enteredValue, {}));
             const resultJson = await result.json();
             setSearchResults(resultJson.results);
           }, SEARCH_DELAY_TIME)

--- a/src/hooks/use-click-outside.js
+++ b/src/hooks/use-click-outside.js
@@ -9,17 +9,17 @@ import { useEffect } from 'react';
  */
 export const useClickOutside = (ref, onClickOutside) => {
   useEffect(() => {
-    function handleClickOutside(event) {
-      if (ref.current && !ref.current.contains(event.target)) {
+    const handleClickOutside = e => {
+      if (ref.current && !ref.current.contains(e.target)) {
         onClickOutside();
       }
-    }
-    function handleEscape(event) {
-      event = event || window.event;
-      if (event.key === 'Escape') {
+    };
+    const handleEscape = e => {
+      e = e || window.event;
+      if (e.key === 'Escape') {
         onClickOutside();
       }
-    }
+    };
     document.addEventListener('mousedown', handleClickOutside);
     // Cannot handle ESC on FF https://bugzilla.mozilla.org/show_bug.cgi?id=1443758
     document.addEventListener('keydown', handleEscape);

--- a/src/hooks/use-click-outside.js
+++ b/src/hooks/use-click-outside.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+/**
+ * This hook fires an onClickOutside handler if the given node ref is clicked
+ * outside of or the escape key is pressed
+ * @param {*} ref a node which we will fire the onClickOutside handler if clicked
+ * outside of
+ * @param {*} onClickOutside a callback handler
+ */
+export const useClickOutside = (ref, onClickOutside) => {
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        onClickOutside();
+      }
+    }
+    function handleEscape(event) {
+      event = event || window.event;
+      if (event.keyCode == 27) {
+        onClickOutside();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClickOutside, ref]);
+};

--- a/src/hooks/use-click-outside.js
+++ b/src/hooks/use-click-outside.js
@@ -16,11 +16,12 @@ export const useClickOutside = (ref, onClickOutside) => {
     }
     function handleEscape(event) {
       event = event || window.event;
-      if (event.keyCode == 27) {
+      if (event.key === 'Escape') {
         onClickOutside();
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
+    // Cannot handle ESC on FF https://bugzilla.mozilla.org/show_bug.cgi?id=1443758
     document.addEventListener('keydown', handleEscape);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -1,0 +1,6 @@
+// Search helper function to generate marian URL from params and filters
+const MARIAN_URL = 'https://marian.mongodb.com';
+export const searchParamsToURL = (searchQuery, searchFilters) => {
+  // TODO: implement filters
+  return `${MARIAN_URL}/search?q=${searchQuery}`;
+};


### PR DESCRIPTION
[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/fetch-results/)
[Guides Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/guides/jordanstapinski/fetch-results/)

This PR adds the ability to pull results from Marian and display (specifically for Desktop) in the searchbar. One idea to note is Deepak wants us to abstract Marian-specific details out of the component if possible for future re-use. As such I decided to move Marian references into utils (such as `searchParamsToUtil`) and will continue to expand on that as I continue to work on this ticket.

Highlighting relevant text, mobile responsiveness, and abstracting the marian result/removing property will come in separate PRs, this one is large enough :)