### PR TITLE
DOP-1339 Part 3: Search Results Empty State

### DIFF
--- a/src/components/SearchResults/EmptyResults.js
+++ b/src/components/SearchResults/EmptyResults.js
@@ -4,6 +4,7 @@ import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 
+export const EMPTY_STATE_HEIGHT = '150px';
 const MAGNIFYING_GLASS_SIZE = '40px';
 const MAX_WIDTH = '337px';
 

--- a/src/components/SearchResults/EmptyResults.js
+++ b/src/components/SearchResults/EmptyResults.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import { theme } from '../../theme/docsTheme';
+
+const MAGNIFYING_GLASS_SIZE = '40px';
+const MAX_WIDTH = '337px';
+
+const MagnifyingGlass = styled(Icon)`
+  color: ${uiColors.black};
+  height: ${MAGNIFYING_GLASS_SIZE};
+  width: ${MAGNIFYING_GLASS_SIZE};
+`;
+
+const SupportingText = styled('p')`
+  font-size: ${theme.fontSize.default};
+  line-height: ${theme.size.medium};
+`;
+
+const TitleText = styled('h3')`
+  color: ${uiColors.black};
+  font-size: ${theme.fontSize.h3};
+  line-height: 21px;
+  margin-bottom: ${theme.size.default};
+`;
+
+const EmptyStateContainer = styled('div')`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-family: Akzidenz;
+  letter-spacing: 0.5px;
+  margin: 0 auto;
+  max-width: ${MAX_WIDTH};
+  text-align: center;
+`;
+
+const EmptyResults = () => (
+  <EmptyStateContainer>
+    <MagnifyingGlass glyph="MagnifyingGlass" />
+    <TitleText>
+      <strong>Search MongoDB Documentation</strong>
+    </TitleText>
+    <SupportingText>
+      Find guides, examples, and best practices for working with the MongoDB data platform.
+    </SupportingText>
+  </EmptyStateContainer>
+);
+
+export default EmptyResults;

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -13,11 +13,12 @@ import { searchParamsToURL } from '../../utils/search-params-to-url';
 import SearchContext from '../Searchbar/SearchContext';
 import SearchFilters from '../Searchbar/SearchFilters';
 import SearchResult from '../Searchbar/SearchResult';
-import EmptyResults from './EmptyResults';
+import EmptyResults, { EMPTY_STATE_HEIGHT } from './EmptyResults';
 
 const DESKTOP_COLUMN_GAP = '46px';
 const FILTER_BY_TEXT_WIDTH = '62px';
 const FILTER_COLUMN_WIDTH = '173px';
+const LANDING_MARGIN = '40px';
 const MAX_MOBILE_WIDTH = '616px';
 const SEARCH_RESULT_HEIGHT = '128px';
 
@@ -26,6 +27,10 @@ const commonTextStyling = css`
   font-weight: bolder;
   letter-spacing: 0.5px;
   margin: 0;
+`;
+
+const EmptyResultsContainer = styled('div')`
+  margin-top: calc(50vh - ${theme.navbar.height} - ${LANDING_MARGIN} - ${EMPTY_STATE_HEIGHT} / 2);
 `;
 
 const HeaderText = styled('h1')`
@@ -215,7 +220,9 @@ const SearchResults = () => {
           <StyledSearchFilters hasSideLabels={false} />
         </SearchResultsContainer>
       ) : (
-        <EmptyResults />
+        <EmptyResultsContainer>
+          <EmptyResults />
+        </EmptyResultsContainer>
       )}
     </SearchContext.Provider>
   );

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -13,6 +13,7 @@ import { searchParamsToURL } from '../../utils/search-params-to-url';
 import SearchContext from '../Searchbar/SearchContext';
 import SearchFilters from '../Searchbar/SearchFilters';
 import SearchResult from '../Searchbar/SearchResult';
+import EmptyResults from './EmptyResults';
 
 const DESKTOP_COLUMN_GAP = '46px';
 const FILTER_BY_TEXT_WIDTH = '62px';
@@ -191,27 +192,31 @@ const SearchResults = () => {
       <Helmet>
         <title>Search Results</title>
       </Helmet>
-      <SearchResultsContainer>
-        <HeaderText>
-          {searchFilterProperty ? `${searchFilterProperty} results` : 'All search results'} for "{searchTerm}"
-        </HeaderText>
-        <StyledSearchResults>
-          {searchResults.map(({ title, preview, url }, index) => (
-            <StyledSearchResult
-              key={`${url}${index}`}
-              onClick={() =>
-                reportAnalytics('SearchSelection', { areaFound: 'ResultsPage', rank: index, selectionUrl: url })
-              }
-              title={title}
-              preview={preview}
-              url={url}
-              useLargeTitle
-            />
-          ))}
-        </StyledSearchResults>
-        <FilterHeader>Filter By</FilterHeader>
-        <StyledSearchFilters hasSideLabels={false} />
-      </SearchResultsContainer>
+      {searchResults && searchResults.length ? (
+        <SearchResultsContainer>
+          <HeaderText>
+            {searchFilterProperty ? `${searchFilterProperty} results` : 'All search results'} for "{searchTerm}"
+          </HeaderText>
+          <StyledSearchResults>
+            {searchResults.map(({ title, preview, url }, index) => (
+              <StyledSearchResult
+                key={`${url}${index}`}
+                onClick={() =>
+                  reportAnalytics('SearchSelection', { areaFound: 'ResultsPage', rank: index, selectionUrl: url })
+                }
+                title={title}
+                preview={preview}
+                url={url}
+                useLargeTitle
+              />
+            ))}
+          </StyledSearchResults>
+          <FilterHeader>Filter By</FilterHeader>
+          <StyledSearchFilters hasSideLabels={false} />
+        </SearchResultsContainer>
+      ) : (
+        <EmptyResults />
+      )}
     </SearchContext.Provider>
   );
 };

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -18,7 +18,8 @@ import EmptyResults, { EMPTY_STATE_HEIGHT } from './EmptyResults';
 const DESKTOP_COLUMN_GAP = '46px';
 const FILTER_BY_TEXT_WIDTH = '62px';
 const FILTER_COLUMN_WIDTH = '173px';
-const LANDING_MARGIN = '40px';
+const LANDING_MODULE_MARGIN = '28px';
+const LANDING_PAGE_MARGIN = '40px';
 const MAX_MOBILE_WIDTH = '616px';
 const SEARCH_RESULT_HEIGHT = '128px';
 
@@ -30,7 +31,12 @@ const commonTextStyling = css`
 `;
 
 const EmptyResultsContainer = styled('div')`
-  margin-top: calc(50vh - ${theme.navbar.height} - ${LANDING_MARGIN} - ${EMPTY_STATE_HEIGHT} / 2);
+  /* We want to place the empty state in the middle of the page. To do so, we
+  must account for the navbar, any margins added from using the blank landing
+  template, and half of the height of the empty state component */
+  margin-top: calc(
+    50vh - ${theme.navbar.height} - ${LANDING_MODULE_MARGIN} - ${LANDING_PAGE_MARGIN} - ${EMPTY_STATE_HEIGHT} / 2
+  );
 `;
 
 const HeaderText = styled('h1')`


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-1339)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1337/landing/jordanstapinski/results-empty-state/search)
[InVision](https://mongodb.invisionapp.com/d/#/console/19596736/422509204/preview)

This PR adds the empty state for search results centered vertically on the page. Positioning was a bit wonky so super open to suggestions there.

I spoke to Allison and we will be keeping the footer, so the blank template still is fine.