### PR TITLE
DOP-1334: Implement MongoWebShell component

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -52,8 +52,12 @@ import Field from './Field';
 import FieldList from './FieldList';
 import Operation from './Operation';
 import OpenAPI from './OpenAPI';
+<<<<<<< HEAD
 import Root from './Root';
 import Steps from './Steps';
+=======
+import MongoWebShell from './MongoWebShell';
+>>>>>>> DOP-1334: Implement MongoWebShell component
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -126,6 +130,7 @@ const componentMap = {
   literal_block: LiteralBlock,
   literalinclude: LiteralInclude,
   meta: Meta,
+  'mongo-web-shell': MongoWebShell,
   only: Cond,
   openapi: OpenAPI,
   operation: Operation,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -52,12 +52,9 @@ import Field from './Field';
 import FieldList from './FieldList';
 import Operation from './Operation';
 import OpenAPI from './OpenAPI';
-<<<<<<< HEAD
 import Root from './Root';
 import Steps from './Steps';
-=======
 import MongoWebShell from './MongoWebShell';
->>>>>>> DOP-1334: Implement MongoWebShell component
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -112,38 +112,39 @@ ListTableBody.propTypes = {
 
 const ListTableBodyRow = ({ row, rowIndex, stubColumnCount, ...rest }) => (
   <tr className={rowIndex % 2 === 0 ? 'row-odd' : 'row-even'}>
-    {row.map((column, colIndex) => {
-      let isStub = colIndex <= stubColumnCount - 1;
-      const CellTag = isStub ? 'th' : 'td';
-      let cellClass = isStub ? 'stub' : '';
-      return (
-        <CellTag className={cellClass} key={colIndex}>
-          {column.children.length === 1 ? (
-            <CSSWrapper className={['first', 'last'].join(' ')}>
-              <ComponentFactory {...rest} nodeData={getNestedValue(['children', 0], column)} parentNode="listTable" />
-            </CSSWrapper>
-          ) : (
-            column.children.map((element, index) => {
-              if (index === 0) {
-                return (
-                  <CSSWrapper key={index} className="first">
-                    <ComponentFactory {...rest} nodeData={element} />
-                  </CSSWrapper>
-                );
-              }
-              if (index === column.children.length - 1) {
-                return (
-                  <CSSWrapper key={index} className="last">
-                    <ComponentFactory {...rest} nodeData={element} />
-                  </CSSWrapper>
-                );
-              }
-              return <ComponentFactory {...rest} key={index} nodeData={element} />;
-            })
-          )}
-        </CellTag>
-      );
-    })}
+    {row &&
+      row.map((column, colIndex) => {
+        let isStub = colIndex <= stubColumnCount - 1;
+        const CellTag = isStub ? 'th' : 'td';
+        let cellClass = isStub ? 'stub' : '';
+        return (
+          <CellTag className={cellClass} key={colIndex}>
+            {column.children.length === 1 ? (
+              <CSSWrapper className={['first', 'last'].join(' ')}>
+                <ComponentFactory {...rest} nodeData={getNestedValue(['children', 0], column)} parentNode="listTable" />
+              </CSSWrapper>
+            ) : (
+              column.children.map((element, index) => {
+                if (index === 0) {
+                  return (
+                    <CSSWrapper key={index} className="first">
+                      <ComponentFactory {...rest} nodeData={element} />
+                    </CSSWrapper>
+                  );
+                }
+                if (index === column.children.length - 1) {
+                  return (
+                    <CSSWrapper key={index} className="last">
+                      <ComponentFactory {...rest} nodeData={element} />
+                    </CSSWrapper>
+                  );
+                }
+                return <ComponentFactory {...rest} key={index} nodeData={element} />;
+              })
+            )}
+          </CellTag>
+        );
+      })}
   </tr>
 );
 

--- a/src/components/MongoWebShell.js
+++ b/src/components/MongoWebShell.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SOURCE_URL = 'https://mws.mongodb.com/';
+
+const MongoWebShell = ({
+  nodeData: {
+    options: { version },
+  },
+}) => {
+  return (
+    <iframe
+      className="mws-root"
+      title="MongoDB Web Shell"
+      allowFullScreen
+      sandbox="allow-scripts allow-same-origin"
+      width="100%"
+      height="320"
+      src={version ? SOURCE_URL + `?version=${version}` : SOURCE_URL}
+    ></iframe>
+  );
+};
+
+MongoWebShell.propTypes = {
+  nodeData: PropTypes.shape({
+    options: PropTypes.shape({
+      version: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default MongoWebShell;

--- a/src/components/MongoWebShell.js
+++ b/src/components/MongoWebShell.js
@@ -19,7 +19,7 @@ const MongoWebShell = ({
       sandbox="allow-scripts allow-same-origin"
       width="100%"
       height="320"
-      src={version ? `${SOURCE_URL}/?version=${version}` : SOURCE_URL}
+      src={version ? `${SOURCE_URL}?version=${version}` : SOURCE_URL}
     />
   );
 };

--- a/src/components/MongoWebShell.js
+++ b/src/components/MongoWebShell.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 
 const SOURCE_URL = 'https://mws.mongodb.com/';
 
@@ -10,14 +11,16 @@ const MongoWebShell = ({
 }) => {
   return (
     <iframe
-      className="mws-root"
+      css={css`
+        border: 0;
+      `}
       title="MongoDB Web Shell"
       allowFullScreen
       sandbox="allow-scripts allow-same-origin"
       width="100%"
       height="320"
-      src={version ? SOURCE_URL + `?version=${version}` : SOURCE_URL}
-    ></iframe>
+      src={version ? `${SOURCE_URL}/?version=${version}` : SOURCE_URL}
+    />
   );
 };
 

--- a/tests/unit/MongoWebShell.test.js
+++ b/tests/unit/MongoWebShell.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'enzyme';
+import MongoWebShell from '../../src/components/MongoWebShell';
+
+// data for this component
+import mockDataDefault from './data/MongoWebShell-default.test.json';
+import mockDataVersioned from './data/MongoWebShell-v4.2.test.json';
+
+it('correctly renders a MongoDB Web Shell', () => {
+  const tree = render(<MongoWebShell nodeData={mockDataDefault} />);
+  expect(tree).toMatchSnapshot();
+});
+
+it('correctly renders a MongoDB Web Shell v4.2.9', () => {
+  const tree = render(<MongoWebShell nodeData={mockDataVersioned} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -27,7 +27,6 @@ const shallowTabs = ({ mockData, mockAddTabset }) =>
 describe('Tabs testing', () => {
   describe('Tab unit tests', () => {
     let wrapper;
-    const mockSetActiveTab = jest.fn();
     const mockAddTabset = jest.fn();
 
     beforeAll(() => {

--- a/tests/unit/__snapshots__/MongoWebShell.test.js.snap
+++ b/tests/unit/__snapshots__/MongoWebShell.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correctly renders a MongoDB Web Shell 1`] = `
+<iframe
+  allowfullscreen=""
+  class="mws-root"
+  height="320"
+  sandbox="allow-scripts allow-same-origin"
+  src="https://mws.mongodb.com/"
+  title="MongoDB Web Shell"
+  width="100%"
+/>
+`;
+
+exports[`correctly renders a MongoDB Web Shell v4.2.9 1`] = `
+<iframe
+  allowfullscreen=""
+  class="mws-root"
+  height="320"
+  sandbox="allow-scripts allow-same-origin"
+  src="https://mws.mongodb.com/?version=4.2"
+  title="MongoDB Web Shell"
+  width="100%"
+/>
+`;

--- a/tests/unit/__snapshots__/MongoWebShell.test.js.snap
+++ b/tests/unit/__snapshots__/MongoWebShell.test.js.snap
@@ -1,9 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`correctly renders a MongoDB Web Shell 1`] = `
+.emotion-0 {
+  border: 0;
+}
+
 <iframe
   allowfullscreen=""
-  class="mws-root"
+  class="emotion-0"
   height="320"
   sandbox="allow-scripts allow-same-origin"
   src="https://mws.mongodb.com/"
@@ -13,9 +17,13 @@ exports[`correctly renders a MongoDB Web Shell 1`] = `
 `;
 
 exports[`correctly renders a MongoDB Web Shell v4.2.9 1`] = `
+.emotion-0 {
+  border: 0;
+}
+
 <iframe
   allowfullscreen=""
-  class="mws-root"
+  class="emotion-0"
   height="320"
   sandbox="allow-scripts allow-same-origin"
   src="https://mws.mongodb.com/?version=4.2"

--- a/tests/unit/data/MongoWebShell-default.test.json
+++ b/tests/unit/data/MongoWebShell-default.test.json
@@ -1,0 +1,11 @@
+{
+  "type": "directive",
+  "position": {
+    "start": {
+      "line": 0
+    }
+  },
+  "domain": "",
+  "name": "mongo-web-shell",
+  "options": {}
+}

--- a/tests/unit/data/MongoWebShell-default.test.json
+++ b/tests/unit/data/MongoWebShell-default.test.json
@@ -5,7 +5,7 @@
       "line": 0
     }
   },
-  "domain": "",
+  "domain": "mongodb",
   "name": "mongo-web-shell",
   "options": {}
 }

--- a/tests/unit/data/MongoWebShell-v4.2.test.json
+++ b/tests/unit/data/MongoWebShell-v4.2.test.json
@@ -1,0 +1,13 @@
+{
+  "type": "directive",
+  "position": {
+    "start": {
+      "line": 0
+    }
+  },
+  "domain": "",
+  "name": "mongo-web-shell",
+  "options": {
+    "version": "4.2"
+  }
+}

--- a/tests/unit/data/MongoWebShell-v4.2.test.json
+++ b/tests/unit/data/MongoWebShell-v4.2.test.json
@@ -5,7 +5,7 @@
       "line": 0
     }
   },
-  "domain": "",
+  "domain": "mongodb",
   "name": "mongo-web-shell",
   "options": {
     "version": "4.2"


### PR DESCRIPTION
[[JIRA Ticket](https://jira.mongodb.org/browse/DOP-1334)]
[[Server Staging Link: /tutorial/update-documents-with-aggregation-pipeline](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1334/manual/raymundrodriguez/DOP-1334/tutorial/update-documents-with-aggregation-pipeline)]
[[Server Staging Link: /tutorial/getting-started](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1334/manual/raymundrodriguez/DOP-1334/tutorial/getting-started)]

This PR allows the MongoDB Web Shell to be rendered on server docs. 

Staging link was built with a locally changed version of `docs`, using
```
.. mongo-web-shell::
   :version: 4.2
```
instead of the `.. raw::` directive. Additionally, instances of `.. only:: website` were changed to `.. cond:: html` for the staging link page.