### PR TITLE
fix: "class" -> "className"

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -27,7 +27,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
         </HeadingContainer>
       )}
     >
-      <HeadingTag class="contains-headerlink" id={id}>
+      <HeadingTag className="contains-headerlink" id={id}>
         {nodeData.children.map((element, index) => {
           return <ComponentFactory {...rest} nodeData={element} key={index} />;
         })}


### PR DESCRIPTION
Fixes #281; React requires use of `className` instead of `class` ([source](https://reactjs.org/docs/dom-elements.html#classname)).