### PR TITLE
DOP-1221 Part 1: Basic Filter Pane Navigation

### DIFF
--- a/src/components/Searchbar/AdvancedFiltersPane.js
+++ b/src/components/Searchbar/AdvancedFiltersPane.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { keyframes } from '@emotion/core';
+import styled from '@emotion/styled';
+import Button from '@leafygreen-ui/button';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import { theme } from '../../theme/docsTheme';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const StyledContentContainer = styled('div')`
+  animation: ${fadeIn} 300ms ease;
+`;
+
+const StyledAdvancedFiltersPane = styled('div')`
+  box-shadow: 0 0 ${theme.size.tiny} 0 rgba(184, 196, 194, 0.48);
+  position: relative;
+  padding: ${theme.size.large} ${theme.size.default} 0;
+`;
+
+const StyledReturnButton = styled(Button)`
+  color: ${uiColors.blue.base};
+  font-family: Akzidenz;
+  font-size: ${theme.fontSize.tiny};
+  letter-spacing: 0.5px;
+  line-height: ${theme.size.default};
+  margin: 0;
+  padding: ${theme.size.tiny};
+  /* Below removes default hover effects from button */
+  background: none;
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
+const AdvancedFiltersPane = ({ closeFiltersPane, ...props }) => (
+  <StyledAdvancedFiltersPane {...props}>
+    <StyledContentContainer>
+      <StyledReturnButton onClick={closeFiltersPane}>
+        <Icon glyph="ArrowLeft" size="small" />
+        &nbsp;Cancel
+      </StyledReturnButton>
+    </StyledContentContainer>
+  </StyledAdvancedFiltersPane>
+);
+
+export default AdvancedFiltersPane;

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -1,14 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { css, keyframes } from '@emotion/core';
 import styled from '@emotion/styled';
+import Button from '@leafygreen-ui/button';
 import { uiColors } from '@leafygreen-ui/palette';
 import useScreenSize from '../../hooks/useScreenSize';
 import { theme } from '../../theme/docsTheme';
+import AdvancedFiltersPane from './AdvancedFiltersPane';
 import Pagination from './Pagination';
 import SearchResults from './SearchResults';
 
 const RESULTS_PER_PAGE = 3;
 const SEARCH_FOOTER_DESKTOP_HEIGHT = theme.size.xlarge;
+const SEARCH_RESULTS_DESKTOP_HEIGHT = '368px';
 
 const animationKeyframe = startingOpacity => keyframes`
     0% {
@@ -24,6 +27,14 @@ const fadeInAnimation = (startingOpacity, seconds) => css`
   animation-iteration-count: 1;
   animation-timing-function: ease-in;
   animation-duration: ${seconds};
+`;
+
+const FixedHeightFiltersPane = styled(AdvancedFiltersPane)`
+  height: ${SEARCH_RESULTS_DESKTOP_HEIGHT};
+`;
+
+const FixedHeightSearchResults = styled(SearchResults)`
+  height: ${SEARCH_RESULTS_DESKTOP_HEIGHT};
 `;
 
 const SearchResultsContainer = styled('div')`
@@ -47,7 +58,7 @@ const SearchFooter = styled('div')`
   box-shadow: 0 0 ${theme.size.tiny} 0 rgba(184, 196, 194, 0.64);
   display: flex;
   height: ${SEARCH_FOOTER_DESKTOP_HEIGHT};
-  justify-content: flex-end;
+  justify-content: space-between;
   position: relative;
   padding-left: ${theme.size.default};
   padding-right: ${theme.size.default};
@@ -57,11 +68,36 @@ const SearchFooter = styled('div')`
   }
 `;
 
+const FilterFooterButton = styled(Button)`
+  color: ${uiColors.blue.base};
+  font-family: Akzidenz;
+  font-weight: bolder;
+  font-size: ${theme.fontSize.small};
+  letter-spacing: 0.5px;
+  line-height: ${theme.size.default};
+  margin: 0;
+  padding: ${theme.size.tiny};
+  /* Below removes default hover effects from button */
+  background: none;
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
 const SearchDropdown = ({ results = [] }) => {
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [visibleResults, setVisibleResults] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const { isMobile } = useScreenSize();
   const totalPages = results ? Math.ceil(results.length / RESULTS_PER_PAGE) : 0;
+  const closeFiltersPane = useCallback(() => setShowAdvancedFilters(false), []);
+  const openFiltersPane = useCallback(() => setShowAdvancedFilters(true), []);
   useEffect(() => {
     if (isMobile) {
       // If mobile, we give an overflow view, so no pagination is needed
@@ -72,10 +108,18 @@ const SearchDropdown = ({ results = [] }) => {
       setVisibleResults(results.slice(start, end));
     }
   }, [currentPage, isMobile, results]);
-  return (
+  return showAdvancedFilters ? (
     <SearchResultsContainer>
-      <SearchResults totalResultsCount={results.length} visibleResults={visibleResults} />
+      <FixedHeightFiltersPane closeFiltersPane={closeFiltersPane} />
       <SearchFooter>
+        <FilterFooterButton onClick={closeFiltersPane}>Apply Search Criteria</FilterFooterButton>
+      </SearchFooter>
+    </SearchResultsContainer>
+  ) : (
+    <SearchResultsContainer>
+      <FixedHeightSearchResults totalResultsCount={results.length} visibleResults={visibleResults} />
+      <SearchFooter>
+        <FilterFooterButton onClick={openFiltersPane}>Advanced Filters</FilterFooterButton>
         <Pagination currentPage={currentPage} setCurrentPage={setCurrentPage} totalPages={totalPages} />
       </SearchFooter>
     </SearchResultsContainer>

--- a/src/components/Searchbar/SearchResults.js
+++ b/src/components/Searchbar/SearchResults.js
@@ -5,7 +5,6 @@ import { theme } from '../../theme/docsTheme';
 import SearchResult from './SearchResult';
 
 const SEARCHBAR_HEIGHT = '36px';
-const SEARCH_RESULTS_DESKTOP_HEIGHT = '368px';
 const SEARCH_RESULT_HEIGHT = '102px';
 const SEARCH_RESULT_MOBILE_HEIGHT = '156px';
 
@@ -23,10 +22,9 @@ const SearchResultsContainer = styled('div')`
   display: grid;
   grid-template-columns: 100%;
   grid-template-rows: ${theme.size.medium} ${SEARCH_RESULT_HEIGHT} ${SEARCH_RESULT_HEIGHT} ${SEARCH_RESULT_HEIGHT};
-  height: ${SEARCH_RESULTS_DESKTOP_HEIGHT};
   position: relative;
   /* Give top padding on desktop to offset this extending into the searchbar */
-  padding-top: 38px;
+  padding-top: ${theme.size.large};
   width: 100%;
   @media ${theme.screenSize.upToSmall} {
     box-shadow: none;
@@ -60,10 +58,10 @@ const StyledSearchResult = styled(SearchResult)`
   }
 `;
 
-const SearchResults = ({ totalResultsCount, visibleResults }) => {
+const SearchResults = ({ totalResultsCount, visibleResults, ...props }) => {
   const { isMobile } = useScreenSize();
   return (
-    <SearchResultsContainer>
+    <SearchResultsContainer {...props}>
       <StyledResultText>
         <strong>Most Relevant Results ({totalResultsCount})</strong>
       </StyledResultText>


### PR DESCRIPTION
[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/filter-navigation/)
[Guides Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/guides/jordanstapinski/filter-navigation/)

This PR sets up a simple navigation between the results pane and a new `AdvancedFiltersPane` which will be used to display the advanced filters.
- Adds the Advanced Filters button in the results pane footer
- Adds an empty new `AdvancedFiltersPane`
- Adds logic for navigating back to the original results pane (easy to split the handler from the cancel vs apply search criteria buttons)