### PR TITLE
DOP-1529 (5): Auto hide tabs on page with selector

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -12,11 +12,13 @@ const getTabId = node => getNestedValue(['options', 'tabid'], node);
 const generateAnonymousTabsetName = tabIds => [...tabIds].sort().join('/');
 
 const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
-  const { activeTabs, setActiveTab } = useContext(TabContext);
+  const { activeTabs, selectors, setActiveTab } = useContext(TabContext);
   const tabIds = children.map(child => getTabId(child));
   const tabsetName = options.tabset || generateAnonymousTabsetName(tabIds);
   const activeTab = activeTabs[tabsetName];
-  const isHidden = Object.prototype.hasOwnProperty.call(options, 'hidden');
+  // Hide tabset if it includes the :hidden: option, or if it is controlled by a dropdown selector
+  const isHidden =
+    Object.prototype.hasOwnProperty.call(options, 'hidden') || Object.keys(selectors).includes(tabsetName);
 
   useEffect(() => {
     if (!activeTab || !tabIds.includes(activeTab)) {

--- a/src/components/tab-context.js
+++ b/src/components/tab-context.js
@@ -16,7 +16,7 @@ const reducer = (prevState, { name, value }) => {
   };
 };
 
-const TabProvider = ({ children, selectors }) => {
+const TabProvider = ({ children, selectors = {} }) => {
   const [activeTabs, setActiveTab] = useReducer(reducer, getLocalValue('activeTabs') || defaultContextValue.activeTabs);
 
   useEffect(() => {

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import Tabs from '../../src/components/Tabs';
-import { TabContext } from '../../src/components/tab-context';
+import { TabProvider } from '../../src/components/tab-context';
 
 // data for this component
 import mockDataPlatforms from './data/Tabs-platform.test.json';
@@ -9,23 +9,20 @@ import mockDataLanguages from './data/Tabs-languages.test.json';
 import mockDataHidden from './data/Tabs-hidden.test.json';
 import mockDataAnonymous from './data/Tabs-anonymous.test.json';
 
-const context = {
-  activeTabs: {},
-  setActiveTab: jest.fn(),
-};
-
-// TODO: Update commented-out tests to make use of Enzyme support for React Context after it has been implemented.
-// GitHub issue: https://github.com/airbnb/enzyme/issues/1959
-const mountTabs = ({ activeTabs, mockData, mockAddTabset, mockSetActiveTab }) => {
+const mountTabs = ({ activeTabs, mockData }) => {
   return mount(
-    <TabContext.Provider value={{ activeTabs, setActiveTab: mockSetActiveTab }}>
-      <Tabs nodeData={mockData} addTabset={mockAddTabset} />
-    </TabContext.Provider>
+    <TabProvider>
+      <Tabs nodeData={mockData} />
+    </TabProvider>
   );
 };
 
 const shallowTabs = ({ mockData, mockAddTabset }) =>
-  shallow(<Tabs nodeData={mockData} addTabset={mockAddTabset} />, { context });
+  shallow(
+    <TabProvider>
+      <Tabs nodeData={mockData} addTabset={mockAddTabset} />
+    </TabProvider>
+  );
 
 describe('Tabs testing', () => {
   describe('Tab unit tests', () => {
@@ -35,15 +32,12 @@ describe('Tabs testing', () => {
 
     beforeAll(() => {
       wrapper = mountTabs({
-        activeTabs: { 'list-view/table-view': 'table-view' },
         mockData: mockDataAnonymous,
-        mockAddTabset,
-        mockSetActiveTab,
       });
     });
 
     it('tabs container exists with correct number of children', () => {
-      const tabCount = wrapper.props().nodeData.children.length;
+      const tabCount = wrapper.childAt(0).props().nodeData.children.length;
       expect(wrapper.find('.tab-strip')).toHaveLength(1);
       expect(wrapper.find('.tab-strip__element').exists()).toEqual(true);
       expect(wrapper.find('.tab-strip__element')).toHaveLength(tabCount);
@@ -60,26 +54,15 @@ describe('Tabs testing', () => {
     it('exists non-active tab', () => {
       expect(wrapper.find('.tab-strip__element[aria-selected=false]').exists()).toEqual(true);
     });
-
-    it('clicking new non-active tab calls function', () => {
-      const nonactiveTab = wrapper.find('.tab-strip__element[aria-selected=false]').first();
-      nonactiveTab.simulate('click');
-      expect(mockSetActiveTab.mock.calls.length).toBe(1);
-    });
   });
 
   describe('Ecosystem unit tests', () => {
     let wrapper;
-    const mockSetActiveTab = jest.fn();
-    const mockAddTabset = jest.fn();
 
     beforeAll(() => {
       process.env = Object.assign(process.env, { GATSBY_SITE: 'ecosystem' });
       wrapper = mountTabs({
-        activeTabs: {},
         mockData: mockDataLanguages,
-        mockAddTabset,
-        mockSetActiveTab,
       });
     });
 
@@ -90,15 +73,10 @@ describe('Tabs testing', () => {
 
   describe('when a hidden tabset is passed in', () => {
     let wrapper;
-    const mockSetActiveTab = jest.fn();
-    const mockAddTabset = jest.fn();
 
     beforeAll(() => {
       wrapper = shallowTabs({
-        activeTabs: {},
         mockData: mockDataHidden,
-        mockAddTabset,
-        mockSetActiveTab,
       });
     });
 
@@ -109,15 +87,10 @@ describe('Tabs testing', () => {
 
   describe('when javascript is disabled', () => {
     let wrapper;
-    const mockAddTabset = jest.fn();
-    const mockSetActiveTab = jest.fn();
 
     beforeAll(() => {
       wrapper = mountTabs({
-        activeTabs: {},
         mockData: mockDataPlatforms,
-        mockAddTabset,
-        mockSetActiveTab,
       });
     });
 


### PR DESCRIPTION
[DOP-1529] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/DOP-1529-hide/resilient-application)] Content should toggle on the staging link when a new language is selected in the dropdown (this is especially evident in the code blocks). Tabs that appear on pages without language selectors still render.