### PR TITLE
Allow users with adblockers to open the feedback widget

### DIFF
--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -38,9 +38,10 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
       ...test.feedback,
     };
     const { _id } = await createNewFeedback(newFeedback);
+
     setFeedback({ _id, ...newFeedback });
     setView(nextView);
-    return newFeedback;
+    return { _id, ...newFeedback };
   }
 
   // Sets the user's star rating for the page

--- a/src/utils/segment.js
+++ b/src/utils/segment.js
@@ -1,13 +1,21 @@
 export function getSegmentUserId() {
-  const user = window.analytics.user();
-  // Get the user's persistent Segment ID, if they have one
-  const segmentId = user.id();
-  return {
-    // If the user doesn't have a persistent Segment ID then they're anonymous
-    isAnonymous: !Boolean(segmentId),
-    // Return the Persistent ID or Anonymous ID as a string
-    id: segmentId ? segmentId.toString() : user.anonymousId().toString(),
-  };
+  if (window.analytics) {
+    // Get the user's persistent Segment ID, if they have one
+    const user = window.analytics.user();
+    const segmentId = user.id();
+    return {
+      // If the user doesn't have a persistent Segment ID then they're anonymous
+      isAnonymous: !Boolean(segmentId),
+      // Return the Persistent ID or Anonymous ID as a string
+      id: segmentId ? segmentId.toString() : user.anonymousId().toString(),
+    };
+  } else {
+    // The user has an ad/tracker blocker enabled
+    return {
+      isAnonymous: true,
+      id: '<notrack>',
+    };
+  }
 }
 
 export function sendAnalytics(eventName, eventObj) {
@@ -18,7 +26,10 @@ export function sendAnalytics(eventName, eventObj) {
     } else {
       eventObj.segmentUID = id;
     }
-    window.analytics.track(eventName, eventObj);
+    if (window.analytics) {
+      // If the user doesn't block trackers, track the event
+      window.analytics.track(eventName, eventObj);
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
Fixes a bug where a tracker/ad blocker (specifically uBlock Origin in this case) blocks Segment and prevents the feedback widget from opening.

Given that a significant portion of developers use ad blockers, this may lead to an increase in feedback.