### PR TITLE
Use Context for footnotes

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
 
-const DocumentBody = ({ addPillstrip, footnotes, pillstrips, pageContext: { metadata, page, slug } }) => {
+const DocumentBody = ({ addPillstrip, pillstrips, pageContext: { metadata, page, slug } }) => {
   const pageNodes = getNestedValue(['ast', 'children'], page) || [];
   return (
     <React.Fragment>
       {pageNodes.map((child, index) => (
         <ComponentFactory
           addPillstrip={addPillstrip}
-          footnotes={footnotes}
           key={index}
           metadata={metadata}
           nodeData={child}
@@ -25,7 +24,6 @@ const DocumentBody = ({ addPillstrip, footnotes, pillstrips, pageContext: { meta
 
 DocumentBody.propTypes = {
   addPillstrip: PropTypes.func,
-  footnotes: PropTypes.objectOf(PropTypes.object),
   pillstrips: PropTypes.objectOf(PropTypes.object),
   page: PropTypes.shape({
     ast: PropTypes.shape({
@@ -37,7 +35,6 @@ DocumentBody.propTypes = {
 
 DocumentBody.defaultProps = {
   addPillstrip: () => {},
-  footnotes: {},
   pillstrips: {},
 };
 

--- a/src/components/Footnote.js
+++ b/src/components/Footnote.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
 import { intersperse } from '../utils/intersperse';
+import FootnoteContext from './footnote-context';
 
-const Footnote = ({ nodeData, footnotes, nodeData: { children, id, name }, ...rest }) => {
+const Footnote = ({ nodeData: { children, id, name }, ...rest }) => {
+  const { footnotes } = useContext(FootnoteContext);
   const ref = name || id;
   const footnoteReferences = footnotes[ref] ? footnotes[ref].references : [];
   const footnoteReferenceNodes = footnoteReferences.map((footnote, index) => (
@@ -33,7 +35,6 @@ const Footnote = ({ nodeData, footnotes, nodeData: { children, id, name }, ...re
 };
 
 Footnote.propTypes = {
-  footnotes: PropTypes.objectOf(PropTypes.object).isRequired,
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object),
     id: PropTypes.string.isRequired,

--- a/src/components/FootnoteReference.js
+++ b/src/components/FootnoteReference.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { getNestedValue } from '../utils/get-nested-value';
+import FootnoteContext from './footnote-context';
 
-const FootnoteReference = ({ footnotes, nodeData: { id, refname } }) => {
+const FootnoteReference = ({ nodeData: { id, refname } }) => {
+  const { footnotes } = useContext(FootnoteContext);
+
   // Get the ID of the parent of an anonymous footnote reference
   const getAnonymousFootnote = () => {
     return Object.keys(footnotes).find(key => {
@@ -19,7 +22,6 @@ const FootnoteReference = ({ footnotes, nodeData: { id, refname } }) => {
 };
 
 FootnoteReference.propTypes = {
-  footnotes: PropTypes.objectOf(PropTypes.object).isRequired,
   nodeData: PropTypes.shape({
     id: PropTypes.string.isRequired,
     refname: PropTypes.string,

--- a/src/components/footnote-context.js
+++ b/src/components/footnote-context.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const FootnoteContext = createContext({
+  footnotes: {},
+});
+
+export default FootnoteContext;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import { getPlaintext } from '../utils/get-plaintext';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { theme } from '../theme/docsTheme.js';
 import { getTemplate } from '../utils/get-template';
+import FootnoteContext from '../components/footnote-context';
 
 const Widgets = loadable(() => import('../components/Widgets'));
 
@@ -166,17 +167,13 @@ export default class DefaultLayout extends Component {
             slug={slug}
           >
             <SiteMetadata siteTitle={siteTitle} pageTitle={pageTitle} />
-            <Template
-              pageContext={pageContext}
-              pillstrips={pillstrips}
-              addPillstrip={this.addPillstrip}
-              footnotes={this.footnotes}
-            >
-              {React.cloneElement(children, {
-                pillstrips,
-                addPillstrip: this.addPillstrip,
-                footnotes: this.footnotes,
-              })}
+            <Template pageContext={pageContext} pillstrips={pillstrips} addPillstrip={this.addPillstrip}>
+              <FootnoteContext.Provider value={{ footnotes: this.footnotes }}>
+                {React.cloneElement(children, {
+                  pillstrips,
+                  addPillstrip: this.addPillstrip,
+                })}
+              </FootnoteContext.Provider>
             </Template>
           </Widgets>
         </TabContext.Provider>


### PR DESCRIPTION
[[Cloud Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/footnote-context/database-auditing#id2)] I noticed a bad case of [prop drilling](https://kentcdodds.com/blog/prop-drilling/) w.r.t. footnotes, so this PR adds a small [Context](https://reactjs.org/docs/context.html) to handle that data.