### PR TITLE
DOP-1943: Fix double active page bug

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -30,7 +30,7 @@ const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => 
             </h3>
             {publishedBranches && <VersionDropdown slug={slug} publishedBranches={publishedBranches} />}
           </div>
-          <TableOfContents toctreeData={toctreeData} height={fixedHeight} />
+          <TableOfContents toctreeData={toctreeData} height={fixedHeight} activeSection={slug} />
         </div>
       </div>
     </aside>

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -1,46 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import TOCNode from './TOCNode';
 import { TOCContext } from './toc-context';
-import { isBrowser } from '../utils/is-browser';
 
 /**
  * Overall Table of Contents component, which manages open sections as children
  */
-const TableOfContents = ({ height, toctreeData: { children } }) => {
-  // Want to check this on each re-render
-  let currentPage;
-  if (isBrowser) {
-    currentPage = window.location.pathname;
-  }
-
-  const [activeSection, setActiveSection] = useState(currentPage);
-  useEffect(() => {
-    setActiveSection(currentPage);
-  }, [currentPage]);
-
-  return (
-    <TOCContext.Provider value={{ activeSection, setActiveSection }}>
-      <ul
-        className="current"
-        css={css`
-          height: calc(100% - ${height}px);
-          overflow-y: auto;
-          position: absolute;
-          width: 100%;
-        `}
-      >
-        {children.map(c => {
-          const key = c.slug || c.url;
-          return <TOCNode node={c} key={key} />;
-        })}
-      </ul>
-    </TOCContext.Provider>
-  );
-};
+const TableOfContents = ({ activeSection, height, toctreeData: { children } }) => (
+  <TOCContext.Provider value={{ activeSection }}>
+    <ul
+      className="current"
+      css={css`
+        height: calc(100% - ${height}px);
+        overflow-y: auto;
+        position: absolute;
+        width: 100%;
+      `}
+    >
+      {children.map(c => {
+        const key = c.slug || c.url;
+        return <TOCNode node={c} key={key} />;
+      })}
+    </ul>
+  </TOCContext.Provider>
+);
 
 TableOfContents.propTypes = {
+  activeSection: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
   toctreeData: PropTypes.shape({
     children: PropTypes.array.isRequired,

--- a/src/components/toc-context.js
+++ b/src/components/toc-context.js
@@ -2,5 +2,4 @@ import React from 'react';
 
 export const TOCContext = React.createContext({
   activeSection: undefined,
-  setActiveSection: () => {},
 });

--- a/src/utils/ends-with.js
+++ b/src/utils/ends-with.js
@@ -1,7 +1,0 @@
-export const endsWith = (baseString, testSuffix) => {
-  if (!baseString || !testSuffix) return false;
-  const stringLength = baseString.length;
-  const searchLen = testSuffix.length;
-  if (stringLength < searchLen) return false;
-  return baseString.substring(stringLength - searchLen, stringLength) === testSuffix;
-};

--- a/src/utils/is-active-toc-node.js
+++ b/src/utils/is-active-toc-node.js
@@ -1,4 +1,4 @@
-import { endsWith } from './ends-with';
+import { isCurrentPage } from './is-current-page';
 /*
   Provided a current page slug, a slug, and a list of node children, returns
   true if either the given slug matches the current page slug or one of its children
@@ -6,7 +6,7 @@ import { endsWith } from './ends-with';
 */
 export const isActiveTocNode = (currentUrl, slug, children) => {
   if (currentUrl === undefined) return false;
-  if (endsWith(currentUrl, slug) || endsWith(currentUrl, `${slug}/`)) return true;
+  if (isCurrentPage(currentUrl, slug)) return true;
   if (children) {
     return children.reduce((a, b) => a || isActiveTocNode(currentUrl, b.slug, b.children), false);
   }

--- a/src/utils/is-current-page.js
+++ b/src/utils/is-current-page.js
@@ -1,0 +1,5 @@
+export const isCurrentPage = (currentUrl, slug) => {
+  const trimSlashes = str => str.replace(/^\/|\/$/g, '');
+  if (!currentUrl || !slug) return false;
+  return trimSlashes(currentUrl) === trimSlashes(slug);
+};

--- a/src/utils/is-selected-toc-node.js
+++ b/src/utils/is-selected-toc-node.js
@@ -1,4 +1,4 @@
-import { endsWith } from './ends-with';
+import { isCurrentPage } from './is-current-page';
 
 /*
   Provided the current url and a node slug, returns true if the user is on this
@@ -6,5 +6,5 @@ import { endsWith } from './ends-with';
 */
 export const isSelectedTocNode = (currentUrl, slug) => {
   if (currentUrl === undefined) return false;
-  return endsWith(currentUrl, slug) || endsWith(currentUrl, `${slug}/`);
+  return isCurrentPage(currentUrl, slug);
 };

--- a/tests/unit/TableOfContents.test.js
+++ b/tests/unit/TableOfContents.test.js
@@ -10,19 +10,19 @@ import TableOfContents from '../../src/components/TableOfContents';
   Test links
 */
 
-const mountedToc = mockData => mount(<TableOfContents toctreeData={mockData} height={0} />);
+const mountedToc = (mockData, page) =>
+  mount(<TableOfContents toctreeData={mockData} height={0} activeSection={page} />);
 
 describe('Table of Contents testing', () => {
   describe('Table of Contents unit tests', () => {
     let testComponent;
 
-    const remountTOC = () => {
-      testComponent = mountedToc(mockTocData);
+    const remountTOC = page => {
+      testComponent = mountedToc(mockTocData, page);
     };
 
     const updatePageLocation = (title, newLocation) => {
-      window.history.pushState({}, title, newLocation);
-      remountTOC();
+      remountTOC(newLocation);
     };
 
     beforeEach(() => {
@@ -35,34 +35,30 @@ describe('Table of Contents testing', () => {
     });
 
     it('TOC exists with proper number of sections and nodes per section', () => {
-      expect(window.location.pathname).toBe('/');
       // Child list of sections
       expect(testComponent.find('ul.current')).toHaveLength(1);
       // Child sections themselves
       expect(testComponent.find('ul li.toctree-l1')).toHaveLength(4);
       // Number in section
       expect(testComponent.find('.toctree-l2')).toHaveLength(0);
-      updatePageLocation('Drivers', '/drivers');
-      expect(window.location.pathname).toBe('/drivers');
+      updatePageLocation('Drivers', 'drivers');
       const numDriverNodes = mockTocData.children[0].children.length;
       expect(testComponent.find('.toctree-l2')).toHaveLength(numDriverNodes);
     });
 
     describe('TOC navigation should render and work as expected', () => {
       it('TOC slugs work as expected', () => {
-        expect(window.location.pathname).toBe('/');
         const testTOCLink = testComponent.find('ul li.toctree-l1 .reference').first();
         expect(testTOCLink.hasClass('internal')).toBe(true);
         expect(testTOCLink.prop('to')).toBe('drivers');
         expect(testComponent.find('.toctree-l2')).toHaveLength(0);
-        updatePageLocation('Drivers', '/drivers');
-        expect(window.location.pathname).toBe('/drivers');
+        updatePageLocation('Drivers', 'drivers');
         const numDriverNodes = mockTocData.children[0].children.length;
         expect(testComponent.find('.toctree-l2')).toHaveLength(numDriverNodes);
       });
 
       it('TOC external navigation (urls) should work as expected', () => {
-        updatePageLocation('Tools', '/tools');
+        updatePageLocation('Tools', 'tools');
         const biConnectorLink = testComponent
           .find('.toctree-l2')
           .first()
@@ -84,7 +80,6 @@ describe('Table of Contents testing', () => {
         drawer.simulate('click');
         const numUseCasesNodes = mockTocData.children[3].children.length;
         expect(testComponent.find('.toctree-l2')).toHaveLength(numUseCasesNodes);
-        expect(window.location.pathname).toBe('/');
         const otherDrawer = testComponent
           .find('.toctree-l1')
           .at(2)


### PR DESCRIPTION
[DOP-1943] [[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/sophstad/DOP-1943/tutorial/react-native)] Fix toctree bug where pages that ended with the same string were mistakenly both identified as active.