### PR TITLE
DOP-1529 (2): Add tab selector to non-mobile screens

### DIFF
--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const RightColumn = ({ children }) => (
+  <div
+    css={css`
+      flex-grow: 1;
+      margin: 40px 15px;
+      min-width: 180px;
+      order: 2;
+    `}
+  >
+    {children}
+  </div>
+);
+
+RightColumn.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};
+
+export default RightColumn;

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -6,7 +6,7 @@ const RightColumn = ({ children }) => (
   <div
     css={css`
       flex-grow: 1;
-      margin: 40px 15px;
+      margin: 70px 15px 40px 65px;
       min-width: 180px;
       order: 2;
 

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -9,6 +9,10 @@ const RightColumn = ({ children }) => (
       margin: 40px 15px;
       min-width: 180px;
       order: 2;
+
+      & > * {
+        position: fixed;
+      }
     `}
   >
     {children}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -26,7 +26,7 @@ const activeSelectStyles = css`
 const Label = styled('p')`
   font-weight: bolder;
   letter-spacing: 0;
-  margin: 0 0 ${theme.size.tiny};
+  margin: 0 0 12px;
 `;
 
 const SelectedText = styled('p')`

--- a/src/components/TabSelectors.js
+++ b/src/components/TabSelectors.js
@@ -1,0 +1,51 @@
+import React, { useContext } from 'react';
+import { css } from '@emotion/core';
+import { TabContext } from './tab-context';
+import Select from './Select';
+
+const capitalizeFirstLetter = str => str.trim().replace(/^\w/, c => c.toUpperCase());
+
+const getLabel = name => {
+  switch (name) {
+    case 'drivers':
+      return 'Select your language';
+    case 'deployments':
+      return 'Select your deployment type';
+    case 'platforms':
+      return 'Select your platform';
+    default:
+      capitalizeFirstLetter(name);
+  }
+};
+
+const TabSelectors = () => {
+  const { activeTabs, selectors, setActiveTab } = useContext(TabContext);
+
+  if (!selectors) {
+    return null;
+  }
+
+  return (
+    <>
+      {Object.entries(selectors).map(([name, options], i) => {
+        const choices = Object.entries(options).map(([key, value]) => ({ value, text: key }));
+        return (
+          <Select
+            css={css`
+              max-width: 200px;
+            `}
+            choices={choices}
+            key={i}
+            label={getLabel(name)}
+            onChange={({ value }) => {
+              setActiveTab({ name, value });
+            }}
+            value={activeTabs[name]}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default TabSelectors;

--- a/src/components/TabSelectors.js
+++ b/src/components/TabSelectors.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { css } from '@emotion/core';
 import { TabContext } from './tab-context';
 import Select from './Select';
+import { getPlaintext } from '../utils/get-plaintext';
 
 const capitalizeFirstLetter = str => str.trim().replace(/^\w/, c => c.toUpperCase());
 
@@ -28,11 +29,13 @@ const TabSelectors = () => {
   return (
     <>
       {Object.entries(selectors).map(([name, options], i) => {
-        const choices = Object.entries(options).map(([key, value]) => ({ value, text: key }));
+        const choices = Object.entries(options).map(([tabId, title]) => ({ text: getPlaintext(title), value: tabId }));
         return (
           <Select
             css={css`
-              max-width: 200px;
+              /* Min width of right panel */
+              max-width: 180px;
+              width: 100%;
             `}
             choices={choices}
             key={i}

--- a/src/components/tab-context.js
+++ b/src/components/tab-context.js
@@ -3,6 +3,7 @@ import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 
 const defaultContextValue = {
   activeTabs: {},
+  selectors: {},
   setActiveTab: () => {},
 };
 
@@ -15,14 +16,14 @@ const reducer = (prevState, { name, value }) => {
   };
 };
 
-const TabProvider = ({ children }) => {
+const TabProvider = ({ children, selectors }) => {
   const [activeTabs, setActiveTab] = useReducer(reducer, getLocalValue('activeTabs') || defaultContextValue.activeTabs);
 
   useEffect(() => {
     setLocalValue('activeTabs', activeTabs);
   }, [activeTabs]);
 
-  return <TabContext.Provider value={{ activeTabs, setActiveTab }}>{children}</TabContext.Provider>;
+  return <TabContext.Provider value={{ activeTabs, selectors, setActiveTab }}>{children}</TabContext.Provider>;
 };
 
 export { TabContext, TabProvider };

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -120,7 +120,7 @@ export default class DefaultLayout extends Component {
             }
           `}
         />
-        <TabProvider>
+        <TabProvider selectors={getNestedValue(['ast', 'options', 'selectors'], page)}>
           <Widgets
             location={location}
             pageOptions={getNestedValue(['ast', 'options'], page)}

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -5,7 +5,10 @@ import { getNestedValue } from '../utils/get-nested-value';
 import Breadcrumbs from '../components/Breadcrumbs';
 import InternalPageNav from '../components/InternalPageNav';
 import Sidebar from '../components/Sidebar';
+import RightColumn from '../components/RightColumn';
+import TabSelectors from '../components/TabSelectors';
 import { useWindowSize } from '../hooks/use-window-size.js';
+import useScreenSize from '../hooks/useScreenSize.js';
 import style from '../styles/navigation.module.css';
 import { isBrowser } from '../utils/is-browser.js';
 
@@ -28,6 +31,9 @@ const Document = ({
   const toggleLeftColumn = () => {
     setShowLeftColumn(!showLeftColumn);
   };
+
+  const { isTabletOrMobile } = useScreenSize();
+  const showRightColumn = !isTabletOrMobile;
 
   return (
     <div className="content">
@@ -64,6 +70,11 @@ const Document = ({
           </div>
         </div>
       </div>
+      {showRightColumn && (
+        <RightColumn>
+          <TabSelectors />
+        </RightColumn>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
[DOP-1529] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/DOP-1529-selector/tutorial/connect-to-your-cluster)] Adds selector dropdown to pages that include `tabs-pillstrip` directives. The selected drivers tab should update whenever a dropdown option is selected, and vice versa.

**Note:** The dropdown only displays on laptop screens; tablet and mobile will be included in a forthcoming PR.