### PR TITLE
DOP-1759: Fix typo

### DIFF
--- a/src/utils/parse-marian-manifests.js
+++ b/src/utils/parse-marian-manifests.js
@@ -6,7 +6,7 @@ const PROPERTY_MAPPING = {
   charts: 'Charts',
   compass: 'Compass',
   'database-tools': 'Database Tools',
-  datalake: 'Atlas Datalake',
+  datalake: 'Atlas Data Lake',
   'docs-php-library': 'PHP Driver',
   'docs-ruby': 'Ruby Driver',
   drivers: 'Drivers',

--- a/tests/utils/data/parsed-marian-manifests.json
+++ b/tests/utils/data/parsed-marian-manifests.json
@@ -14,7 +14,7 @@
   },
   "Compass": { "beta": "compass-beta", "Latest": "compass-master" },
   "Database Tools": { "Latest": "database-tools-master" },
-  "Atlas Datalake": { "Latest": "datalake-master", "test": "datalake-test" },
+  "Atlas Data Lake": { "Latest": "datalake-master", "test": "datalake-test" },
   "Drivers": { "Latest": "drivers-master" },
   "Ecosystem": { "Latest": "ecosystem-master" },
   "Guides": { "Latest": "guides-master" },


### PR DESCRIPTION
`Atlas Datalake` ➡️ `Atlas Data Lake`