### PR TITLE
tabs-fix: Fix tab-button failures; change tab buttons to LG tab buttons

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -27,9 +27,14 @@ const hiddenTabsStyling = css`
 `;
 
 const landingTabsStyling = css`
-  ${'' /* Insert space between the tab buttons and the tab panels */}
   & > div:first-child {
+    margin-top: ${theme.size.large};
     margin-bottom: ${theme.size.xlarge};
+
+    button {
+      display: block;
+      flex-grow: 1;
+    }
 
     @media ${theme.screenSize.upToSmall} {
       margin-bottom: 40px;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -21,13 +21,13 @@ const getPosition = (element) => {
 };
 
 const hiddenTabsStyling = css`
-  & > div:first-child {
+  & > div:first-of-type {
     display: none;
   }
 `;
 
 const landingTabsStyling = css`
-  & > div:first-child {
+  & > div:first-of-type {
     margin-top: ${theme.size.large};
     margin-bottom: ${theme.size.xlarge};
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -27,18 +27,12 @@ const hiddenTabsStyling = css`
 `;
 
 const landingTabsStyling = css`
-  width: 100%;
+  ${'' /* Insert space between the tab buttons and the tab panels */}
+  & > div:first-child {
+    margin-bottom: ${theme.size.xlarge};
 
-  & > div:first-child > button {
-    flex-grow: 1;
-    min-width: 55px;
-    padding: 12px ${theme.size.default};
-
-    @media ${theme.screenSize.upToMedium} {
-      padding: 12px ${theme.size.small};
-    }
     @media ${theme.screenSize.upToSmall} {
-      padding: 12px ${theme.size.tiny};
+      margin-bottom: 40px;
     }
   }
 `;
@@ -52,7 +46,6 @@ const landingTabStyling = css`
   display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
-  margin-top: ${theme.size.xlarge};
 
   img {
     border-radius: ${theme.size.small};
@@ -63,10 +56,6 @@ const landingTabStyling = css`
 
   @media ${theme.screenSize.upToMedium} {
     display: block;
-  }
-
-  @media ${theme.screenSize.upToSmall} {
-    margin-top: 40px;
   }
 `;
 

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -50,30 +50,31 @@ const Wrapper = styled('main')`
     }
   }
 
-  & > section:first-of-type {
+  & > section {
+    h1 {
+      align-self: end;
+    }
+
+    ${'' /* Split the content into two columns on large screens. */}
     @media ${theme.screenSize.mediumAndUp} {
       display: grid;
       grid-template-columns: 1fr 1fr;
+
+      & > h1,
+      & > .introduction {
+        grid-column: 1;
+      }
+
+      & > .right-column {
+        grid-column: 2;
+        grid-row: 1 / span 2;
+      }
+
+      ${'' /* Sub-sections should take up the full width of the main section */}
+      & > section {
+        grid-column: 1 / -1;
+      }
     }
-  }
-
-  & > section > h1:first-child,
-  & > section > div:first-child {
-    align-self: end;
-  }
-
-  & > section > h1:first-of-type,
-  & > section > .introduction {
-    grid-column: 1;
-  }
-
-  & > section > .right-column {
-    grid-column: 2;
-    grid-row: 1 / span 2;
-  }
-
-  & > section > section {
-    grid-column: 1 / -1;
   }
 `;
 


### PR DESCRIPTION
When I merged in changes from `master`, there were a few breakages around tabs. Namely: 

- `margin`s had to be removed from `tab-panels`
- `tab-button`s were not obeying the laws of physics on small screens

### Changes:
- Rewrite `Tabs` CSS to be compatible with changes from `master`
- Bonus: Rewrite large chunk of CSS in `Wrapper` in `product-landing.js`
- Bonus: Remove all instances of `:first-child` selector to avoid SSR warnings


### Staging Links:

My change: [Tabs-fix](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/tabs-fix/) 
Current [BROKEN PLP branch](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/plp/), so you can see what's happening right now

### .env.development
```
GATSBY_SITE=compass
GATSBY_PARSER_USER=cgoecknerwald
GATSBY_PARSER_BRANCH=DOP-1979
GATSBY_SNOOTY_DEV=true
```

### Notes:
- @allisonmui9 Is this an acceptable behavior of tab buttons? In the Figma designs, tab buttons start to truncate with "..." on small screens, which is no longer occurring with this PR. 
