### PR TITLE
DOP-1371: Add 'blank-wide' template

### DIFF
--- a/src/templates/blank-wide.js
+++ b/src/templates/blank-wide.js
@@ -11,8 +11,8 @@ const Content = styled('div')`
 `;
 
 const Wrapper = styled('div')`
-  max-width: ${theme.size.maxWidth};
   margin: 40px auto;
+  max-width: ${theme.size.maxWidth};
   width: 100%;
 `;
 

--- a/src/templates/blank-wide.js
+++ b/src/templates/blank-wide.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import Footer from '../components/Footer';
+import Navbar from '../components/Navbar';
+import DocumentBody from '../components/DocumentBody';
+import { theme } from '../theme/docsTheme';
+
+const Wrapper = styled('div')`
+  max-width: ${theme.size.maxWidth};
+  margin: 40px auto;
+  width: 100%;
+`;
+
+const BlankWide = ({ pageContext: { metadata, slug, __refDocMapping }, ...rest }) => (
+  <React.Fragment>
+    <div className="content">
+      <Wrapper id="main-column">
+        <DocumentBody refDocMapping={__refDocMapping} slug={slug} metadata={metadata} {...rest} />
+        <Footer />
+      </Wrapper>
+    </div>
+    <Navbar />
+  </React.Fragment>
+);
+
+BlankWide.propTypes = {
+  pageContext: PropTypes.shape({
+    __refDocMapping: PropTypes.object.isRequired,
+    slug: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default BlankWide;

--- a/src/templates/blank-wide.js
+++ b/src/templates/blank-wide.js
@@ -6,6 +6,10 @@ import Navbar from '../components/Navbar';
 import DocumentBody from '../components/DocumentBody';
 import { theme } from '../theme/docsTheme';
 
+const Content = styled('div')`
+  margin: 0 ${theme.size.default};
+`;
+
 const Wrapper = styled('div')`
   max-width: ${theme.size.maxWidth};
   margin: 40px auto;
@@ -16,8 +20,10 @@ const BlankWide = ({ pageContext: { metadata, slug, __refDocMapping }, ...rest }
   <React.Fragment>
     <div className="content">
       <Wrapper id="main-column">
-        <DocumentBody refDocMapping={__refDocMapping} slug={slug} metadata={metadata} {...rest} />
-        <Footer />
+        <Content>
+          <DocumentBody refDocMapping={__refDocMapping} slug={slug} metadata={metadata} {...rest} />
+          <Footer />
+        </Content>
       </Wrapper>
     </div>
     <Navbar />


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-1371)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1337/landing/jordanstapinski/DOP-1371/search)

This PR adds a new "blank-wide" Gatsby template. This template is super simple, and uses emotion `styled` to add a max-width/width 100% for this template with a small interior margin. 