### PR TITLE
Fix version dropdown link generation

### DIFF
--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -89,8 +89,8 @@ const VersionDropdown = ({
 
     // For production builds, append version after project name
     if (pathPrefix) {
-      const [, project] = pathPrefix.split('/');
-      return `/${project}/${version}`;
+      const noVersion = pathPrefix.substr(0, pathPrefix.lastIndexOf('/'));
+      return `${noVersion}/${version}`;
     }
 
     // For staging, replace current version in dynamically generated path prefix


### PR DESCRIPTION
Fix links generated when using a path prefix that contains a slash within it. Previously, we used to split up a `pathPrefix` by slashes to separate its project and its version—e.g. splitting `/bi-connector/v4.0` became `['', 'bi-connector', 'v4.0']`.

The node docs use a path prefix that contains an additional slash (`/drivers/node/v3.6`) which introduced a problem. Now, identify the version via the string that appears after the final slash.

Staging would be pretty useless here as the link would not adhere to the path used in production, but I did some logging to verify and will test later in the integration environment!