### PR TITLE
DOP-1296: Render Fields

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -50,6 +50,8 @@ import RefRole from './RefRole';
 import Target from './Target';
 import Glossary from './Glossary';
 import Rubric from './Rubric';
+import Field from './Field';
+import FieldList from './FieldList';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -92,6 +94,8 @@ const componentMap = {
   definitionListItem: DefinitionListItem,
   deprecated: Deprecated,
   emphasis: Emphasis,
+  field: Field,
+  field_list: FieldList,
   figure: Figure,
   footnote: Footnote,
   footnote_reference: FootnoteReference,

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const Field = ({ nodeData: { children, label, name }, ...rest }) => (
+  <tr>
+    <th>{label || name}:</th>
+    <td>
+      {children.map((element, index) => (
+        <ComponentFactory {...rest} nodeData={element} key={index} parentNode="field" />
+      ))}
+    </td>
+  </tr>
+);
+
+Field.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+    label: PropTypes.string,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default Field;

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -7,7 +7,7 @@ const Field = ({ nodeData: { children, label, name }, ...rest }) => (
     <th>{label || name}:</th>
     <td>
       {children.map((element, index) => (
-        <ComponentFactory {...rest} nodeData={element} key={index} parentNode="field" />
+        <ComponentFactory {...rest} nodeData={element} key={index} parentNode={index === 0 ? 'field' : undefined} />
       ))}
     </td>
   </tr>

--- a/src/components/FieldList.js
+++ b/src/components/FieldList.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import ComponentFactory from './ComponentFactory';
+
+const Table = styled('table')`
+  border-spacing: 0;
+  font-size: ${({ theme }) => `${theme.fontSize.small}`};
+  line-height: ${({ theme }) => `${theme.size.medium}`};
+  margin: ${({ theme }) => `${theme.size.medium} 0`};
+  max-width: 100%;
+
+  tbody {
+    vertical-align: top;
+  }
+
+  th,
+  td {
+    padding: 11px 5px 12px;
+    text-align: left;
+  }
+`;
+
+const FieldList = ({ nodeData: { children }, ...rest }) => (
+  <Table>
+    <colgroup>
+      <col className="field-name" />
+      <col className="field-body" />
+    </colgroup>
+    <tbody>
+      {children.map((element, index) => (
+        <ComponentFactory {...rest} nodeData={element} key={index} />
+      ))}
+    </tbody>
+  </Table>
+);
+
+FieldList.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default FieldList;

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const SKIP_P_TAGS = ['caption', 'listItem', 'listTable', 'footnote', 'definitionListItem'];
+const SKIP_P_TAGS = ['caption', 'listItem', 'listTable', 'footnote', 'definitionListItem', 'field'];
 
 const Paragraph = ({ nodeData, parentNode, ...rest }) => {
   // For paragraph nodes that appear inside certain containers, skip <p> tags and just render their contents

--- a/tests/unit/Field.test.js
+++ b/tests/unit/Field.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Field from '../../src/components/Field';
+
+// data for this component
+import mockData from './data/FieldList.test.json';
+
+it('renders correctly', () => {
+  const tree = shallow(<Field nodeData={mockData.children[0]} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/FieldList.test.js
+++ b/tests/unit/FieldList.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FieldList from '../../src/components/FieldList';
+
+// data for this component
+import mockData from './data/FieldList.test.json';
+
+it('renders correctly', () => {
+  const tree = shallow(<FieldList nodeData={mockData} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/Field.test.js.snap
+++ b/tests/unit/__snapshots__/Field.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<tr>
+  <th>
+    Returns
+    :
+  </th>
+  <td>
+    <ComponentFactory
+      key="0"
+      nodeData={
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 137,
+                },
+              },
+              "type": "text",
+              "value": "A JSON Web Token string encoded for the provided ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 137,
+                    },
+                  },
+                  "type": "text",
+                  "value": "payload",
+                },
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 137,
+                },
+              },
+              "type": "literal",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 137,
+                },
+              },
+              "type": "text",
+              "value": ".",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 137,
+            },
+          },
+          "type": "paragraph",
+        }
+      }
+      parentNode="field"
+    />
+  </td>
+</tr>
+`;

--- a/tests/unit/__snapshots__/FieldList.test.js.snap
+++ b/tests/unit/__snapshots__/FieldList.test.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Table>
+  <colgroup>
+    <col
+      className="field-name"
+    />
+    <col
+      className="field-body"
+    />
+  </colgroup>
+  <tbody>
+    <ComponentFactory
+      key="0"
+      nodeData={
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 137,
+                    },
+                  },
+                  "type": "text",
+                  "value": "A JSON Web Token string encoded for the provided ",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 137,
+                        },
+                      },
+                      "type": "text",
+                      "value": "payload",
+                    },
+                  ],
+                  "position": Object {
+                    "start": Object {
+                      "line": 137,
+                    },
+                  },
+                  "type": "literal",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 137,
+                    },
+                  },
+                  "type": "text",
+                  "value": ".",
+                },
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 137,
+                },
+              },
+              "type": "paragraph",
+            },
+          ],
+          "label": "Returns",
+          "name": "returns",
+          "position": Object {
+            "start": Object {
+              "line": 136,
+            },
+          },
+          "type": "field",
+        }
+      }
+    />
+  </tbody>
+</Table>
+`;

--- a/tests/unit/data/FieldList.test.json
+++ b/tests/unit/data/FieldList.test.json
@@ -1,0 +1,69 @@
+{
+  "type": "field_list",
+  "position": {
+    "start": {
+      "line": 136
+    }
+  },
+  "children": [
+    {
+      "type": "field",
+      "position": {
+        "start": {
+          "line": 136
+        }
+      },
+      "children": [
+        {
+          "type": "paragraph",
+          "position": {
+            "start": {
+              "line": 137
+            }
+          },
+          "children": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": 137
+                }
+              },
+              "value": "A JSON Web Token string encoded for the provided "
+            },
+            {
+              "type": "literal",
+              "position": {
+                "start": {
+                  "line": 137
+                }
+              },
+              "children": [
+                {
+                  "type": "text",
+                  "position": {
+                    "start": {
+                      "line": 137
+                    }
+                  },
+                  "value": "payload"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": 137
+                }
+              },
+              "value": "."
+            }
+          ]
+        }
+      ],
+      "name": "returns",
+      "label": "Returns"
+    }
+  ]
+}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1296)] [[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/sophstad/DOP-1296/functions/utilities)] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/manual/sophstad/DOP-1296/reference/method/db.collection.aggregate)] 
- Render directive fields as tables.
- Front-end component of https://github.com/mongodb/snooty-parser/pull/187.
- Tip: Search for "returns" on the staging link pages to find the `:returns:` field in action