### PR TITLE
DOP-2023: LeafyGreen table fixes

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table, Row, Cell, TableHeader, HeaderRow } from '@leafygreen-ui/table';
+import { uiColors } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
 import ComponentFactory from './ComponentFactory';
 
@@ -42,6 +43,12 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
       return (
         <Cell
           className={cx(css`
+            /* Force top alignment rather than LeafyGreen default middle (PD-1217) */
+            vertical-align: top;
+
+            /* Apply grey background to stub <th> cells (PD-1216) */
+            ${isStub && `background-clip: padding-box; background-color: ${uiColors.gray.light3};`}
+
             /* TODO: Increase margin when Table component supports base font size of 16px */
             & > div > span > * {
               margin: 0 0 10px;

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -133,6 +133,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   font-size: 14px;
   line-height: 20px;
   position: relative;
+  vertical-align: top;
 }
 
 .emotion-22 > div > span > * {
@@ -535,6 +536,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   line-height: 20px;
   position: relative;
   font-weight: bold;
+  vertical-align: top;
+  background-clip: padding-box;
+  background-color: #F9FBFA;
 }
 
 .emotion-21 > div > span > * {
@@ -553,6 +557,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   font-size: 14px;
   line-height: 20px;
   position: relative;
+  vertical-align: top;
 }
 
 .emotion-23 > div > span > * {


### PR DESCRIPTION
[DOP-2023] [[BI Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-2023/reference/drdl/#field-types)]
- Apply light grey background to stub (`<th>`) cells
- Vertical align table contents to top