### PR TITLE
DOP-1988: Prevent RightColumn and FeedbackTab from appearing on mobile first

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -42,6 +42,10 @@ const NavbarContainer = styled('div')`
     top: unset !important;
   }`
     : ''}
+
+  .navbar-brand {
+    width: 90px;
+  }
 `;
 
 const Banner = React.memo(({ altText, imgPath, mobileImgPath, url }) => {

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import { theme } from '../theme/docsTheme';
 
 const RightColumn = ({ children }) => (
   <div
@@ -9,6 +10,10 @@ const RightColumn = ({ children }) => (
       margin: 70px 24px 40px 54px;
       min-width: 180px;
       order: 2;
+
+      @media ${theme.screenSize.upToLarge} {
+        display: none;
+      }
     `}
   >
     <div

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
-import { theme } from '../theme/docsTheme';
+import { displayNone } from '../utils/display-none';
 
 const RightColumn = ({ children }) => (
   <div
@@ -11,9 +11,7 @@ const RightColumn = ({ children }) => (
       min-width: 180px;
       order: 2;
 
-      @media ${theme.screenSize.upToLarge} {
-        display: none;
-      }
+      ${displayNone.onMobileAndTablet};
     `}
   >
     <div

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -14,6 +14,7 @@ import SearchContext from '../Searchbar/SearchContext';
 import SearchFilters from '../Searchbar/SearchFilters';
 import SearchResult from '../Searchbar/SearchResult';
 import EmptyResults, { EMPTY_STATE_HEIGHT } from './EmptyResults';
+import { displayNone } from '../../utils/display-none';
 
 const DESKTOP_COLUMN_GAP = '46px';
 const FILTER_BY_TEXT_WIDTH = '62px';
@@ -57,9 +58,7 @@ const FilterHeader = styled('h2')`
   text-transform: uppercase;
   white-space: nowrap;
   ${commonTextStyling};
-  @media ${theme.screenSize.upToSmall} {
-    display: none;
-  }
+  ${displayNone.onMobile};
 `;
 
 const SearchResultsContainer = styled('div')`

--- a/src/components/Searchbar/SearchDropdown.js
+++ b/src/components/Searchbar/SearchDropdown.js
@@ -9,6 +9,7 @@ import AdvancedFiltersPane from './AdvancedFiltersPane';
 import Pagination from './Pagination';
 import SearchResults from './SearchResults';
 import SearchContext from './SearchContext';
+import { displayNone } from '../../utils/display-none';
 
 const RESULTS_PER_PAGE = 3;
 const SEARCH_FOOTER_DESKTOP_HEIGHT = theme.size.xlarge;
@@ -93,9 +94,7 @@ const SearchFooter = styled('div')`
   padding-left: ${theme.size.default};
   padding-right: ${theme.size.default};
   width: 100%;
-  @media ${theme.screenSize.upToSmall} {
-    display: none;
-  }
+  ${displayNone.onMobile};
 `;
 
 const FilterFooterButton = styled(Button)`

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -1,22 +1,14 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useFeedbackState } from './context';
-import { theme } from '../../../theme/docsTheme';
+import { displayNone } from '../../../utils/display-none';
 
 export default function FeedbackTab(props) {
   const { feedback, initializeFeedback } = useFeedbackState();
   return (
     !feedback && (
-      <Container
-        css={css`
-          @media ${theme.screenSize.upToLarge} {
-            display: none;
-          }
-        `}
-        onClick={() => initializeFeedback()}
-      >
+      <Container css={displayNone.onMobileAndTablet} onClick={() => initializeFeedback()}>
         Give Feedback
       </Container>
     )

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -1,23 +1,34 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { useFeedbackState } from './context';
-import useScreenSize from '../../../hooks/useScreenSize';
-
 import LeafygreenCard from '@leafygreen-ui/card';
+import { useFeedbackState } from './context';
+import { theme } from '../../../theme/docsTheme';
 
 export default function FeedbackTab(props) {
   const { feedback, initializeFeedback } = useFeedbackState();
-  const { isTabletOrMobile } = useScreenSize();
-  const shouldShowFeedbackTab = !feedback && !isTabletOrMobile;
-  return shouldShowFeedbackTab && <Container onClick={() => initializeFeedback()}>Give Feedback</Container>;
+  return (
+    !feedback && (
+      <Container
+        css={css`
+          @media ${theme.screenSize.upToLarge} {
+            display: none;
+          }
+        `}
+        onClick={() => initializeFeedback()}
+      >
+        Give Feedback
+      </Container>
+    )
+  );
 }
 
 const Container = styled(LeafygreenCard)`
+  bottom: -6px;
+  cursor: pointer;
   padding: 12px;
   position: fixed;
-  bottom: -6px;
   right: 42px;
   user-select: none;
-  cursor: pointer;
   z-index: 9;
 `;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -25,7 +25,6 @@ const Document = ({
   const renderStatus = isBrowser ? style.postRender : '';
   const pageOptions = page?.options;
   const showPrevNext = !(pageOptions && pageOptions.noprevnext === '');
-  const showRightColumn = !isTabletOrMobile;
 
   const toggleLeftColumn = () => {
     setShowLeftColumn(!showLeftColumn);
@@ -69,12 +68,10 @@ const Document = ({
           </div>
         </div>
       </div>
-      {showRightColumn && (
-        <RightColumn>
-          <TabSelectors />
-          <Contents />
-        </RightColumn>
-      )}
+      <RightColumn>
+        <TabSelectors />
+        <Contents />
+      </RightColumn>
     </div>
   );
 };

--- a/src/utils/display-none.js
+++ b/src/utils/display-none.js
@@ -1,0 +1,14 @@
+import { css } from '@emotion/core';
+import { theme } from '../theme/docsTheme';
+
+const mediaQuery = size => css`
+  @media ${size} {
+    display: none;
+  }
+`;
+
+// Add "display: none" to a component's css based on size for media query
+export const displayNone = {
+  onMobile: mediaQuery(theme.screenSize.upToSmall),
+  onMobileAndTablet: mediaQuery(theme.screenSize.upToLarge),
+};

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -7,6 +7,7 @@ import {
   FeedbackFooter,
 } from '../../src/components/Widgets/FeedbackWidget';
 import { BSON } from 'mongodb-stitch-server-sdk';
+import { matchers } from 'jest-emotion';
 
 import { FEEDBACK_QUALIFIERS_POSITIVE, FEEDBACK_QUALIFIERS_NEGATIVE } from './data/FeedbackWidget';
 
@@ -18,6 +19,7 @@ import {
 } from '../utils/feedbackWidgetStitchFunctions';
 import Heading from '../../src/components/Heading';
 import headingData from './data/Heading.test.json';
+import { theme } from '../../src/theme/docsTheme';
 
 async function mountFormWithFeedbackState(feedbackState = {}, options = {}) {
   const { view, isSupportRequest, hideHeader, ...feedback } = feedbackState;
@@ -48,6 +50,8 @@ async function mountFormWithFeedbackState(feedbackState = {}, options = {}) {
   await tick({ wrapper });
   return wrapper;
 }
+
+expect.extend(matchers);
 
 describe('FeedbackWidget', () => {
   jest.useFakeTimers();
@@ -95,18 +99,13 @@ describe('FeedbackWidget', () => {
       expect(wrapper.find('FeedbackTab').children()).toHaveLength(0);
     });
 
-    it('is hidden on medium/tablet screens', async () => {
-      setTablet();
+    it('is hidden on small/mobile and medium/tablet screens', async () => {
       wrapper = await mountFormWithFeedbackState({});
       expect(wrapper.exists('FeedbackTab')).toBe(true);
-      expect(wrapper.find('FeedbackTab').children()).toHaveLength(0);
-    });
-
-    it('is hidden on small/mobile screens', async () => {
-      setMobile();
-      wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.exists('FeedbackTab')).toBe(true);
-      expect(wrapper.find('FeedbackTab').children()).toHaveLength(0);
+      expect(wrapper.find('FeedbackTab').children()).toHaveLength(1);
+      expect(wrapper).toHaveStyleRule('display', 'none', {
+        media: `${theme.screenSize.upToLarge}`,
+      });
     });
   });
 


### PR DESCRIPTION
[[Jira Ticket](https://jira.mongodb.org/browse/DOP-1988)]
[[Node Driver Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/node/raymundrodriguez/DOP-1988/)]

**Changes:**

Added css media queries for `RightColumn` and `FeedbackTab` to prevent them from rendering on mobile load.
- On a mobile screen, go to any page on staging to see that neither components load before rendering properly. Desktop screen should load and look the same as deployed site.
- See that Cumulative Layout Shift (CLS) score is generally down (or around the same score depending on page) on staging when compared to deployed site. This can be checked manually by using the `Performance` tab in Chrome Dev Tools while on a mobile responsive screen size, or using the [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) site and looking for the page's CLS. Example: page `/drivers/node/fundamentals/crud/write-operations/change-a-document/` [staging](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fdocs-mongodbcom-staging.corp.mongodb.com%2Fmaster%2Fnode%2Fraymundrodriguez%2FDOP-1988%2Ffundamentals%2Fcrud%2Fwrite-operations%2Fchange-a-document%2F&hl=en) vs. [deployed site](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fdocs.mongodb.com%2Fdrivers%2Fnode%2Ffundamentals%2Fcrud%2Fwrite-operations%2Fchange-a-document%2F&tab=mobile&hl=en).

Fixed small CLS issue with waiting for MongoDB logo to load causes `Documentation` span to shift upon the image loading at times.
* This does not impact the CLS score very much but might as well have included it.

**Note:**

CLS scores may be around the same or slightly higher for some pages on the staging site vs. the deployed site. This is mostly due to the shift caused by the rendering of `FeedbackHeading` and `Contents` (but mostly on `Contents`, since it's often the bigger component). 
- For `Contents`, this may likely be due to the process of looking for heading nodes client-side. This could potentially be fixed by processing headings on the backend instead. 
- Not sure what's causing `FeedbackHeading` to render later than the rest of the content.