### PR TITLE
DOP-1425: Update anchor link styling due to interference from #271 and with #241

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,14 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import loadable from '@loadable/component';
-import { Global, css } from '@emotion/core';
 import SiteMetadata from '../components/site-metadata';
 import { TabContext } from '../components/tab-context';
 import { findAllKeyValuePairs } from '../utils/find-all-key-value-pairs';
 import { getNestedValue } from '../utils/get-nested-value';
 import { getPlaintext } from '../utils/get-plaintext';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
-import { theme } from '../theme/docsTheme.js';
 import { getTemplate } from '../utils/get-template';
 import FootnoteContext from '../components/footnote-context';
 import Navbar from '../components/Navbar';
@@ -146,19 +144,6 @@ export default class DefaultLayout extends Component {
     const Template = getTemplate(template, slug);
     return (
       <>
-        {/* Anchor-link styling to compensate for navbar height */}
-        <Global
-          styles={css`
-            :target::before {
-              content: '';
-              display: block;
-              height: calc(${theme.navbar.height} + 10px);
-              margin-top: calc((${theme.navbar.height} + 10px) * -1);
-              position: relative;
-              width: 0;
-            }
-          `}
-        />
         <TabContext.Provider value={{ ...this.state, setActiveTab: this.setActiveTab }}>
           <Widgets
             location={location}

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import loadable from '@loadable/component';
+import { Global, css } from '@emotion/core';
 import SiteMetadata from '../components/site-metadata';
 import { TabContext } from '../components/tab-context';
 import { findAllKeyValuePairs } from '../utils/find-all-key-value-pairs';
@@ -8,6 +9,7 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { getPlaintext } from '../utils/get-plaintext';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { getTemplate } from '../utils/get-template';
+import { theme } from '../theme/docsTheme.js';
 import FootnoteContext from '../components/footnote-context';
 import Navbar from '../components/Navbar';
 
@@ -144,6 +146,22 @@ export default class DefaultLayout extends Component {
     const Template = getTemplate(template, slug);
     return (
       <>
+        {/* Anchor-link styling to compensate for navbar height */}
+        <Global
+          styles={css`
+            h1::before,
+            h2::before,
+            h3::before,
+            h4::before {
+              content: '';
+              display: block;
+              height: calc(${theme.navbar.height} + 10px);
+              margin-top: calc((${theme.navbar.height} + 10px) * -1);
+              position: relative;
+              width: 0;
+            }
+          `}
+        />
         <TabContext.Provider value={{ ...this.state, setActiveTab: this.setActiveTab }}>
           <Widgets
             location={location}


### PR DESCRIPTION
[DOP-1425](https://jira.mongodb.org/browse/DOP-1425). [Datalake with added footnotes](https://docs-mongodborg-staging.corp.mongodb.com/DOP-931/datalake/cgoecknerwald/DOP-1425/). [Drivers](https://docs-mongodborg-staging.corp.mongodb.com/master/datalake/cgoecknerwald/DOP-1425/).

- Target overhaul caused `dt` / `code` elements to have `href=#undefined`, which was failing with the old CSS of `:target::before`.
- Footnotes refactoring was blocked due to `:target::before` selecting the footnote href's and causing them too jump all over the page when clicked
- I dropped an import statement down a few lines in a modest attempt at slowly alphabetizing imports