### PR TITLE
Remove segment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ public/
 .cache/
 .DS_Store
 static/*
-# Don't ignore the scripts or svg directory
-!static/scripts
+# Don't ignore the assets directory
 !static/assets
 docs-tools/
 coverage/

--- a/src/html.js
+++ b/src/html.js
@@ -38,7 +38,6 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
       {headComponents}
     </head>
     <body {...bodyAttributes}>
-      <script async src={withPrefix('scripts/segment.js')} />
       {preBodyComponents}
       {/* eslint-disable-next-line react/no-danger */}
       <div key="body" id="___gatsby" dangerouslySetInnerHTML={{ __html: body }} />

--- a/static/scripts/segment.js
+++ b/static/scripts/segment.js
@@ -1,5 +1,0 @@
-// segment js
-// eslint-disable-next-line no-unused-expressions
- !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";  
-   analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
- }}();


### PR DESCRIPTION
[[Datalake Staging](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1643/datalake/sophstad/segment-fix/)] Get rid of `Segment snippet included twice.` error as thrown by the GA plugin. GTM handles loading of Segment on its own.