### PR TITLE
DOP-1914: Wrap table content

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -43,6 +43,9 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
       return (
         <Cell
           className={cx(css`
+            overflow-wrap: anywhere;
+            word-break: break-word;
+
             /* Force top alignment rather than LeafyGreen default middle (PD-1217) */
             vertical-align: top;
 

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -133,6 +133,8 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   font-size: 14px;
   line-height: 20px;
   position: relative;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   vertical-align: top;
 }
 
@@ -536,6 +538,8 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   line-height: 20px;
   position: relative;
   font-weight: bold;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   vertical-align: top;
   background-clip: padding-box;
   background-color: #F9FBFA;
@@ -557,6 +561,8 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   font-size: 14px;
   line-height: 20px;
   position: relative;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   vertical-align: top;
 }
 


### PR DESCRIPTION
[DOP-1914] [[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/sophstad/DOP-1914/reference/api/clusters-modify-one/#request-body-parameters)] Wrap table content to avoid unmanageable overflows.