### PR TITLE
DOP-1947: Anchor scroll to clicked tab component

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -61,6 +61,7 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
     (index) => {
       const tabId = tabIds[index];
 
+      // Calculate an offset of current top of viewport from the scroll anchor ref vs. scrollY position
       const offsetY = window.scrollY - getPosition(scrollAnchorRef.current).y;
 
       setActiveTab({
@@ -72,11 +73,10 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
         tabSet: tabsetName,
       });
 
+      // Delay preserving scroll behavior by 40ms to allow other tabset content bodies to render
       window.setTimeout(() => {
         window.scrollTo(0, getPosition(scrollAnchorRef.current).y + offsetY);
       }, 40);
-
-      // setPosition(getPosition(scrollAnchorRef.current).y);
     },
     [setActiveTab, tabIds, tabsetName] // eslint-disable-line react-hooks/exhaustive-deps
   );

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -7,11 +7,18 @@ import ComponentFactory from './ComponentFactory';
 import { TabContext } from './tab-context';
 import { reportAnalytics } from '../utils/report-analytics';
 import { getNestedValue } from '../utils/get-nested-value';
+import { isBrowser } from '../utils/is-browser';
 
 const getTabId = (node) => getNestedValue(['options', 'tabid'], node);
 
 // Name anonymous tabsets by alphabetizing their tabids and concatenating with a forward slash
 const generateAnonymousTabsetName = (tabIds) => [...tabIds].sort().join('/');
+
+const getPosition = (element) => {
+  if (!isBrowser || !element) return { x: 0, y: 0 };
+  const { x, y } = element.getBoundingClientRect();
+  return { x, y };
+};
 
 const TabButton = ({ ...props }) => <button {...props} />;
 
@@ -30,6 +37,8 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   const tabIds = children.map((child) => getTabId(child));
   const tabsetName = options.tabset || generateAnonymousTabsetName(tabIds);
   const [activeTab, setActiveTabIndex] = useState(0);
+
+  const scrollAnchorRef = useRef();
   const previousTabsetChoice = activeTabs[tabsetName];
   // Hide tabset if it includes the :hidden: option, or if it is controlled by a dropdown selector
   const isHidden = options.hidden || Object.keys(selectors).includes(tabsetName);
@@ -51,6 +60,9 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
   const handleClick = useCallback(
     (index) => {
       const tabId = tabIds[index];
+
+      const offsetY = window.scrollY - getPosition(scrollAnchorRef.current).y;
+
       setActiveTab({
         name: tabsetName,
         value: tabId,
@@ -59,31 +71,39 @@ const Tabs = ({ nodeData: { children, options = {} }, ...rest }) => {
         tabId,
         tabSet: tabsetName,
       });
+
+      window.setTimeout(() => {
+        window.scrollTo(0, getPosition(scrollAnchorRef.current).y + offsetY);
+      }, 40);
+
+      // setPosition(getPosition(scrollAnchorRef.current).y);
     },
-    [setActiveTab, tabIds, tabsetName]
+    [setActiveTab, tabIds, tabsetName] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return (
-    <StyledTabs as={TabButton} isHidden={isHidden} selected={activeTab} setSelected={handleClick}>
-      {children.map((tab) => {
-        if (tab.name !== 'tab') {
-          return null;
-        }
-
-        const tabId = getTabId(tab);
-        const tabTitle =
-          tab.argument.length > 0
-            ? tab.argument.map((arg, i) => <ComponentFactory {...rest} key={`${tabId}-arg-${i}`} nodeData={arg} />)
-            : tabId;
-        return (
-          <LeafyTab key={tabId} name={tabTitle}>
-            {tab.children.map((child, i) => (
-              <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
-            ))}
-          </LeafyTab>
-        );
-      })}
-    </StyledTabs>
+    <>
+      <div ref={scrollAnchorRef} aria-hidden="true"></div>
+      <StyledTabs as={TabButton} isHidden={isHidden} selected={activeTab} setSelected={handleClick}>
+        {children.map((tab) => {
+          if (tab.name !== 'tab') {
+            return null;
+          }
+          const tabId = getTabId(tab);
+          const tabTitle =
+            tab.argument.length > 0
+              ? tab.argument.map((arg, i) => <ComponentFactory {...rest} key={`${tabId}-arg-${i}`} nodeData={arg} />)
+              : tabId;
+          return (
+            <LeafyTab key={tabId} name={tabTitle}>
+              {tab.children.map((child, i) => (
+                <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
+              ))}
+            </LeafyTab>
+          );
+        })}
+      </StyledTabs>
+    </>
   );
 };
 

--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -16,7 +16,7 @@ const mountTabs = ({ activeTabs, mockData }) => {
     </TabProvider>
   )
     .childAt(0)
-    .childAt(0);
+    .childAt(1);
 };
 
 const shallowTabs = ({ mockData, mockAddTabset }) =>
@@ -26,7 +26,7 @@ const shallowTabs = ({ mockData, mockAddTabset }) =>
     </TabProvider>
   )
     .childAt(0)
-    .childAt(0);
+    .childAt(1);
 
 describe('Tabs testing', () => {
   describe('Tab unit tests', () => {


### PR DESCRIPTION
### Stories/Links:

DOP-1947

### Staging Links:

https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/cassidy.schaufele/DOP-1947/sdk/ios/data-types/embedded-objects/

### Notes:
Replicates some of the logic from here: https://github.com/mongodb/docs-tools/blob/master/themes/mongodb/src/js/componentTabs.js#L94-L133

Also adds a minor delay on scroll to account for renders in anything dependent on `TabContext` propagation.

Utilizes an empty `<div/>` tag with a ref to anchor our scroll logic to the parent tabset clicked. 
