### PR TITLE
DOP-1006: Fix version selector and title in dropdown

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import Link from './Link';
 import VersionDropdown from './VersionDropdown';
 import TableOfContents from './TableOfContents';
@@ -7,20 +7,30 @@ import style from '../styles/sidebar.module.css';
 
 const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => {
   const { title } = toctreeData;
+
+  // Calculate height of the fixed header so that the TOC can occupy the rest of the vertical space.
+  const [fixedHeight, setFixedHeight] = useState(0);
+  const fixedHeading = useRef(null);
+  useLayoutEffect(() => {
+    setFixedHeight(fixedHeading.current.clientHeight);
+  }, []);
+
   return (
     <aside className={`sidebar ${style.sidebar}`} id="sidebar">
       <div className={`sphinxsidebar ${style.sphinxsidebar}`} id="sphinxsidebar">
         <div id="sphinxsidebarwrapper" className="sphinxsidebarwrapper">
-          <span className="closeNav" id="closeNav" onClick={toggleLeftColumn} style={{ cursor: 'pointer' }}>
-            Close ×
-          </span>
-          <h3>
-            <Link className="index-link" to="/">
-              {formatText(title)}
-            </Link>
-          </h3>
-          {publishedBranches && <VersionDropdown slug={slug} publishedBranches={publishedBranches} />}
-          <TableOfContents toctreeData={toctreeData} />
+          <div ref={fixedHeading}>
+            <span className="closeNav" id="closeNav" onClick={toggleLeftColumn} style={{ cursor: 'pointer' }}>
+              Close ×
+            </span>
+            <h3>
+              <Link className="index-link" to="/">
+                {formatText(title)}
+              </Link>
+            </h3>
+            {publishedBranches && <VersionDropdown slug={slug} publishedBranches={publishedBranches} />}
+          </div>
+          <TableOfContents toctreeData={toctreeData} height={fixedHeight} />
         </div>
       </div>
     </aside>

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -8,7 +8,7 @@ import { isBrowser } from '../utils/is-browser';
 /**
  * Overall Table of Contents component, which manages open sections as children
  */
-const TableOfContents = ({ toctreeData: { children } }) => {
+const TableOfContents = ({ height, toctreeData: { children } }) => {
   // Want to check this on each re-render
   let currentPage;
   if (isBrowser) {
@@ -25,7 +25,7 @@ const TableOfContents = ({ toctreeData: { children } }) => {
       <ul
         className="current"
         css={css`
-          height: 100%;
+          height: calc(100% - ${height}px);
           overflow-y: auto;
           position: absolute;
           width: 100%;
@@ -41,6 +41,7 @@ const TableOfContents = ({ toctreeData: { children } }) => {
 };
 
 TableOfContents.propTypes = {
+  height: PropTypes.number.isRequired,
   toctreeData: PropTypes.shape({
     children: PropTypes.array.isRequired,
   }).isRequired,

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -28,6 +28,7 @@ const TableOfContents = ({ toctreeData: { children } }) => {
           height: 100%;
           overflow-y: auto;
           position: absolute;
+          width: 100%;
         `}
       >
         {children.map(c => {

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import TOCNode from './TOCNode';
 import { TOCContext } from './toc-context';
 import { isBrowser } from '../utils/is-browser';
@@ -21,7 +22,14 @@ const TableOfContents = ({ toctreeData: { children } }) => {
 
   return (
     <TOCContext.Provider value={{ activeSection, setActiveSection }}>
-      <ul className="current">
+      <ul
+        className="current"
+        css={css`
+          height: 100%;
+          overflow-y: auto;
+          position: absolute;
+        `}
+      >
         {children.map(c => {
           const key = c.slug || c.url;
           return <TOCNode node={c} key={key} />;

--- a/src/styles/sidebar.module.css
+++ b/src/styles/sidebar.module.css
@@ -1,6 +1,7 @@
 .sidebar {
-    display: block;
+  display: block;
 }
 .sphinxsidebar {
-    display: block;
+  display: block;
+  overflow-y: visible !important;
 }

--- a/tests/unit/TableOfContents.test.js
+++ b/tests/unit/TableOfContents.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import mockTocData from './data/Table-Of-Contents.test.json';
 import TableOfContents from '../../src/components/TableOfContents';
 /*
@@ -11,12 +11,10 @@ import TableOfContents from '../../src/components/TableOfContents';
 */
 
 const mountedToc = mockData => mount(<TableOfContents toctreeData={mockData} />);
-const shallowToc = mockData => shallow(<TableOfContents toctreeData={mockData} />);
 
 describe('Table of Contents testing', () => {
   describe('Table of Contents unit tests', () => {
     let testComponent;
-    let testShallowComponent;
 
     const remountTOC = () => {
       testComponent = mountedToc(mockTocData);
@@ -27,17 +25,13 @@ describe('Table of Contents testing', () => {
       remountTOC();
     };
 
-    beforeAll(() => {
-      testShallowComponent = shallowToc(mockTocData);
-    });
-
     beforeEach(() => {
       updatePageLocation('Ecosystem', '/');
       remountTOC();
     });
 
     it('renders correctly', () => {
-      expect(testShallowComponent).toMatchSnapshot();
+      expect(testComponent).toMatchSnapshot();
     });
 
     it('TOC exists with proper number of sections and nodes per section', () => {

--- a/tests/unit/TableOfContents.test.js
+++ b/tests/unit/TableOfContents.test.js
@@ -10,7 +10,7 @@ import TableOfContents from '../../src/components/TableOfContents';
   Test links
 */
 
-const mountedToc = mockData => mount(<TableOfContents toctreeData={mockData} />);
+const mountedToc = mockData => mount(<TableOfContents toctreeData={mockData} height={0} />);
 
 describe('Table of Contents testing', () => {
   describe('Table of Contents unit tests', () => {

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -1,16 +1,223 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table of Contents testing Table of Contents unit tests renders correctly 1`] = `
-<ContextProvider
-  value={
+.emotion-0 {
+  height: 100%;
+  overflow-y: auto;
+  position: absolute;
+  width: 100%;
+}
+
+<TableOfContents
+  toctreeData={
     Object {
-      "activeSection": "/",
-      "setActiveSection": [Function],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "slug": "drivers/c",
+              "title": "C Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/cxx",
+              "title": "C++ Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/csharp",
+              "title": "C# and .NET Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/go",
+              "title": "Go Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/java",
+              "title": "Java Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/node",
+              "title": "Node.js Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/perl",
+              "title": "Perl Driver",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "slug": "drivers/php-libraries",
+                  "title": "PHP Libraries, Frameworks, and Tools",
+                },
+              ],
+              "slug": "drivers/php",
+              "title": "PHP Driver",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "slug": "drivers/pymongo",
+                  "title": "PyMongo",
+                },
+                Object {
+                  "children": Array [],
+                  "slug": "drivers/motor",
+                  "title": "Motor (Async Driver)",
+                },
+              ],
+              "slug": "drivers/python",
+              "title": "Python Drivers",
+            },
+            Object {
+              "children": Array [],
+              "title": "Ruby Driver",
+              "url": "https://docs.mongodb.com/ruby-driver/current/",
+            },
+            Object {
+              "children": Array [],
+              "title": "Mongoid ODM",
+              "url": "https://docs.mongodb.com/mongoid/current/",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/scala",
+              "title": "Scala Driver",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/community-supported-drivers",
+              "title": "Community Supported Drivers Reference",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/specs",
+              "title": "MongoDB Drivers Specs",
+            },
+            Object {
+              "children": Array [],
+              "slug": "drivers/driver-compatibility-reference",
+              "title": "Driver Compatibility",
+            },
+          ],
+          "slug": "drivers",
+          "title": "MongoDB Drivers and ODM",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "title": "MongoDB Connector for Business Intelligence",
+              "url": "https://docs.mongodb.com/bi-connector/current/",
+            },
+            Object {
+              "children": Array [],
+              "title": "MongoDB ODBC Driver for BI Connector",
+              "url": "https://docs.mongodb.com/bi-connector/current/reference/odbc-driver/",
+            },
+            Object {
+              "children": Array [],
+              "slug": "tools/http-interfaces",
+              "title": "HTTP Interface",
+            },
+          ],
+          "slug": "tools",
+          "title": "MongoDB Integration and Tools",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "slug": "platforms/amazon-ec2",
+              "title": "Amazon EC2",
+            },
+            Object {
+              "children": Array [],
+              "slug": "tutorial/backup-and-restore-mongodb-on-amazon-ec2",
+              "title": "EC2 Backup and Restore",
+            },
+            Object {
+              "children": Array [],
+              "slug": "platforms/windows-azure",
+              "title": "Microsoft Azure",
+            },
+            Object {
+              "children": Array [],
+              "slug": "platforms/windows",
+              "title": "Windows Quick Links and Reference Center",
+            },
+          ],
+          "options": Object {
+            "drawer": true,
+            "styles": Object {
+              "code": "Platforms",
+            },
+          },
+          "slug": "platforms",
+          "title": "Platforms",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "slug": "use-cases/storing-log-data",
+              "title": "Storing Log Data",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/hierarchical-aggregation",
+              "title": "Hierarchical Aggregation",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/product-catalog",
+              "title": "Product Catalog",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/inventory-management",
+              "title": "Inventory Management",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/category-hierarchy",
+              "title": "Category Hierarchy",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/metadata-and-asset-management",
+              "title": "Metadata and Asset Management",
+            },
+            Object {
+              "children": Array [],
+              "slug": "use-cases/storing-comments",
+              "title": "Storing Comments",
+            },
+          ],
+          "options": Object {
+            "drawer": true,
+            "styles": Object {
+              "strong": "Use Cases",
+            },
+          },
+          "slug": "use-cases",
+          "title": "Use Cases",
+        },
+      ],
+      "slug": "/",
+      "title": "MongoDB Ecosystem",
     }
   }
 >
   <ul
-    className="current"
+    className="current emotion-0"
   >
     <TOCNode
       key="drivers"
@@ -115,7 +322,33 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "title": "MongoDB Drivers and ODM",
         }
       }
-    />
+    >
+      <li
+        className="toctree-l1  "
+      >
+        <NodeLink>
+          <Link
+            aria-expanded={false}
+            className="reference  internal"
+            to="drivers"
+          >
+            <mockConstructor
+              aria-expanded={false}
+              className="reference  internal"
+              to="/drivers"
+            >
+              <a
+                aria-expanded={false}
+                className="reference  internal"
+                href="/drivers"
+              >
+                MongoDB Drivers and ODM
+              </a>
+            </mockConstructor>
+          </Link>
+        </NodeLink>
+      </li>
+    </TOCNode>
     <TOCNode
       key="tools"
       level={1}
@@ -142,7 +375,33 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "title": "MongoDB Integration and Tools",
         }
       }
-    />
+    >
+      <li
+        className="toctree-l1  "
+      >
+        <NodeLink>
+          <Link
+            aria-expanded={false}
+            className="reference  internal"
+            to="tools"
+          >
+            <mockConstructor
+              aria-expanded={false}
+              className="reference  internal"
+              to="/tools"
+            >
+              <a
+                aria-expanded={false}
+                className="reference  internal"
+                href="/tools"
+              >
+                MongoDB Integration and Tools
+              </a>
+            </mockConstructor>
+          </Link>
+        </NodeLink>
+      </li>
+    </TOCNode>
     <TOCNode
       key="platforms"
       level={1}
@@ -180,7 +439,35 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "title": "Platforms",
         }
       }
-    />
+    >
+      <li
+        className="toctree-l1  "
+      >
+        <NodeLink>
+          <Link
+            aria-expanded={false}
+            className="reference  internal"
+            href="platforms"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="0"
+          >
+            <a
+              aria-expanded={false}
+              className="reference  internal"
+              href="platforms"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              Platforms
+            </a>
+          </Link>
+        </NodeLink>
+      </li>
+    </TOCNode>
     <TOCNode
       key="use-cases"
       level={1}
@@ -233,7 +520,35 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           "title": "Use Cases",
         }
       }
-    />
+    >
+      <li
+        className="toctree-l1  "
+      >
+        <NodeLink>
+          <Link
+            aria-expanded={false}
+            className="reference  internal"
+            href="use-cases"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="0"
+          >
+            <a
+              aria-expanded={false}
+              className="reference  internal"
+              href="use-cases"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              Use Cases
+            </a>
+          </Link>
+        </NodeLink>
+      </li>
+    </TOCNode>
   </ul>
-</ContextProvider>
+</TableOfContents>
 `;

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -2,13 +2,14 @@
 
 exports[`Table of Contents testing Table of Contents unit tests renders correctly 1`] = `
 .emotion-0 {
-  height: 100%;
+  height: calc(100% - 0px);
   overflow-y: auto;
   position: absolute;
   width: 100%;
 }
 
 <TableOfContents
+  height={0}
   toctreeData={
     Object {
       "children": Array [


### PR DESCRIPTION
[DOP-1006] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty/bi-connector/sophstad/DOP-1006/)] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/test2/docs/sophstad/DOP-1006/)] Fix title and version selector in the sidebar so that only the table of contents scrolls.