### PR TITLE
DOP-1962: Reduce page-data.json bloat

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -78,7 +78,7 @@ export default class DocumentBody extends Component {
   constructor(props) {
     super(props);
     const { pageContext } = this.props;
-    this.pageNodes = getNestedValue(['page', 'ast', 'children'], pageContext) || [];
+    this.pageNodes = getNestedValue(['page', 'children'], pageContext) || [];
     // Standardize cssclass nodes that appear on the page
     normalizeCssClassNodes(this.pageNodes, 'name', 'cssclass');
     this.footnotes = getFootnotes(this.pageNodes);
@@ -97,7 +97,7 @@ export default class DocumentBody extends Component {
         <SEO pageTitle={pageTitle} siteTitle={siteTitle} />
         <Widgets
           location={location}
-          pageOptions={getNestedValue(['ast', 'options'], page)}
+          pageOptions={page?.options}
           pageTitle={pageTitle}
           publishedBranches={getNestedValue(['publishedBranches'], metadata)}
           slug={slug}
@@ -119,9 +119,7 @@ DocumentBody.propTypes = {
   pageContext: PropTypes.shape({
     metadata: PropTypes.object.isRequired,
     page: PropTypes.shape({
-      ast: PropTypes.shape({
-        children: PropTypes.array,
-      }).isRequired,
+      children: PropTypes.array,
     }).isRequired,
     slug: PropTypes.string.isRequired,
   }),

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,7 +5,6 @@ import SiteMetadata from '../components/site-metadata';
 import { ContentsProvider } from '../components/contents-context';
 import { TabProvider } from '../components/tab-context';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { getNestedValue } from '../utils/get-nested-value';
 import { theme } from '../theme/docsTheme.js';
 import { getTemplate } from '../utils/get-template';
 import Navbar from '../components/Navbar';

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -67,8 +67,8 @@ const DefaultLayout = props => {
       {/* Anchor-link styling to compensate for navbar height */}
       <Global styles={globalCSS} />
       <SiteMetadata siteTitle={title} />
-      <TabProvider selectors={getNestedValue(['ast', 'options', 'selectors'], page)}>
-        <ContentsProvider nodes={getNestedValue(['ast', 'children'], page)}>
+      <TabProvider selectors={page?.options?.selectors}>
+        <ContentsProvider nodes={page?.children}>
           <Template {...props}>{template === 'landing' ? [children] : children}</Template>
         </ContentsProvider>
       </TabProvider>
@@ -81,9 +81,7 @@ DefaultLayout.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   pageContext: PropTypes.shape({
     page: PropTypes.shape({
-      ast: PropTypes.shape({
-        options: PropTypes.object,
-      }).isRequired,
+      options: PropTypes.object,
     }).isRequired,
     slug: PropTypes.string,
     template: PropTypes.string,

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -23,7 +23,7 @@ const Document = ({
   const [showLeftColumn, setShowLeftColumn] = useState(!isTabletOrMobile);
   /* Add the postRender CSS class without disturbing pre-render functionality */
   const renderStatus = isBrowser ? style.postRender : '';
-  const pageOptions = getNestedValue(['ast', 'options'], page);
+  const pageOptions = page?.options;
   const showPrevNext = !(pageOptions && pageOptions.noprevnext === '');
   const showRightColumn = !isTabletOrMobile;
 
@@ -82,9 +82,8 @@ const Document = ({
 Document.propTypes = {
   pageContext: PropTypes.shape({
     page: PropTypes.shape({
-      ast: PropTypes.shape({
-        children: PropTypes.array,
-      }).isRequired,
+      children: PropTypes.array,
+      options: PropTypes.object,
     }).isRequired,
     parentPaths: PropTypes.arrayOf(PropTypes.string),
     slug: PropTypes.string.isRequired,

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -19,7 +19,7 @@ export default class Guide extends Component {
     } = this.props;
 
     // get data from server
-    this.sections = getNestedValue(['ast', 'children', 0, 'children'], page);
+    this.sections = getNestedValue(['children', 0, 'children'], page);
     this.bodySections = this.sections.filter(section => Object.keys(SECTION_NAME_MAPPING).includes(section.name));
 
     this.state = {
@@ -135,9 +135,7 @@ export default class Guide extends Component {
 Guide.propTypes = {
   pageContext: PropTypes.shape({
     page: PropTypes.shape({
-      ast: PropTypes.shape({
-        children: PropTypes.array,
-      }).isRequired,
+      children: PropTypes.array,
     }).isRequired,
     slug: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/templates/guides-index.js
+++ b/src/templates/guides-index.js
@@ -5,7 +5,7 @@ import { findKeyValuePair } from '../utils/find-key-value-pair';
 import { getNestedValue } from '../utils/get-nested-value';
 
 const Index = ({ pageContext: { guidesMetadata, page } }) => {
-  const guides = findKeyValuePair(getNestedValue(['ast', 'children'], page), 'name', 'guide-index') || [];
+  const guides = findKeyValuePair(getNestedValue(['children'], page), 'name', 'guide-index') || [];
 
   return (
     <div className="content">
@@ -28,9 +28,7 @@ Index.propTypes = {
   pageContext: PropTypes.shape({
     guidesMetadata: PropTypes.objectOf(PropTypes.object).isRequired,
     page: PropTypes.shape({
-      ast: PropTypes.shape({
-        children: PropTypes.array,
-      }).isRequired,
+      children: PropTypes.array,
     }).isRequired,
   }).isRequired,
 };


### PR DESCRIPTION
[DOP-1962] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-1962/) [[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/sophstad/DOP-1962/)] [[Drivers Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/DOP-1962/)] Reduce "static" data being written to `page-data.json` files:

- Only pass a document's `ast` field into each page's context (previously we were passing the entire document as returned by Realm)
- Ensure that the `static_files` field found in a property's metadata doc is also omitted from `page-data.json`

Included a few staging links to ensure that the various templates are still ingesting page data correctly.