### PR TITLE
DOP-1667: Fix root and step components

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -54,6 +54,8 @@ import Field from './Field';
 import FieldList from './FieldList';
 import Operation from './Operation';
 import OpenAPI from './OpenAPI';
+import Root from './Root';
+import Steps from './Steps';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -132,10 +134,12 @@ const componentMap = {
   paragraph: Paragraph,
   ref_role: RefRole,
   reference: Reference,
+  root: Root,
   rubric: Rubric,
   'search-results': SearchResults,
   section: Section,
   step: Step,
+  steps: Steps,
   strong: Strong,
   substitution_reference: SubstitutionReference,
   tabs: Tabs,

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Include = ({ nodeData: { children }, ...rest }) =>
+const Root = ({ nodeData: { children }, ...rest }) =>
   children.map((child, i) => <ComponentFactory {...rest} key={i} nodeData={child} />);
 
-Include.propTypes = {
+Root.propTypes = {
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
 };
 
-export default Include;
+export default Root;

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -5,7 +5,7 @@ import ComponentFactory from './ComponentFactory';
 const Step = ({ nodeData: { children }, stepNum, ...rest }) => (
   <div className="sequence-block">
     <div className="bullet-block">
-      <div className="sequence-step">{stepNum + 1}</div>
+      <div className="sequence-step">{stepNum}</div>
     </div>
     <div className="section">
       {children.map((child, index) => (
@@ -23,7 +23,7 @@ Step.propTypes = {
 };
 
 Step.defaultProps = {
-  stepNum: 0,
+  stepNum: 1,
 };
 
 export default Step;

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Include = ({ nodeData: { children }, ...rest }) =>
-  children.map((child, i) => <ComponentFactory {...rest} key={i} nodeData={child} />);
+const Steps = ({ nodeData: { children }, ...rest }) =>
+  children.map((child, i) => <ComponentFactory {...rest} key={i} nodeData={child} stepNum={i + 1} />);
 
-Include.propTypes = {
+Steps.propTypes = {
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
 };
 
-export default Include;
+export default Steps;


### PR DESCRIPTION
[DOP-1667] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-1667/)]
- Render children of `root` nodes
- Render children of `steps` nodes
  - Simplify `Include` component, which used to handle numbering of `Step` components