### PR TITLE
Refactor Searchbar into Smaller Components

### DIFF
--- a/src/components/Searchbar/CondensedSearchbar.js
+++ b/src/components/Searchbar/CondensedSearchbar.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import IconButton from '@leafygreen-ui/icon-button';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import { theme } from '../../theme/docsTheme';
+
+// Defining as a styled component allows us to use as a selector in ExpandButton
+const ExpandMagnifyingGlass = styled(Icon)``;
+
+const ExpandButton = styled(IconButton)`
+  background-color: #fff;
+  background-image: none;
+  border: none;
+  border-radius: ${theme.size.medium};
+  box-shadow: none;
+  height: ${theme.size.large};
+  position: absolute;
+  right: ${theme.size.small};
+  /* 32px button in a 36px container, 2px top gives equal spacing */
+  top: 2px;
+  width: ${theme.size.large};
+  z-index: 1;
+  :hover,
+  :focus {
+    background-color: #f7f9f8;
+    ${ExpandMagnifyingGlass} {
+      color: ${uiColors.gray.dark3};
+      transition: color 150ms ease-in;
+    }
+  }
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
+const CondensedSearchbar = ({ onExpand }) => (
+  <ExpandButton aria-label="Open MongoDB Docs Search" onClick={onExpand}>
+    <ExpandMagnifyingGlass glyph="MagnifyingGlass" fill={uiColors.gray.base} />
+  </ExpandButton>
+);
+
+export default CondensedSearchbar;

--- a/src/components/Searchbar/CondensedSearchbar.js
+++ b/src/components/Searchbar/CondensedSearchbar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
+import IconButton from '@leafygreen-ui/icon-button';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 

--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -1,0 +1,107 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import IconButton from '@leafygreen-ui/icon-button';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import useScreenSize from '../../hooks/useScreenSize';
+import SearchTextInput from './SearchTextInput';
+import { theme } from '../../theme/docsTheme';
+
+const CLOSE_BUTTON_SIZE = theme.size.medium;
+const GO_BUTTON_COLOR = uiColors.green.light3;
+const GO_BUTTON_SIZE = '20px';
+
+const removeDefaultHoverEffects = css`
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
+const CloseButton = styled(IconButton)`
+  background-color: #fff;
+  border-radius: ${CLOSE_BUTTON_SIZE};
+  height: ${CLOSE_BUTTON_SIZE};
+  position: absolute;
+  right: ${theme.size.small};
+  /* button is 24 px and entire container is 36px so 6px top gives equal spacing */
+  top: 6px;
+  width: ${CLOSE_BUTTON_SIZE};
+  z-index: 1;
+  ${removeDefaultHoverEffects};
+`;
+
+const GoButton = styled(IconButton)`
+  background-color: ${GO_BUTTON_COLOR};
+  border-radius: ${GO_BUTTON_SIZE};
+  height: ${GO_BUTTON_SIZE};
+  padding: 0;
+  position: absolute;
+  right: ${theme.size.default};
+  /* button is 20 px and entire container is 36px so 8px top gives equal spacing */
+  top: ${theme.size.small};
+  width: ${GO_BUTTON_SIZE};
+  z-index: 1;
+  ${removeDefaultHoverEffects};
+`;
+
+const GoIcon = styled(Icon)`
+  /* Icon box size is 16px, 3px gives equal width and height */
+  left: 2px;
+  top: 2px;
+  height: 12px;
+  position: absolute;
+  width: 12px;
+`;
+
+const MagnifyingGlass = styled(Icon)`
+  color: ${uiColors.gray.base};
+  left: ${theme.size.default};
+  position: absolute;
+  /* This icon is 16px tall in a 36px tall container, so 10px gives equal spacing */
+  top: 10px;
+  transition: color 150ms ease-in;
+  z-index: 1;
+`;
+
+const ExpandedSearchbar = ({ isFocused, onMobileClose, onChange }) => {
+  const [value, setValue] = useState('');
+  const { isMobile } = useScreenSize();
+  const shouldShowGoButton = useMemo(() => !!value && !isMobile, [isMobile, value]);
+  const isSearching = useMemo(() => !!value && isFocused, [isFocused, value]);
+
+  const onSearchQueryChange = useCallback(
+    e => {
+      const searchTerm = e.target.value;
+      setValue(searchTerm);
+      onChange(searchTerm);
+    },
+    [onChange]
+  );
+
+  return (
+    <>
+      <MagnifyingGlass glyph="MagnifyingGlass" />
+      <SearchTextInput isSearching={isSearching} onChange={onSearchQueryChange} value={value} />
+      {shouldShowGoButton && (
+        <GoButton aria-label="Go" href="#">
+          <GoIcon glyph="ArrowRight" fill="#13AA52" />
+        </GoButton>
+      )}
+      {isMobile && (
+        <CloseButton aria-label="Close Search" onClick={onMobileClose}>
+          <Icon glyph="X" fill={uiColors.gray.base} />
+        </CloseButton>
+      )}
+    </>
+  );
+};
+
+export { MagnifyingGlass };
+export default ExpandedSearchbar;

--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -1,12 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
+import IconButton from '@leafygreen-ui/icon-button';
 import { uiColors } from '@leafygreen-ui/palette';
 import useScreenSize from '../../hooks/useScreenSize';
-import SearchTextInput from './SearchTextInput';
 import { theme } from '../../theme/docsTheme';
+import SearchTextInput from './SearchTextInput';
 
 const CLOSE_BUTTON_SIZE = theme.size.medium;
 const GO_BUTTON_COLOR = uiColors.green.light3;
@@ -70,16 +70,14 @@ const MagnifyingGlass = styled(Icon)`
   z-index: 1;
 `;
 
-const ExpandedSearchbar = ({ isFocused, onMobileClose, onChange }) => {
-  const [value, setValue] = useState('');
+const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose, value }) => {
   const { isMobile } = useScreenSize();
-  const shouldShowGoButton = useMemo(() => !!value && !isMobile, [isMobile, value]);
   const isSearching = useMemo(() => !!value && isFocused, [isFocused, value]);
+  const shouldShowGoButton = useMemo(() => !!value && !isMobile, [isMobile, value]);
 
-  const onSearchQueryChange = useCallback(
+  const onSearchChange = useCallback(
     e => {
       const searchTerm = e.target.value;
-      setValue(searchTerm);
       onChange(searchTerm);
     },
     [onChange]
@@ -88,7 +86,7 @@ const ExpandedSearchbar = ({ isFocused, onMobileClose, onChange }) => {
   return (
     <>
       <MagnifyingGlass glyph="MagnifyingGlass" />
-      <SearchTextInput isSearching={isSearching} onChange={onSearchQueryChange} value={value} />
+      <SearchTextInput isSearching={isSearching} onChange={onSearchChange} value={value} />
       {shouldShowGoButton && (
         <GoButton aria-label="Go" href="#">
           <GoIcon glyph="ArrowRight" fill="#13AA52" />
@@ -103,5 +101,6 @@ const ExpandedSearchbar = ({ isFocused, onMobileClose, onChange }) => {
   );
 };
 
+// Export this icon to be used as a selector by a parent component
 export { MagnifyingGlass };
 export default ExpandedSearchbar;

--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -53,11 +53,11 @@ const GoButton = styled(IconButton)`
 
 const GoIcon = styled(Icon)`
   /* Icon box size is 16px, 3px gives equal width and height */
-  left: 2px;
-  top: 2px;
-  height: 12px;
+  left: 3px;
+  top: 3px;
+  height: 10px;
   position: absolute;
-  width: 12px;
+  width: 10px;
 `;
 
 const MagnifyingGlass = styled(Icon)`

--- a/src/components/Searchbar/SearchTextInput.js
+++ b/src/components/Searchbar/SearchTextInput.js
@@ -1,10 +1,17 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import TextInput from '@leafygreen-ui/text-input';
 import { theme } from '../../theme/docsTheme';
 
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
+
+const activeTextBarStyling = css`
+  background-color: #fff;
+  border: none;
+  color: ${uiColors.gray.dark3};
+`;
 
 const StyledTextInput = styled(TextInput)`
   /* Curve the text input box and put padding around text for icons/buttons */
@@ -43,7 +50,14 @@ const StyledTextInput = styled(TextInput)`
   @media ${theme.screenSize.upToSmall} {
     background-color: #fff;
     padding-bottom: ${theme.size.tiny};
-    ${({ issearching }) => issearching && `box-shadow: 0 2px 2px 0 rgba(231,238,236,0.2);`};
+    ${({ isSearching }) => isSearching && `box-shadow: 0 2px 2px 0 rgba(231,238,236,0.2);`};
+    div > input {
+      /* Always have this element filled in for mobile */
+      ${activeTextBarStyling}
+      /* Switching font size on mobile allows us to prevent iOS Safari from zooming in */
+      font-size: ${theme.fontSize.default};
+      line-height: 20px;
+    }
     /**
     On mobile, there is some space above the searchbar that is uncovered (on
       desktop this is taken care of by the navbar). Here we can block elements
@@ -64,7 +78,7 @@ const SearchTextInput = ({ isSearching, onChange, value, ...props }) => (
   <StyledTextInput
     autoFocus
     label="Search Docs"
-    issearching={isSearching}
+    isSearching={isSearching}
     onChange={onChange}
     placeholder="Search Documentation"
     tabIndex="0"
@@ -74,5 +88,5 @@ const SearchTextInput = ({ isSearching, onChange, value, ...props }) => (
 );
 
 // Also export the styled component for styled selector use
-export { StyledTextInput };
+export { activeTextBarStyling, StyledTextInput };
 export default SearchTextInput;

--- a/src/components/Searchbar/SearchTextInput.js
+++ b/src/components/Searchbar/SearchTextInput.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { uiColors } from '@leafygreen-ui/palette';
+import TextInput from '@leafygreen-ui/text-input';
+import { theme } from '../../theme/docsTheme';
+
+const SEARCHBAR_HEIGHT_OFFSET = '5px';
+
+const StyledTextInput = styled(TextInput)`
+  /* Curve the text input box and put padding around text for icons/buttons */
+  div > input {
+    border: none;
+    background-color: ${uiColors.gray.light3};
+    border-radius: ${theme.size.medium};
+    color: ${uiColors.gray.dark1};
+    /* 24 px for magnifying glass plus 16px margin */
+    padding-left: 40px;
+    padding-right: ${theme.size.large};
+    font-weight: 300;
+    letter-spacing: 0.5px;
+    transition: background-color 150ms ease-in;
+    ::placeholder {
+      color: ${uiColors.gray.dark1};
+    }
+    @media ${theme.screenSize.upToSmall} {
+      border: none;
+      :hover,
+      :focus {
+        border: none;
+        box-shadow: none;
+      }
+    }
+  }
+
+  /* Remove blue border on focus */
+  div > div:last-child {
+    display: none;
+  }
+  > label {
+    display: none;
+  }
+
+  @media ${theme.screenSize.upToSmall} {
+    background-color: #fff;
+    padding-bottom: ${theme.size.tiny};
+    ${({ issearching }) => issearching && `box-shadow: 0 2px 2px 0 rgba(231,238,236,0.2);`};
+    /**
+    On mobile, there is some space above the searchbar that is uncovered (on
+      desktop this is taken care of by the navbar). Here we can block elements
+      below from peeking through with a pseudoelement to cover this top space
+    */
+    :before {
+      background-color: #fff;
+      bottom: 100%;
+      content: '';
+      position: absolute;
+      top: -${SEARCHBAR_HEIGHT_OFFSET};
+      width: 100%;
+    }
+  }
+`;
+
+const SearchTextInput = ({ isSearching, onChange, value, ...props }) => (
+  <StyledTextInput
+    autoFocus
+    label="Search Docs"
+    issearching={isSearching}
+    onChange={onChange}
+    placeholder="Search Documentation"
+    tabIndex="0"
+    value={value}
+    {...props}
+  />
+);
+
+// Also export the styled component for styled selector use
+export { StyledTextInput };
+export default SearchTextInput;

--- a/src/components/Searchbar/SearchTextInput.js
+++ b/src/components/Searchbar/SearchTextInput.js
@@ -56,7 +56,7 @@ const StyledTextInput = styled(TextInput)`
       ${activeTextBarStyling}
       /* Switching font size on mobile allows us to prevent iOS Safari from zooming in */
       font-size: ${theme.fontSize.default};
-      line-height: 20px;
+      padding-top: 2px;
     }
     /**
     On mobile, there is some space above the searchbar that is uncovered (on

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -1,11 +1,10 @@
 import React, { useCallback, useMemo, useState, useRef } from 'react';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import CondensedSearchbar from './CondensedSearchbar';
 import ExpandedSearchbar, { MagnifyingGlass } from './ExpandedSearchbar';
 import SearchContext from './SearchContext';
-import { StyledTextInput } from './SearchTextInput';
+import { activeTextBarStyling, StyledTextInput } from './SearchTextInput';
 import { useClickOutside } from '../../hooks/use-click-outside';
 import { theme } from '../../theme/docsTheme';
 import SearchDropdown from './SearchDropdown';
@@ -17,12 +16,6 @@ const SEARCHBAR_DESKTOP_WIDTH = '372px';
 const SEARCHBAR_HEIGHT = '36px';
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
 const TRANSITION_SPEED = '150ms';
-
-const activeTextBarStyling = css`
-  background-color: #fff;
-  border: none;
-  color: ${uiColors.gray.dark3};
-`;
 
 const SearchbarContainer = styled('div')`
   height: ${SEARCHBAR_HEIGHT};
@@ -55,14 +48,6 @@ const SearchbarContainer = styled('div')`
     left: 0;
     top: ${SEARCHBAR_HEIGHT_OFFSET};
     width: 100%;
-    ${StyledTextInput} {
-      div > input {
-        /* Always have this element filled in for mobile */
-        ${activeTextBarStyling}
-        /* Switching font size on mobile allows us to prevent iOS Safari from zooming in */
-        font-size: ${theme.fontSize.default};
-      }
-    }
   }
 `;
 
@@ -116,7 +101,7 @@ const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParams
     <SearchbarContainer isSearching={isSearching} isExpanded={isExpanded} onFocus={onFocus} ref={searchContainerRef}>
       {isExpanded ? (
         <SearchContext.Provider value={value}>
-          <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} />
+          <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} value={value} />
           {isSearching && <SearchDropdown results={searchResults} />}
         </SearchContext.Provider>
       ) : (

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -1,23 +1,20 @@
 import React, { useCallback, useMemo, useState, useRef } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import Button from '@leafygreen-ui/button';
-import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
-import TextInput from '@leafygreen-ui/text-input';
-import useScreenSize from '../../hooks/useScreenSize';
+import CondensedSearchbar from './CondensedSearchbar';
+import ExpandedSearchbar, { MagnifyingGlass } from './ExpandedSearchbar';
 import SearchContext from './SearchContext';
+import { StyledTextInput } from './SearchTextInput';
 import { useClickOutside } from '../../hooks/use-click-outside';
 import { theme } from '../../theme/docsTheme';
 import SearchDropdown from './SearchDropdown';
 
 const BUTTON_SIZE = theme.size.medium;
-const GO_BUTTON_COLOR = uiColors.green.light3;
-const GO_BUTTON_SIZE = '20px';
 const NUMBER_SEARCH_RESULTS = 9;
 const SEARCH_DELAY_TIME = 200;
-const SEARCHBAR_DESKTOP_WIDTH = 372;
-const SEARCHBAR_HEIGHT = 36;
+const SEARCHBAR_DESKTOP_WIDTH = '372px';
+const SEARCHBAR_HEIGHT = '36px';
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
 const TRANSITION_SPEED = '150ms';
 
@@ -27,156 +24,13 @@ const activeTextBarStyling = css`
   color: ${uiColors.gray.dark3};
 `;
 
-const commonSearchButtonStyling = css`
-  background-color: #fff;
-  border-radius: ${BUTTON_SIZE};
-  height: ${BUTTON_SIZE};
-  position: absolute;
-  right: ${theme.size.small};
-  /* button is 24 px and entire container is 36px so 6px top gives equal spacing */
-  top: 6px;
-  width: ${BUTTON_SIZE};
-  z-index: 1;
-  /* Below removes default hover effects from button */
-  background-image: none;
-  border: none;
-  box-shadow: none;
-  :before {
-    display: none;
-  }
-  :after {
-    display: none;
-  }
-`;
-
-const commonSearchIconStyling = css`
-  position: absolute;
-  z-index: 1;
-`;
-
-const TextActionIcon = styled(Icon)`
-  left: ${theme.size.tiny};
-  position: absolute;
-`;
-
-const GoIcon = styled(Icon)`
-  /* Go Button size is 20px, 5px gives equal width on each size */
-  left: 5px;
-  position: absolute;
-  height: 10px;
-  width: 10px;
-`;
-
-const GoButton = styled(Button)`
-  ${commonSearchButtonStyling};
-  background-color: ${GO_BUTTON_COLOR};
-  right: ${theme.size.default};
-  border-radius: ${GO_BUTTON_SIZE};
-  height: ${GO_BUTTON_SIZE};
-  padding: 0;
-  position: absolute;
-  /* button is 20 px and entire container is 36px so 8px top gives equal spacing */
-  top: ${theme.size.small};
-  width: ${GO_BUTTON_SIZE};
-`;
-
-const CloseButton = styled(Button)`
-  ${commonSearchButtonStyling};
-`;
-
-const ExpandMagnifyingGlass = styled(Icon)`
-  /* This icon is 16px tall in a 32 px button, so 8px gives equal spacing */
-  left: ${theme.size.small};
-  top: ${theme.size.small};
-  ${commonSearchIconStyling};
-`;
-
-const ExpandButton = styled(Button)`
-  ${commonSearchButtonStyling};
-  height: ${theme.size.large};
-  width: ${theme.size.large};
-  /* 32px button in a 36px container, 2px top gives equal spacing */
-  top: 2px;
-  :hover,
-  :focus {
-    background-color: #f7f9f8;
-    ${ExpandMagnifyingGlass} {
-      color: ${uiColors.gray.dark3};
-      transition: color ${TRANSITION_SPEED} ease-in;
-    }
-  }
-`;
-
-const StyledTextInput = styled(TextInput)`
-  /* Curve the text input box and put padding around text for icons/buttons */
-  div > input {
-    border: none;
-    background-color: ${uiColors.gray.light3};
-    border-radius: ${theme.size.medium};
-    color: ${uiColors.gray.dark1};
-    /* 24 px for magnifying glass plus 16px margin */
-    padding-left: 40px;
-    padding-right: ${theme.size.large};
-    font-weight: 300;
-    letter-spacing: 0.5px;
-    transition: background-color ${TRANSITION_SPEED} ease-in;
-    ::placeholder {
-      color: ${uiColors.gray.dark1};
-    }
-    @media ${theme.screenSize.upToSmall} {
-      border: none;
-      :hover,
-      :focus {
-        border: none;
-        box-shadow: none;
-      }
-    }
-  }
-
-  /* Remove blue border on focus */
-  div > div:last-child {
-    display: none;
-  }
-  > label {
-    display: none;
-  }
-
-  @media ${theme.screenSize.upToSmall} {
-    background-color: #fff;
-    padding-bottom: ${theme.size.tiny};
-    ${({ isSearching }) => isSearching && `box-shadow: 0 2px 2px 0 rgba(231,238,236,0.2);`};
-    /**
-    On mobile, there is some space above the searchbar that is uncovered (on
-      desktop this is taken care of by the navbar). Here we can block elements
-      below from peeking through with a pseudoelement to cover this top space
-    */
-    :before {
-      background-color: #fff;
-      bottom: 100%;
-      content: '';
-      position: absolute;
-      top: -${SEARCHBAR_HEIGHT_OFFSET};
-      width: 100%;
-    }
-  }
-`;
-
-const MagnifyingGlass = styled(Icon)`
-  color: ${uiColors.gray.base};
-  left: ${theme.size.default};
-  /* This icon is 16px tall in a 36px tall container, so 10px gives equal spacing */
-  top: 10px;
-  transition: color ${TRANSITION_SPEED} ease-in;
-  ${commonSearchIconStyling};
-`;
-
 const SearchbarContainer = styled('div')`
-  height: ${SEARCHBAR_HEIGHT}px;
+  height: ${SEARCHBAR_HEIGHT};
   position: fixed;
   right: ${theme.size.default};
   top: ${SEARCHBAR_HEIGHT_OFFSET};
   transition: width ${TRANSITION_SPEED} ease-in;
-  width: ${({ isExpanded }) => (isExpanded ? `${SEARCHBAR_DESKTOP_WIDTH}px` : BUTTON_SIZE)};
+  width: ${({ isExpanded }) => (isExpanded ? SEARCHBAR_DESKTOP_WIDTH : BUTTON_SIZE)};
   /* docs-tools navbar z-index is 9999 */
   z-index: 10000;
   :hover,
@@ -197,7 +51,7 @@ const SearchbarContainer = styled('div')`
     }
   }
   @media ${theme.screenSize.upToSmall} {
-    height: ${({ isExpanded, isSearching }) => (isExpanded && isSearching ? '100%' : `${SEARCHBAR_HEIGHT}px`)};
+    height: ${({ isExpanded, isSearching }) => (isExpanded && isSearching ? '100%' : SEARCHBAR_HEIGHT)};
     left: 0;
     top: ${SEARCHBAR_HEIGHT_OFFSET};
     width: 100%;
@@ -213,77 +67,62 @@ const SearchbarContainer = styled('div')`
 `;
 
 const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParamsToURL }) => {
-  const [value, setValue] = useState('');
-  const { isMobile } = useScreenSize();
+  const [value, setValue] = useState(false);
   const [searchEvent, setSearchEvent] = useState(null);
   const [searchResults, setSearchResults] = useState([]);
   const [isFocused, setIsFocused] = useState(false);
-  const ref = useRef(null);
-
+  const searchContainerRef = useRef(null);
   // A user is searching if the text input is focused and it is not empty
   const isSearching = useMemo(() => !!value && isFocused, [isFocused, value]);
-  const shouldShowGoButton = useMemo(() => !!value && !isMobile, [isMobile, value]);
+
+  // Focus Handlers
+  const onExpand = useCallback(() => setIsExpanded(true), [setIsExpanded]);
   const onFocus = useCallback(() => setIsFocused(true), []);
+  // Remove focus and close searchbar if it disrupts the navbar
   const onBlur = useCallback(() => {
     setIsFocused(false);
+    // The parent controls whether a searchbar is expanded by default, so this may
+    // have no effect where the searchbar should always be open
     setIsExpanded(false);
   }, [setIsExpanded]);
+  // Close the dropdown and remove focus when clicked outside
+  useClickOutside(searchContainerRef, onBlur);
+  const onClose = useCallback(() => setIsExpanded(false), [setIsExpanded]);
+
+  // Update state on a new search query
+  const fetchNewSearchResults = useCallback(
+    async (searchTerm, filters) => {
+      const result = await fetch(searchParamsToURL(searchTerm, filters));
+      const resultJson = await result.json();
+      setSearchResults(getResultsFromJSON(resultJson, NUMBER_SEARCH_RESULTS));
+    },
+    [getResultsFromJSON, searchParamsToURL]
+  );
   const onSearchChange = useCallback(
-    e => {
-      const enteredValue = e.target.value;
-      setValue(enteredValue);
+    searchTerm => {
       setIsFocused(true);
+      setValue(searchTerm);
       // Debounce any queued search event since the query has changed
       clearTimeout(searchEvent);
-      if (enteredValue) {
+      if (searchTerm) {
         // Set a timeout to trigger the search to avoid over-requesting
-        setSearchEvent(
-          setTimeout(async () => {
-            const result = await fetch(searchParamsToURL(enteredValue, {}));
-            const resultJson = await result.json();
-            setSearchResults(getResultsFromJSON(resultJson, NUMBER_SEARCH_RESULTS));
-          }, SEARCH_DELAY_TIME)
-        );
+        setSearchEvent(setTimeout(async () => fetchNewSearchResults(searchTerm, {}), SEARCH_DELAY_TIME));
       }
     },
-    [getResultsFromJSON, searchEvent, searchParamsToURL]
+    [fetchNewSearchResults, searchEvent]
   );
-  // Close the dropdown and remove focus when clicked outside
-  useClickOutside(ref, onBlur);
+
   return (
-    <SearchContext.Provider value={value}>
-      <SearchbarContainer isSearching={isSearching} isExpanded={isExpanded} onFocus={onFocus} ref={ref}>
-        {isExpanded ? (
-          <>
-            <MagnifyingGlass glyph="MagnifyingGlass" />
-            <StyledTextInput
-              autoFocus
-              label="Search Docs"
-              isSearching={isSearching}
-              onChange={onSearchChange}
-              placeholder="Search Documentation"
-              tabIndex="0"
-              value={value}
-            />
-            {shouldShowGoButton && (
-              <GoButton aria-label="Go" href="#" glyph={<GoIcon glyph="ArrowRight" fill="#13AA52" />} />
-            )}
-            {isMobile && (
-              <CloseButton
-                aria-label="Close Search"
-                onClick={() => setIsExpanded(false)}
-                glyph={<TextActionIcon glyph="X" fill={uiColors.gray.base} />}
-              />
-            )}
-            {isSearching && <SearchDropdown results={searchResults} />}
-          </>
-        ) : (
-          <ExpandButton aria-label="Open MongoDB Docs Search" onClick={() => setIsExpanded(true)}>
-            <ExpandMagnifyingGlass glyph="MagnifyingGlass" fill={uiColors.gray.base} />
-          </ExpandButton>
-        )}
-      </SearchbarContainer>
-    </SearchContext.Provider>
+    <SearchbarContainer isSearching={isSearching} isExpanded={isExpanded} onFocus={onFocus} ref={searchContainerRef}>
+      {isExpanded ? (
+        <SearchContext.Provider value={value}>
+          <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} />
+          {isSearching && <SearchDropdown results={searchResults} />}
+        </SearchContext.Provider>
+      ) : (
+        <CondensedSearchbar onExpand={onExpand} />
+      )}
+    </SearchbarContainer>
   );
 };
 


### PR DESCRIPTION
[Ecosystem Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/refactor-search-component/)
[Prior Branch Ecosystem Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/mobile-results/)
[Guides Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/guides/jordanstapinski/refactor-search-component/)

This PR eliminates some building technical debt by splitting the `Searchbar` component into four components:
- The main `Searchbar` parent which acts as an overall controller of the experience
- `CondensedSearchbar` which is the magnifying glass to pop-open the searchbar
- `ExpandedSearchbar` which is the searchbar open
- `SearchTextInput` which is the custom LeafyGreen text input

These were all in one component before and it was getting tricky to manage state and control changes. This approach is much more maintainable and clean! Passing state now also feels more natural as well.

I'll bump the snapshots separately since this is large enough. I looked side by side on this branch versus the old one (and on mobile). The only change is on mobile the magnifying glass while searching is always filled in. This is actually what the design calls for anyway. No other looks or functionality should change.