### PR TITLE
DOP-1492: Render highlight roles

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -60,6 +60,7 @@ import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
 import RoleFile from './Roles/File';
 import RoleGUILabel from './Roles/GUILabel';
+import RoleHighlight from './Roles/Highlight';
 import RoleIcon from './Roles/Icon';
 import RoleRed from './Roles/Red';
 import RoleRequired from './Roles/Required';
@@ -74,6 +75,10 @@ const roleMap = {
   file: RoleFile,
   guilabel: RoleGUILabel,
   icon: RoleIcon,
+  'highlight-blue': RoleHighlight,
+  'highlight-green': RoleHighlight,
+  'highlight-red': RoleHighlight,
+  'highlight-yellow': RoleHighlight,
   'icon-fa5': RoleIcon,
   'icon-fa5-brands': RoleIcon,
   'icon-fa4': RoleIcon,

--- a/src/components/Roles/Highlight.js
+++ b/src/components/Roles/Highlight.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { uiColors } from '@leafygreen-ui/palette';
+import ComponentFactory from '../ComponentFactory';
+
+const colorMap = {
+  'highlight-blue': uiColors.blue.light3,
+  'highlight-green': uiColors.green.light3,
+  'highlight-red': uiColors.red.light3,
+  'highlight-yellow': uiColors.yellow.light3,
+};
+
+const Highlight = ({ nodeData: { children, name } }) => (
+  <span
+    css={css`
+      background-color: ${colorMap[name]};
+    `}
+  >
+    {children.map((node, i) => (
+      <ComponentFactory key={i} nodeData={node} />
+    ))}
+  </span>
+);
+
+Highlight.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default Highlight;


### PR DESCRIPTION
[DOP-1492] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/test2/docs/sophstad/DOP-1492/reference/map-reduce-to-aggregation-pipeline#map-reduce-to-aggregation-pipeline-translation-table)] Render the following roles:
- `:highlight-red:`
- `:highlight-yellow:`
- `:highlight-green:`
- `:highlight-blue:`