### PR TITLE
DOP-1766: Add frontend support for release_specification

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -56,6 +56,7 @@ import Steps from './Steps';
 import MongoWebShell from './MongoWebShell';
 import Extract from './Extract';
 import Describe from './Describe';
+import ReleaseSpecification from './ReleaseSpecification';
 
 import RoleAbbr from './Roles/Abbr';
 import RoleClass from './Roles/Class';
@@ -138,6 +139,7 @@ const componentMap = {
   paragraph: Paragraph,
   ref_role: RefRole,
   reference: Reference,
+  release_specification: ReleaseSpecification,
   root: Root,
   rubric: Rubric,
   'search-results': SearchResults,

--- a/src/components/ReleaseSpecification.js
+++ b/src/components/ReleaseSpecification.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const ReleaseSpecification = ({ nodeData: { children }, ...rest }) => {
+  return children.map((child, i) => <ComponentFactory {...rest} key={i} nodeData={child} />);
+};
+
+ReleaseSpecification.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default ReleaseSpecification;

--- a/tests/unit/ReleaseSpecification.test.js
+++ b/tests/unit/ReleaseSpecification.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'enzyme';
+import ReleaseSpecification from '../../src/components/ReleaseSpecification';
+
+// data for this component
+import mockData from './data/ReleaseSpecification.test.json';
+
+it('renders correctly', () => {
+  const tree = render(<ReleaseSpecification nodeData={mockData} />);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+.emotion-0 {
+  border-spacing: 0;
+  padding: 0;
+  vertical-align: top;
+}
+
+.emotion-0:first-of-type {
+  padding-left: 12px;
+}
+
+.emotion-0:last-of-type {
+  padding-right: 12px;
+}
+
+.emotion-2 {
+  color: inherit;
+  font-size: 13px;
+  font-family: 'Source Code Pro',Menlo,monospace;
+  line-height: 24px;
+}
+
+.emotion-4 {
+  overflow-x: auto;
+  border-left: 2px solid;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  margin: 0;
+  position: relative;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border-color: #E7EEEC;
+  background-color: #F9FBFA;
+  color: #21313C;
+}
+
+.emotion-6 {
+  border: 1px solid #E7EEEC;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  border-spacing: 0;
+  width: 100%;
+}
+
+.emotion-7 {
+  display: table;
+  margin: 16px 0;
+  min-width: 150px;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.emotion-3 * {
+  overflow-wrap: normal !important;
+  white-space: pre;
+  word-break: normal !important;
+}
+
+.emotion-3 table {
+  margin-bottom: 0px;
+}
+
+.emotion-3 table > tbody > tr > td {
+  border-style: none;
+  padding: 0px;
+}
+
+<div
+  class="emotion-7"
+>
+  <div
+    class="emotion-6"
+  >
+    <div
+      class="emotion-5"
+    >
+      <pre
+        class="emotion-3 emotion-4"
+      >
+        <code
+          class="lg-highlight-hljs-light emotion-2 none"
+        >
+          <table
+            class="emotion-1"
+          >
+            <tbody>
+              <tr
+                class=""
+              >
+                <td
+                  class="emotion-0"
+                >
+                  test code
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </code>
+      </pre>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/unit/data/ReleaseSpecification.test.json
+++ b/tests/unit/data/ReleaseSpecification.test.json
@@ -1,0 +1,23 @@
+{
+  "type": "directive",
+  "position": {
+    "start": {
+      "line": 0
+    }
+  },
+  "children": [
+    {
+      "type": "code",
+      "position": {
+        "start": {
+          "line": 0
+        }
+      },
+      "lang": "bat",
+      "copyable": true,
+      "value": "test code",
+      "linenos": false
+    }
+  ],
+  "name": "release_specification"
+}


### PR DESCRIPTION
[[Jira Ticket](https://jira.mongodb.org/browse/DOP-1766)]
[[Server Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/manual/raymundrodriguez/DOP-1766/tutorial/install-mongodb-on-windows-unattended#run-the-windows-installer-from-the-windows-command-interpreter)]
[[Link to same server page in legacy](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows-unattended/#run-the-windows-installer-from-the-windows-command-interpreter)]

Instances of the `release_specification` directive seem to basically act as containers for code blocks. Using ComponentFactory here will allow for flexibility in case the directive acts as a container for other components in the future. Not sure if this should be stricter and we should instead only accept/expect code blocks