### PR TITLE
DOP-2105: Use allowDeselect prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@leafygreen-ui/leafygreen-provider": "^2.0.2",
         "@leafygreen-ui/modal": "^6.0.2",
         "@leafygreen-ui/palette": "^3.1.1",
-        "@leafygreen-ui/select": "^2.0.4",
+        "@leafygreen-ui/select": "^2.1.0",
         "@leafygreen-ui/table": "^1.4.0",
         "@leafygreen-ui/tabs": "^5.1.1",
         "@leafygreen-ui/text-input": "^5.0.11",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@leafygreen-ui/select": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-2.0.4.tgz",
-      "integrity": "sha512-9ZeRWoFRFG4D6xZoh8iWl7qpPM9yxBzeyO8+tvfjzp8nDUYrSHnm09qmyTlT0Eumj/lbv7rIizwiRCEZufIhaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-sTlmqbGcXtfyd6P/YPHIp9gIkLoou9H8GOvItHDAaGL1hFBFrxqJqj2P/xr/jSWtv7SeZAa9u18ototWSprQSQ==",
       "dependencies": {
         "@leafygreen-ui/button": "^11.0.2",
         "@leafygreen-ui/emotion": "^3.0.1",
@@ -31131,9 +31131,9 @@
       }
     },
     "@leafygreen-ui/select": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-2.0.4.tgz",
-      "integrity": "sha512-9ZeRWoFRFG4D6xZoh8iWl7qpPM9yxBzeyO8+tvfjzp8nDUYrSHnm09qmyTlT0Eumj/lbv7rIizwiRCEZufIhaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-2.1.0.tgz",
+      "integrity": "sha512-sTlmqbGcXtfyd6P/YPHIp9gIkLoou9H8GOvItHDAaGL1hFBFrxqJqj2P/xr/jSWtv7SeZAa9u18ototWSprQSQ==",
       "requires": {
         "@leafygreen-ui/button": "^11.0.2",
         "@leafygreen-ui/emotion": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@leafygreen-ui/leafygreen-provider": "^2.0.2",
     "@leafygreen-ui/modal": "^6.0.2",
     "@leafygreen-ui/palette": "^3.1.1",
-    "@leafygreen-ui/select": "^2.0.4",
+    "@leafygreen-ui/select": "^2.1.0",
     "@leafygreen-ui/table": "^1.4.0",
     "@leafygreen-ui/tabs": "^5.1.1",
     "@leafygreen-ui/text-input": "^5.0.11",

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,5 +1,4 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { css } from '@emotion/core';
 import Link from './Link';
 import VersionDropdown from './VersionDropdown';
 import TableOfContents from './TableOfContents';
@@ -20,15 +19,7 @@ const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => 
     <aside className={`sidebar ${style.sidebar}`} id="sidebar">
       <div className={`sphinxsidebar ${style.sphinxsidebar}`} id="sphinxsidebar">
         <div id="sphinxsidebarwrapper" className="sphinxsidebarwrapper">
-          <div
-            ref={fixedHeading}
-            css={css`
-              /* Ensure that version dropdown appears above TOC */
-              /* TODO: May be deletable when LG SideNav is in use */
-              position: relative;
-              z-index: 10;
-            `}
-          >
+          <div ref={fixedHeading}>
             <span className="closeNav" id="closeNav" onClick={toggleLeftColumn} style={{ cursor: 'pointer' }}>
               Close ×
             </span>

--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -21,15 +21,13 @@ const StyledSelect = styled(Select)`
   span {
     font-size: 16px;
   }
-
-  /* Remove "null" selection from dropdown */
-  ul > li:first-of-type {
-    display: none;
-  }
 `;
 
 const OptionLink = styled('a')`
-  &:hover {
+  color: unset;
+
+  :hover {
+    color: unset;
     text-decoration: none;
   }
 `;
@@ -92,11 +90,11 @@ const VersionDropdown = ({
 
   return (
     <StyledSelect
+      allowDeselect={false}
       aria-labelledby="View a different version of documentation."
       onChange={navigate}
       placeholder={null}
       size={Size.Large}
-      usePortal={false}
       value={parserBranch}
     >
       {Object.entries(gitNamedMapping).map(([branch, name]) => {


### PR DESCRIPTION
### Stories/Links:

DOP-2105 (updates #384)

### Staging Links:

- [BI Connector v2.14](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-2105-update/)
- [BI Connector v2.13](https://docs-mongodbcom-staging.corp.mongodb.com/v2.13/bi-connector/sophstad/DOP-2105-update/)

### Notes:

- [@leafygreen-ui/select@2.1.0](https://github.com/mongodb/leafygreen-ui/releases/tag/%40leafygreen-ui/select%402.1.0) adds support for `allowDeselect`, so we no longer have to hide this option ourselves 💯 