### PR TITLE
DOP-1975: Add breadcrumb schema and simplify component

### DIFF
--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -6,7 +6,7 @@ module.exports = {
   ...gatsby,
   graphql: jest.fn(),
   StaticQuery: jest.fn(),
-  withPrefix: jest.fn().mockImplementation((str) => str),
+  withPrefix: jest.fn().mockImplementation((path) => (path.startsWith(`/`) ? path : `/${path}`)),
   useStaticQuery: jest.fn(),
   // https://www.gatsbyjs.org/docs/unit-testing/
   Link: jest.fn().mockImplementation(

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { transformBreadcrumbs } = require('./src/utils/setup/transform-breadcrumbs.js');
 const { initStitch } = require('./src/utils/setup/init-stitch');
 const { saveAssetFiles, saveStaticFiles } = require('./src/utils/setup/save-asset-files');
 const { validateEnvVariables } = require('./src/utils/setup/validate-env-variables');
@@ -90,6 +91,11 @@ exports.createPages = async ({ actions }) => {
     saveAssetFiles(assets, stitchClient),
     stitchClient.callFunction('fetchDocument', [DB, METADATA_COLLECTION, buildFilter]),
   ]);
+
+  const { parentPaths, slugToTitle } = metadataMinusStatic;
+  if (parentPaths) {
+    transformBreadcrumbs(parentPaths, slugToTitle);
+  }
 
   // Save files in the static_files field of metadata document, including intersphinx inventories
   if (staticFiles) {

--- a/src/components/BreadcrumbSchema.js
+++ b/src/components/BreadcrumbSchema.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withPrefix } from 'gatsby';
+import { Helmet } from 'react-helmet';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { assertTrailingSlash } from '../utils/assert-trailing-slash';
+
+const getBreadcrumbList = (breadcrumb, siteUrl) =>
+  breadcrumb.map(({ path, plaintext }, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: plaintext,
+    item: assertTrailingSlash(`${siteUrl}${withPrefix(path)}`),
+  }));
+
+const BreadcrumbSchema = ({ breadcrumb, siteTitle }) => {
+  const { siteUrl } = useSiteMetadata();
+  return (
+    <Helmet>
+      {Array.isArray(breadcrumb) && (
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: getBreadcrumbList([{ path: '/', plaintext: siteTitle }, ...breadcrumb], siteUrl),
+          })}
+        </script>
+      )}
+    </Helmet>
+  );
+};
+
+BreadcrumbSchema.propTypes = {
+  breadcrumb: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string,
+      plaintext: PropTypes.string,
+    })
+  ).isRequired,
+  siteTitle: PropTypes.string.isRequired,
+};
+
+export default BreadcrumbSchema;

--- a/src/components/BreadcrumbSchema.js
+++ b/src/components/BreadcrumbSchema.js
@@ -13,7 +13,7 @@ const getBreadcrumbList = (breadcrumb, siteUrl) =>
     item: assertTrailingSlash(`${siteUrl}${withPrefix(path)}`),
   }));
 
-const BreadcrumbSchema = ({ breadcrumb, siteTitle }) => {
+const BreadcrumbSchema = ({ breadcrumb = [], siteTitle }) => {
   const { siteUrl } = useSiteMetadata();
   return (
     <Helmet>
@@ -22,7 +22,14 @@ const BreadcrumbSchema = ({ breadcrumb, siteTitle }) => {
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'BreadcrumbList',
-            itemListElement: getBreadcrumbList([{ path: '/', plaintext: siteTitle }, ...breadcrumb], siteUrl),
+            itemListElement: getBreadcrumbList(
+              [
+                ...(siteUrl === 'https://docs.mongodb.com' ? [{ path: '', plaintext: 'MongoDB Documentation' }] : []),
+                ...(breadcrumb.length > 0 ? [{ path: '/', plaintext: siteTitle }] : []),
+                ...breadcrumb,
+              ],
+              siteUrl
+            ),
           })}
         </script>
       )}

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,46 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import BreadcrumbSchema from './BreadcrumbSchema';
+import ComponentFactory from './ComponentFactory';
 import Link from './Link';
-import { formatText } from '../utils/format-text';
-import { getNestedValue } from '../utils/get-nested-value';
 import { reportAnalytics } from '../utils/report-analytics';
+import { theme } from '../theme/docsTheme';
 
-const Breadcrumbs = ({ parentPaths, slugTitleMapping }) => (
-  <div className="bc">
-    {parentPaths && (
-      <ul>
-        {parentPaths.map((path, index) => {
-          const title = getNestedValue([path], slugTitleMapping);
-          return (
-            <li key={path}>
-              <Link
-                to={path}
-                onClick={() => {
-                  reportAnalytics('BreadcrumbClick', {
-                    parentPaths: parentPaths,
-                    breadcrumbClicked: path,
-                  });
-                }}
-              >
-                {formatText(title)}
-              </Link>
-              {index !== parentPaths.length - 1 && <span className="bcpoint"> &gt; </span>}
-            </li>
-          );
-        })}
-      </ul>
-    )}
-  </div>
-);
+const BreadcrumbContainer = styled('nav')`
+  font-size: ${theme.fontSize.small};
 
-Breadcrumbs.propTypes = {
-  parentPaths: PropTypes.arrayOf(PropTypes.string),
-  slugTitleMapping: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.string])),
+  & > p {
+    margin-top: 0;
+  }
+`;
+
+const Breadcrumbs = ({ parentPaths, siteTitle }) => {
+  if (!parentPaths) {
+    return null;
+  }
+
+  return (
+    <>
+      <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} />
+      <BreadcrumbContainer>
+        <p>
+          {parentPaths.map(({ path, plaintext, title }, index) => {
+            const isLast = index === parentPaths.length - 1;
+            return (
+              <React.Fragment key={path}>
+                <Link
+                  to={path}
+                  onClick={() => {
+                    reportAnalytics('BreadcrumbClick', {
+                      parentPaths: parentPaths,
+                      breadcrumbClicked: path,
+                    });
+                  }}
+                >
+                  {title.map((t, i) => (
+                    <ComponentFactory key={i} nodeData={t} />
+                  ))}
+                </Link>
+                {!isLast && <> &gt; </>}
+              </React.Fragment>
+            );
+          })}
+        </p>
+      </BreadcrumbContainer>
+    </>
+  );
 };
 
-Breadcrumbs.defaultProps = {
-  parentPaths: [],
-  slugTitleMapping: {},
+Breadcrumbs.propTypes = {
+  parentPaths: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string,
+      plaintext: PropTypes.string,
+      title: PropTypes.arrayOf(PropTypes.object),
+    })
+  ),
+  siteTitle: PropTypes.string.isRequired,
 };
 
 export default Breadcrumbs;

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -15,14 +15,10 @@ const BreadcrumbContainer = styled('nav')`
   }
 `;
 
-const Breadcrumbs = ({ parentPaths, siteTitle }) => {
-  if (!parentPaths) {
-    return null;
-  }
-
-  return (
-    <>
-      <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} />
+const Breadcrumbs = ({ parentPaths, siteTitle }) => (
+  <>
+    <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} />
+    {parentPaths && (
       <BreadcrumbContainer>
         <p>
           {parentPaths.map(({ path, plaintext, title }, index) => {
@@ -48,9 +44,9 @@ const Breadcrumbs = ({ parentPaths, siteTitle }) => {
           })}
         </p>
       </BreadcrumbContainer>
-    </>
-  );
-};
+    )}
+  </>
+);
 
 Breadcrumbs.propTypes = {
   parentPaths: PropTypes.arrayOf(

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -16,7 +16,7 @@ const Document = ({
   pageContext: {
     slug,
     page,
-    metadata: { parentPaths, publishedBranches, slugToTitle: slugTitleMapping, toctree, toctreeOrder },
+    metadata: { parentPaths, publishedBranches, slugToTitle: slugTitleMapping, title, toctree, toctreeOrder },
   },
 }) => {
   const { isTabletOrMobile } = useScreenSize();
@@ -58,7 +58,7 @@ const Document = ({
           <div className="documentwrapper">
             <div className="bodywrapper">
               <div className="body">
-                <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
+                <Breadcrumbs parentPaths={parentPaths?.[slug]} siteTitle={title} />
                 <div>{children}</div>
                 {showPrevNext && (
                   <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { getNestedValue } from '../utils/get-nested-value';
 import Breadcrumbs from '../components/Breadcrumbs';
 import InternalPageNav from '../components/InternalPageNav';
 import Sidebar from '../components/Sidebar';

--- a/src/utils/get-plaintext.js
+++ b/src/utils/get-plaintext.js
@@ -3,7 +3,7 @@
  * Returns plaintext string indicating the nested title.
  */
 
-export const getPlaintext = (nodeArray) => {
+const getPlaintext = (nodeArray) => {
   const extractText = (title, node) => {
     if (node.type === 'text') {
       return title + node.value;
@@ -14,3 +14,5 @@ export const getPlaintext = (nodeArray) => {
 
   return nodeArray && nodeArray.length > 0 ? nodeArray.reduce(extractText, '') : '';
 };
+
+module.exports = { getPlaintext };

--- a/src/utils/setup/transform-breadcrumbs.js
+++ b/src/utils/setup/transform-breadcrumbs.js
@@ -1,0 +1,16 @@
+const { getPlaintext } = require('../get-plaintext');
+
+const transformBreadcrumbs = (breadcrumbs, slugToTitle) => {
+  Object.entries(breadcrumbs).forEach(([slug, breadcrumbList]) => {
+    breadcrumbs[slug] = breadcrumbList.map((path) => {
+      const title = slugToTitle?.[path] || [];
+      return {
+        path,
+        title,
+        plaintext: getPlaintext(title),
+      };
+    });
+  });
+};
+
+module.exports = { transformBreadcrumbs };

--- a/tests/unit/BreadcrumbSchema.test.js
+++ b/tests/unit/BreadcrumbSchema.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BreadcrumbSchema from '../../src/components/BreadcrumbSchema';
+
+import mockData from './data/Breadcrumbs.test.json';
+
+const siteUrl = 'https://docs.mongodb.com';
+
+jest.mock('../../src/hooks/use-site-metadata', () => ({
+  useSiteMetadata: () => ({ siteUrl }),
+}));
+
+describe('BreadcrumbSchema', () => {
+  let shallowWrapper;
+
+  beforeAll(() => {
+    shallowWrapper = shallow(<BreadcrumbSchema breadcrumb={mockData} siteTitle="MongoDB Compass" />);
+  });
+
+  it('renders correctly', () => {
+    expect(shallowWrapper).toMatchSnapshot();
+  });
+
+  it('script has a correct schema', () => {
+    const script = shallowWrapper.find('script');
+
+    expect(script.text()).toEqual(
+      JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'MongoDB Compass', item: `${siteUrl}/` },
+          { '@type': 'ListItem', position: 2, name: 'Interact with Your Data', item: `${siteUrl}/manage-data/` },
+          { '@type': 'ListItem', position: 3, name: 'Manage Documents', item: `${siteUrl}/documents/` },
+        ],
+      })
+    );
+  });
+});

--- a/tests/unit/BreadcrumbSchema.test.js
+++ b/tests/unit/BreadcrumbSchema.test.js
@@ -29,9 +29,10 @@ describe('BreadcrumbSchema', () => {
         '@context': 'https://schema.org',
         '@type': 'BreadcrumbList',
         itemListElement: [
-          { '@type': 'ListItem', position: 1, name: 'MongoDB Compass', item: `${siteUrl}/` },
-          { '@type': 'ListItem', position: 2, name: 'Interact with Your Data', item: `${siteUrl}/manage-data/` },
-          { '@type': 'ListItem', position: 3, name: 'Manage Documents', item: `${siteUrl}/documents/` },
+          { '@type': 'ListItem', position: 1, name: 'MongoDB Documentation', item: `${siteUrl}/` },
+          { '@type': 'ListItem', position: 2, name: 'MongoDB Compass', item: `${siteUrl}/` },
+          { '@type': 'ListItem', position: 3, name: 'Interact with Your Data', item: `${siteUrl}/manage-data/` },
+          { '@type': 'ListItem', position: 4, name: 'Manage Documents', item: `${siteUrl}/documents/` },
         ],
       })
     );

--- a/tests/unit/Breadcrumbs.test.js
+++ b/tests/unit/Breadcrumbs.test.js
@@ -1,16 +1,15 @@
 import React from 'react';
-import { render } from 'enzyme';
+import { shallow } from 'enzyme';
 import Breadcrumbs from '../../src/components/Breadcrumbs';
-import slugTitleMapping from './data/ecosystem/slugTitleMapping.json';
 
-const mockData = ['drivers', 'drivers/php'];
+import mockData from './data/Breadcrumbs.test.json';
 
 it('renders correctly', () => {
-  const tree = render(<Breadcrumbs parentPaths={mockData} slugTitleMapping={slugTitleMapping} />);
+  const tree = shallow(<Breadcrumbs parentPaths={mockData} siteTitle="MongoDB Compass" />);
   expect(tree).toMatchSnapshot();
 });
 
 it('fails gracefully', () => {
-  const tree = render(<Breadcrumbs parentPaths={null} slugTitleMapping={slugTitleMapping} />);
+  const tree = shallow(<Breadcrumbs parentPaths={null} siteTitle="untitled" />);
   expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
@@ -8,7 +8,7 @@ exports[`BreadcrumbSchema renders correctly 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"MongoDB Compass","item":"https://docs.mongodb.com/"},{"@type":"ListItem","position":2,"name":"Interact with Your Data","item":"https://docs.mongodb.com/manage-data/"},{"@type":"ListItem","position":3,"name":"Manage Documents","item":"https://docs.mongodb.com/documents/"}]}
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"MongoDB Documentation","item":"https://docs.mongodb.com/"},{"@type":"ListItem","position":2,"name":"MongoDB Compass","item":"https://docs.mongodb.com/"},{"@type":"ListItem","position":3,"name":"Interact with Your Data","item":"https://docs.mongodb.com/manage-data/"},{"@type":"ListItem","position":4,"name":"Manage Documents","item":"https://docs.mongodb.com/documents/"}]}
   </script>
 </HelmetWrapper>
 `;

--- a/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BreadcrumbSchema renders correctly 1`] = `
+<HelmetWrapper
+  defer={true}
+  encodeSpecialCharacters={true}
+>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"MongoDB Compass","item":"https://docs.mongodb.com/"},{"@type":"ListItem","position":2,"name":"Interact with Your Data","item":"https://docs.mongodb.com/manage-data/"},{"@type":"ListItem","position":3,"name":"Manage Documents","item":"https://docs.mongodb.com/documents/"}]}
+  </script>
+</HelmetWrapper>
+`;

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fails gracefully 1`] = `""`;
+exports[`fails gracefully 1`] = `
+<Fragment>
+  <BreadcrumbSchema
+    breadcrumb={null}
+    siteTitle="untitled"
+  />
+</Fragment>
+`;
 
 exports[`renders correctly 1`] = `
 <Fragment>

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -1,35 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fails gracefully 1`] = `
-<div
-  class="bc"
-/>
-`;
+exports[`fails gracefully 1`] = `""`;
 
 exports[`renders correctly 1`] = `
-<div
-  class="bc"
->
-  <ul>
-    <li>
-      <a
-        href="/drivers/"
+<Fragment>
+  <BreadcrumbSchema
+    breadcrumb={
+      Array [
+        Object {
+          "path": "manage-data",
+          "plaintext": "Interact with Your Data",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 2,
+                },
+              },
+              "type": "text",
+              "value": "Interact with Your Data",
+            },
+          ],
+        },
+        Object {
+          "path": "documents",
+          "plaintext": "Manage Documents",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Manage Documents",
+            },
+          ],
+        },
+      ]
+    }
+    siteTitle="MongoDB Compass"
+  />
+  <BreadcrumbContainer>
+    <p>
+      <Link
+        onClick={[Function]}
+        to="manage-data"
       >
-        MongoDB Drivers and ODM
-      </a>
-      <span
-        class="bcpoint"
+        <ComponentFactory
+          key="0"
+          nodeData={
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 2,
+                },
+              },
+              "type": "text",
+              "value": "Interact with Your Data",
+            }
+          }
+        />
+      </Link>
+       &gt; 
+      <Link
+        onClick={[Function]}
+        to="documents"
       >
-         &gt; 
-      </span>
-    </li>
-    <li>
-      <a
-        href="/drivers/php/"
-      >
-        MongoDB PHP Driver
-      </a>
-    </li>
-  </ul>
-</div>
+        <ComponentFactory
+          key="0"
+          nodeData={
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Manage Documents",
+            }
+          }
+        />
+      </Link>
+    </p>
+  </BreadcrumbContainer>
+</Fragment>
 `;

--- a/tests/unit/data/Breadcrumbs.test.json
+++ b/tests/unit/data/Breadcrumbs.test.json
@@ -1,0 +1,32 @@
+[
+  {
+    "path": "manage-data",
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": 2
+          }
+        },
+        "value": "Interact with Your Data"
+      }
+    ],
+    "plaintext": "Interact with Your Data"
+  },
+  {
+    "path": "documents",
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": 4
+          }
+        },
+        "value": "Manage Documents"
+      }
+    ],
+    "plaintext": "Manage Documents"
+  }
+]


### PR DESCRIPTION
### Stories/Links:

DOP-1975

### Staging Links:

[Compass Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/sophstad/DOP-1975/)

### Notes:

- Attach page titles (both rich & plaintext) in `gatsby-node.js` to minimize logic performed by the breadcrumb components
- Remove dependency on legacy `mongodb-docs.css` in breadcrumb render
- Will ask Croud team to perform acceptance testing before merging