### PR TITLE
DOP-1220 Part 3: Abstract Marian Result Parsing, Limit Results

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,12 @@ module.exports = {
         '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
       },
     },
+    {
+      displayName: 'utils',
+      testMatch: ['<rootDir>/tests/utils/*.test.js'],
+      transform: {
+        '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
+      },
+    },
   ],
 };

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -94,7 +94,7 @@ const Navbar = () => {
         data-navprops={navprops}
       />
       <Searchbar
-        getResultsFromJson={getSearchbarResultsFromJSON}
+        getResultsFromJSON={getSearchbarResultsFromJSON}
         isExpanded={isSearchbarExpanded}
         setIsExpanded={onSearchbarExpand}
         searchParamsToURL={searchParamsToURL}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,6 +3,7 @@ import useMedia from '../hooks/use-media';
 import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import { isBrowser } from '../utils/is-browser';
+import { getSearchbarResultsFromJSON } from '../utils/get-searchbar-results-from-json';
 import { searchParamsToURL } from '../utils/search-params-to-url';
 import { URL_SLUGS } from '../constants';
 import Searchbar from './Searchbar';
@@ -93,6 +94,7 @@ const Navbar = () => {
         data-navprops={navprops}
       />
       <Searchbar
+        getResultsFromJson={getSearchbarResultsFromJSON}
         isExpanded={isSearchbarExpanded}
         setIsExpanded={onSearchbarExpand}
         searchParamsToURL={searchParamsToURL}

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import React, { useCallback, useMemo, useState, useRef } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Button from '@leafygreen-ui/button';
@@ -6,8 +6,8 @@ import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import TextInput from '@leafygreen-ui/text-input';
 import useScreenSize from '../../hooks/useScreenSize';
-import { theme } from '../../theme/docsTheme';
 import { useClickOutside } from '../../hooks/use-click-outside';
+import { theme } from '../../theme/docsTheme';
 import SearchDropdown from './SearchDropdown';
 
 const BUTTON_SIZE = theme.size.medium;
@@ -198,7 +198,7 @@ const SearchbarContainer = styled('div')`
   }
 `;
 
-const Searchbar = ({ isExpanded, setIsExpanded, searchParamsToURL }) => {
+const Searchbar = ({ getResultsFromJson, isExpanded, setIsExpanded, searchParamsToURL }) => {
   const [value, setValue] = useState('');
   const { isMobile } = useScreenSize();
   const [searchEvent, setSearchEvent] = useState(null);
@@ -227,12 +227,12 @@ const Searchbar = ({ isExpanded, setIsExpanded, searchParamsToURL }) => {
           setTimeout(async () => {
             const result = await fetch(searchParamsToURL(enteredValue, {}));
             const resultJson = await result.json();
-            setSearchResults(resultJson.results);
+            setSearchResults(getResultsFromJson(resultJson));
           }, SEARCH_DELAY_TIME)
         );
       }
     },
-    [searchEvent, searchParamsToURL]
+    [getResultsFromJson, searchEvent, searchParamsToURL]
   );
   // Close the dropdown and remove focus when clicked outside
   useClickOutside(ref, onBlur);

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -13,6 +13,7 @@ import SearchDropdown from './SearchDropdown';
 const BUTTON_SIZE = theme.size.medium;
 const GO_BUTTON_COLOR = uiColors.green.light3;
 const GO_BUTTON_SIZE = '20px';
+const NUMBER_SEARCH_RESULTS = 9;
 const SEARCH_DELAY_TIME = 200;
 const SEARCHBAR_DESKTOP_WIDTH = 372;
 const SEARCHBAR_HEIGHT = 36;
@@ -227,7 +228,7 @@ const Searchbar = ({ getResultsFromJson, isExpanded, setIsExpanded, searchParams
           setTimeout(async () => {
             const result = await fetch(searchParamsToURL(enteredValue, {}));
             const resultJson = await result.json();
-            setSearchResults(getResultsFromJson(resultJson));
+            setSearchResults(getResultsFromJson(resultJson, NUMBER_SEARCH_RESULTS));
           }, SEARCH_DELAY_TIME)
         );
       }

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -199,7 +199,7 @@ const SearchbarContainer = styled('div')`
   }
 `;
 
-const Searchbar = ({ getResultsFromJson, isExpanded, setIsExpanded, searchParamsToURL }) => {
+const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParamsToURL }) => {
   const [value, setValue] = useState('');
   const { isMobile } = useScreenSize();
   const [searchEvent, setSearchEvent] = useState(null);
@@ -228,12 +228,12 @@ const Searchbar = ({ getResultsFromJson, isExpanded, setIsExpanded, searchParams
           setTimeout(async () => {
             const result = await fetch(searchParamsToURL(enteredValue, {}));
             const resultJson = await result.json();
-            setSearchResults(getResultsFromJson(resultJson, NUMBER_SEARCH_RESULTS));
+            setSearchResults(getResultsFromJSON(resultJson, NUMBER_SEARCH_RESULTS));
           }, SEARCH_DELAY_TIME)
         );
       }
     },
-    [getResultsFromJson, searchEvent, searchParamsToURL]
+    [getResultsFromJSON, searchEvent, searchParamsToURL]
   );
   // Close the dropdown and remove focus when clicked outside
   useClickOutside(ref, onBlur);

--- a/src/utils/get-searchbar-results-from-json.js
+++ b/src/utils/get-searchbar-results-from-json.js
@@ -1,4 +1,10 @@
 // Helper function which extracts a marian title based on the format
-// title — property
-export const getSearchbarResultsFromJSON = resultJSON =>
-  resultJSON.results.map(r => ({ ...r, title: r.title.split(' —')[0] }));
+// title — property. Also optionally only parse the first 9 results for the dropdown
+
+export const getSearchbarResultsFromJSON = (resultJSON, limitResults) => {
+  const resultsWithoutProperty = resultJSON.results.map(r => ({ ...r, title: r.title.split(' —')[0] }));
+  if (limitResults) {
+    return resultsWithoutProperty.slice(0, limitResults);
+  }
+  return resultsWithoutProperty;
+};

--- a/src/utils/get-searchbar-results-from-json.js
+++ b/src/utils/get-searchbar-results-from-json.js
@@ -1,0 +1,4 @@
+// Helper function which extracts a marian title based on the format
+// title — property
+export const getSearchbarResultsFromJSON = resultJSON =>
+  resultJSON.results.map(r => ({ ...r, title: r.title.split(' —')[0] }));

--- a/tests/unit/__snapshots__/Navbar.test.js.snap
+++ b/tests/unit/__snapshots__/Navbar.test.js.snap
@@ -17,7 +17,9 @@ exports[`renders correctly without browser 1`] = `
     tabIndex="0"
   />
   <Searchbar
+    getResultsFromJson={[Function]}
     isExpanded={false}
+    searchParamsToURL={[Function]}
     setIsExpanded={[Function]}
   />
 </Fragment>

--- a/tests/unit/__snapshots__/Pagination.test.js.snap
+++ b/tests/unit/__snapshots__/Pagination.test.js.snap
@@ -3,16 +3,17 @@
 exports[`Pagination renders pagination correctly 1`] = `
 <PaginationContainer>
   <PaginationButton
-    ariaLabel="Back Page"
+    aria-label="Back Page"
     disabled={true}
+    glyph={
+      <ForwardRef(render)
+        fill="#B8C4C2"
+        glyph="ChevronLeft"
+      />
+    }
     onClick={[Function]}
     title="Back Page"
-  >
-    <Icon
-      fill="#B8C4C2"
-      glyph="ChevronLeft"
-    />
-  </PaginationButton>
+  />
   <PaginationText>
     <strong>
       1
@@ -21,15 +22,16 @@ exports[`Pagination renders pagination correctly 1`] = `
     </strong>
   </PaginationText>
   <PaginationButton
-    ariaLabel="Forward Page"
+    aria-label="Forward Page"
     disabled={false}
+    glyph={
+      <ForwardRef(render)
+        fill="#3D4F58"
+        glyph="ChevronRight"
+      />
+    }
     onClick={[Function]}
     title="Forward Page"
-  >
-    <Icon
-      fill="#3D4F58"
-      glyph="ChevronRight"
-    />
-  </PaginationButton>
+  />
 </PaginationContainer>
 `;

--- a/tests/unit/__snapshots__/Pagination.test.js.snap
+++ b/tests/unit/__snapshots__/Pagination.test.js.snap
@@ -3,17 +3,16 @@
 exports[`Pagination renders pagination correctly 1`] = `
 <PaginationContainer>
   <PaginationButton
-    aria-label="Back Page"
+    ariaLabel="Back Page"
     disabled={true}
-    glyph={
-      <ForwardRef(render)
-        fill="#B8C4C2"
-        glyph="ChevronLeft"
-      />
-    }
     onClick={[Function]}
     title="Back Page"
-  />
+  >
+    <Icon
+      fill="#B8C4C2"
+      glyph="ChevronLeft"
+    />
+  </PaginationButton>
   <PaginationText>
     <strong>
       1
@@ -22,16 +21,15 @@ exports[`Pagination renders pagination correctly 1`] = `
     </strong>
   </PaginationText>
   <PaginationButton
-    aria-label="Forward Page"
+    ariaLabel="Forward Page"
     disabled={false}
-    glyph={
-      <ForwardRef(render)
-        fill="#3D4F58"
-        glyph="ChevronRight"
-      />
-    }
     onClick={[Function]}
     title="Forward Page"
-  />
+  >
+    <Icon
+      fill="#3D4F58"
+      glyph="ChevronRight"
+    />
+  </PaginationButton>
 </PaginationContainer>
 `;

--- a/tests/unit/__snapshots__/Searchbar.test.js.snap
+++ b/tests/unit/__snapshots__/Searchbar.test.js.snap
@@ -3,7 +3,6 @@
 exports[`renders correctly without browser 1`] = `
 <SearchbarContainer
   isExpanded={false}
-  onBlur={[Function]}
   onFocus={[Function]}
 >
   <ExpandButton
@@ -21,7 +20,6 @@ exports[`renders correctly without browser 1`] = `
 exports[`renders correctly without browser 2`] = `
 <SearchbarContainer
   isExpanded={true}
-  onBlur={[Function]}
   onFocus={[Function]}
 >
   <MagnifyingGlass

--- a/tests/utils/get-searchbar-results-from-json.test.js
+++ b/tests/utils/get-searchbar-results-from-json.test.js
@@ -1,0 +1,10 @@
+import { getSearchbarResultsFromJSON } from '../../src/utils/get-searchbar-results-from-json';
+
+it('Properly parses a Marian Title (to remove properties)', () => {
+  const sampleDocTitle = 'Sample Title';
+  const samplePreview = 'preview';
+  const sampleResponse = { results: [{ title: `${sampleDocTitle} — MongoDB Stitch`, preview: samplePreview }] };
+  const result = getSearchbarResultsFromJSON(sampleResponse)[0];
+  expect(result.title).toBe(sampleDocTitle);
+  expect(result.preview).toBe(samplePreview);
+});

--- a/tests/utils/get-searchbar-results-from-json.test.js
+++ b/tests/utils/get-searchbar-results-from-json.test.js
@@ -8,3 +8,13 @@ it('Properly parses a Marian Title (to remove properties)', () => {
   expect(result.title).toBe(sampleDocTitle);
   expect(result.preview).toBe(samplePreview);
 });
+
+it('Returns a specified number of results', () => {
+  const sampleDocTitle = 'Sample Title';
+  const samplePreview = 'preview';
+  const sampleResponse = {
+    results: Array(10).fill({ title: `${sampleDocTitle} — MongoDB Stitch`, preview: samplePreview }),
+  };
+  const result = getSearchbarResultsFromJSON(sampleResponse, 3);
+  expect(result.length).toBe(3);
+});


### PR DESCRIPTION
[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/abstract-marian/)
[Guides Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/guides/jordanstapinski/abstract-marian/)

This PR pulls the property out of the search title and abstracts out data postprocessing after fetching the search results to a helper function called `getSearchbarResultsFromJSON`. This function adds the ability to pull the property title out as well as optionally limit the number of returned results. We also will use this on the dedicated search page.

Allison would like us to limit dropdown results to at most 9 (3 pages), so this helper function gives us that functionality (with tests!).

I also updated the relevant snapshots since I did not do so in the previous PR.