### PR TITLE
DOP-2113: Render extra-compact cards

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -69,7 +69,16 @@ import RoleKbd from './Roles/Kbd';
 import RoleRed from './Roles/Red';
 import RoleRequired from './Roles/Required';
 
-const IGNORED_NAMES = new Set(['default-domain', 'raw', 'toctree', 'tabs-pillstrip', 'tabs-selector', 'contents']);
+const IGNORED_NAMES = new Set([
+  'default-domain',
+  'raw',
+  'toctree',
+  'tabs-pillstrip',
+  'tabs-selector',
+  'contents',
+  'ia',
+  'entry',
+]);
 const IGNORED_TYPES = new Set(['comment', 'substitution_definition', 'inline_target', 'named_reference']);
 const DEPRECATED_ADMONITIONS = new Set(['admonition', 'topic', 'caution', 'danger']);
 

--- a/src/components/landing/Card.js
+++ b/src/components/landing/Card.js
@@ -15,7 +15,6 @@ const StyledCard = styled(LeafyGreenCard)`
   padding: ${({ theme }) => `${theme.size.large}`};
 
   p:last-of-type {
-    margin-top: auto;
     margin-bottom: 0;
   }
 `;
@@ -30,8 +29,9 @@ const H4 = styled('h4')`
     compact ? `0 0 ${theme.size.small}` : `${theme.size.medium} 0 ${theme.size.small} 0`};
 `;
 
-const CTA = styled(Link)`
+const CTA = styled('p')`
   font-weight: bold;
+  margin-top: auto;
 `;
 
 const FlexTag = styled(Tag)`
@@ -77,9 +77,9 @@ const Card = ({
           <ComponentFactory nodeData={child} key={i} />
         ))}
         {cta && (
-          <p>
-            <CTA to={url}>{cta}</CTA>
-          </p>
+          <CTA>
+            <Link to={url}>{cta}</Link>
+          </CTA>
         )}
       </ConditionalWrapper>
     </Card>

--- a/src/components/landing/Card.js
+++ b/src/components/landing/Card.js
@@ -4,6 +4,7 @@ import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import LeafyGreenCard from '@leafygreen-ui/card';
 import ComponentFactory from '../ComponentFactory';
+import ConditionalWrapper from '../ConditionalWrapper';
 import Link from '../Link';
 import Tag from '../Tag';
 
@@ -12,6 +13,11 @@ const StyledCard = styled(LeafyGreenCard)`
   flex-direction: column;
   height: 100%;
   padding: ${({ theme }) => `${theme.size.large}`};
+
+  p:last-of-type {
+    margin-top: auto;
+    margin-bottom: 0;
+  }
 `;
 
 const CardIcon = styled('img')`
@@ -20,39 +26,63 @@ const CardIcon = styled('img')`
 
 const H4 = styled('h4')`
   letter-spacing: 0.5px;
-  margin: ${({ theme }) => `${theme.size.medium} 0 ${theme.size.small} 0`};
+  margin: ${({ isExtraCompact, theme }) =>
+    isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.medium} 0 ${theme.size.small} 0`};
 `;
 
 const CTA = styled(Link)`
   font-weight: bold;
-  margin-top: auto;
-  margin-bottom: 0;
 `;
 
 const FlexTag = styled(Tag)`
   margin-right: auto;
 `;
 
+const CompactCard = styled(StyledCard)`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+`;
+
+const CompactWrapper = styled('div')`
+  margin-left: ${({ theme }) => theme.size.default};
+`;
+
 const Card = ({
+  isCompact,
+  isExtraCompact,
+  nodeData,
   nodeData: {
     children,
     options: { cta, headline, icon, 'icon-alt': iconAlt, tag, url },
   },
-}) => (
-  <StyledCard
-    onClick={() => {
-      window.location.href = url;
-    }}
-  >
-    {icon && <CardIcon src={withPrefix(icon)} alt={iconAlt} />}
-    {tag && <FlexTag text={tag} />}
-    <H4>{headline}</H4>
-    {children.map((child, i) => (
-      <ComponentFactory nodeData={child} key={i} />
-    ))}
-    <CTA to={url}>{cta}</CTA>
-  </StyledCard>
-);
+}) => {
+  const Card = isCompact || isExtraCompact ? CompactCard : StyledCard;
+  return (
+    <Card
+      onClick={() => {
+        window.location.href = url;
+      }}
+    >
+      {icon && <CardIcon src={withPrefix(icon)} alt={iconAlt} />}
+      <ConditionalWrapper
+        condition={isCompact || isExtraCompact}
+        wrapper={(children) => <CompactWrapper>{children}</CompactWrapper>}
+      >
+        {tag && <FlexTag text={tag} />}
+        <H4 isExtraCompact={isExtraCompact}>{headline}</H4>
+        {children.map((child, i) => (
+          <ComponentFactory nodeData={child} key={i} />
+        ))}
+        {cta && (
+          <p>
+            <CTA to={url}>{cta}</CTA>
+          </p>
+        )}
+      </ConditionalWrapper>
+    </Card>
+  );
+};
 
 Card.propTypes = {
   nodeData: PropTypes.shape({

--- a/src/components/landing/Card.js
+++ b/src/components/landing/Card.js
@@ -26,8 +26,8 @@ const CardIcon = styled('img')`
 
 const H4 = styled('h4')`
   letter-spacing: 0.5px;
-  margin: ${({ isExtraCompact, theme }) =>
-    isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.medium} 0 ${theme.size.small} 0`};
+  margin: ${({ compact, theme }) =>
+    compact ? `0 0 ${theme.size.small}` : `${theme.size.medium} 0 ${theme.size.small} 0`};
 `;
 
 const CTA = styled(Link)`
@@ -45,13 +45,15 @@ const CompactCard = styled(StyledCard)`
 `;
 
 const CompactWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   margin-left: ${({ theme }) => theme.size.default};
 `;
 
 const Card = ({
   isCompact,
   isExtraCompact,
-  nodeData,
   nodeData: {
     children,
     options: { cta, headline, icon, 'icon-alt': iconAlt, tag, url },
@@ -70,7 +72,7 @@ const Card = ({
         wrapper={(children) => <CompactWrapper>{children}</CompactWrapper>}
       >
         {tag && <FlexTag text={tag} />}
-        <H4 isExtraCompact={isExtraCompact}>{headline}</H4>
+        <H4 compact={isCompact || isExtraCompact}>{headline}</H4>
         {children.map((child, i) => (
           <ComponentFactory nodeData={child} key={i} />
         ))}

--- a/src/components/landing/CardGroup.js
+++ b/src/components/landing/CardGroup.js
@@ -1,9 +1,27 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import ComponentFactory from '../ComponentFactory';
 
 const getColumnValue = (props) => props.columns || React.Children.count(props.children);
+
+const carouselStyling = ({ children, theme }) => css`
+  grid-gap: calc(${theme.size.medium} * 0.75);
+  grid-template-columns:
+    calc(${theme.size.medium} / 2) repeat(${React.Children.count(children)}, calc(75% - calc(2 * ${theme.size.medium})))
+    calc(${theme.size.medium} / 2);
+  grid-template-rows: minmax(150px, 1fr);
+  margin: ${theme.size.medium} 0;
+  overflow-x: scroll;
+  padding-bottom: calc(${theme.size.medium} / 2);
+  scroll-snap-type: x proximity;
+
+  &:before,
+  &:after {
+    content: '';
+  }
+`;
 
 const StyledGrid = styled('div')`
   align-items: stretch;
@@ -19,37 +37,28 @@ const StyledGrid = styled('div')`
   }
 
   @media ${({ theme }) => theme.screenSize.upToMedium} {
-    grid-gap: ${({ theme }) => `calc(${theme.size.medium} * 0.75)`};
-    grid-template-columns: ${({ children, theme }) =>
-      `calc(${theme.size.medium} / 2) repeat(${React.Children.count(children)}, calc(75% - calc( 2 * ${
-        theme.size.medium
-      }))) calc(${theme.size.medium} / 2)`};
-    grid-template-rows: minmax(150px, 1fr);
-    margin: ${({ theme }) => theme.size.medium} 0;
-    overflow-x: scroll;
-    padding-bottom: ${({ theme }) => `calc(${theme.size.medium} / 2)`};
-    scroll-snap-type: x proximity;
-
-    &:before,
-    &:after {
-      content: '';
-    }
+    ${({ isCarousel, ...props }) => (isCarousel ? carouselStyling(props) : 'grid-template-columns: repeat(1, 1fr);')}
   }
 `;
 
 const CardGroup = ({
   nodeData: {
     children,
-    options: { columns },
+    options: { columns, style },
   },
   ...rest
-}) => (
-  <StyledGrid columns={columns} noMargin={true}>
-    {children.map((child) => (
-      <ComponentFactory nodeData={child} {...rest} />
-    ))}
-  </StyledGrid>
-);
+}) => {
+  const isCompact = style === 'compact';
+  const isExtraCompact = style === 'extra-compact';
+  const isCarousel = !(isCompact || isExtraCompact);
+  return (
+    <StyledGrid columns={columns} noMargin={true} isCarousel={isCarousel}>
+      {children.map((child, i) => (
+        <ComponentFactory {...rest} key={i} nodeData={child} isCompact={isCompact} isExtraCompact={isExtraCompact} />
+      ))}
+    </StyledGrid>
+  );
+};
 
 CardGroup.propTypes = {
   nodeData: PropTypes.shape({


### PR DESCRIPTION
### Stories/Links:

DOP-2113

### Staging Links:

- https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-2113/
- https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-2113/develop-applications/
- https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-2113/view-analyze/
- https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-2113/launch-manage/
- [docs-landing content branch](https://github.com/sophstad/docs-landing/tree/nav)

### Notes:

- Render new `extra-compact` cards that appear on docs-landing pages
- Stack (rather than carousel) these cards on mobile
- This branch has been opened against `master` rather than `docs-nav` so that it can be easily merged into PLP. Since we don't currently have any `extra-compact` cards in use, landing page render will continue to look as expected.