### PR TITLE
DOP-1312 Actually Filtering Part 1 (UI only/non-functional)

### DIFF
--- a/src/components/Searchbar/AdvancedFiltersPane.js
+++ b/src/components/Searchbar/AdvancedFiltersPane.js
@@ -5,6 +5,7 @@ import Button from '@leafygreen-ui/button';
 import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
+import SearchFilters from './SearchFilters';
 
 const fadeIn = keyframes`
   from {
@@ -32,7 +33,7 @@ const StyledReturnButton = styled(Button)`
   letter-spacing: 0.5px;
   line-height: ${theme.size.default};
   margin: 0;
-  padding: ${theme.size.tiny};
+  padding: 0;
   /* Below removes default hover effects from button */
   background: none;
   background-image: none;
@@ -46,13 +47,18 @@ const StyledReturnButton = styled(Button)`
   }
 `;
 
+const StyledSearchFilters = styled(SearchFilters)`
+  margin-top: ${theme.size.default};
+`;
+
 const AdvancedFiltersPane = ({ closeFiltersPane, ...props }) => (
   <StyledAdvancedFiltersPane {...props}>
     <StyledContentContainer>
       <StyledReturnButton onClick={closeFiltersPane}>
         <Icon glyph="ArrowLeft" size="small" />
-        &nbsp;Cancel
+        &nbsp;Back to results
       </StyledReturnButton>
+      <StyledSearchFilters hasSideLabels />
     </StyledContentContainer>
   </StyledAdvancedFiltersPane>
 );

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -13,6 +13,26 @@ const RESULTS_PER_PAGE = 3;
 const SEARCH_FOOTER_DESKTOP_HEIGHT = theme.size.xlarge;
 const SEARCH_RESULTS_DESKTOP_HEIGHT = '368px';
 
+const baseFooterButtonStyle = css`
+  font-family: Akzidenz;
+  font-size: ${theme.fontSize.small};
+  letter-spacing: 0.5px;
+  line-height: ${theme.size.default};
+  margin: 0;
+  padding: ${theme.size.tiny};
+  /* Below removes default hover effects from button */
+  background: none;
+  background-image: none;
+  border: none;
+  box-shadow: none;
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
+`;
+
 const animationKeyframe = startingOpacity => keyframes`
     0% {
       opacity: ${startingOpacity};
@@ -72,24 +92,17 @@ const SearchFooter = styled('div')`
 
 const FilterFooterButton = styled(Button)`
   color: ${uiColors.blue.base};
-  font-family: Akzidenz;
   font-weight: bolder;
-  font-size: ${theme.fontSize.small};
-  letter-spacing: 0.5px;
-  line-height: ${theme.size.default};
-  margin: 0;
-  padding: ${theme.size.tiny};
-  /* Below removes default hover effects from button */
-  background: none;
-  background-image: none;
-  border: none;
-  box-shadow: none;
-  :before {
-    display: none;
+  ${baseFooterButtonStyle};
+`;
+
+const FilterResetButton = styled(Button)`
+  color: ${uiColors.gray.base};
+  :hover,
+  :active {
+    color: ${uiColors.blue.base};
   }
-  :after {
-    display: none;
-  }
+  ${baseFooterButtonStyle};
 `;
 
 const SearchDropdown = ({ results = [] }) => {
@@ -114,6 +127,7 @@ const SearchDropdown = ({ results = [] }) => {
     <SearchResultsContainer>
       <FixedHeightFiltersPane closeFiltersPane={closeFiltersPane} />
       <SearchFooter>
+        <FilterResetButton>Reset</FilterResetButton>
         <FilterFooterButton onClick={closeFiltersPane}>Apply Search Criteria</FilterFooterButton>
       </SearchFooter>
     </SearchResultsContainer>
@@ -121,8 +135,8 @@ const SearchDropdown = ({ results = [] }) => {
     <SearchResultsContainer>
       <FixedHeightSearchResults totalResultsCount={results.length} visibleResults={visibleResults} />
       <SearchFooter>
-        <FilterFooterButton onClick={openFiltersPane}>Advanced Filters</FilterFooterButton>
         <Pagination currentPage={currentPage} setCurrentPage={setCurrentPage} totalPages={totalPages} />
+        <FilterFooterButton onClick={openFiltersPane}>Advanced Filters</FilterFooterButton>
       </SearchFooter>
     </SearchResultsContainer>
   );

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -31,6 +31,8 @@ const fadeInAnimation = (startingOpacity, seconds) => css`
 
 const FixedHeightFiltersPane = styled(AdvancedFiltersPane)`
   height: ${SEARCH_RESULTS_DESKTOP_HEIGHT};
+  padding-left: ${theme.size.medium};
+  padding-right: ${theme.size.medium};
 `;
 
 const FixedHeightSearchResults = styled(SearchResults)`

--- a/src/components/Searchbar/SearchFilters.js
+++ b/src/components/Searchbar/SearchFilters.js
@@ -1,8 +1,7 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { theme } from '../../theme/docsTheme';
 import Select from '../Select';
-import SearchContext from './SearchContext';
 import { getSortedBranchesForProperty, parseMarianManifest } from '../../utils/parse-marian-manifests';
 import { useMarianManifests } from '../../hooks/use-marian-manifests';
 
@@ -28,60 +27,42 @@ const MaxWidthSelect = styled(Select)`
   width: ${FILTER_WIDTH};
 `;
 
-const SearchFilters = ({ hasSideLabels, localSearchFilter, setLocalSearchFilter, ...props }) => {
+const SearchFilters = ({ hasSideLabels, ...props }) => {
   const { filters } = useMarianManifests();
-  const [propertyChoices, setPropertyChoices] = useState([]);
-  const [property, setProperty] = useState(null);
+  const [productChoices, setProductChoices] = useState([]);
+  const [product, setProduct] = useState(null);
   const [branchChoices, setBranchChoices] = useState([]);
   const [branch, setBranch] = useState(null);
 
-  // On mount, update filters with current values
-  // TODO fix so other hooks don't trigger
-  useEffect(() => {
-    if (localSearchFilter) {
-      const { property, branch } = parseMarianManifest(localSearchFilter);
-      setProperty(property);
-      setBranch(branch);
-    } else {
-      setProperty(null);
-      setBranch(null);
-    }
-    // Ignoring exhaustive deps allows us to only run this on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [localSearchFilter]);
+  // TODO: On mount, update filters with current values
 
   // Update property choices when the filter results from Marian are loaded
   useEffect(() => {
     const properties = Object.keys(filters);
     properties.sort();
-    setPropertyChoices(properties.map(p => ({ text: p, value: p })));
+    setProductChoices(properties.map(p => ({ text: p, value: p })));
   }, [filters]);
 
   // Update branch choices when a property is chosen
   useEffect(() => {
-    if (filters && filters[property]) {
-      const branches = getSortedBranchesForProperty(filters, property);
+    if (filters && filters[product]) {
+      const branches = getSortedBranchesForProperty(filters, product);
       setBranch(branches[0]);
       setBranchChoices(branches.map(b => ({ text: b, value: b })));
     }
-  }, [filters, property]);
+  }, [filters, product]);
 
-  // When a property and branch are chosen, update the filter to the Marian manifest value
-  useEffect(() => {
-    if (filters && property && branch && filters[property]) {
-      setLocalSearchFilter(filters[property][branch]);
-    }
-  }, [branch, filters, property, setLocalSearchFilter]);
+  // TODO: Update parent when choices are made
 
   return (
     <div {...props}>
       <SelectWrapper>
         {hasSideLabels && <SideLabelText>Product</SideLabelText>}
         <MaxWidthSelect
-          choices={propertyChoices}
-          onChange={({ value }) => setProperty(value)}
+          choices={productChoices}
+          onChange={({ value }) => setProduct(value)}
           defaultText="Select a Product"
-          value={property}
+          value={product}
         />
       </SelectWrapper>
       <SelectWrapper>
@@ -89,7 +70,7 @@ const SearchFilters = ({ hasSideLabels, localSearchFilter, setLocalSearchFilter,
         <MaxWidthSelect
           choices={branchChoices}
           onChange={({ value }) => setBranch(value)}
-          disabled={!property}
+          disabled={!product}
           defaultText="Select a Version"
           value={branch}
         />

--- a/src/components/Searchbar/SearchFilters.js
+++ b/src/components/Searchbar/SearchFilters.js
@@ -1,0 +1,101 @@
+import React, { useContext, useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { theme } from '../../theme/docsTheme';
+import Select from '../Select';
+import SearchContext from './SearchContext';
+import { getSortedBranchesForProperty, parseMarianManifest } from '../../utils/parse-marian-manifests';
+import { useMarianManifests } from '../../hooks/use-marian-manifests';
+
+const FILTER_WIDTH = '175px';
+
+const SideLabelText = styled('p')`
+  font-family: Akzidenz;
+  font-size: ${theme.fontSize.small};
+  letter-spacing: 0.5px;
+  margin: 0;
+`;
+
+const SelectWrapper = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  :first-of-type {
+    margin-bottom: ${theme.size.medium};
+  }
+`;
+
+const MaxWidthSelect = styled(Select)`
+  width: ${FILTER_WIDTH};
+`;
+
+const SearchFilters = ({ hasSideLabels, localSearchFilter, setLocalSearchFilter, ...props }) => {
+  const { filters } = useMarianManifests();
+  const [propertyChoices, setPropertyChoices] = useState([]);
+  const [property, setProperty] = useState(null);
+  const [branchChoices, setBranchChoices] = useState([]);
+  const [branch, setBranch] = useState(null);
+
+  // On mount, update filters with current values
+  // TODO fix so other hooks don't trigger
+  useEffect(() => {
+    if (localSearchFilter) {
+      const { property, branch } = parseMarianManifest(localSearchFilter);
+      setProperty(property);
+      setBranch(branch);
+    } else {
+      setProperty(null);
+      setBranch(null);
+    }
+    // Ignoring exhaustive deps allows us to only run this on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localSearchFilter]);
+
+  // Update property choices when the filter results from Marian are loaded
+  useEffect(() => {
+    const properties = Object.keys(filters);
+    properties.sort();
+    setPropertyChoices(properties.map(p => ({ text: p, value: p })));
+  }, [filters]);
+
+  // Update branch choices when a property is chosen
+  useEffect(() => {
+    if (filters && filters[property]) {
+      const branches = getSortedBranchesForProperty(filters, property);
+      setBranch(branches[0]);
+      setBranchChoices(branches.map(b => ({ text: b, value: b })));
+    }
+  }, [filters, property]);
+
+  // When a property and branch are chosen, update the filter to the Marian manifest value
+  useEffect(() => {
+    if (filters && property && branch && filters[property]) {
+      setLocalSearchFilter(filters[property][branch]);
+    }
+  }, [branch, filters, property, setLocalSearchFilter]);
+
+  return (
+    <div {...props}>
+      <SelectWrapper>
+        {hasSideLabels && <SideLabelText>Product</SideLabelText>}
+        <MaxWidthSelect
+          choices={propertyChoices}
+          onChange={({ value }) => setProperty(value)}
+          defaultText="Select a Product"
+          value={property}
+        />
+      </SelectWrapper>
+      <SelectWrapper>
+        {hasSideLabels && <SideLabelText>Version</SideLabelText>}
+        <MaxWidthSelect
+          choices={branchChoices}
+          onChange={({ value }) => setBranch(value)}
+          disabled={!property}
+          defaultText="Select a Version"
+          value={branch}
+        />
+      </SelectWrapper>
+    </div>
+  );
+};
+
+export default SearchFilters;

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -76,8 +76,8 @@ const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParams
 
   // Update state on a new search query
   const fetchNewSearchResults = useCallback(
-    async (searchTerm, filters) => {
-      const result = await fetch(searchParamsToURL(searchTerm, filters));
+    async searchTerm => {
+      const result = await fetch(searchParamsToURL(searchTerm, null));
       const resultJson = await result.json();
       setSearchResults(getResultsFromJSON(resultJson, NUMBER_SEARCH_RESULTS));
     },

--- a/src/hooks/use-marian-manifests.js
+++ b/src/hooks/use-marian-manifests.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { parseMarianManifests } from '../utils/parse-marian-manifests';
+
+// TODO: remove when Marian change is in prod
+const PARSED_MANIFESTS = {
+  Atlas: { master: 'atlas-master' },
+  'Atlas Open Service Broker': { current: 'atlas-open-service-broker-current' },
+  Charts: {
+    '19.06': 'charts-19.06',
+    '19.09': 'charts-19.09',
+    '19.12': 'charts-19.12',
+    current: 'charts-current',
+    master: 'charts-master',
+    'v0.10': 'charts-v0.10',
+    'v0.11': 'charts-v0.11',
+    'v0.12': 'charts-v0.12',
+    'v0.9': 'charts-v0.9',
+  },
+};
+
+export const useMarianManifests = () => {
+  const [filters, setFilters] = useState({});
+
+  useEffect(() => {
+    async function fetchManifests() {
+      // TODO: Fix when Marian change is in production
+      // const result = await fetch('http://marian.mongodb.com/status');
+      // const jsonResult = await result.json();
+      // setFilters(parseMarianManifests(jsonResult.manifests));
+      setFilters(PARSED_MANIFESTS);
+    }
+    fetchManifests();
+  }, []);
+
+  return { filters };
+};

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -1,6 +1,4 @@
 // Search helper function to generate marian URL from params and filters
 const MARIAN_URL = 'https://marian.mongodb.com';
-export const searchParamsToURL = (searchQuery, searchFilters) => {
-  // TODO: implement filters
-  return `${MARIAN_URL}/search?q=${searchQuery}`;
-};
+export const searchParamsToURL = (searchQuery, searchFilters) =>
+  `${MARIAN_URL}/search?q=${searchQuery}${searchFilters ? `&searchProperty=${searchFilters}` : ''}`;


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/advanced-filters-redux/)
[Updated Relevant Invision](https://mongodb.invisionapp.com/d/#/console/19596736/417891823/preview)

This PR adds the UI for filtering search results. I was additionally going to include the logic to actually filter here as well but after speaking with Elle and Allison I want to change my approach there so I figured this could be split into two PRs. This PR does the following:
1. Flips footer button ordering of pagination and "Advanced Filters" by request from Allison
2. Adds a `reset` button on the advanced filter pane (that does not do anything yet)
3. Adds the search dropdowns to the advanced filter pane, with logic to control enabled/disabled
4. Adds a custom hook to get Marian results (when Marian is available. For now I hardcoded some samples to see)
5. Cleans up the `searchParamsToURL` function to account for a string filter.