### PR TITLE
DOP-1549: Fix version dropdown links

### DIFF
--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -8,8 +8,9 @@ import Button from '@leafygreen-ui/button';
 
 const zip = (a, b) => {
   // Zip arrays a and b into an object where a is used for keys and b for values
+  const shorter = a.length > b.length ? b : a;
   const dict = {};
-  a.forEach((key, i) => (dict[key] = b[i]));
+  shorter.forEach((key, i) => (dict[a[i]] = b[i]));
   return dict;
 };
 
@@ -54,7 +55,7 @@ const VersionDropdown = ({
   };
 
   // Zip two sections of data to map git branches to their "pretty" names
-  const gitNamedMapping = zip(gitBranches, published);
+  const gitNamedMapping = zip(gitBranches, active);
   const currentBranch = gitNamedMapping[parserBranch] || parserBranch;
 
   const wrapperRef = useRef(null);
@@ -110,12 +111,12 @@ const VersionDropdown = ({
       </Button>
       {!hidden && (
         <ul className={['dropdown-menu', dropdownStyles.menu].join(' ')} role="menu">
-          {active.map(version => {
-            const url = normalizePath(`${generatePrefix(version)}/${slug}`);
+          {Object.entries(gitNamedMapping).map(([branch, name]) => {
+            const url = normalizePath(`${generatePrefix(branch)}/${slug}`);
             return (
-              <li className={currentBranch === version ? 'active' : ''} key={version}>
+              <li className={parserBranch === branch ? 'active' : ''} key={branch}>
                 <a className="version-selector" href={url}>
-                  {prefixVersion(version)}
+                  {prefixVersion(name)}
                 </a>
               </li>
             );

--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -89,7 +89,7 @@ const VersionDropdown = ({
 
     // For production builds, append version after project name
     if (pathPrefix) {
-      const [project] = pathPrefix.split('/');
+      const [, project] = pathPrefix.split('/');
       return `/${project}/${version}`;
     }
 

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -22,6 +22,17 @@ const gitBranch = execSync('git rev-parse --abbrev-ref HEAD')
   .toString('utf8')
   .replace(/[\n\r\s]+$/, '');
 
+const getPathPrefix = () => {
+  const pathPrefix = process.env.PATH_PREFIX;
+  if (!pathPrefix) {
+    return '';
+  }
+  if (pathPrefix.startsWith('/')) {
+    return pathPrefix;
+  }
+  return `/${pathPrefix}`;
+};
+
 /**
  * Get site metadata used to identify this build and query correct documents
  */
@@ -31,7 +42,7 @@ const siteMetadata = {
   parserBranch: process.env.GATSBY_PARSER_BRANCH,
   parserUser: process.env.GATSBY_PARSER_USER,
   patchId: process.env.PATCH_ID || '',
-  pathPrefix: process.env.PATH_PREFIX || '',
+  pathPrefix: getPathPrefix(),
   project: process.env.GATSBY_SITE,
   snootyBranch: gitBranch,
   snootyEnv: process.env.SNOOTY_ENV || 'development',

--- a/tests/unit/VersionDropdown.test.js
+++ b/tests/unit/VersionDropdown.test.js
@@ -38,6 +38,7 @@ useStaticQuery.mockImplementation(() => ({
   site: {
     siteMetadata: {
       parserBranch: 'master',
+      pathPrefix: '/bi-connector/master',
       project: 'bi-connector',
       snootyBranch: 'DOCSP-7502',
       user: 'docsworker',
@@ -50,7 +51,7 @@ describe('when rendered', () => {
   let wrapper;
 
   beforeAll(() => {
-    wrapper = mount(<VersionDropdown pathname="installation" publishedBranches={publishedBranches} />);
+    wrapper = mount(<VersionDropdown slug="installation" publishedBranches={publishedBranches} />);
   });
 
   it('shows a button group', () => {
@@ -77,6 +78,16 @@ describe('when rendered', () => {
           .first()
           .hasClass('active')
       ).toBe(true);
+    });
+
+    it('generates the correct links', () => {
+      expect(
+        wrapper
+          .find('li')
+          .at(1)
+          .childAt(0)
+          .prop('href')
+      ).toBe('/bi-connector/v2.11/installation');
     });
 
     // The 9th element links to the Legacy Docs page
@@ -118,7 +129,7 @@ describe('when rendering a property without legacy docs', () => {
   let wrapper;
 
   beforeAll(() => {
-    wrapper = mount(<VersionDropdown pathname="installation" publishedBranches={publishedBranchesNoLegacy} />);
+    wrapper = mount(<VersionDropdown slug="installation" publishedBranches={publishedBranchesNoLegacy} />);
   });
 
   describe('when the button is clicked in a property without legacy docs', () => {


### PR DESCRIPTION
[DOP-1549] [[Charts Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/charts/sophstad/master/)] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-1549/)] Use values from the [`git.branches.published` table](https://github.com/mongodb/docs-worker-pool/blob/meta/publishedbranches/docs-charts.yaml#L15-L18)  of the published-branches.yaml file. These are the values that correspond to the git branches of each version, and also to the slug that should appear in the URL. Previously, the component was using the values that appear in the `version.active` table, which understandably worked out badly!