### PR TITLE
DOP-1950: Fix handling of RefRole links to index page

### DIFF
--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import Link from './Link';
+import { normalizePath } from '../utils/normalize-path';
 
 const RefRole = ({ nodeData: { children, domain, fileid, name, url }, slug }) => {
   // Render intersphinx target links
   if (url) {
     return (
-      <Link to={url} className="reference external">
+      <Link to={url}>
         {children.map((node, i) => (
           <ComponentFactory key={i} nodeData={node} />
         ))}
@@ -18,7 +19,9 @@ const RefRole = ({ nodeData: { children, domain, fileid, name, url }, slug }) =>
   // Render internal target and page links
   let link = '';
   if (fileid) {
-    const [filename, html_id] = fileid;
+    let [filename, html_id] = fileid;
+    if (filename === 'index') filename = '/';
+
     if (filename === slug) {
       // Internal page link
       link = `#${html_id}`;
@@ -31,7 +34,7 @@ const RefRole = ({ nodeData: { children, domain, fileid, name, url }, slug }) =>
   }
 
   return (
-    <Link to={link} className="reference internal">
+    <Link to={normalizePath(link)}>
       {children.map((node, i) => (
         <ComponentFactory key={i} nodeData={node} />
       ))}

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -24,7 +24,6 @@ exports[`renders correctly with a directive_argument node 1`] = `
 configuration file is the preferred method for runtime configuration of
 
       <a
-        class="reference internal"
         href="/reference/program/mongos/#std-program-mongos"
       >
         <code>
@@ -34,7 +33,6 @@ configuration file is the preferred method for runtime configuration of
       . The options are equivalent to the command-line
 configuration options. See 
       <a
-        class="reference internal"
         href="/reference/configuration-options/"
       >
         Configuration File Options
@@ -45,7 +43,6 @@ more information.
     <p>
       Ensure the configuration file uses ASCII encoding. The 
       <a
-        class="reference internal"
         href="/reference/program/mongos/#std-program-mongos"
       >
         <code>


### PR DESCRIPTION
[DOP-1950] [[Data Lake Staging](https://docs-mongodbcom-staging.corp.mongodb.com/HEAD/datalake/sophstad/DOP-1950/tutorial/getting-started/)] Links to the index page were mistakenly being rendered as `<a href="/index#hash">`. They should be `<a href="/#hash">`. Check to see if we are dealing with a link to the index page and update the filename accordingly.

To test: visit the `/tutorial/getting-started` page and click on the "Billing" link in the note toward the bottom of the page. It should work!