### PR TITLE
DOP-1660: Fix code blocks overflowing when nested in tables

### DIFF
--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -32,7 +32,7 @@ const getLanguage = lang => {
   } else if (lang === 'sh') {
     // Writers commonly use 'sh' to represent shell scripts, but LeafyGreen and Highlight.js use the key 'shell'
     return 'shell';
-  } else if (['c', 'csharp'].includes(lang)) {
+  } else if (['c', 'cpp', 'csharp'].includes(lang)) {
     // LeafyGreen renders all C-family languages with "clike"
     return 'clike';
   }
@@ -58,6 +58,10 @@ const Code = ({
     <div
       css={css`
         margin: ${theme.size.default} 0;
+        display: table;
+        table-layout: fixed;
+        width: 100%;
+        min-width: 150px;
       `}
     >
       <CodeBlock

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -57,11 +57,11 @@ const Code = ({
   return (
     <div
       css={css`
-        margin: ${theme.size.default} 0;
         display: table;
+        margin: ${theme.size.default} 0;
+        min-width: 150px;
         table-layout: fixed;
         width: 100%;
-        min-width: 150px;
       `}
     >
       <CodeBlock


### PR DESCRIPTION
[[JIRA Ticket](https://jira.mongodb.org/browse/DOP-1660)]
[[Realm Staging: /functions/utilities](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-1660/functions/utilities)]
[[Drivers Staging: /security/client-side-field-level-encryption-guide](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/raymundrodriguez/DOP-1660/security/client-side-field-level-encryption-guide)]

Currently, a code block nested in a table results in the code block expanding to the max size of its longest row, and thus making the whole table and its contents widen with them. This PR makes code blocks fit within the width of a table but also gives them a minimum width (so blocks aren't too narrow if nested in an admonition in a table, for example).

Bonus:
- C++ language can be used by code blocks.