### PR TITLE
DOP-1407: Populate page title on server

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { theme } from './src/theme/docsTheme';
+import DefaultLayout from './src/components/layout';
 
 export const wrapRootElement = ({ element }) => <ThemeProvider theme={theme}>{element}</ThemeProvider>;
+
+export const wrapPageElement = ({ element, props }) => <DefaultLayout {...props}>{element}</DefaultLayout>;


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1407)] [[Datalake Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/datalake/sophstad/master/)] Populate `<title>` tag during Server-Side Rendering so that Marian can access it.

To test, open the staging link and view page source. You can see that the `<title>` tag is no longer empty. [Here](https://docs-mongodbcom-staging.corp.mongodb.com/master/datalake/sophstad/master/reference/cli/stores/drop-store) is a page with monospace in the title. In its source:
```html
<title data-react-helmet="true">dropStore — MongoDB Atlas Data Lake</title>
```