### PR TITLE
DOP-1529 (3): Add mobile support for tab selector

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -3,28 +3,18 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { getNestedValue } from '../utils/get-nested-value';
 
-const DocumentBody = ({ addPillstrip, pillstrips, pageContext: { metadata, page, slug } }) => {
+const DocumentBody = ({ pageContext: { metadata, page, slug } }) => {
   const pageNodes = getNestedValue(['ast', 'children'], page) || [];
   return (
     <React.Fragment>
       {pageNodes.map((child, index) => (
-        <ComponentFactory
-          addPillstrip={addPillstrip}
-          key={index}
-          metadata={metadata}
-          nodeData={child}
-          page={page}
-          pillstrips={pillstrips}
-          slug={slug}
-        />
+        <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
       ))}
     </React.Fragment>
   );
 };
 
 DocumentBody.propTypes = {
-  addPillstrip: PropTypes.func,
-  pillstrips: PropTypes.objectOf(PropTypes.object),
   pageContext: PropTypes.shape({
     metadata: PropTypes.object.isRequired,
     page: PropTypes.shape({
@@ -34,11 +24,6 @@ DocumentBody.propTypes = {
     }).isRequired,
     slug: PropTypes.string.isRequired,
   }),
-};
-
-DocumentBody.defaultProps = {
-  addPillstrip: () => {},
-  pillstrips: {},
 };
 
 export default DocumentBody;

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 import Loadable from '@loadable/component';
 import useScreenSize from '../hooks/useScreenSize';
+import TabSelectors from './TabSelectors';
+import { TabContext } from './tab-context';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
@@ -16,6 +19,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const isPageTitle = sectionDepth === 1;
   const { isTabletOrMobile, isSmallScreen } = useScreenSize();
   const shouldShowStarRating = isPageTitle && isTabletOrMobile;
+  const { selectors } = useContext(TabContext);
 
   return (
     <ConditionalWrapper
@@ -23,7 +27,9 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
       wrapper={children => (
         <HeadingContainer stackVertically={isSmallScreen}>
           {children}
-          <FeedbackHeading isStacked={isSmallScreen} />
+          <ChildContainer isStacked={isSmallScreen}>
+            {selectors ? <TabSelectors /> : <FeedbackHeading isStacked={isSmallScreen} />}
+          </ChildContainer>
         </HeadingContainer>
       )}
     >
@@ -44,6 +50,16 @@ const HeadingContainer = styled.div`
   flex-direction: ${props => (props.stackVertically ? 'column' : 'row')};
   justify-content: space-between;
 `;
+
+const ChildContainer = styled.div(
+  ({ isStacked }) => css`
+    margin: ${isStacked ? '4px 0 16px 0' : '-24px 0 0 0'};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: ${isStacked ? 'flex-start' : 'center'};
+  `
+);
 
 Heading.propTypes = {
   sectionDepth: PropTypes.number.isRequired,

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -20,6 +20,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const { isTabletOrMobile, isSmallScreen } = useScreenSize();
   const shouldShowStarRating = isPageTitle && isTabletOrMobile;
   const { selectors } = useContext(TabContext);
+  const hasSelectors = selectors && Object.keys(selectors).length > 0;
 
   return (
     <ConditionalWrapper
@@ -28,7 +29,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
         <HeadingContainer stackVertically={isSmallScreen}>
           {children}
           <ChildContainer isStacked={isSmallScreen}>
-            {selectors ? <TabSelectors /> : <FeedbackHeading isStacked={isSmallScreen} />}
+            {hasSelectors ? <TabSelectors /> : <FeedbackHeading isStacked={isSmallScreen} />}
           </ChildContainer>
         </HeadingContainer>
       )}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -24,6 +24,7 @@ const activeSelectStyles = css`
 `;
 
 const Label = styled('p')`
+  font-size: ${theme.fontSize.default};
   font-weight: bolder;
   letter-spacing: 0;
   /* TODO: Remove !important when mongodb-docs.css is removed */
@@ -47,7 +48,8 @@ const Option = styled('li')`
   color: black;
   display: block;
   overflow: hidden;
-  padding: 10px ${theme.size.default};
+  /* TODO: Remove !important when mongodb-docs.css is removed */
+  padding: 10px ${theme.size.default} !important;
   text-overflow: ellipsis;
   white-space: nowrap;
   :focus,

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -26,14 +26,16 @@ const activeSelectStyles = css`
 const Label = styled('p')`
   font-weight: bolder;
   letter-spacing: 0;
-  margin: 0 0 12px;
+  /* TODO: Remove !important when mongodb-docs.css is removed */
+  margin: 0 0 12px !important;
 `;
 
 const SelectedText = styled('p')`
   display: block;
   font-family: Akzidenz;
   font-size: ${theme.fontSize.small};
-  margin: 0;
+  /* TODO: Remove !important when mongodb-docs.css is removed */
+  margin: 0 !important;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/TabSelectors.js
+++ b/src/components/TabSelectors.js
@@ -3,6 +3,7 @@ import { css } from '@emotion/core';
 import { TabContext } from './tab-context';
 import Select from './Select';
 import { getPlaintext } from '../utils/get-plaintext';
+import { theme } from '../theme/docsTheme';
 
 const capitalizeFirstLetter = str => str.trim().replace(/^\w/, c => c.toUpperCase());
 
@@ -33,9 +34,12 @@ const TabSelectors = () => {
         return (
           <Select
             css={css`
-              /* Min width of right panel */
-              max-width: 180px;
               width: 100%;
+
+              @media ${theme.screenSize.smallAndUp} {
+                /* Min width of right panel */
+                max-width: 180px;
+              }
             `}
             choices={choices}
             key={i}

--- a/src/components/TabSelectors.js
+++ b/src/components/TabSelectors.js
@@ -23,7 +23,7 @@ const getLabel = name => {
 const TabSelectors = () => {
   const { activeTabs, selectors, setActiveTab } = useContext(TabContext);
 
-  if (!selectors) {
+  if (!selectors || Object.keys(selectors).length === 0) {
     return null;
   }
 

--- a/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
@@ -4,25 +4,15 @@ import { css } from '@emotion/core';
 import StarRating, { StarRatingLabel } from './components/StarRating';
 import { useFeedbackState } from './context';
 
-export default function FeedbackHeading({ isVisible = true, isStacked = false }) {
+export default function FeedbackHeading({ isVisible = true }) {
   const { hideHeader } = useFeedbackState();
   return (
     isVisible &&
     !hideHeader && (
-      <StarRatingContainer isStacked={isStacked}>
+      <>
         <StarRating size="lg" />
         <StarRatingLabel>Give Feedback</StarRatingLabel>
-      </StarRatingContainer>
+      </>
     )
   );
 }
-
-const StarRatingContainer = styled.div(
-  ({ isStacked }) => css`
-    margin-top: 4px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: ${isStacked ? 'flex-start' : 'center'};
-  `
-);

--- a/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import StarRating, { StarRatingLabel } from './components/StarRating';
 import { useFeedbackState } from './context';
 

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -92,7 +92,7 @@ const widthForSize = size => {
 const marginForSize = size => {
   switch (size) {
     case 'lg':
-      return '-24px 0 0px 0';
+      return '0';
     case '2x':
       return '16px 0 32px 0';
     case '3x':

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -10,7 +10,6 @@ import { LANGUAGES, DEPLOYMENTS, SECTION_NAME_MAPPING } from '../constants';
 import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { throttle } from '../utils/throttle';
 import { getNestedValue } from '../utils/get-nested-value';
-import { TabContext } from '../components/tab-context';
 
 export default class Guide extends Component {
   constructor(propsFromServer) {
@@ -30,7 +29,6 @@ export default class Guide extends Component {
     };
 
     this.sectionRefs = this.bodySections.map(() => React.createRef());
-    this.namedTabsets = new Set();
   }
 
   componentDidMount() {
@@ -74,37 +72,6 @@ export default class Guide extends Component {
     }
   };
 
-  addGuidesTabset = (tabsetName, tabData) => {
-    const tabs = tabData.map(tab => getNestedValue(['options', 'tabid'], tab));
-    if (tabsetName === 'cloud') {
-      const tabsFiltered = DEPLOYMENTS.filter(tab => tabs.includes(tab));
-      this.setNamedTabData(tabsetName, tabsFiltered, DEPLOYMENTS);
-    } else if (tabsetName === 'drivers') {
-      const tabsFiltered = LANGUAGES.filter(tab => tabs.includes(tab));
-      this.setNamedTabData(tabsetName, tabsFiltered, LANGUAGES);
-    }
-  };
-
-  matchArraySorting = (tabs, referenceArray) => referenceArray.filter(t => tabs.includes(t));
-
-  setNamedTabData = (tabsetName, tabs, constants) => {
-    const { activeTabs, setActiveTab } = this.context;
-    this.setState(
-      prevState => ({
-        [tabsetName]: this.matchArraySorting(
-          Array.from(new Set([...(prevState[tabsetName] || []), ...tabs])),
-          constants
-        ),
-      }),
-      () => {
-        // If a tab preference isn't saved to local storage, select the first tab by default
-        if (!Object.prototype.hasOwnProperty.call(activeTabs, tabsetName)) {
-          setActiveTab(tabsetName, this.state[tabsetName][0]); // eslint-disable-line react/destructuring-assignment
-        }
-      }
-    );
-  };
-
   // Temporarily disable scrolling listener by changing state of 'isScrollable'
   disableScrollable = clickedSection => {
     this.setState({
@@ -114,7 +81,7 @@ export default class Guide extends Component {
   };
 
   createSections() {
-    const { addPillstrip, pageContext, pillstrips } = this.props;
+    const { pageContext } = this.props;
     if (this.bodySections.length === 0) {
       return this.sections.map(section => {
         return <ComponentFactory nodeData={section} page={pageContext.page} />;
@@ -124,14 +91,11 @@ export default class Guide extends Component {
     return this.bodySections.map((section, index) => {
       return (
         <GuideSection
-          addPillstrip={addPillstrip}
           sectionDepth={2}
           guideSectionData={section}
           key={index}
           headingRef={this.sectionRefs[index]}
           page={pageContext.page}
-          addTabset={this.addGuidesTabset}
-          pillstrips={pillstrips}
         />
       );
     });
@@ -171,7 +135,6 @@ export default class Guide extends Component {
 }
 
 Guide.propTypes = {
-  addPillstrip: PropTypes.func,
   pageContext: PropTypes.shape({
     page: PropTypes.shape({
       ast: PropTypes.shape({
@@ -181,12 +144,4 @@ Guide.propTypes = {
     slug: PropTypes.string.isRequired,
   }).isRequired,
   path: PropTypes.string.isRequired,
-  pillstrips: PropTypes.objectOf(PropTypes.object),
 };
-
-Guide.defaultProps = {
-  addPillstrip: () => {},
-  pillstrips: {},
-};
-
-Guide.contextType = TabContext;

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -6,7 +6,7 @@ import Footer from '../components/Footer';
 import GuideBreadcrumbs from '../components/GuideBreadcrumbs';
 import GuideSection from '../components/GuideSection';
 import GuideHeading from '../components/GuideHeading';
-import { LANGUAGES, DEPLOYMENTS, SECTION_NAME_MAPPING } from '../constants';
+import { SECTION_NAME_MAPPING } from '../constants';
 import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { throttle } from '../utils/throttle';
 import { getNestedValue } from '../utils/get-nested-value';

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -120,13 +120,13 @@ describe('FeedbackWidget', () => {
     it('is visible on medium/tablet screens', async () => {
       wrapper = await mountFormWithFeedbackState({}, withScreenSize('ipad-pro'));
       expect(wrapper.exists('FeedbackHeading')).toBe(true);
-      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(1);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(2);
     });
 
     it('is visible on small/mobile screens', async () => {
       wrapper = await mountFormWithFeedbackState({}, withScreenSize('iphone-x'));
       expect(wrapper.exists('FeedbackHeading')).toBe(true);
-      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(1);
+      expect(wrapper.find('FeedbackHeading').children()).toHaveLength(2);
     });
 
     it('is hidden on small/mobile screens when configured with page option', async () => {


### PR DESCRIPTION
[DOP-1529] [[Cloud Docs Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/DOP-1529-mobile/tutorial/connect-to-your-cluster)]
- On mobile, replace feedback widget with a language selector (if the page has one)
- Remove more references to pillstrips, particularly in Guides