### PR TITLE
DOP-1825: Fix definition list rendering

### DIFF
--- a/src/components/DefinitionListItem.js
+++ b/src/components/DefinitionListItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import ComponentFactory from './ComponentFactory';
 import { findKeyValuePair } from '../utils/find-key-value-pair';
 
@@ -17,9 +18,15 @@ const DefinitionListItem = ({ nodeData: { children, term }, ...rest }) => {
           <ComponentFactory nodeData={child} key={`dt-${index}`} />
         ))}
       </dt>
-      <dd>
+      <dd
+        css={css`
+          p:first-child {
+            margin-top: 0 !important;
+          }
+        `}
+      >
         {children.map((child, index) => (
-          <ComponentFactory {...rest} nodeData={child} key={`dd-${index}`} parentNode="definitionListItem" />
+          <ComponentFactory {...rest} nodeData={child} key={`dd-${index}`} skipPTag={children.length === 1} />
         ))}
       </dd>
     </>

--- a/src/components/DefinitionListItem.js
+++ b/src/components/DefinitionListItem.js
@@ -20,7 +20,7 @@ const DefinitionListItem = ({ nodeData: { children, term }, ...rest }) => {
       </dt>
       <dd
         css={css`
-          p:first-child {
+          p:first-of-type {
             margin-top: 0 !important;
           }
         `}

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const SKIP_P_TAGS = ['caption', 'listItem', 'listTable', 'footnote', 'field'];
+const SKIP_P_TAGS = new Set(['caption', 'listItem', 'listTable', 'footnote', 'field']);
 
 const Paragraph = ({ nodeData, parentNode, skipPTag, ...rest }) => {
   // For paragraph nodes that appear inside certain containers, skip <p> tags and just render their contents
-  if (SKIP_P_TAGS.includes(parentNode) || skipPTag) {
+  if (skipPTag || SKIP_P_TAGS.has(parentNode)) {
     return nodeData.children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
   }
   return (

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const SKIP_P_TAGS = ['caption', 'listItem', 'listTable', 'footnote', 'definitionListItem', 'field'];
+const SKIP_P_TAGS = ['caption', 'listItem', 'listTable', 'footnote', 'field'];
 
-const Paragraph = ({ nodeData, parentNode, ...rest }) => {
+const Paragraph = ({ nodeData, parentNode, skipPTag, ...rest }) => {
   // For paragraph nodes that appear inside certain containers, skip <p> tags and just render their contents
-  if (SKIP_P_TAGS.includes(parentNode)) {
+  if (SKIP_P_TAGS.includes(parentNode) || skipPTag) {
     return nodeData.children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
   }
   return (
@@ -28,6 +28,7 @@ Paragraph.propTypes = {
     ).isRequired,
   }).isRequired,
   parentNode: PropTypes.string,
+  skipPTag: PropTypes.bool,
 };
 
 Paragraph.defaultProps = {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -66,6 +66,10 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   return (
     <StyledTabs as={TabButton} isHidden={isHidden} selected={activeTab} setSelected={handleClick}>
       {children.map(tab => {
+        if (tab.type !== 'tab') {
+          return null;
+        }
+
         const tabId = getTabId(tab);
         const tabTitle =
           tab.argument.length > 0

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -66,7 +66,7 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   return (
     <StyledTabs as={TabButton} isHidden={isHidden} selected={activeTab} setSelected={handleClick}>
       {children.map(tab => {
-        if (tab.type !== 'tab') {
+        if (tab.name !== 'tab') {
           return null;
         }
 

--- a/tests/unit/__snapshots__/DefinitionList.test.js.snap
+++ b/tests/unit/__snapshots__/DefinitionList.test.js.snap
@@ -1,13 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DefinitionList renders correctly 1`] = `
+.emotion-0 p:first-of-type {
+  margin-top: 0 !important;
+}
+
 <dl>
   <dt>
     <code>
       MongoDefaultPartitioner
     </code>
   </dt>
-  <dd>
+  <dd
+    class="emotion-0"
+  >
     <strong>
       Default
     </strong>


### PR DESCRIPTION
[DOP-1825] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/483d743/v0.8.5-test/bi-connector/sophstad/DOP-1825/)] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/docs/sophstad/DOP-1825/)] Omit `<p>` tags from dictionary list items with only one paragraph. If multiple paragraphs, ensure 0 margin between term and description.

Includes bonus fix to present non-`tab` nodes from rendering as children of `tabs` node.