### PR TITLE
DOP-1340 Part 2: Focus/Blur Instrumentation

### DIFF
--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -7,6 +7,7 @@ import SearchContext from './SearchContext';
 import { activeTextBarStyling, StyledTextInput } from './SearchTextInput';
 import { useClickOutside } from '../../hooks/use-click-outside';
 import { theme } from '../../theme/docsTheme';
+import { reportAnalytics } from '../../utils/report-analytics';
 import SearchDropdown from './SearchDropdown';
 
 const BUTTON_SIZE = theme.size.medium;
@@ -62,14 +63,22 @@ const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParams
 
   // Focus Handlers
   const onExpand = useCallback(() => setIsExpanded(true), [setIsExpanded]);
-  const onFocus = useCallback(() => setIsFocused(true), []);
+  const onFocus = useCallback(() => {
+    setIsFocused(true);
+    reportAnalytics('SearchFocus', {});
+  }, []);
   // Remove focus and close searchbar if it disrupts the navbar
   const onBlur = useCallback(() => {
+    // Since this is tied to a document click off event, we want to be sure this is
+    // really a blur and not just clicking outside of the searchbar
+    if (isFocused) {
+      reportAnalytics('SearchBlur', { query: value });
+    }
     setIsFocused(false);
     // The parent controls whether a searchbar is expanded by default, so this may
     // have no effect where the searchbar should always be open
     setIsExpanded(false);
-  }, [setIsExpanded]);
+  }, [isFocused, setIsExpanded, value]);
   // Close the dropdown and remove focus when clicked outside
   useClickOutside(searchContainerRef, onBlur);
   const onClose = useCallback(() => setIsExpanded(false), [setIsExpanded]);


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-1340)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/ecosystem/jordanstapinski/search-instrumentation-focus/)

Adding Elle to verify reporting structure/needs (these were a bit less defined)

This PR adds two more reporting metrics for the search experience:
- `SearchFocus` reports when the searchbar was clicked into and is focused. It does not report any additional information
- `SearchBlur` reports when the searchbar was clicked out of. It also reports the existing query the user has tried searching for

Similar to Part 1 you can see the reports in the network tab. Here is one:
![Screen Shot 2020-08-14 at 1 41 46 PM](https://user-images.githubusercontent.com/9064401/90278151-ec290b80-de34-11ea-8cc1-ab15260dceda.png)
