### PR TITLE
Add onClick for magnifying glasses

### DIFF
--- a/src/components/SearchResults/EmptyResults.js
+++ b/src/components/SearchResults/EmptyResults.js
@@ -51,7 +51,10 @@ const EmptyStateContainer = styled('div')`
 
 const EmptyResults = () => {
   const focusOnSearchbar = useCallback(() => {
-    document.querySelector(`${StyledTextInput} input`).focus();
+    const searchbar = document.querySelector(`${StyledTextInput} input`);
+    if (searchbar) {
+      searchbar.focus();
+    }
   }, []);
   return (
     <EmptyStateContainer>

--- a/src/components/SearchResults/EmptyResults.js
+++ b/src/components/SearchResults/EmptyResults.js
@@ -1,12 +1,24 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
+import IconButton from '@leafygreen-ui/icon-button';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
+import { StyledTextInput } from '../Searchbar/SearchTextInput';
 
-export const EMPTY_STATE_HEIGHT = '150px';
+export const EMPTY_STATE_HEIGHT = '166px';
 const MAGNIFYING_GLASS_SIZE = '40px';
 const MAX_WIDTH = '337px';
+
+const MagnifyingGlassButton = styled(IconButton)`
+  /* Give 8px space on each side for hover state */
+  height: calc(${MAGNIFYING_GLASS_SIZE} + ${theme.size.default});
+  width: calc(${MAGNIFYING_GLASS_SIZE} + ${theme.size.default});
+  span {
+    height: ${MAGNIFYING_GLASS_SIZE};
+    width: ${MAGNIFYING_GLASS_SIZE};
+  }
+`;
 
 const MagnifyingGlass = styled(Icon)`
   color: ${uiColors.black};
@@ -37,16 +49,23 @@ const EmptyStateContainer = styled('div')`
   text-align: center;
 `;
 
-const EmptyResults = () => (
-  <EmptyStateContainer>
-    <MagnifyingGlass glyph="MagnifyingGlass" />
-    <TitleText>
-      <strong>Search MongoDB Documentation</strong>
-    </TitleText>
-    <SupportingText>
-      Find guides, examples, and best practices for working with the MongoDB data platform.
-    </SupportingText>
-  </EmptyStateContainer>
-);
+const EmptyResults = () => {
+  const focusOnSearchbar = useCallback(() => {
+    document.querySelector(`${StyledTextInput} input`).focus();
+  }, []);
+  return (
+    <EmptyStateContainer>
+      <MagnifyingGlassButton ariaLabel="Search MongoDB Documentation" onClick={focusOnSearchbar}>
+        <MagnifyingGlass glyph="MagnifyingGlass" />
+      </MagnifyingGlassButton>
+      <TitleText>
+        <strong>Search MongoDB Documentation</strong>
+      </TitleText>
+      <SupportingText>
+        Find guides, examples, and best practices for working with the MongoDB data platform.
+      </SupportingText>
+    </EmptyStateContainer>
+  );
+};
 
 export default EmptyResults;

--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -71,11 +71,11 @@ const MagnifyingGlass = styled(Icon)`
 `;
 
 const MagnifyingGlassButton = styled(IconButton)`
+  left: ${theme.size.small};
   padding: 0;
   position: absolute;
   /* This button is 28px tall in a 36px tall container, so 4px gives equal spacing */
   top: ${theme.size.tiny};
-  left: ${theme.size.small};
   z-index: 1;
   /* Remove hover state */
   :before {

--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -67,12 +67,23 @@ const GoIcon = styled(Icon)`
 
 const MagnifyingGlass = styled(Icon)`
   color: ${uiColors.gray.base};
-  left: ${theme.size.default};
-  position: absolute;
-  /* This icon is 16px tall in a 36px tall container, so 10px gives equal spacing */
-  top: 10px;
   transition: color 150ms ease-in;
+`;
+
+const MagnifyingGlassButton = styled(IconButton)`
+  padding: 0;
+  position: absolute;
+  /* This button is 28px tall in a 36px tall container, so 4px gives equal spacing */
+  top: ${theme.size.tiny};
+  left: ${theme.size.small};
   z-index: 1;
+  /* Remove hover state */
+  :before {
+    display: none;
+  }
+  :after {
+    display: none;
+  }
 `;
 
 const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
@@ -89,6 +100,12 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
     [onChange]
   );
 
+  const onSearchFocus = useCallback(() => {
+    if (searchTextbox && searchTextbox.current) {
+      searchTextbox.current.focus();
+    }
+  }, []);
+
   const goButton = useRef(null);
   const searchTextbox = useRef(null);
 
@@ -102,7 +119,10 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
         e.preventDefault();
         // find first result in the dropdown and focus
         if (searchContainerRef && searchContainerRef.current) {
-          searchContainerRef.current.querySelector(`${SearchResultLink}`).focus();
+          const firstLink = searchContainerRef.current.querySelector(`${SearchResultLink}`);
+          if (firstLink) {
+            firstLink.focus();
+          }
         }
       }
     },
@@ -115,7 +135,9 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
 
   return (
     <>
-      <MagnifyingGlass glyph="MagnifyingGlass" />
+      <MagnifyingGlassButton ariaLabel="Search MongoDB Documentation" onClick={onSearchFocus}>
+        <MagnifyingGlass glyph="MagnifyingGlass" />
+      </MagnifyingGlassButton>
       <SearchTextInput ref={searchTextbox} isSearching={isSearching} onChange={onSearchChange} value={searchTerm} />
       {shouldShowGoButton && (
         <GoButton ref={goButton} type="submit" aria-label="Go" href={searchUrl}>

--- a/src/components/Searchbar/SearchResult.js
+++ b/src/components/Searchbar/SearchResult.js
@@ -119,7 +119,10 @@ const SearchResult = React.memo(
         } else {
           // This is the last result, so let's loop back to the top
           if (searchContainerRef && searchContainerRef.current) {
-            searchContainerRef.current.querySelector(`${SearchResultLink}`).focus();
+            const firstLink = searchContainerRef.current.querySelector(`${SearchResultLink}`);
+            if (firstLink) {
+              firstLink.focus();
+            }
           }
         }
       },


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1337/landing/jordanstapinski/focus-text-search/search)

This PR addresses a comment from #260 involving making the empty state magnifying glass clickable. In addition, we also made the magnifying glass in the expanded searchbar clickable.

I also found a bug where using arrow keys with empty search results threw an error so I added the quick fix for that here as well.