### PR TITLE
DOP-1965: Enforce trailing slashes

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -18,6 +18,10 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   // Use Gatsby Link for internal links, and <a> for others
   if (to && !external && !anchor) {
     if (!to.startsWith('/')) to = `/${to}`;
+
+    // Ensure trailing slash
+    to = to.replace(/\/?(\?|#|$)/, '/$1');
+
     return (
       <GatsbyLink to={to} activeClassName={activeClassName} partiallyActive={partiallyActive} {...other}>
         {children}

--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -26,7 +26,7 @@ const RefRole = ({ nodeData: { children, domain, fileid, name, url }, slug }) =>
       // :doc: link
       link = filename;
     } else {
-      link = `${filename}#${html_id}`;
+      link = `${filename}/#${html_id}`;
     }
   }
 

--- a/tests/unit/Link.test.js
+++ b/tests/unit/Link.test.js
@@ -19,4 +19,19 @@ describe('Link component renders a variety of strings correctly', () => {
     const tree = setup({ to: 'drivers/c', text: 'C Driver', className: 'test-class' });
     expect(tree).toMatchSnapshot();
   });
+
+  it('internal link with hash', () => {
+    const tree = setup({ to: 'drivers/pymongo#installation', text: 'C Driver', className: 'test-class' });
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('internal link query param', () => {
+    const tree = setup({ to: 'drivers/ruby?site=drivers', text: 'C Driver', className: 'test-class' });
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('internal link that already includes trailing slash', () => {
+    const tree = setup({ to: 'drivers/nodejs/#installation', text: 'C Driver', className: 'test-class' });
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -13,7 +13,7 @@ exports[`renders correctly 1`] = `
   <ul>
     <li>
       <a
-        href="/drivers"
+        href="/drivers/"
       >
         MongoDB Drivers and ODM
       </a>
@@ -25,7 +25,7 @@ exports[`renders correctly 1`] = `
     </li>
     <li>
       <a
-        href="/drivers/php"
+        href="/drivers/php/"
       >
         MongoDB PHP Driver
       </a>

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -16,7 +16,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/insert"
+        href="/server/insert/"
       >
         Insert Data into MongoDB
       </a>
@@ -25,7 +25,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/read"
+        href="/server/read/"
       >
         Read Data from MongoDB
       </a>
@@ -34,7 +34,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/read_queries"
+        href="/server/read_queries/"
       >
         Read Data from MongoDB With Queries
       </a>
@@ -43,7 +43,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/read_operators"
+        href="/server/read_operators/"
       >
         Read Data using Operators and Compound Queries
       </a>
@@ -52,7 +52,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/update"
+        href="/server/update/"
       >
         Update Data in MongoDB
       </a>
@@ -61,7 +61,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
       class="guide__entry"
     >
       <a
-        href="/server/delete"
+        href="/server/delete/"
       >
         Delete Data from MongoDB
       </a>
@@ -73,7 +73,7 @@ exports[`Card component when a multi card is mounted renders correctly 1`] = `
 exports[`Card component when a standard card is mounted renders correctly 1`] = `
 <a
   class="guide guide--regular"
-  href="/server/install"
+  href="/server/install/"
 >
   <div
     class="guide__title"

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -11,7 +11,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   </span>
   <a
     class="btn-prev-text"
-    href="/drivers/csharp"
+    href="/drivers/csharp/"
     title="Previous Section"
   >
     <span>
@@ -20,7 +20,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   </a>
   <a
     class="btn-next-text"
-    href="/drivers/java"
+    href="/drivers/java/"
     title="Next Section"
   >
     <span>
@@ -46,7 +46,7 @@ exports[`renders a page with no next link correctly 1`] = `
   </span>
   <a
     class="btn-prev-text"
-    href="/drivers/go"
+    href="/drivers/go/"
     title="Previous Section"
   >
     <span>
@@ -62,7 +62,7 @@ exports[`renders a page with no previous link correctly 1`] = `
 >
   <a
     class="btn-next-text"
-    href="/drivers/go"
+    href="/drivers/go/"
     title="Next Section"
   >
     <span>

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -19,7 +19,34 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 exports[`Link component renders a variety of strings correctly internal link 1`] = `
 <a
   class="test-class"
-  href="/drivers/c"
+  href="/drivers/c/"
+>
+  C Driver
+</a>
+`;
+
+exports[`Link component renders a variety of strings correctly internal link query param 1`] = `
+<a
+  class="test-class"
+  href="/drivers/ruby/?site=drivers"
+>
+  C Driver
+</a>
+`;
+
+exports[`Link component renders a variety of strings correctly internal link that already includes trailing slash 1`] = `
+<a
+  class="test-class"
+  href="/drivers/nodejs/#installation"
+>
+  C Driver
+</a>
+`;
+
+exports[`Link component renders a variety of strings correctly internal link with hash 1`] = `
+<a
+  class="test-class"
+  href="/drivers/pymongo/#installation"
 >
   C Driver
 </a>

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -336,12 +336,12 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
             <mockConstructor
               aria-expanded={false}
               className="reference  internal"
-              to="/drivers"
+              to="/drivers/"
             >
               <a
                 aria-expanded={false}
                 className="reference  internal"
-                href="/drivers"
+                href="/drivers/"
               >
                 MongoDB Drivers and ODM
               </a>
@@ -389,12 +389,12 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
             <mockConstructor
               aria-expanded={false}
               className="reference  internal"
-              to="/tools"
+              to="/tools/"
             >
               <a
                 aria-expanded={false}
                 className="reference  internal"
-                href="/tools"
+                href="/tools/"
               >
                 MongoDB Integration and Tools
               </a>

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -25,7 +25,7 @@ configuration file is the preferred method for runtime configuration of
 
       <a
         class="reference internal"
-        href="/reference/program/mongos#std-program-mongos"
+        href="/reference/program/mongos/#std-program-mongos"
       >
         <code>
           mongos
@@ -35,7 +35,7 @@ configuration file is the preferred method for runtime configuration of
 configuration options. See 
       <a
         class="reference internal"
-        href="/reference/configuration-options"
+        href="/reference/configuration-options/"
       >
         Configuration File Options
       </a>
@@ -46,7 +46,7 @@ more information.
       Ensure the configuration file uses ASCII encoding. The 
       <a
         class="reference internal"
-        href="/reference/program/mongos#std-program-mongos"
+        href="/reference/program/mongos/#std-program-mongos"
       >
         <code>
           mongos


### PR DESCRIPTION
[DOP-1985] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/sophstad/DOP-1965/)] Enforce trailing slashes across Snooty internal links.