### PR TITLE
Switch metric label from areaFound to areaFrom

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -226,7 +226,7 @@ const SearchResults = () => {
               <StyledSearchResult
                 key={`${url}${index}`}
                 onClick={() =>
-                  reportAnalytics('SearchSelection', { areaFound: 'ResultsPage', rank: index, selectionUrl: url })
+                  reportAnalytics('SearchSelection', { areaFrom: 'ResultsPage', rank: index, selectionUrl: url })
                 }
                 title={title}
                 preview={preview}


### PR DESCRIPTION
[Landing Staging](https://docs-mongodborg-staging.corp.mongodb.com/DOP-1337/landing/jordanstapinski/area-found-from/)
[GA Doc](https://docs.google.com/document/d/1L5HTF5BV3_iuNm-vGKBubwYUCPyq7nIQGTCaJ8GTFq0/edit)

This short PR switches a typo instrumentation label from `areaFound` to `areaFrom` for the search results page.