### PR TITLE
DOP-1841: Update page breadcrumbs to fetch parents

### DIFF
--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,11 +1,10 @@
 import React, { useContext, useEffect } from 'react';
-import { AnonymousCredential } from 'mongodb-stitch-browser-sdk';
 import styled from '@emotion/styled';
 import { HeaderContext } from './header-context';
 import { SNOOTY_STITCH_ID } from '../build-constants';
 import { theme } from '../theme/docsTheme';
 import { normalizePath } from '../utils/normalize-path';
-import { getStitchClient } from '../utils/stitch';
+import { fetchBanner } from '../utils/stitch';
 
 const getBannerSource = (src) => {
   if (src == null || src === '') return null;
@@ -37,10 +36,7 @@ const Banner = () => {
 
   useEffect(() => {
     const fetchBannerContent = async () => {
-      const client = getStitchClient(SNOOTY_STITCH_ID);
-      await client.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
-      const banner = await client.callFunction('getBanner');
-      setBannerContent(banner);
+      setBannerContent(await fetchBanner(SNOOTY_STITCH_ID));
     };
     fetchBannerContent();
   }, [setBannerContent]);

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -58,7 +58,11 @@ const BreadcrumbContainer = ({ lastCrumb }) => {
   useEffect(() => {
     const fetchBreadcrumbData = async () => {
       let parentCrumbs = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
-      const breadcrumbs = [{ title: 'Docs Home', url: 'https://docs.mongodb.com/' }, ...parentCrumbs, lastCrumb];
+      const breadcrumbs = [
+        { title: 'Docs Home', url: project === 'landing' ? '/' : 'https://docs.mongodb.com/' },
+        ...parentCrumbs,
+        lastCrumb,
+      ];
       setBreadcrumbs(breadcrumbs);
     };
     fetchBreadcrumbData();

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -6,29 +6,12 @@ import { css } from '@emotion/core';
 import Link from './Link';
 import { SNOOTY_STITCH_ID } from '../build-constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { theme } from '../theme/docsTheme';
 import { formatText } from '../utils/format-text';
 import { reportAnalytics } from '../utils/report-analytics';
 import { fetchProjectParents } from '../utils/stitch';
 
 const activeColor = css`
   color: ${uiColors.gray.dark3};
-`;
-
-const StyledNav = styled('nav')`
-  font-size: ${theme.fontSize.small};
-
-  * {
-    color: ${uiColors.gray.dark1};
-  }
-
-  & > p {
-    margin-top: 0;
-  }
-`;
-
-const P = styled('p')`
-  min-height: ${theme.size.medium};
 `;
 
 const StyledArrow = styled('span')`
@@ -68,29 +51,27 @@ const BreadcrumbContainer = ({ homeCrumb, lastCrumb }) => {
   }, [database, homeCrumb, lastCrumb, project]);
 
   return (
-    <StyledNav>
-      <P>
-        {breadcrumbs.map(({ title, url }, index) => {
-          const isFirst = index === 0;
-          return (
-            <React.Fragment key={title}>
-              {!isFirst && <StyledArrow> &#8594; </StyledArrow>}
-              <StyledLink
-                to={url}
-                onClick={() => {
-                  reportAnalytics('BreadcrumbClick', {
-                    parentPaths: breadcrumbs,
-                    breadcrumbClicked: url,
-                  });
-                }}
-              >
-                {formatText(title)}
-              </StyledLink>
-            </React.Fragment>
-          );
-        })}
-      </P>
-    </StyledNav>
+    <>
+      {breadcrumbs.map(({ title, url }, index) => {
+        const isFirst = index === 0;
+        return (
+          <React.Fragment key={title}>
+            {!isFirst && <StyledArrow> &#8594; </StyledArrow>}
+            <StyledLink
+              to={url}
+              onClick={() => {
+                reportAnalytics('BreadcrumbClick', {
+                  parentPaths: breadcrumbs,
+                  breadcrumbClicked: url,
+                });
+              }}
+            >
+              {formatText(title)}
+            </StyledLink>
+          </React.Fragment>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { uiColors } from '@leafygreen-ui/palette';
+import { css } from '@emotion/core';
+import Link from './Link';
+import { SNOOTY_STITCH_ID } from '../build-constants';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { theme } from '../theme/docsTheme';
+import { formatText } from '../utils/format-text';
+import { reportAnalytics } from '../utils/report-analytics';
+import { fetchProjectParents } from '../utils/stitch';
+
+const activeColor = css`
+  color: ${uiColors.gray.dark3};
+`;
+
+const StyledNav = styled('nav')`
+  font-size: ${theme.fontSize.small};
+  min-height: ${theme.size.medium};
+
+  * {
+    color: ${uiColors.gray.dark1};
+  }
+
+  & > p {
+    margin-top: 0;
+  }
+`;
+
+const StyledArrow = styled('span')`
+  ${({ isLast }) => isLast && activeColor}
+  cursor: default;
+`;
+
+const StyledLink = styled(Link, {
+  shouldForwardProp: (prop) => prop !== 'isLast',
+})`
+  ${({ isLast }) => isLast && activeColor}
+
+  :hover, :focus {
+    ${({ isLast }) => (isLast ? activeColor : 'color: inherit;')}
+    text-decoration: none;
+  }
+`;
+
+const BreadcrumbContainer = ({ lastCrumb }) => {
+  const { database, project } = useSiteMetadata();
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+
+  useEffect(() => {
+    const fetchBreadcrumbData = async () => {
+      let parentCrumbs = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
+      const breadcrumbs = [{ title: 'Docs Home', url: 'https://docs.mongodb.com/' }, ...parentCrumbs, lastCrumb];
+      setBreadcrumbs(breadcrumbs);
+    };
+    fetchBreadcrumbData();
+  }, [database, lastCrumb, project]);
+
+  if (breadcrumbs.length === 0) {
+    return null;
+  }
+
+  return (
+    <StyledNav>
+      <p>
+        {breadcrumbs.map(({ title, url }, index) => {
+          const isFirst = index === 0;
+          const isLast = index === breadcrumbs.length - 1;
+          return (
+            <React.Fragment key={title}>
+              {!isFirst && <StyledArrow isLast={isLast}> &#8594; </StyledArrow>}
+              <StyledLink
+                isLast={isLast}
+                to={url}
+                onClick={() => {
+                  reportAnalytics('BreadcrumbClick', {
+                    parentPaths: breadcrumbs,
+                    breadcrumbClicked: url,
+                  });
+                }}
+              >
+                {formatText(title)}
+              </StyledLink>
+            </React.Fragment>
+          );
+        })}
+      </p>
+    </StyledNav>
+  );
+};
+
+BreadcrumbContainer.propTypes = {
+  lastCrumb: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default BreadcrumbContainer;

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -51,22 +51,18 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const BreadcrumbContainer = ({ lastCrumb }) => {
+const BreadcrumbContainer = ({ homeCrumb, lastCrumb }) => {
   const { database, project } = useSiteMetadata();
   const [breadcrumbs, setBreadcrumbs] = useState([]);
 
   useEffect(() => {
     const fetchBreadcrumbData = async () => {
       let parentCrumbs = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
-      const breadcrumbs = [
-        { title: 'Docs Home', url: project === 'landing' ? '/' : 'https://docs.mongodb.com/' },
-        ...parentCrumbs,
-        lastCrumb,
-      ];
+      const breadcrumbs = [homeCrumb, ...parentCrumbs, lastCrumb];
       setBreadcrumbs(breadcrumbs);
     };
     fetchBreadcrumbData();
-  }, [database, lastCrumb, project]);
+  }, [database, homeCrumb, lastCrumb, project]);
 
   if (breadcrumbs.length === 0) {
     return null;
@@ -99,11 +95,14 @@ const BreadcrumbContainer = ({ lastCrumb }) => {
   );
 };
 
+const crumbObjectShape = {
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+};
+
 BreadcrumbContainer.propTypes = {
-  lastCrumb: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired,
-  }).isRequired,
+  homeCrumb: PropTypes.shape(crumbObjectShape).isRequired,
+  lastCrumb: PropTypes.shape(crumbObjectShape).isRequired,
 };
 
 export default BreadcrumbContainer;

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -29,18 +29,25 @@ const StyledNav = styled('nav')`
 `;
 
 const StyledArrow = styled('span')`
-  ${({ isLast }) => isLast && activeColor}
   cursor: default;
+
+  :last-of-type {
+    ${activeColor}
+  }
 `;
 
-const StyledLink = styled(Link, {
-  shouldForwardProp: (prop) => prop !== 'isLast',
-})`
-  ${({ isLast }) => isLast && activeColor}
+const StyledLink = styled(Link)`
+  :last-of-type {
+    ${activeColor}
+  }
 
-  :hover, :focus {
-    ${({ isLast }) => (isLast ? activeColor : 'color: inherit;')}
+  :hover,
+  :focus {
     text-decoration: none;
+
+    :not(:last-of-type) {
+      ${activeColor}
+    }
   }
 `;
 
@@ -66,12 +73,10 @@ const BreadcrumbContainer = ({ lastCrumb }) => {
       <p>
         {breadcrumbs.map(({ title, url }, index) => {
           const isFirst = index === 0;
-          const isLast = index === breadcrumbs.length - 1;
           return (
             <React.Fragment key={title}>
-              {!isFirst && <StyledArrow isLast={isLast}> &#8594; </StyledArrow>}
+              {!isFirst && <StyledArrow> &#8594; </StyledArrow>}
               <StyledLink
-                isLast={isLast}
                 to={url}
                 onClick={() => {
                   reportAnalytics('BreadcrumbClick', {

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -17,7 +17,6 @@ const activeColor = css`
 
 const StyledNav = styled('nav')`
   font-size: ${theme.fontSize.small};
-  min-height: ${theme.size.medium};
 
   * {
     color: ${uiColors.gray.dark1};
@@ -26,6 +25,10 @@ const StyledNav = styled('nav')`
   & > p {
     margin-top: 0;
   }
+`;
+
+const P = styled('p')`
+  min-height: ${theme.size.medium};
 `;
 
 const StyledArrow = styled('span')`
@@ -64,13 +67,9 @@ const BreadcrumbContainer = ({ homeCrumb, lastCrumb }) => {
     fetchBreadcrumbData();
   }, [database, homeCrumb, lastCrumb, project]);
 
-  if (breadcrumbs.length === 0) {
-    return null;
-  }
-
   return (
     <StyledNav>
-      <p>
+      <P>
         {breadcrumbs.map(({ title, url }, index) => {
           const isFirst = index === 0;
           return (
@@ -90,7 +89,7 @@ const BreadcrumbContainer = ({ homeCrumb, lastCrumb }) => {
             </React.Fragment>
           );
         })}
-      </p>
+      </P>
     </StyledNav>
   );
 };

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,54 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import BreadcrumbSchema from './BreadcrumbSchema';
-import ComponentFactory from './ComponentFactory';
-import Link from './Link';
-import { reportAnalytics } from '../utils/report-analytics';
-import { theme } from '../theme/docsTheme';
+import Loadable from '@loadable/component';
 
-const BreadcrumbContainer = styled('nav')`
-  font-size: ${theme.fontSize.small};
+const BreadcrumbContainer = Loadable(() => import('./BreadcrumbContainer'));
 
-  & > p {
-    margin-top: 0;
-  }
-`;
+const Breadcrumbs = ({ pageTitle = null, parentPaths, siteTitle, slug }) => {
+  // If a pageTitle prop is passed, use that as the last breadcrumb instead
+  const lastCrumb = {
+    title: pageTitle || siteTitle,
+    url: pageTitle ? slug : '/',
+  };
 
-const Breadcrumbs = ({ parentPaths, siteTitle, slug }) => (
-  <>
-    <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} slug={slug} />
-    {parentPaths && (
-      <BreadcrumbContainer>
-        <p>
-          {parentPaths.map(({ path, plaintext, title }, index) => {
-            const isLast = index === parentPaths.length - 1;
-            return (
-              <React.Fragment key={path}>
-                <Link
-                  to={path}
-                  onClick={() => {
-                    reportAnalytics('BreadcrumbClick', {
-                      parentPaths: parentPaths,
-                      breadcrumbClicked: path,
-                    });
-                  }}
-                >
-                  {title.map((t, i) => (
-                    <ComponentFactory key={i} nodeData={t} />
-                  ))}
-                </Link>
-                {!isLast && <> &gt; </>}
-              </React.Fragment>
-            );
-          })}
-        </p>
-      </BreadcrumbContainer>
-    )}
-  </>
-);
+  return (
+    <>
+      <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} slug={slug} />
+      <BreadcrumbContainer lastCrumb={lastCrumb} />
+    </>
+  );
+};
 
 Breadcrumbs.propTypes = {
+  pageTitle: PropTypes.string,
   parentPaths: PropTypes.arrayOf(
     PropTypes.shape({
       path: PropTypes.string,

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import BreadcrumbSchema from './BreadcrumbSchema';
 import Loadable from '@loadable/component';
+import BreadcrumbSchema from './BreadcrumbSchema';
 
 const BreadcrumbContainer = Loadable(() => import('./BreadcrumbContainer'));
 
-const Breadcrumbs = ({ pageTitle = null, parentPaths, siteTitle, slug }) => {
+const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle, slug }) => {
+  const homeCrumb = {
+    title: 'Docs Home',
+    url: homeUrl || 'https://docs.mongodb.com/',
+  };
   // If a pageTitle prop is passed, use that as the last breadcrumb instead
   const lastCrumb = {
     title: pageTitle || siteTitle,
@@ -15,12 +19,13 @@ const Breadcrumbs = ({ pageTitle = null, parentPaths, siteTitle, slug }) => {
   return (
     <>
       <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} slug={slug} />
-      <BreadcrumbContainer lastCrumb={lastCrumb} />
+      <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
     </>
   );
 };
 
 Breadcrumbs.propTypes = {
+  homeUrl: PropTypes.string,
   pageTitle: PropTypes.string,
   parentPaths: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import Loadable from '@loadable/component';
 import BreadcrumbSchema from './BreadcrumbSchema';
 
 const BreadcrumbContainer = Loadable(() => import('./BreadcrumbContainer'));
+
+// Placeholder space for breadcrumbs before they load; add extra space due to negative
+// margin-top of page's h1
+const Wrapper = styled('div')`
+  min-height: 48px;
+`;
 
 const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle, slug }) => {
   const homeCrumb = {
@@ -19,7 +26,9 @@ const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle,
   return (
     <>
       <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} slug={slug} />
-      <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
+      <Wrapper>
+        <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
+      </Wrapper>
     </>
   );
 };

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { uiColors } from '@leafygreen-ui/palette';
 import Loadable from '@loadable/component';
 import BreadcrumbSchema from './BreadcrumbSchema';
+import { theme } from '../theme/docsTheme';
 
 const BreadcrumbContainer = Loadable(() => import('./BreadcrumbContainer'));
 
-// Placeholder space for breadcrumbs before they load; add extra space due to negative
-// margin-top of page's h1
-const Wrapper = styled('div')`
-  min-height: 48px;
+const Wrapper = styled('nav')`
+  font-size: ${theme.fontSize.small};
+
+  * {
+    color: ${uiColors.gray.dark1};
+  }
+
+  & > p {
+    margin-top: 0;
+    min-height: ${theme.size.medium};
+  }
 `;
 
 const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle, slug }) => {
@@ -27,7 +36,9 @@ const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle,
     <>
       <BreadcrumbSchema breadcrumb={parentPaths} siteTitle={siteTitle} slug={slug} />
       <Wrapper>
-        <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
+        <p>
+          <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
+        </p>
       </Wrapper>
     </>
   );

--- a/src/components/EcosystemHomepageTiles.js
+++ b/src/components/EcosystemHomepageTiles.js
@@ -84,8 +84,8 @@ const EcosystemHomepageTiles = () => {
 
   return (
     <ul className={tileStyles.tileOuter}>
-      {tileValues.map((element, index) => (
-        <Link to={element.slug} className={tileStyles.tileAnchor}>
+      {tileValues.map((element) => (
+        <Link to={element.slug} className={tileStyles.tileAnchor} key={element.slug}>
           <Card as="li" className={tileStyles.tile}>
             {element.icon}
             {element.title}

--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -17,7 +17,7 @@ const MainColumn = ({ children, className }) => (
 
 MainColumn.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
 };
 
 export default MainColumn;

--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -17,7 +17,7 @@ const MainColumn = ({ children, className }) => (
 
 MainColumn.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.array,
+  children: PropTypes.node,
 };
 
 export default MainColumn;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -35,7 +35,7 @@ const Document = ({
   pageContext: {
     slug,
     page,
-    metadata: { parentPaths, slugToTitle: slugTitleMapping, toctreeOrder },
+    metadata: { parentPaths, slugToTitle: slugTitleMapping, title, toctreeOrder },
   },
 }) => {
   const pageOptions = page?.options;
@@ -47,7 +47,7 @@ const Document = ({
       <DocumentContainer className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <StyledMainColumn>
           <MainBody className="body">
-            <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} slugTitleMapping={slugTitleMapping} />
+            <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} siteTitle={title} slug={slug} />
             {children}
             {showPrevNext && (
               <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -9,6 +9,7 @@ import RightColumn from '../components/RightColumn';
 import Sidenav from '../components/Sidenav';
 import TabSelectors from '../components/TabSelectors';
 import { TEMPLATE_CLASSNAME } from '../constants';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getNestedValue } from '../utils/get-nested-value';
 
 const DocumentContainer = styled('div')`
@@ -38,10 +39,12 @@ const Document = ({
     metadata: { parentPaths, slugToTitle: slugTitleMapping, title, toctreeOrder },
   },
 }) => {
+  const { project } = useSiteMetadata();
   const pageOptions = page?.options;
   const showPrevNext = !(pageOptions && pageOptions.noprevnext === '');
-  const breadcrumbsPageTitle = pageOptions?.['breadcrumbs-page-title'] === '';
-  const pageTitle = breadcrumbsPageTitle ? slugTitleMapping[slug] : null;
+  const isLanding = project === 'landing';
+  const breadcrumbsPageTitle = isLanding ? slugTitleMapping[slug] : null;
+  const breadcrumbsHomeUrl = isLanding ? '/' : null;
 
   return (
     <>
@@ -50,7 +53,8 @@ const Document = ({
         <StyledMainColumn>
           <MainBody className="body">
             <Breadcrumbs
-              pageTitle={pageTitle}
+              homeUrl={breadcrumbsHomeUrl}
+              pageTitle={breadcrumbsPageTitle}
               parentPaths={getNestedValue([slug], parentPaths)}
               siteTitle={title}
               slug={slug}

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -40,6 +40,8 @@ const Document = ({
 }) => {
   const pageOptions = page?.options;
   const showPrevNext = !(pageOptions && pageOptions.noprevnext === '');
+  const breadcrumbsPageTitle = pageOptions?.['breadcrumbs-page-title'] === '';
+  const pageTitle = breadcrumbsPageTitle ? slugTitleMapping[slug] : null;
 
   return (
     <>
@@ -47,7 +49,12 @@ const Document = ({
       <DocumentContainer className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <StyledMainColumn>
           <MainBody className="body">
-            <Breadcrumbs parentPaths={getNestedValue([slug], parentPaths)} siteTitle={title} slug={slug} />
+            <Breadcrumbs
+              pageTitle={pageTitle}
+              parentPaths={getNestedValue([slug], parentPaths)}
+              siteTitle={title}
+              slug={slug}
+            />
             {children}
             {showPrevNext && (
               <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -6,8 +6,16 @@ import MainColumn from '../components/MainColumn';
 import Sidenav from '../components/Sidenav';
 import { TEMPLATE_CLASSNAME } from '../constants';
 import EcosystemHomepageStyles from '../styles/ecosystem-homepage.module.css';
+import Breadcrumbs from '../components/Breadcrumbs';
 
-const EcosystemIndex = ({ className, pageContext: { page } }) => (
+const EcosystemIndex = ({
+  className,
+  pageContext: {
+    metadata: { title, parentPaths },
+    page,
+    slug,
+  },
+}) => (
   <>
     <Sidenav page={page} />
     <div className={`${TEMPLATE_CLASSNAME} ${className}`}>
@@ -23,6 +31,7 @@ const EcosystemIndex = ({ className, pageContext: { page } }) => (
               padding-bottom: 50px;
             `}
           >
+            <Breadcrumbs parentPaths={parentPaths.slug} siteTitle={title} slug={slug} />
             <h1>Start Developing with MongoDB</h1>
             <p>Connect your application to your database with one of our official libraries.</p>
             <p>
@@ -47,7 +56,12 @@ const EcosystemIndex = ({ className, pageContext: { page } }) => (
 EcosystemIndex.propTypes = {
   className: PropTypes.string,
   pageContext: PropTypes.shape({
+    metadata: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      parentPaths: PropTypes.arrayOf(PropTypes.string),
+    }),
     page: PropTypes.object.isRequired,
+    slug: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import Breadcrumbs from '../components/Breadcrumbs';
 import EcosystemHomepageTiles from '../components/EcosystemHomepageTiles';
 import MainColumn from '../components/MainColumn';
 import Sidenav from '../components/Sidenav';
 import { TEMPLATE_CLASSNAME } from '../constants';
 import EcosystemHomepageStyles from '../styles/ecosystem-homepage.module.css';
-import Breadcrumbs from '../components/Breadcrumbs';
 
 const EcosystemIndex = ({
   className,

--- a/src/utils/stitch.js
+++ b/src/utils/stitch.js
@@ -5,7 +5,9 @@ export const getStitchClient = (appId) =>
 
 const fetchData = async (appId, funcName, argsList = []) => {
   const client = getStitchClient(appId);
-  await client.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
+  if (!client.auth.isLoggedIn) {
+    await client.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
+  }
   return await client.callFunction(funcName, argsList);
 };
 

--- a/src/utils/stitch.js
+++ b/src/utils/stitch.js
@@ -1,4 +1,18 @@
-import { Stitch } from 'mongodb-stitch-browser-sdk';
+import { Stitch, AnonymousCredential } from 'mongodb-stitch-browser-sdk';
 
 export const getStitchClient = (appId) =>
   Stitch.hasAppClient(appId) ? Stitch.getAppClient(appId) : Stitch.initializeAppClient(appId);
+
+const fetchData = async (appId, funcName, argsList = []) => {
+  const client = getStitchClient(appId);
+  await client.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
+  return await client.callFunction(funcName, argsList);
+};
+
+export const fetchBanner = async (appId) => {
+  return await fetchData(appId, 'getBanner', []);
+};
+
+export const fetchProjectParents = async (appId, database, project) => {
+  return await fetchData(appId, 'fetchProjectParents', [database, project]);
+};

--- a/tests/unit/Banner.test.js
+++ b/tests/unit/Banner.test.js
@@ -3,21 +3,13 @@ import { mount } from 'enzyme';
 import * as StitchUtil from '../../src/utils/stitch';
 import Banner from '../../src/components/Banner';
 import { HeaderContext } from '../../src/components/header-context';
+import { tick } from '../utils';
 
 const mockBannerContent = {
   altText: 'Test',
   imgPath: '/banners/test.png',
   mobileImgPath: '/banners/test-mobile.png',
   url: 'https://mongodb.com',
-};
-
-const mockClient = {
-  auth: {
-    loginWithCredential: jest.fn(() => {
-      return new Promise((resolve) => resolve());
-    }),
-  },
-  callFunction: jest.fn(() => Promise.resolve(mockBannerContent)),
 };
 
 describe('Banner component', () => {
@@ -28,15 +20,15 @@ describe('Banner component', () => {
   });
 
   it('renders with a banner image', async () => {
-    jest.spyOn(StitchUtil, 'getStitchClient').mockImplementation(() => mockClient);
+    jest.useFakeTimers();
+    jest.spyOn(StitchUtil, 'fetchBanner').mockImplementation(() => mockBannerContent);
     const setBannerContent = jest.fn();
-
     const wrapper = mount(
       <HeaderContext.Provider value={{ bannerContent: mockBannerContent, setBannerContent: setBannerContent }}>
         <Banner />
       </HeaderContext.Provider>
     );
-
+    await tick({ wrapper });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/tests/unit/BreadcrumbContainer.test.js
+++ b/tests/unit/BreadcrumbContainer.test.js
@@ -14,6 +14,11 @@ jest.mock('../../src/hooks/use-site-metadata', () => ({
 describe('BreadcrumbContainer', () => {
   jest.useFakeTimers();
 
+  const mockHomeCrumb = {
+    title: 'Docs Home',
+    url: 'https://docs.mongodb.com/',
+  };
+
   it('renders correctly with project parent', async () => {
     const mockLastCrumb = {
       title: 'MongoDB Compass',
@@ -26,7 +31,7 @@ describe('BreadcrumbContainer', () => {
       },
     ]);
 
-    const tree = mount(<BreadcrumbContainer lastCrumb={mockLastCrumb} />);
+    const tree = mount(<BreadcrumbContainer homeCrumb={mockHomeCrumb} lastCrumb={mockLastCrumb} />);
     await tick({ wrapper: tree });
     expect(tree).toMatchSnapshot();
   });
@@ -38,7 +43,7 @@ describe('BreadcrumbContainer', () => {
     };
     jest.spyOn(StitchUtil, 'fetchProjectParents').mockImplementation(() => []);
 
-    const tree = mount(<BreadcrumbContainer lastCrumb={mockLastCrumb} />);
+    const tree = mount(<BreadcrumbContainer homeCrumb={mockHomeCrumb} lastCrumb={mockLastCrumb} />);
     await tick({ wrapper: tree });
     expect(tree).toMatchSnapshot();
   });

--- a/tests/unit/BreadcrumbContainer.test.js
+++ b/tests/unit/BreadcrumbContainer.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import BreadcrumbContainer from '../../src/components/BreadcrumbContainer';
+import * as StitchUtil from '../../src/utils/stitch';
+import { tick } from '../utils';
+
+jest.mock('../../src/hooks/use-site-metadata', () => ({
+  useSiteMetadata: () => ({
+    database: 'snooty_dev',
+    project: 'test',
+  }),
+}));
+
+describe('BreadcrumbContainer', () => {
+  jest.useFakeTimers();
+
+  it('renders correctly with project parent', async () => {
+    const mockLastCrumb = {
+      title: 'MongoDB Compass',
+      url: 'documents/view',
+    };
+    jest.spyOn(StitchUtil, 'fetchProjectParents').mockImplementation(() => [
+      {
+        title: 'View & Analyze',
+        url: 'https://docs.mongodb.com/view-analyze',
+      },
+    ]);
+
+    const tree = mount(<BreadcrumbContainer lastCrumb={mockLastCrumb} />);
+    await tick({ wrapper: tree });
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly without project parent', async () => {
+    const mockLastCrumb = {
+      title: 'View & Analyze Data',
+      url: 'view-analyze',
+    };
+    jest.spyOn(StitchUtil, 'fetchProjectParents').mockImplementation(() => []);
+
+    const tree = mount(<BreadcrumbContainer lastCrumb={mockLastCrumb} />);
+    await tick({ wrapper: tree });
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/tests/unit/Breadcrumbs.test.js
+++ b/tests/unit/Breadcrumbs.test.js
@@ -4,12 +4,19 @@ import Breadcrumbs from '../../src/components/Breadcrumbs';
 
 import mockData from './data/Breadcrumbs.test.json';
 
-it('renders correctly', () => {
+it('renders correctly with siteTitle', () => {
   const tree = shallow(<Breadcrumbs parentPaths={mockData} siteTitle="MongoDB Compass" slug="documents/view" />);
   expect(tree).toMatchSnapshot();
 });
 
-it('fails gracefully', () => {
-  const tree = shallow(<Breadcrumbs parentPaths={null} siteTitle="untitled" slug="/" />);
+it('renders correctly with pageTitle', () => {
+  const tree = shallow(
+    <Breadcrumbs
+      pageTitle={'View & Analyze Data'}
+      parentPaths={[]}
+      siteTitle={'MongoDB Documentation'}
+      slug={'view-analyze'}
+    />
+  );
   expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
+.emotion-18 {
+  font-size: 14px;
+}
+
+.emotion-18 * {
+  color: #5D6C74;
+}
+
+.emotion-18 > p {
+  margin-top: 0;
+}
+
+.emotion-0:hover,
+.emotion-0:focus {
+  color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-4 {
+  cursor: default;
+}
+
+.emotion-10 {
+  color: #21313C;
+  cursor: default;
+}
+
+.emotion-12 {
+  color: #21313C;
+}
+
+.emotion-12:hover,
+.emotion-12:focus {
+  color: #21313C;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<BreadcrumbContainer
+  lastCrumb={
+    Object {
+      "title": "MongoDB Compass",
+      "url": "documents/view",
+    }
+  }
+>
+  <StyledNav>
+    <nav
+      className="emotion-18 emotion-19"
+    >
+      <p>
+        <StyledLink
+          isLast={false}
+          onClick={[Function]}
+          to="https://docs.mongodb.com/"
+        >
+          <Link
+            className="emotion-0 emotion-1"
+            onClick={[Function]}
+            to="https://docs.mongodb.com/"
+          >
+            <a
+              className="emotion-0 emotion-1"
+              href="https://docs.mongodb.com/"
+              onClick={[Function]}
+            >
+              Docs Home
+            </a>
+          </Link>
+        </StyledLink>
+        <StyledArrow
+          isLast={false}
+        >
+          <span
+            className="emotion-4 emotion-5"
+          >
+             → 
+          </span>
+        </StyledArrow>
+        <StyledLink
+          isLast={false}
+          onClick={[Function]}
+          to="https://docs.mongodb.com/view-analyze"
+        >
+          <Link
+            className="emotion-0 emotion-1"
+            onClick={[Function]}
+            to="https://docs.mongodb.com/view-analyze"
+          >
+            <a
+              className="emotion-0 emotion-1"
+              href="https://docs.mongodb.com/view-analyze"
+              onClick={[Function]}
+            >
+              View & Analyze
+            </a>
+          </Link>
+        </StyledLink>
+        <StyledArrow
+          isLast={true}
+        >
+          <span
+            className="emotion-10 emotion-5"
+          >
+             → 
+          </span>
+        </StyledArrow>
+        <StyledLink
+          isLast={true}
+          onClick={[Function]}
+          to="documents/view"
+        >
+          <Link
+            className="emotion-12 emotion-1"
+            onClick={[Function]}
+            to="documents/view"
+          >
+            <mockConstructor
+              className="emotion-12 emotion-1"
+              onClick={[Function]}
+              to="/documents/view/"
+            >
+              <a
+                className="emotion-12 emotion-1"
+                href="/documents/view/"
+                onClick={[Function]}
+              >
+                MongoDB Compass
+              </a>
+            </mockConstructor>
+          </Link>
+        </StyledLink>
+      </p>
+    </nav>
+  </StyledNav>
+</BreadcrumbContainer>
+`;
+
+exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
+.emotion-12 {
+  font-size: 14px;
+}
+
+.emotion-12 * {
+  color: #5D6C74;
+}
+
+.emotion-12 > p {
+  margin-top: 0;
+}
+
+.emotion-0:hover,
+.emotion-0:focus {
+  color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-4 {
+  color: #21313C;
+  cursor: default;
+}
+
+.emotion-6 {
+  color: #21313C;
+}
+
+.emotion-6:hover,
+.emotion-6:focus {
+  color: #21313C;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<BreadcrumbContainer
+  lastCrumb={
+    Object {
+      "title": "View & Analyze Data",
+      "url": "view-analyze",
+    }
+  }
+>
+  <StyledNav>
+    <nav
+      className="emotion-12 emotion-13"
+    >
+      <p>
+        <StyledLink
+          isLast={false}
+          onClick={[Function]}
+          to="https://docs.mongodb.com/"
+        >
+          <Link
+            className="emotion-0 emotion-1"
+            onClick={[Function]}
+            to="https://docs.mongodb.com/"
+          >
+            <a
+              className="emotion-0 emotion-1"
+              href="https://docs.mongodb.com/"
+              onClick={[Function]}
+            >
+              Docs Home
+            </a>
+          </Link>
+        </StyledLink>
+        <StyledArrow
+          isLast={true}
+        >
+          <span
+            className="emotion-4 emotion-5"
+          >
+             → 
+          </span>
+        </StyledArrow>
+        <StyledLink
+          isLast={true}
+          onClick={[Function]}
+          to="view-analyze"
+        >
+          <Link
+            className="emotion-6 emotion-1"
+            onClick={[Function]}
+            to="view-analyze"
+          >
+            <mockConstructor
+              className="emotion-6 emotion-1"
+              onClick={[Function]}
+              to="/view-analyze/"
+            >
+              <a
+                className="emotion-6 emotion-1"
+                href="/view-analyze/"
+                onClick={[Function]}
+              >
+                View & Analyze Data
+              </a>
+            </mockConstructor>
+          </Link>
+        </StyledLink>
+      </p>
+    </nav>
+  </StyledNav>
+</BreadcrumbContainer>
+`;

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -3,6 +3,7 @@
 exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 .emotion-18 {
   font-size: 14px;
+  min-height: 24px;
 }
 
 .emotion-18 * {
@@ -143,6 +144,7 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 .emotion-12 {
   font-size: 14px;
+  min-height: 24px;
 }
 
 .emotion-12 * {

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -1,22 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
-.emotion-20 {
-  font-size: 14px;
-}
-
-.emotion-20 * {
-  color: #5D6C74;
-}
-
-.emotion-20 > p {
-  margin-top: 0;
-}
-
-.emotion-18 {
-  min-height: 24px;
-}
-
 .emotion-0:last-of-type {
   color: #21313C;
 }
@@ -54,112 +38,84 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
     }
   }
 >
-  <StyledNav>
-    <nav
-      className="emotion-20 emotion-21"
+  <StyledLink
+    onClick={[Function]}
+    to="https://docs.mongodb.com/"
+  >
+    <Link
+      className="emotion-0 emotion-1"
+      onClick={[Function]}
+      to="https://docs.mongodb.com/"
     >
-      <P>
-        <p
-          className="emotion-18 emotion-19"
+      <a
+        className="emotion-0 emotion-1"
+        href="https://docs.mongodb.com/"
+        onClick={[Function]}
+      >
+        Docs Home
+      </a>
+    </Link>
+  </StyledLink>
+  <StyledArrow>
+    <span
+      className="emotion-4 emotion-5"
+    >
+       → 
+    </span>
+  </StyledArrow>
+  <StyledLink
+    onClick={[Function]}
+    to="https://docs.mongodb.com/view-analyze"
+  >
+    <Link
+      className="emotion-0 emotion-1"
+      onClick={[Function]}
+      to="https://docs.mongodb.com/view-analyze"
+    >
+      <a
+        className="emotion-0 emotion-1"
+        href="https://docs.mongodb.com/view-analyze"
+        onClick={[Function]}
+      >
+        View & Analyze
+      </a>
+    </Link>
+  </StyledLink>
+  <StyledArrow>
+    <span
+      className="emotion-4 emotion-5"
+    >
+       → 
+    </span>
+  </StyledArrow>
+  <StyledLink
+    onClick={[Function]}
+    to="documents/view"
+  >
+    <Link
+      className="emotion-0 emotion-1"
+      onClick={[Function]}
+      to="documents/view"
+    >
+      <mockConstructor
+        className="emotion-0 emotion-1"
+        onClick={[Function]}
+        to="/documents/view/"
+      >
+        <a
+          className="emotion-0 emotion-1"
+          href="/documents/view/"
+          onClick={[Function]}
         >
-          <StyledLink
-            onClick={[Function]}
-            to="https://docs.mongodb.com/"
-          >
-            <Link
-              className="emotion-0 emotion-1"
-              onClick={[Function]}
-              to="https://docs.mongodb.com/"
-            >
-              <a
-                className="emotion-0 emotion-1"
-                href="https://docs.mongodb.com/"
-                onClick={[Function]}
-              >
-                Docs Home
-              </a>
-            </Link>
-          </StyledLink>
-          <StyledArrow>
-            <span
-              className="emotion-4 emotion-5"
-            >
-               → 
-            </span>
-          </StyledArrow>
-          <StyledLink
-            onClick={[Function]}
-            to="https://docs.mongodb.com/view-analyze"
-          >
-            <Link
-              className="emotion-0 emotion-1"
-              onClick={[Function]}
-              to="https://docs.mongodb.com/view-analyze"
-            >
-              <a
-                className="emotion-0 emotion-1"
-                href="https://docs.mongodb.com/view-analyze"
-                onClick={[Function]}
-              >
-                View & Analyze
-              </a>
-            </Link>
-          </StyledLink>
-          <StyledArrow>
-            <span
-              className="emotion-4 emotion-5"
-            >
-               → 
-            </span>
-          </StyledArrow>
-          <StyledLink
-            onClick={[Function]}
-            to="documents/view"
-          >
-            <Link
-              className="emotion-0 emotion-1"
-              onClick={[Function]}
-              to="documents/view"
-            >
-              <mockConstructor
-                className="emotion-0 emotion-1"
-                onClick={[Function]}
-                to="/documents/view/"
-              >
-                <a
-                  className="emotion-0 emotion-1"
-                  href="/documents/view/"
-                  onClick={[Function]}
-                >
-                  MongoDB Compass
-                </a>
-              </mockConstructor>
-            </Link>
-          </StyledLink>
-        </p>
-      </P>
-    </nav>
-  </StyledNav>
+          MongoDB Compass
+        </a>
+      </mockConstructor>
+    </Link>
+  </StyledLink>
 </BreadcrumbContainer>
 `;
 
 exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
-.emotion-14 {
-  font-size: 14px;
-}
-
-.emotion-14 * {
-  color: #5D6C74;
-}
-
-.emotion-14 > p {
-  margin-top: 0;
-}
-
-.emotion-12 {
-  min-height: 24px;
-}
-
 .emotion-0:last-of-type {
   color: #21313C;
 }
@@ -197,66 +153,54 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
     }
   }
 >
-  <StyledNav>
-    <nav
-      className="emotion-14 emotion-15"
+  <StyledLink
+    onClick={[Function]}
+    to="https://docs.mongodb.com/"
+  >
+    <Link
+      className="emotion-0 emotion-1"
+      onClick={[Function]}
+      to="https://docs.mongodb.com/"
     >
-      <P>
-        <p
-          className="emotion-12 emotion-13"
+      <a
+        className="emotion-0 emotion-1"
+        href="https://docs.mongodb.com/"
+        onClick={[Function]}
+      >
+        Docs Home
+      </a>
+    </Link>
+  </StyledLink>
+  <StyledArrow>
+    <span
+      className="emotion-4 emotion-5"
+    >
+       → 
+    </span>
+  </StyledArrow>
+  <StyledLink
+    onClick={[Function]}
+    to="view-analyze"
+  >
+    <Link
+      className="emotion-0 emotion-1"
+      onClick={[Function]}
+      to="view-analyze"
+    >
+      <mockConstructor
+        className="emotion-0 emotion-1"
+        onClick={[Function]}
+        to="/view-analyze/"
+      >
+        <a
+          className="emotion-0 emotion-1"
+          href="/view-analyze/"
+          onClick={[Function]}
         >
-          <StyledLink
-            onClick={[Function]}
-            to="https://docs.mongodb.com/"
-          >
-            <Link
-              className="emotion-0 emotion-1"
-              onClick={[Function]}
-              to="https://docs.mongodb.com/"
-            >
-              <a
-                className="emotion-0 emotion-1"
-                href="https://docs.mongodb.com/"
-                onClick={[Function]}
-              >
-                Docs Home
-              </a>
-            </Link>
-          </StyledLink>
-          <StyledArrow>
-            <span
-              className="emotion-4 emotion-5"
-            >
-               → 
-            </span>
-          </StyledArrow>
-          <StyledLink
-            onClick={[Function]}
-            to="view-analyze"
-          >
-            <Link
-              className="emotion-0 emotion-1"
-              onClick={[Function]}
-              to="view-analyze"
-            >
-              <mockConstructor
-                className="emotion-0 emotion-1"
-                onClick={[Function]}
-                to="/view-analyze/"
-              >
-                <a
-                  className="emotion-0 emotion-1"
-                  href="/view-analyze/"
-                  onClick={[Function]}
-                >
-                  View & Analyze Data
-                </a>
-              </mockConstructor>
-            </Link>
-          </StyledLink>
-        </p>
-      </P>
-    </nav>
-  </StyledNav>
+          View & Analyze Data
+        </a>
+      </mockConstructor>
+    </Link>
+  </StyledLink>
 </BreadcrumbContainer>
 `;

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -1,17 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
-.emotion-18 {
+.emotion-20 {
   font-size: 14px;
-  min-height: 24px;
 }
 
-.emotion-18 * {
+.emotion-20 * {
   color: #5D6C74;
 }
 
-.emotion-18 > p {
+.emotion-20 > p {
   margin-top: 0;
+}
+
+.emotion-18 {
+  min-height: 24px;
 }
 
 .emotion-0:last-of-type {
@@ -53,101 +56,108 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 >
   <StyledNav>
     <nav
-      className="emotion-18 emotion-19"
+      className="emotion-20 emotion-21"
     >
-      <p>
-        <StyledLink
-          onClick={[Function]}
-          to="https://docs.mongodb.com/"
+      <P>
+        <p
+          className="emotion-18 emotion-19"
         >
-          <Link
-            className="emotion-0 emotion-1"
+          <StyledLink
             onClick={[Function]}
             to="https://docs.mongodb.com/"
           >
-            <a
-              className="emotion-0 emotion-1"
-              href="https://docs.mongodb.com/"
-              onClick={[Function]}
-            >
-              Docs Home
-            </a>
-          </Link>
-        </StyledLink>
-        <StyledArrow>
-          <span
-            className="emotion-4 emotion-5"
-          >
-             → 
-          </span>
-        </StyledArrow>
-        <StyledLink
-          onClick={[Function]}
-          to="https://docs.mongodb.com/view-analyze"
-        >
-          <Link
-            className="emotion-0 emotion-1"
-            onClick={[Function]}
-            to="https://docs.mongodb.com/view-analyze"
-          >
-            <a
-              className="emotion-0 emotion-1"
-              href="https://docs.mongodb.com/view-analyze"
-              onClick={[Function]}
-            >
-              View & Analyze
-            </a>
-          </Link>
-        </StyledLink>
-        <StyledArrow>
-          <span
-            className="emotion-4 emotion-5"
-          >
-             → 
-          </span>
-        </StyledArrow>
-        <StyledLink
-          onClick={[Function]}
-          to="documents/view"
-        >
-          <Link
-            className="emotion-0 emotion-1"
-            onClick={[Function]}
-            to="documents/view"
-          >
-            <mockConstructor
+            <Link
               className="emotion-0 emotion-1"
               onClick={[Function]}
-              to="/documents/view/"
+              to="https://docs.mongodb.com/"
             >
               <a
                 className="emotion-0 emotion-1"
-                href="/documents/view/"
+                href="https://docs.mongodb.com/"
                 onClick={[Function]}
               >
-                MongoDB Compass
+                Docs Home
               </a>
-            </mockConstructor>
-          </Link>
-        </StyledLink>
-      </p>
+            </Link>
+          </StyledLink>
+          <StyledArrow>
+            <span
+              className="emotion-4 emotion-5"
+            >
+               → 
+            </span>
+          </StyledArrow>
+          <StyledLink
+            onClick={[Function]}
+            to="https://docs.mongodb.com/view-analyze"
+          >
+            <Link
+              className="emotion-0 emotion-1"
+              onClick={[Function]}
+              to="https://docs.mongodb.com/view-analyze"
+            >
+              <a
+                className="emotion-0 emotion-1"
+                href="https://docs.mongodb.com/view-analyze"
+                onClick={[Function]}
+              >
+                View & Analyze
+              </a>
+            </Link>
+          </StyledLink>
+          <StyledArrow>
+            <span
+              className="emotion-4 emotion-5"
+            >
+               → 
+            </span>
+          </StyledArrow>
+          <StyledLink
+            onClick={[Function]}
+            to="documents/view"
+          >
+            <Link
+              className="emotion-0 emotion-1"
+              onClick={[Function]}
+              to="documents/view"
+            >
+              <mockConstructor
+                className="emotion-0 emotion-1"
+                onClick={[Function]}
+                to="/documents/view/"
+              >
+                <a
+                  className="emotion-0 emotion-1"
+                  href="/documents/view/"
+                  onClick={[Function]}
+                >
+                  MongoDB Compass
+                </a>
+              </mockConstructor>
+            </Link>
+          </StyledLink>
+        </p>
+      </P>
     </nav>
   </StyledNav>
 </BreadcrumbContainer>
 `;
 
 exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
-.emotion-12 {
+.emotion-14 {
   font-size: 14px;
-  min-height: 24px;
 }
 
-.emotion-12 * {
+.emotion-14 * {
   color: #5D6C74;
 }
 
-.emotion-12 > p {
+.emotion-14 > p {
   margin-top: 0;
+}
+
+.emotion-12 {
+  min-height: 24px;
 }
 
 .emotion-0:last-of-type {
@@ -189,59 +199,63 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 >
   <StyledNav>
     <nav
-      className="emotion-12 emotion-13"
+      className="emotion-14 emotion-15"
     >
-      <p>
-        <StyledLink
-          onClick={[Function]}
-          to="https://docs.mongodb.com/"
+      <P>
+        <p
+          className="emotion-12 emotion-13"
         >
-          <Link
-            className="emotion-0 emotion-1"
+          <StyledLink
             onClick={[Function]}
             to="https://docs.mongodb.com/"
           >
-            <a
-              className="emotion-0 emotion-1"
-              href="https://docs.mongodb.com/"
-              onClick={[Function]}
-            >
-              Docs Home
-            </a>
-          </Link>
-        </StyledLink>
-        <StyledArrow>
-          <span
-            className="emotion-4 emotion-5"
-          >
-             → 
-          </span>
-        </StyledArrow>
-        <StyledLink
-          onClick={[Function]}
-          to="view-analyze"
-        >
-          <Link
-            className="emotion-0 emotion-1"
-            onClick={[Function]}
-            to="view-analyze"
-          >
-            <mockConstructor
+            <Link
               className="emotion-0 emotion-1"
               onClick={[Function]}
-              to="/view-analyze/"
+              to="https://docs.mongodb.com/"
             >
               <a
                 className="emotion-0 emotion-1"
-                href="/view-analyze/"
+                href="https://docs.mongodb.com/"
                 onClick={[Function]}
               >
-                View & Analyze Data
+                Docs Home
               </a>
-            </mockConstructor>
-          </Link>
-        </StyledLink>
-      </p>
+            </Link>
+          </StyledLink>
+          <StyledArrow>
+            <span
+              className="emotion-4 emotion-5"
+            >
+               → 
+            </span>
+          </StyledArrow>
+          <StyledLink
+            onClick={[Function]}
+            to="view-analyze"
+          >
+            <Link
+              className="emotion-0 emotion-1"
+              onClick={[Function]}
+              to="view-analyze"
+            >
+              <mockConstructor
+                className="emotion-0 emotion-1"
+                onClick={[Function]}
+                to="/view-analyze/"
+              >
+                <a
+                  className="emotion-0 emotion-1"
+                  href="/view-analyze/"
+                  onClick={[Function]}
+                >
+                  View & Analyze Data
+                </a>
+              </mockConstructor>
+            </Link>
+          </StyledLink>
+        </p>
+      </P>
     </nav>
   </StyledNav>
 </BreadcrumbContainer>

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -14,31 +14,27 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
   margin-top: 0;
 }
 
+.emotion-0:last-of-type {
+  color: #21313C;
+}
+
 .emotion-0:hover,
 .emotion-0:focus {
-  color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:hover:not(:last-of-type),
+.emotion-0:focus:not(:last-of-type) {
+  color: #21313C;
 }
 
 .emotion-4 {
   cursor: default;
 }
 
-.emotion-10 {
+.emotion-4:last-of-type {
   color: #21313C;
-  cursor: default;
-}
-
-.emotion-12 {
-  color: #21313C;
-}
-
-.emotion-12:hover,
-.emotion-12:focus {
-  color: #21313C;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <BreadcrumbContainer
@@ -55,7 +51,6 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
     >
       <p>
         <StyledLink
-          isLast={false}
           onClick={[Function]}
           to="https://docs.mongodb.com/"
         >
@@ -73,9 +68,7 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
             </a>
           </Link>
         </StyledLink>
-        <StyledArrow
-          isLast={false}
-        >
+        <StyledArrow>
           <span
             className="emotion-4 emotion-5"
           >
@@ -83,7 +76,6 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
           </span>
         </StyledArrow>
         <StyledLink
-          isLast={false}
           onClick={[Function]}
           to="https://docs.mongodb.com/view-analyze"
         >
@@ -101,32 +93,29 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
             </a>
           </Link>
         </StyledLink>
-        <StyledArrow
-          isLast={true}
-        >
+        <StyledArrow>
           <span
-            className="emotion-10 emotion-5"
+            className="emotion-4 emotion-5"
           >
              → 
           </span>
         </StyledArrow>
         <StyledLink
-          isLast={true}
           onClick={[Function]}
           to="documents/view"
         >
           <Link
-            className="emotion-12 emotion-1"
+            className="emotion-0 emotion-1"
             onClick={[Function]}
             to="documents/view"
           >
             <mockConstructor
-              className="emotion-12 emotion-1"
+              className="emotion-0 emotion-1"
               onClick={[Function]}
               to="/documents/view/"
             >
               <a
-                className="emotion-12 emotion-1"
+                className="emotion-0 emotion-1"
                 href="/documents/view/"
                 onClick={[Function]}
               >
@@ -155,27 +144,27 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
   margin-top: 0;
 }
 
+.emotion-0:last-of-type {
+  color: #21313C;
+}
+
 .emotion-0:hover,
 .emotion-0:focus {
-  color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:hover:not(:last-of-type),
+.emotion-0:focus:not(:last-of-type) {
+  color: #21313C;
 }
 
 .emotion-4 {
-  color: #21313C;
   cursor: default;
 }
 
-.emotion-6 {
+.emotion-4:last-of-type {
   color: #21313C;
-}
-
-.emotion-6:hover,
-.emotion-6:focus {
-  color: #21313C;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <BreadcrumbContainer
@@ -192,7 +181,6 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
     >
       <p>
         <StyledLink
-          isLast={false}
           onClick={[Function]}
           to="https://docs.mongodb.com/"
         >
@@ -210,9 +198,7 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
             </a>
           </Link>
         </StyledLink>
-        <StyledArrow
-          isLast={true}
-        >
+        <StyledArrow>
           <span
             className="emotion-4 emotion-5"
           >
@@ -220,22 +206,21 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
           </span>
         </StyledArrow>
         <StyledLink
-          isLast={true}
           onClick={[Function]}
           to="view-analyze"
         >
           <Link
-            className="emotion-6 emotion-1"
+            className="emotion-0 emotion-1"
             onClick={[Function]}
             to="view-analyze"
           >
             <mockConstructor
-              className="emotion-6 emotion-1"
+              className="emotion-0 emotion-1"
               onClick={[Function]}
               to="/view-analyze/"
             >
               <a
-                className="emotion-6 emotion-1"
+                className="emotion-0 emotion-1"
                 href="/view-analyze/"
                 onClick={[Function]}
               >

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -38,6 +38,12 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 }
 
 <BreadcrumbContainer
+  homeCrumb={
+    Object {
+      "title": "Docs Home",
+      "url": "https://docs.mongodb.com/",
+    }
+  }
   lastCrumb={
     Object {
       "title": "MongoDB Compass",
@@ -168,6 +174,12 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 }
 
 <BreadcrumbContainer
+  homeCrumb={
+    Object {
+      "title": "Docs Home",
+      "url": "https://docs.mongodb.com/",
+    }
+  }
   lastCrumb={
     Object {
       "title": "View & Analyze Data",

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -7,20 +7,22 @@ exports[`renders correctly with pageTitle 1`] = `
     siteTitle="MongoDB Documentation"
     slug="view-analyze"
   />
-  <ForwardRef
-    homeCrumb={
-      Object {
-        "title": "Docs Home",
-        "url": "https://docs.mongodb.com/",
+  <Wrapper>
+    <ForwardRef
+      homeCrumb={
+        Object {
+          "title": "Docs Home",
+          "url": "https://docs.mongodb.com/",
+        }
       }
-    }
-    lastCrumb={
-      Object {
-        "title": "View & Analyze Data",
-        "url": "view-analyze",
+      lastCrumb={
+        Object {
+          "title": "View & Analyze Data",
+          "url": "view-analyze",
+        }
       }
-    }
-  />
+    />
+  </Wrapper>
 </Fragment>
 `;
 
@@ -64,19 +66,21 @@ exports[`renders correctly with siteTitle 1`] = `
     siteTitle="MongoDB Compass"
     slug="documents/view"
   />
-  <ForwardRef
-    homeCrumb={
-      Object {
-        "title": "Docs Home",
-        "url": "https://docs.mongodb.com/",
+  <Wrapper>
+    <ForwardRef
+      homeCrumb={
+        Object {
+          "title": "Docs Home",
+          "url": "https://docs.mongodb.com/",
+        }
       }
-    }
-    lastCrumb={
-      Object {
-        "title": "MongoDB Compass",
-        "url": "/",
+      lastCrumb={
+        Object {
+          "title": "MongoDB Compass",
+          "url": "/",
+        }
       }
-    }
-  />
+    />
+  </Wrapper>
 </Fragment>
 `;

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -8,20 +8,22 @@ exports[`renders correctly with pageTitle 1`] = `
     slug="view-analyze"
   />
   <Wrapper>
-    <ForwardRef
-      homeCrumb={
-        Object {
-          "title": "Docs Home",
-          "url": "https://docs.mongodb.com/",
+    <p>
+      <ForwardRef
+        homeCrumb={
+          Object {
+            "title": "Docs Home",
+            "url": "https://docs.mongodb.com/",
+          }
         }
-      }
-      lastCrumb={
-        Object {
-          "title": "View & Analyze Data",
-          "url": "view-analyze",
+        lastCrumb={
+          Object {
+            "title": "View & Analyze Data",
+            "url": "view-analyze",
+          }
         }
-      }
-    />
+      />
+    </p>
   </Wrapper>
 </Fragment>
 `;
@@ -67,20 +69,22 @@ exports[`renders correctly with siteTitle 1`] = `
     slug="documents/view"
   />
   <Wrapper>
-    <ForwardRef
-      homeCrumb={
-        Object {
-          "title": "Docs Home",
-          "url": "https://docs.mongodb.com/",
+    <p>
+      <ForwardRef
+        homeCrumb={
+          Object {
+            "title": "Docs Home",
+            "url": "https://docs.mongodb.com/",
+          }
         }
-      }
-      lastCrumb={
-        Object {
-          "title": "MongoDB Compass",
-          "url": "/",
+        lastCrumb={
+          Object {
+            "title": "MongoDB Compass",
+            "url": "/",
+          }
         }
-      }
-    />
+      />
+    </p>
   </Wrapper>
 </Fragment>
 `;

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -1,16 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fails gracefully 1`] = `
+exports[`renders correctly with pageTitle 1`] = `
 <Fragment>
   <BreadcrumbSchema
-    breadcrumb={null}
-    siteTitle="untitled"
-    slug="/"
+    breadcrumb={Array []}
+    siteTitle="MongoDB Documentation"
+    slug="view-analyze"
+  />
+  <ForwardRef
+    lastCrumb={
+      Object {
+        "title": "View & Analyze Data",
+        "url": "view-analyze",
+      }
+    }
   />
 </Fragment>
 `;
 
-exports[`renders correctly 1`] = `
+exports[`renders correctly with siteTitle 1`] = `
 <Fragment>
   <BreadcrumbSchema
     breadcrumb={
@@ -50,48 +58,13 @@ exports[`renders correctly 1`] = `
     siteTitle="MongoDB Compass"
     slug="documents/view"
   />
-  <BreadcrumbContainer>
-    <p>
-      <Link
-        onClick={[Function]}
-        to="manage-data"
-      >
-        <ComponentFactory
-          key="0"
-          nodeData={
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 2,
-                },
-              },
-              "type": "text",
-              "value": "Interact with Your Data",
-            }
-          }
-        />
-      </Link>
-       &gt; 
-      <Link
-        onClick={[Function]}
-        to="documents"
-      >
-        <ComponentFactory
-          key="0"
-          nodeData={
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "Manage Documents",
-            }
-          }
-        />
-      </Link>
-    </p>
-  </BreadcrumbContainer>
+  <ForwardRef
+    lastCrumb={
+      Object {
+        "title": "MongoDB Compass",
+        "url": "/",
+      }
+    }
+  />
 </Fragment>
 `;

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -8,6 +8,12 @@ exports[`renders correctly with pageTitle 1`] = `
     slug="view-analyze"
   />
   <ForwardRef
+    homeCrumb={
+      Object {
+        "title": "Docs Home",
+        "url": "https://docs.mongodb.com/",
+      }
+    }
     lastCrumb={
       Object {
         "title": "View & Analyze Data",
@@ -59,6 +65,12 @@ exports[`renders correctly with siteTitle 1`] = `
     slug="documents/view"
   />
   <ForwardRef
+    homeCrumb={
+      Object {
+        "title": "Docs Home",
+        "url": "https://docs.mongodb.com/",
+      }
+    }
     lastCrumb={
       Object {
         "title": "MongoDB Compass",


### PR DESCRIPTION
### Stories/Links:

DOP-1841

### Staging Links:

[Drivers Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/drivers/raymundrodriguez/DOP-1841/)
[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/raymundrodriguez/DOP-1841/)
[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/docs-nav/landing/raymundrodriguez/DOP-1841/view-analyze/)

### Notes:
* Separated `BreadcrumbContainer` into its own component so `BreadcrumbSchema` is added to page source.
* Created Realm function `fetchProjectParents` to return the parents of a given project.
* Re-added some code to `Document.js` that were removed during one of the merges from `master` to `docs-nav`.