### PR TITLE
DOP-2083: Only keydown event listen on searchbar focus

### DIFF
--- a/src/components/Searchbar/ExpandedSearchbar.js
+++ b/src/components/Searchbar/ExpandedSearchbar.js
@@ -129,7 +129,11 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
     [searchContainerRef]
   );
 
-  useEventListener('keydown', onKeyDown, { dependencies: [searchTextbox.current], element: searchTextbox.current });
+  useEventListener('keydown', onKeyDown, {
+    enabled: isFocused,
+    dependencies: [searchTextbox.current],
+    element: searchTextbox.current,
+  });
 
   const searchUrl = useMemo(() => searchParamsToURL(searchTerm, searchFilter, false), [searchFilter, searchTerm]);
 

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -141,7 +141,7 @@ const Searchbar = ({ getResultsFromJSON, isExpanded, setIsExpanded, searchParams
             shouldAutofocus,
           }}
         >
-          <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} value={value} />
+          <ExpandedSearchbar onMobileClose={onClose} onChange={onSearchChange} isFocused={isFocused} value={value} />
           {isSearching && <SearchDropdown applySearchFilter={onApplyFilters} results={searchResults} />}
         </SearchContext.Provider>
       ) : (

--- a/tests/unit/__snapshots__/Searchbar.test.js.snap
+++ b/tests/unit/__snapshots__/Searchbar.test.js.snap
@@ -32,6 +32,7 @@ exports[`Searchbar renders correctly without browser 2`] = `
     }
   >
     <ExpandedSearchbar
+      isFocused={false}
       onChange={[Function]}
       onMobileClose={[Function]}
       value=""


### PR DESCRIPTION
### Stories/Links:

DOP-2083

### Staging Links:

https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/cassidy.schaufele/DOP-2083/

### Notes:

The event listener for the keydown event was inexplicably triggering on page load - this is why arrow down navigation wasn't working until clicking into another element, or until clicking into and then out of the searchbar.

This changeset changes the event listener to only activate when the searchbar has focus, and passes `isFocused` into `ExpandedSearchbar`. We had the prop present in `ExpandedSearchbar` before, we just never drilled it down from `Searchbar`. 