### PR TITLE
Selectively Autofocus Search Input

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -98,6 +98,8 @@ const Navbar = () => {
         isExpanded={isSearchbarExpanded}
         setIsExpanded={onSearchbarExpand}
         searchParamsToURL={searchParamsToURL}
+        // Autofocus the searchbar when the user expands only so the user can start typing
+        shouldAutofocus={!isSearchbarDefaultExpanded}
       />
     </>
   );

--- a/src/components/Searchbar/SearchContext.js
+++ b/src/components/Searchbar/SearchContext.js
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
 // Simple context to pass search results to children
-const SearchContext = createContext('');
+const SearchContext = createContext({ searchTerm: '', shouldAutofocus: false });
 
 export default SearchContext;

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -92,7 +92,7 @@ const sanitizePreviewHtml = text =>
   });
 
 const SearchResult = React.memo(({ learnMoreLink = false, maxLines = 2, preview, title, url, ...props }) => {
-  const searchTerm = useContext(SearchContext);
+  const { searchTerm } = useContext(SearchContext);
   const highlightedTitle = highlightSearchTerm(title, searchTerm);
   const highlightedPreviewText = highlightSearchTerm(preview, searchTerm);
   return (

--- a/src/components/Searchbar/SearchTextInput.js
+++ b/src/components/Searchbar/SearchTextInput.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import TextInput from '@leafygreen-ui/text-input';
 import { theme } from '../../theme/docsTheme';
+import SearchContext from './SearchContext';
 
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
 
@@ -74,18 +75,21 @@ const StyledTextInput = styled(TextInput)`
   }
 `;
 
-const SearchTextInput = ({ isSearching, onChange, value, ...props }) => (
-  <StyledTextInput
-    autoFocus
-    label="Search Docs"
-    isSearching={isSearching}
-    onChange={onChange}
-    placeholder="Search Documentation"
-    tabIndex="0"
-    value={value}
-    {...props}
-  />
-);
+const SearchTextInput = ({ isSearching, onChange, value, ...props }) => {
+  const { shouldAutofocus } = useContext(SearchContext);
+  return (
+    <StyledTextInput
+      autoFocus={shouldAutofocus}
+      label="Search Docs"
+      isSearching={isSearching}
+      onChange={onChange}
+      placeholder="Search Documentation"
+      tabIndex="0"
+      value={value}
+      {...props}
+    />
+  );
+};
 
 // Also export the styled component for styled selector use
 export { activeTextBarStyling, StyledTextInput };

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -51,7 +51,7 @@ const SearchbarContainer = styled('div')`
   }
 `;
 
-const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParamsToURL }) => {
+const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParamsToURL, shouldAutofocus }) => {
   const [value, setValue] = useState(false);
   const [searchEvent, setSearchEvent] = useState(null);
   const [searchResults, setSearchResults] = useState([]);
@@ -100,7 +100,7 @@ const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParams
   return (
     <SearchbarContainer isSearching={isSearching} isExpanded={isExpanded} onFocus={onFocus} ref={searchContainerRef}>
       {isExpanded ? (
-        <SearchContext.Provider value={value}>
+        <SearchContext.Provider value={{ searchTerm: value, shouldAutofocus }}>
           <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} value={value} />
           {isSearching && <SearchDropdown results={searchResults} />}
         </SearchContext.Provider>


### PR DESCRIPTION
[Ecosystem Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/selectively-autofocus/)

This PR adds a new prop to the `Searchbar` to control when `autofocus` is enabled. Previously we would `autofocus` all the time on the searchbar, but this PR chnages the behavior a bit for a good UX:
- If the searchbar is expanded by default (desktop), then we do not autofocus the searchbar
- If the searchbar is condensed by default (mobile/~1200px), when the user clicks the magnifying glass to open the searchbar then we do autofocus, since they should be able to type right away.

Using the SearchContext this was easy to add without prop drilling.

Here is what should happen in the "condensed --> expanded" action. This way the user already has the intent to search, and leaving autofocus off would require them to click again to focus and type.

![Screen Shot 2020-07-30 at 1 09 50 PM](https://user-images.githubusercontent.com/9064401/88953182-86e6ef00-d266-11ea-90dd-080aad668359.png)
![Screen Shot 2020-07-30 at 1 09 59 PM](https://user-images.githubusercontent.com/9064401/88953185-86e6ef00-d266-11ea-87e8-482e0f729ee8.png)
