### PR TITLE
Dive into extract node children

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -55,6 +55,7 @@ import OpenAPI from './OpenAPI';
 import Root from './Root';
 import Steps from './Steps';
 import MongoWebShell from './MongoWebShell';
+import Extract from './Extract';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -108,6 +109,7 @@ const componentMap = {
   definitionListItem: DefinitionListItem,
   deprecated: VersionModified,
   emphasis: Emphasis,
+  extract: Extract,
   field: Field,
   field_list: FieldList,
   figure: Figure,

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const Extract = ({ nodeData: { children }, ...rest }) =>
+  children.map((child, i) => <ComponentFactory {...rest} key={i} nodeData={child} />);
+
+Extract.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default Extract;


### PR DESCRIPTION
[[Atlas Staging](https://docs-mongodborg-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/fix-extracts/)] Fix problem where extract nodes would block rendering. New build log indicates that these nodes are no longer throwing errors:

```
$ npm run build

> snooty@0.7.0 build /Users/sophstad/edu/snooty
> gatsby build --prefix-paths

success open and validate gatsby-configs - 0.094s
success load plugins - 0.708s
success onPreInit - 0.054s
success delete html and css files from previous builds - 0.009s
success initialize cache - 0.029s
success copy gatsby files - 0.110s
success onPreBootstrap - 0.041s
success createSchemaCustomization - 0.010s
success Checking for changed pages - 0.011s
success source and transform nodes - 27.968s
success building schema - 0.221s
info Total nodes: 1030, SitePage nodes: 1005 (use --verbose for breakdown)
success createPages - 20.321s
success Checking for changed pages - 0.002s
success createPagesStatefully - 0.031s
success update schema - 0.027s
success onPreExtractQueries - 0.002s
success extract queries from components - 0.219s
success write out redirect data - 0.009s
success onPostBootstrap - 0.001s
info bootstrap finished - 55.381s
success run static queries - 0.020s - 1/1 49.95/s
success run page queries - 3.856s - 1004/1004 260.34/s
success write out requires - 0.014s
success Building production JavaScript and CSS bundles - 49.231s
success Rewriting compilation hashes - 0.005s
[=======                     ]   13.809 s 250/1004 25% Building static HTML for pages
role "xml" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/release-notes/atlas
FixedTextElement not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/triggers/cron-expressions
role "hardlink" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/resilien[=========                   ]   14.306 s 350/1004 35% Building static HTML for pages
role "hardlink" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/tutorial[===========                 ]   14.429 s 400/1004 40% Building static HTML for pages
role "hardlink" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/schema-suggestions/too-many-indexes
role "hardlink" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/schema-suggestions/too-many-indexes
role "hardlink" not yet implemented on page cloud-docs/sophstad/snooty-setup-tabs/schema-s[===================         ]   17.112 s 700/1004 70% Building static HTML for pages
FixedTextElement not yet implemented on page triggers/cron-expressions
role "xml" not yet implemented on page release-notes/atlas
role "hardlink" not yet implemented on page resilient-application
[=======================     ]   18.082 s 850/1004 85% Building static HTML for pages
role "hardlink" not yet implemented on page schema-suggestions/too-many-indexes
role "hardlink" not yet implemented on page schema-suggestions/too-many-indexes
success Building static HTML for pages - 18.718s - 1004/1004 53.64/s
success onPostBuild - 0.002s
info Done building in 143.028410235 sec
```