### PR TITLE
DOP-2021: Render versionmodified arguments on same line

### DIFF
--- a/src/components/VersionModified.js
+++ b/src/components/VersionModified.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
 const VersionModified = ({ nodeData: { argument, children, name }, ...rest }) => {
-  const introText = useMemo(() => {
+  const { introText, childIndex } = useMemo(() => {
     const version = argument.length > 0 ? <ComponentFactory nodeData={argument[0]} /> : null;
+    let childIndex = 0;
     let additionalArg = '.';
     if (argument.length > 1) {
       additionalArg = (
@@ -16,6 +17,7 @@ const VersionModified = ({ nodeData: { argument, children, name }, ...rest }) =>
         </>
       );
     } else if (children.length > 0) {
+      childIndex = 1;
       additionalArg = (
         <>
           : <ComponentFactory nodeData={children[0]} skipPTag />
@@ -31,18 +33,21 @@ const VersionModified = ({ nodeData: { argument, children, name }, ...rest }) =>
       text = <>Changed{version && <> in version {version}</>}</>;
     }
 
-    return (
-      <>
-        <em>{text}</em>
-        {additionalArg}
-      </>
-    );
+    return {
+      childIndex,
+      introText: (
+        <>
+          <em>{text}</em>
+          {additionalArg}
+        </>
+      ),
+    };
   }, [argument, children, name]);
 
   return (
     <div>
       <p>{introText}</p>
-      {children.slice(1).map((child, index) => (
+      {children.slice(childIndex).map((child, index) => (
         <ComponentFactory {...rest} nodeData={child} key={index} />
       ))}
     </div>

--- a/src/components/VersionModified.js
+++ b/src/components/VersionModified.js
@@ -5,14 +5,23 @@ import ComponentFactory from './ComponentFactory';
 const VersionModified = ({ nodeData: { argument, children, name }, ...rest }) => {
   const introText = useMemo(() => {
     const version = argument.length > 0 ? <ComponentFactory nodeData={argument[0]} /> : null;
-    const additionalArg =
-      argument.length > 1 ? (
+    let additionalArg = '.';
+    if (argument.length > 1) {
+      additionalArg = (
         <>
-          : <ComponentFactory nodeData={argument[1]} />
+          :{' '}
+          {argument.slice(1).map((arg, i) => (
+            <ComponentFactory nodeData={arg} key={i} />
+          ))}
         </>
-      ) : (
-        '.'
       );
+    } else if (children.length > 0) {
+      additionalArg = (
+        <>
+          : <ComponentFactory nodeData={children[0]} skipPTag />
+        </>
+      );
+    }
     let text = '';
     if (name === 'deprecated') {
       text = <>Deprecated{version && <> since version {version}</>}</>;
@@ -28,12 +37,12 @@ const VersionModified = ({ nodeData: { argument, children, name }, ...rest }) =>
         {additionalArg}
       </>
     );
-  }, [argument, name]);
+  }, [argument, children, name]);
 
   return (
-    <div className={name}>
+    <div>
       <p>{introText}</p>
-      {children.map((child, index) => (
+      {children.slice(1).map((child, index) => (
         <ComponentFactory {...rest} nodeData={child} key={index} />
       ))}
     </div>

--- a/tests/unit/__snapshots__/VersionModified.test.js.snap
+++ b/tests/unit/__snapshots__/VersionModified.test.js.snap
@@ -1,94 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when rendering a deprecated directive with 0 arguments renders correctly  1`] = `
-<div
-  className="deprecated"
->
+<div>
   <p>
     <em>
       Deprecated
     </em>
-    .
-  </p>
-  <ComponentFactory
-    key="0"
-    nodeData={
-      Object {
-        "children": Array [
-          Object {
-            "children": Array [
-              Object {
-                "position": Object {
-                  "start": Object {
-                    "line": 679,
+    : 
+    <ComponentFactory
+      nodeData={
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 679,
+                    },
                   },
+                  "type": "text",
+                  "value": "replicationFactor",
                 },
-                "type": "text",
-                "value": "replicationFactor",
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 679,
+                },
               },
-            ],
-            "position": Object {
-              "start": Object {
-                "line": 679,
-              },
+              "type": "literal",
             },
-            "type": "literal",
-          },
-          Object {
-            "position": Object {
-              "start": Object {
-                "line": 679,
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 679,
+                },
               },
-            },
-            "type": "text",
-            "value": " is deprecated. Use
+              "type": "text",
+              "value": " is deprecated. Use
 ",
-          },
-          Object {
-            "children": Array [
-              Object {
-                "position": Object {
-                  "start": Object {
-                    "line": 679,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 679,
+                    },
                   },
+                  "type": "text",
+                  "value": "replicationSpecs",
                 },
-                "type": "text",
-                "value": "replicationSpecs",
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 679,
+                },
               },
-            ],
-            "position": Object {
-              "start": Object {
-                "line": 679,
-              },
+              "type": "literal",
             },
-            "type": "literal",
-          },
-          Object {
-            "position": Object {
-              "start": Object {
-                "line": 679,
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 679,
+                },
               },
+              "type": "text",
+              "value": ".",
             },
-            "type": "text",
-            "value": ".",
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 679,
+            },
           },
-        ],
-        "position": Object {
-          "start": Object {
-            "line": 679,
-          },
-        },
-        "type": "paragraph",
+          "type": "paragraph",
+        }
       }
-    }
-  />
+      skipPTag={true}
+    />
+  </p>
 </div>
 `;
 
 exports[`when rendering a versionadded directive with one argument renders correctly  1`] = `
-<div
-  className="versionadded"
->
+<div>
   <p>
     <em>
       New
@@ -113,9 +109,7 @@ exports[`when rendering a versionadded directive with one argument renders corre
 `;
 
 exports[`when rendering a versionchanged directive with two arguments renders correctly  1`] = `
-<div
-  className="versionchanged"
->
+<div>
   <p>
     <em>
       Changed
@@ -134,8 +128,10 @@ exports[`when rendering a versionchanged directive with two arguments renders co
         }
       />
     </em>
-    : 
+    :
+     
     <ComponentFactory
+      key="0"
       nodeData={
         Object {
           "position": Object {


### PR DESCRIPTION
[DOP-2021] [[Manual Staging](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/docs/sophstad/DOP-2021/reference/program/mongod/#std-option-mongod.--sslCertificateSelector)] Render all arguments of `versionchanged`, `versionadded`, and `deprecated` directives on same line as the version number. Also render the first child on this line. If there are multiple children (i.e. more than one paragraph), apply `<p>` tags as expected.