### PR TITLE
DOP-1014: Use LeafyGreen Tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,6 +3130,19 @@
         }
       }
     },
+    "@leafygreen-ui/tabs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-4.0.3.tgz",
+      "integrity": "sha512-oSdWFyDkVcFTT7DvrCd6qrWt7sWqAt3Cp+CQFbooIxo/iLM2vppmvH8aGHpfv4NJz+PtAQUP7IC4pYrD3biBsw==",
+      "requires": {
+        "@leafygreen-ui/box": "^3.0.1",
+        "@leafygreen-ui/leafygreen-provider": "^2.0.1",
+        "@leafygreen-ui/lib": "^6.1.0",
+        "@leafygreen-ui/palette": "^3.0.1",
+        "@leafygreen-ui/tokens": "^0.5.0",
+        "lodash": "^4.17.20"
+      }
+    },
     "@leafygreen-ui/text-input": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-4.1.0.tgz",
@@ -3168,6 +3181,14 @@
             "polished": "^2.3.0"
           }
         }
+      }
+    },
+    "@leafygreen-ui/tokens": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-0.5.0.tgz",
+      "integrity": "sha512-1rnFI1NSNtddMtRzwy4rS/4NF3rO7eK1dbw/+h+VAqY1OZHNJinV0R283QJajx2dMttm20mOpTN6v099kM0SxQ==",
+      "requires": {
+        "@leafygreen-ui/lib": "^6.0.1"
       }
     },
     "@leafygreen-ui/tooltip": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@leafygreen-ui/leafygreen-provider": "^2.0.1",
     "@leafygreen-ui/modal": "^5.0.1",
     "@leafygreen-ui/palette": "^3.0.1",
+    "@leafygreen-ui/tabs": "^4.0.3",
     "@leafygreen-ui/text-input": "^4.1.0",
     "@leafygreen-ui/tooltip": "^6.0.1",
     "@leafygreen-ui/typography": "^7.0.0",

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -29,16 +29,24 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   const { activeTabs, selectors, setActiveTab } = useContext(TabContext);
   const tabIds = children.map(child => getTabId(child));
   const tabsetName = options.tabset || generateAnonymousTabsetName(tabIds);
-  const activeTab = activeTabs[tabsetName];
+  const [activeTab, setActiveTabIndex] = useState(0);
+  const previousTabsetChoice = activeTabs[tabsetName];
   // Hide tabset if it includes the :hidden: option, or if it is controlled by a dropdown selector
   const isHidden = options.hidden || Object.keys(selectors).includes(tabsetName);
 
   useEffect(() => {
-    if (!activeTab || !tabIds.includes(activeTab)) {
+    if (!previousTabsetChoice || !tabIds.includes(previousTabsetChoice)) {
       // Set first tab as active if no tab was previously selected
       setActiveTab({ name: tabsetName, value: getTabId(children[0]) });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const index = tabIds.indexOf(activeTabs[tabsetName]);
+    if (index !== -1) {
+      setActiveTabIndex(index);
+    }
+  }, [activeTabs, tabIds, tabsetName]);
 
   const handleClick = useCallback(
     index => {
@@ -56,7 +64,7 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   );
 
   return (
-    <StyledTabs as={TabButton} isHidden={isHidden} selected={tabIds.indexOf(activeTab)} setSelected={handleClick}>
+    <StyledTabs as={TabButton} isHidden={isHidden} selected={activeTab} setSelected={handleClick}>
       {children.map(tab => {
         const tabId = getTabId(tab);
         const tabTitle =

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -14,7 +14,9 @@ const mountTabs = ({ activeTabs, mockData }) => {
     <TabProvider>
       <Tabs nodeData={mockData} />
     </TabProvider>
-  );
+  )
+    .childAt(0)
+    .childAt(0);
 };
 
 const shallowTabs = ({ mockData, mockAddTabset }) =>
@@ -22,7 +24,9 @@ const shallowTabs = ({ mockData, mockAddTabset }) =>
     <TabProvider>
       <Tabs nodeData={mockData} addTabset={mockAddTabset} />
     </TabProvider>
-  );
+  )
+    .childAt(0)
+    .childAt(0);
 
 describe('Tabs testing', () => {
   describe('Tab unit tests', () => {
@@ -36,10 +40,10 @@ describe('Tabs testing', () => {
     });
 
     it('tabs container exists with correct number of children', () => {
-      const tabCount = wrapper.childAt(0).props().nodeData.children.length;
-      expect(wrapper.find('.tab-strip')).toHaveLength(1);
-      expect(wrapper.find('.tab-strip__element').exists()).toEqual(true);
-      expect(wrapper.find('.tab-strip__element')).toHaveLength(tabCount);
+      const tabCount = mockDataAnonymous.children.length;
+      expect(wrapper.find('Tabs')).toHaveLength(1);
+      expect(wrapper.find('Tab').exists()).toEqual(true);
+      expect(wrapper.find('Tab')).toHaveLength(tabCount);
     });
 
     it('did not call mockAddTabset for a non-guides tabset', () => {
@@ -47,11 +51,21 @@ describe('Tabs testing', () => {
     });
 
     it('active tab is set in DOM', () => {
-      expect(wrapper.find('.tab-strip__element[aria-selected=true]').exists()).toEqual(true);
+      expect(
+        wrapper
+          .find('Tab')
+          .first()
+          .prop('selected')
+      ).toEqual(true);
     });
 
     it('exists non-active tab', () => {
-      expect(wrapper.find('.tab-strip__element[aria-selected=false]').exists()).toEqual(true);
+      expect(
+        wrapper
+          .find('Tab')
+          .at(1)
+          .prop('selected')
+      ).toEqual(false);
     });
   });
 
@@ -66,7 +80,7 @@ describe('Tabs testing', () => {
     });
 
     it('tabset should be created for drivers/language pills', () => {
-      expect(wrapper.find('.tab-strip__element').exists()).toEqual(true);
+      expect(wrapper.find('Tabs').exists()).toEqual(true);
     });
   });
 
@@ -80,7 +94,7 @@ describe('Tabs testing', () => {
     });
 
     it('does not render a tabset', () => {
-      expect(wrapper.find('.tab-strip')).toHaveLength(0);
+      expect(wrapper.find('Tabs')).toHaveLength(0);
     });
   });
 
@@ -94,7 +108,7 @@ describe('Tabs testing', () => {
     });
 
     it('renders tabs in the set', () => {
-      expect(wrapper.find('.tab-strip')).toHaveLength(1);
+      expect(wrapper.find('Tabs')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
[DOP-1014] [[Datalake Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/datalake/sophstad/DOP-1014/)] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup-v0.7.2/cloud-docs/sophstad/DOP-1014/)] Implementation details borrow from DevHub: https://github.com/mongodb/devhub/pull/528

Note that the unexpected hover behavior (where the border does not become green after clicking) is a known limitation and a consequence of fixing a bug that Jordan explained [here](https://github.com/mongodb/devhub/pull/528#discussion_r502477433).