### PR TITLE
DOP-2099: Use parser data for "On this page" box

### DIFF
--- a/src/components/Contents.js
+++ b/src/components/Contents.js
@@ -63,7 +63,7 @@ const ContentsList = styled.ul`
 `;
 
 const Contents = () => {
-  const { headingNodes, activeSectionIndex } = useContext(ContentsContext);
+  const { headingNodes, activeHeadingId } = useContext(ContentsContext);
   const { isTabletOrMobile } = useScreenSize();
 
   if (headingNodes.length === 0) {
@@ -79,7 +79,7 @@ const Contents = () => {
             depth={depth}
             key={id}
             id={id}
-            isActive={activeSectionIndex === index}
+            isActive={activeHeadingId === id}
             isDesktopOrLaptop={!isTabletOrMobile}
           >
             {title.map((node, i) => (

--- a/src/components/contents-context.js
+++ b/src/components/contents-context.js
@@ -1,116 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { getNestedValue } from '../utils/get-nested-value';
-import { throttle } from '../utils/throttle';
+import React from 'react';
+import useActiveHeading from '../hooks/useActiveHeading';
 
 const defaultContextValue = {
   headingNodes: [],
-  activeSectionIndex: 0,
-};
-
-const findSectionHeadings = (nodes) => {
-  // Max depth is 2 by default to not make the "On This Page" feel too crowded
-  let maxDepth = 2;
-  const key = 'type';
-  const results = [];
-  let hasContentsDirective = false;
-
-  const searchNode = (node, sectionDepth) => {
-    // Search for contents directive before looking for heading nodes.
-    // Ideally, we'd want this in the postprocess layer of the parser.
-    if (node.name === 'contents' && sectionDepth === 1) {
-      hasContentsDirective = true;
-      maxDepth = getNestedValue(['options', 'depth'], node) || maxDepth;
-    }
-
-    if (sectionDepth > 1) {
-      // Return early if no contents directive has been found beyond its expected depth
-      if (!hasContentsDirective) {
-        return null;
-      }
-
-      if (node[key] === 'heading' && sectionDepth - 1 <= maxDepth) {
-        const nodeTitle = node.children;
-        const newNode = {
-          depth: sectionDepth,
-          id: node.id,
-          title: nodeTitle,
-        };
-
-        results.push(newNode);
-      }
-    }
-
-    // Don't include step headings in our TOC regardless of depth
-    if (node.children && node.name !== 'step') {
-      if (node.type === 'section') {
-        sectionDepth += 1; // eslint-disable-line no-param-reassign
-      }
-      return node.children.forEach((child) => searchNode(child, sectionDepth));
-    }
-
-    return null;
-  };
-
-  nodes.forEach((node) => searchNode(node, 0));
-  return results;
-};
-
-const findHeadingsOnPage = (headingNodes, height) => {
-  let positions = [];
-
-  headingNodes.forEach((heading) => {
-    const el = document.getElementById(heading.id);
-    if (el) {
-      positions.push(el.offsetTop / height);
-    }
-  });
-
-  return positions;
+  activeHeadingId: null,
 };
 
 const ContentsContext = React.createContext(defaultContextValue);
 
-const ContentsProvider = ({ children, nodes = [] }) => {
-  const [activeSectionIndex, setActiveSectionIndex] = useState(0);
-  const [headingNodes, setHeadingNodes] = useState([]);
+const ContentsProvider = ({ children, headingNodes = [] }) => {
+  const activeHeadingId = useActiveHeading(headingNodes);
 
-  useEffect(() => {
-    setHeadingNodes(findSectionHeadings(nodes));
-  }, [nodes]);
-
-  useEffect(() => {
-    const height = document.body.clientHeight - window.innerHeight;
-    const headingPositions = findHeadingsOnPage(headingNodes, height);
-
-    const handleScroll = () => {
-      // Calculate current position of the page similar to guides.js
-      const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop);
-      let currentPosition = scrollTop / height;
-      currentPosition = (scrollTop + currentPosition * 0.8 * window.innerHeight) / height;
-
-      // bestMatch = [distance from closest section, closest section index]
-      let bestMatch = [Infinity, 0];
-
-      headingPositions.forEach((headingPosition, index) => {
-        const delta = Math.abs(headingPosition - currentPosition);
-        if (delta <= bestMatch[0]) {
-          bestMatch = [delta, index];
-        }
-      });
-
-      setActiveSectionIndex(bestMatch[1]);
-    };
-
-    const throttledScrollFn = throttle(handleScroll, 50);
-    document.addEventListener('scroll', throttledScrollFn);
-
-    return () => {
-      document.removeEventListener('scroll', throttledScrollFn);
-      setActiveSectionIndex(0);
-    };
-  }, [headingNodes]);
-
-  return <ContentsContext.Provider value={{ headingNodes, activeSectionIndex }}>{children}</ContentsContext.Provider>;
+  return <ContentsContext.Provider value={{ headingNodes, activeHeadingId }}>{children}</ContentsContext.Provider>;
 };
 
 export { ContentsContext, ContentsProvider };

--- a/src/hooks/useActiveHeading.js
+++ b/src/hooks/useActiveHeading.js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+const observeHeadings = (headingNodes, observer) =>
+  headingNodes.flatMap((heading) => {
+    const el = document.getElementById(heading.id);
+    if (el) {
+      observer.observe(el);
+      return [el];
+    }
+    return [];
+  });
+
+const unobserveHeadings = (headings, observer) => {
+  headings.forEach((el) => {
+    observer.unobserve(el);
+  });
+};
+
+const useActiveHeading = (headingNodes) => {
+  const [activeHeadingId, setActiveHeadingId] = useState(headingNodes?.[0]?.id);
+
+  useEffect(() => {
+    // TODO: Change root to document.querySelector('.content') after docs-nav work
+    const options = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    };
+
+    // Callback is first performed upon page load. Ignore checking entries on first load to allow
+    // headings[0] to be counted first when headings[0] and headings[1] are both intersecting
+    let firstLoad = true;
+    let defaultActiveHeadingId = window.location.hash.slice(1) || headingNodes?.[0]?.id;
+    const callback = (entries) => {
+      if (firstLoad) {
+        firstLoad = false;
+        setActiveHeadingId(defaultActiveHeadingId);
+        return;
+      }
+
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActiveHeadingId(entry.target.id);
+        }
+      });
+    };
+
+    const observer = new IntersectionObserver(callback, options);
+    const headings = observeHeadings(headingNodes, observer);
+    return () => {
+      unobserveHeadings(headings, observer);
+      setActiveHeadingId(defaultActiveHeadingId);
+    };
+  }, [headingNodes]);
+
+  return activeHeadingId;
+};
+
+export default useActiveHeading;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -58,7 +58,7 @@ const DefaultLayout = (props) => {
       <Global styles={globalCSS} />
       <SiteMetadata siteTitle={title} />
       <TabProvider selectors={page?.options?.selectors}>
-        <ContentsProvider nodes={page?.children}>
+        <ContentsProvider headingNodes={page?.options?.headings}>
           <Template {...props}>{template === 'landing' ? [children] : children}</Template>
         </ContentsProvider>
       </TabProvider>


### PR DESCRIPTION
### Stories/Links:

DOP-2099

### Staging Links:

- [Compass](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/sophstad/DOP-2099/)
- [Realm](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/sophstad/DOP-2099/)

### Notes:

- Followup to https://github.com/mongodb/snooty-parser/pull/297
- Took Raymund's work from the `docs-nav` feature branch to leverage improved behavior via `IntersectionObserver` ([source](https://github.com/mongodb/snooty/blob/dfee59d6c9f0fe58e648bf47ec06de30ff4e1dc0/src/components/contents-context.js)). I can take care of merging this work into the feature branch!
- Move active heading logic into a separate custom hook