### PR TITLE
DOP-1971: Correctly handle mailto links

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -12,7 +12,7 @@ import { Link as GatsbyLink } from 'gatsby';
 const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   if (!to) to = '';
   // Assume that external links begin with http:// or https://
-  const external = /^http(s)?:\/\//.test(to);
+  const external = /^http(s)?:\/\//.test(to) || to.startsWith('mailto:');
   const anchor = to.startsWith('#');
 
   // Use Gatsby Link for internal links, and <a> for others

--- a/tests/unit/Link.test.js
+++ b/tests/unit/Link.test.js
@@ -34,4 +34,9 @@ describe('Link component renders a variety of strings correctly', () => {
     const tree = setup({ to: 'drivers/nodejs/#installation', text: 'C Driver', className: 'test-class' });
     expect(tree).toMatchSnapshot();
   });
+
+  it('identfies mailto links as external urls', () => {
+    const tree = setup({ to: 'mailto:docs@mongodb.com', text: 'docs@mongodb.com' });
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -16,6 +16,14 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 </a>
 `;
 
+exports[`Link component renders a variety of strings correctly identfies mailto links as external urls 1`] = `
+<a
+  href="mailto:docs@mongodb.com"
+>
+  docs@mongodb.com
+</a>
+`;
+
 exports[`Link component renders a variety of strings correctly internal link 1`] = `
 <a
   class="test-class"


### PR DESCRIPTION
[DOP-1971] [[Cloud Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/sophstad/DOP-1971/tutorial/delete-atlas-account/#email-atlas-support-to-finalize-deletion-process)] I couldn't think of any other special-case URL formats besides `mailto:` so I just went with the easiest approach... but if you can think of other use cases I'd be happy to reassess!