### PR TITLE
DOP-1420: Render Navbar in layout component

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import { getPlaintext } from '../utils/get-plaintext';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { theme } from '../theme/docsTheme.js';
 import { getTemplate } from '../utils/get-template';
+import Navbar from '../components/Navbar';
 
 const Widgets = loadable(() => import('../components/Widgets'));
 
@@ -180,6 +181,7 @@ export default class DefaultLayout extends Component {
             </Template>
           </Widgets>
         </TabContext.Provider>
+        <Navbar />
       </>
     );
   }

--- a/src/templates/blank.js
+++ b/src/templates/blank.js
@@ -1,21 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Footer from '../components/Footer';
-import Navbar from '../components/Navbar';
 import landingStyles from '../styles/landing.module.css';
 
 const Blank = ({ children }) => (
-  <React.Fragment>
-    <div className="content">
-      <div className={`main-column ${landingStyles.fullWidth}`} id="main-column">
-        <div className={landingStyles.document}>
-          {children}
-          <Footer />
-        </div>
+  <div className="content">
+    <div className={`main-column ${landingStyles.fullWidth}`} id="main-column">
+      <div className={landingStyles.document}>
+        {children}
+        <Footer />
       </div>
     </div>
-    <Navbar />
-  </React.Fragment>
+  </div>
 );
 
 Blank.propTypes = {

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Footer from '../components/Footer';
 import { getNestedValue } from '../utils/get-nested-value';
-import Navbar from '../components/Navbar';
 import Breadcrumbs from '../components/Breadcrumbs';
 import InternalPageNav from '../components/InternalPageNav';
 import Sidebar from '../components/Sidebar';
@@ -31,44 +30,41 @@ const Document = ({
   };
 
   return (
-    <React.Fragment>
-      <div className="content">
-        <div>
-          {(!isBrowser || showLeftColumn) && (
-            <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
-              <Sidebar
-                slug={slug}
-                publishedBranches={publishedBranches}
-                toctreeData={toctree}
-                toggleLeftColumn={toggleLeftColumn}
-              />
-            </div>
-          )}
-        </div>
-        <div id="main-column" className="main-column">
-          {(!isBrowser || !showLeftColumn) && (
-            <span className={`showNav ${style.showNav} ${renderStatus}`} id="showNav" onClick={toggleLeftColumn}>
-              Navigation
-            </span>
-          )}
-          <div className="document">
-            <div className="documentwrapper">
-              <div className="bodywrapper">
-                <div className="body">
-                  <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
-                  {children}
-                  {showPrevNext && (
-                    <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />
-                  )}
-                  <Footer />
-                </div>
+    <div className="content">
+      <div>
+        {(!isBrowser || showLeftColumn) && (
+          <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
+            <Sidebar
+              slug={slug}
+              publishedBranches={publishedBranches}
+              toctreeData={toctree}
+              toggleLeftColumn={toggleLeftColumn}
+            />
+          </div>
+        )}
+      </div>
+      <div id="main-column" className="main-column">
+        {(!isBrowser || !showLeftColumn) && (
+          <span className={`showNav ${style.showNav} ${renderStatus}`} id="showNav" onClick={toggleLeftColumn}>
+            Navigation
+          </span>
+        )}
+        <div className="document">
+          <div className="documentwrapper">
+            <div className="bodywrapper">
+              <div className="body">
+                <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
+                {children}
+                {showPrevNext && (
+                  <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />
+                )}
+                <Footer />
               </div>
             </div>
           </div>
         </div>
       </div>
-      <Navbar />
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -1,42 +1,38 @@
 import React from 'react';
 import Footer from '../components/Footer';
-import Navbar from '../components/Navbar';
 import EcosystemHomepageStyles from '../styles/ecosystem-homepage.module.css';
 import EcosystemHomepageTiles from '../components/EcosystemHomepageTiles';
 
 const EcosystemIndex = props => (
-  <React.Fragment>
-    <div className="content">
-      <div className={[EcosystemHomepageStyles.fullWidth, 'main-column'].join(' ')} id="main-column">
-        <div className={[EcosystemHomepageStyles.document, 'document'].join(' ')}>
-          <div className="documentwrapper">
-            <div className="bodywrapper">
-              <div className="body">
-                <section className={EcosystemHomepageStyles.mainContentPadding}>
-                  <h1>Start Developing with MongoDB</h1>
-                  <p>Connect your application to your database with one of our official libraries.</p>
-                  <p>
-                    The following libraries are officially supported by MongoDB. They are actively maintained, support
-                    new MongoDB features, and receive bug fixes, performance enhancements, and security patches.
-                  </p>
-                  <EcosystemHomepageTiles />
-                  <p>
-                    Don’t see your desired language? Browse a list of{' '}
-                    <a href="https://docs.mongodb.com/ecosystem/drivers/community-supported-drivers/">
-                      community supported libraries
-                    </a>
-                    .
-                  </p>
-                </section>
-                <Footer />
-              </div>
+  <div className="content">
+    <div className={[EcosystemHomepageStyles.fullWidth, 'main-column'].join(' ')} id="main-column">
+      <div className={[EcosystemHomepageStyles.document, 'document'].join(' ')}>
+        <div className="documentwrapper">
+          <div className="bodywrapper">
+            <div className="body">
+              <section className={EcosystemHomepageStyles.mainContentPadding}>
+                <h1>Start Developing with MongoDB</h1>
+                <p>Connect your application to your database with one of our official libraries.</p>
+                <p>
+                  The following libraries are officially supported by MongoDB. They are actively maintained, support new
+                  MongoDB features, and receive bug fixes, performance enhancements, and security patches.
+                </p>
+                <EcosystemHomepageTiles />
+                <p>
+                  Don’t see your desired language? Browse a list of{' '}
+                  <a href="https://docs.mongodb.com/ecosystem/drivers/community-supported-drivers/">
+                    community supported libraries
+                  </a>
+                  .
+                </p>
+              </section>
+              <Footer />
             </div>
           </div>
         </div>
       </div>
     </div>
-    <Navbar />
-  </React.Fragment>
+  </div>
 );
 
 export default EcosystemIndex;

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -11,7 +11,6 @@ import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { throttle } from '../utils/throttle';
 import { getNestedValue } from '../utils/get-nested-value';
 import { TabContext } from '../components/tab-context';
-import Navbar from '../components/Navbar';
 
 export default class Guide extends Component {
   constructor(propsFromServer) {
@@ -143,33 +142,30 @@ export default class Guide extends Component {
     const { activeSection, cloud, drivers } = this.state;
 
     return (
-      <React.Fragment>
-        <div className="content">
-          <TOC
-            activeSection={activeSection}
-            sectionKeys={this.bodySections.map(section => section.name)}
-            disableScrollable={this.disableScrollable}
-          />
-          <div className="left-nav-space" />
-          <div id="main-column" className="main-column">
-            <div className="body" data-pagename={pageContext.slug}>
-              <GuideBreadcrumbs />
-              <GuideHeading
-                author={findKeyValuePair(this.sections, 'name', 'author')}
-                cloud={cloud}
-                description={findKeyValuePair(this.sections, 'name', 'result_description')}
-                drivers={drivers}
-                page={pageContext.page}
-                time={findKeyValuePair(this.sections, 'name', 'time')}
-                title={findKeyValuePair(this.sections, 'type', 'heading')}
-              />
-              {this.createSections()}
-              <Footer />
-            </div>
+      <div className="content">
+        <TOC
+          activeSection={activeSection}
+          sectionKeys={this.bodySections.map(section => section.name)}
+          disableScrollable={this.disableScrollable}
+        />
+        <div className="left-nav-space" />
+        <div id="main-column" className="main-column">
+          <div className="body" data-pagename={pageContext.slug}>
+            <GuideBreadcrumbs />
+            <GuideHeading
+              author={findKeyValuePair(this.sections, 'name', 'author')}
+              cloud={cloud}
+              description={findKeyValuePair(this.sections, 'name', 'result_description')}
+              drivers={drivers}
+              page={pageContext.page}
+              time={findKeyValuePair(this.sections, 'name', 'time')}
+              title={findKeyValuePair(this.sections, 'type', 'heading')}
+            />
+            {this.createSections()}
+            <Footer />
           </div>
         </div>
-        <Navbar />
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/src/templates/guides-index.js
+++ b/src/templates/guides-index.js
@@ -3,28 +3,24 @@ import PropTypes from 'prop-types';
 import LandingPageCards from '../components/LandingPage/LandingPageCards';
 import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { getNestedValue } from '../utils/get-nested-value';
-import Navbar from '../components/Navbar';
 
 const Index = ({ pageContext: { guidesMetadata, page } }) => {
   const guides = findKeyValuePair(getNestedValue(['ast', 'children'], page), 'name', 'guide-index') || [];
 
   return (
-    <React.Fragment>
-      <div className="content">
-        <div className="guide-category-list">
-          <div className="section" id="guides">
-            <h1>
-              Guides
-              <a className="headerlink" href="#guides" title="Permalink to this headline">
-                ¶
-              </a>
-            </h1>
-            <LandingPageCards guides={guides.children} guidesMetadata={guidesMetadata} />
-          </div>
+    <div className="content">
+      <div className="guide-category-list">
+        <div className="section" id="guides">
+          <h1>
+            Guides
+            <a className="headerlink" href="#guides" title="Permalink to this headline">
+              ¶
+            </a>
+          </h1>
+          <LandingPageCards guides={guides.children} guidesMetadata={guidesMetadata} />
         </div>
       </div>
-      <Navbar />
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -6,7 +6,6 @@ import { useTheme } from 'emotion-theming';
 import { uiColors } from '@leafygreen-ui/palette';
 import PropTypes from 'prop-types';
 import Footer from '../components/Footer';
-import Navbar from '../components/Navbar';
 
 const Wrapper = styled('main')`
   margin: ${({ theme }) => `calc(${theme.navbar.height} + ${theme.size.large}) auto ${theme.size.xlarge} auto`};
@@ -36,7 +35,6 @@ const Landing = ({ children }) => {
       <Helmet>
         <title>MongoDB Documentation</title>
       </Helmet>
-      <Navbar />
       <Wrapper>{children}</Wrapper>
       <Footer />
       <Global


### PR DESCRIPTION
[DOP-1420] [[Datalake Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/datalake/sophstad/DOP-1420/)] [[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/sophstad/DOP-1420/)] [[Guides Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/guides/sophstad/DOP-1420/)] [[Drivers Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/DOP-1420/)] Render navbar in layout component instead of in each template. This mean that the same instance of the navbar is mounted no matter which template is in use.

Notice how in the Drivers staging link in #268, navigating from the landing page to a content page would result in the navbar re-rendering and the search bar re-animating. This PR fixes that!