### PR TITLE
DOP-1977: Update hidden class

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -28,6 +28,15 @@ const globalCSS = css`
     position: relative;
     width: 0;
   }
+
+  .hidden {
+    display: inherit !important;
+    height: 0;
+    margin: 0;
+    padding: 0;
+    visibility: hidden !important;
+    width: 0;
+  }
 `;
 
 const PageNotFoundLayout = props => {


### PR DESCRIPTION
[DOP-1977] [[Manual Staging](https://docs-mongodborg-staging.corp.mongodb.com/snooty-setup/docs/sophstad/DOP-1977/)] Override the `.hidden` class introduced in legacy CSS so that `display: none` is _not_ applied. This ensures that "hidden" elements will still appear in the DOM so that links to them are valid.