### PR TITLE
DOP-1738: Render describe directive

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -60,6 +60,7 @@ import Describe from './Describe';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
+import RoleCommand from './Roles/Command';
 import RoleFile from './Roles/File';
 import RoleGUILabel from './Roles/GUILabel';
 import RoleHighlight from './Roles/Highlight';
@@ -75,6 +76,7 @@ const DEPRECATED_ADMONITIONS = ['admonition', 'topic', 'caution', 'danger'];
 const roleMap = {
   abbr: RoleAbbr,
   class: RoleClass,
+  command: RoleCommand,
   file: RoleFile,
   guilabel: RoleGUILabel,
   icon: RoleIcon,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -56,6 +56,7 @@ import Root from './Root';
 import Steps from './Steps';
 import MongoWebShell from './MongoWebShell';
 import Extract from './Extract';
+import Describe from './Describe';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -108,6 +109,7 @@ const componentMap = {
   definitionList: DefinitionList,
   definitionListItem: DefinitionListItem,
   deprecated: VersionModified,
+  describe: Describe,
   emphasis: Emphasis,
   extract: Extract,
   field: Field,

--- a/src/components/Describe.js
+++ b/src/components/Describe.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import ComponentFactory from './ComponentFactory.js';
+
+const Describe = ({ nodeData: { argument, children }, ...rest }) => (
+  <dl>
+    <dt>
+      <code
+        css={css`
+          /* TODO: Remove when mongodb-docs.css is removed */
+          font-weight: normal;
+        `}
+      >
+        {argument.map((arg, i) => (
+          <ComponentFactory {...rest} key={i} nodeData={arg} />
+        ))}
+      </code>
+    </dt>
+    <dd>
+      {children.map((child, i) => (
+        <ComponentFactory {...rest} key={i} nodeData={child} />
+      ))}
+    </dd>
+  </dl>
+);
+
+Describe.propTypes = {
+  nodeData: PropTypes.shape({
+    argument: PropTypes.arrayOf(PropTypes.object).isRequired,
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default Describe;

--- a/src/components/Roles/Command.js
+++ b/src/components/Roles/Command.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from '../ComponentFactory';
+
+const RoleCommand = ({ nodeData: { children }, ...rest }) => (
+  <strong>
+    {children.map((child, i) => (
+      <ComponentFactory {...rest} key={i} nodeData={child} />
+    ))}
+  </strong>
+);
+
+RoleCommand.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default RoleCommand;


### PR DESCRIPTION
[DOP-1738] [[Database Tools Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/database-tools/sophstad/DOP-1738/mongostat#fields)] Bonus: add support for `:command:`.