### PR TITLE
DOP-2115: Add Additional Links to SideNav

### DIFF
--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
 import { uiColors } from '@leafygreen-ui/palette';
-import { SideNav as LeafygreenSideNav } from '@leafygreen-ui/side-nav';
-import Link from './Link';
+import { SideNav as LeafygreenSideNav, SideNavItem } from '@leafygreen-ui/side-nav';
 import ProductsList from './ProductsList';
-import { theme } from '../theme/docsTheme';
 
 const StyledLeafygreenSideNav = styled(LeafygreenSideNav)`
   grid-area: sidebar;
@@ -19,33 +17,17 @@ const StyledLeafygreenSideNav = styled(LeafygreenSideNav)`
   }
 `;
 
-const AdditionalLink = styled(Link)`
-  align-items: center;
-  display: flex;
-  letter-spacing: 0;
-  margin-bottom: ${theme.size.default};
-  padding: 0 ${theme.size.medium};
-`;
-
-const AdditionalLinksContainer = styled('div')`
-  margin-top: ${theme.size.large};
-`;
-
-const LinkTitle = styled('span')`
-  color: ${uiColors.gray.dark3};
-  line-height: 20px;
-  padding-left: ${theme.size.default};
-`;
-
 // Allows AdditionalLinks to always be at the bottom of the SideNav
 const Spaceholder = styled('div')`
   flex-grow: 1;
 `;
 
-const StyledIcon = styled(Icon)`
-  color: ${uiColors.black};
-  height: ${theme.size.default};
-  width: ${theme.size.default};
+const StyledSideNavItem = styled(SideNavItem)`
+  letter-spacing: 0;
+
+  :hover {
+    color: ${uiColors.gray.dark2};
+  }
 `;
 
 const additionalLinks = [
@@ -61,16 +43,11 @@ const Sidenav = ({ page }) => {
     <StyledLeafygreenSideNav aria-label="Side navigation">
       {showAllProducts && <ProductsList />}
       <Spaceholder />
-      <AdditionalLinksContainer>
-        {additionalLinks.map(({ glyph, title, url }) => {
-          return (
-            <AdditionalLink to={url} key={title}>
-              <StyledIcon glyph={glyph} />
-              <LinkTitle>{title}</LinkTitle>
-            </AdditionalLink>
-          );
-        })}
-      </AdditionalLinksContainer>
+      {additionalLinks.map(({ glyph, title, url }) => (
+        <StyledSideNavItem glyph={<Icon glyph={glyph} />} href={url}>
+          {title}
+        </StyledSideNavItem>
+      ))}
     </StyledLeafygreenSideNav>
   );
 };

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
-import { uiColors } from '@leafygreen-ui/palette';
 import { SideNav as LeafygreenSideNav, SideNavItem } from '@leafygreen-ui/side-nav';
 import ProductsList from './ProductsList';
 
@@ -25,8 +24,9 @@ const Spaceholder = styled('div')`
 const StyledSideNavItem = styled(SideNavItem)`
   letter-spacing: 0;
 
+  // TODO: Remove when mongodb-docs.css is removed
   :hover {
-    color: ${uiColors.gray.dark2};
+    color: unset;
   }
 `;
 

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -1,13 +1,58 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
 import { SideNav as LeafygreenSideNav } from '@leafygreen-ui/side-nav';
+import Link from './Link';
 import ProductsList from './ProductsList';
+import { theme } from '../theme/docsTheme';
 
 const StyledLeafygreenSideNav = styled(LeafygreenSideNav)`
   grid-area: sidebar;
   z-index: 1;
+
+  // Allows Spaceholder element to flex grow for AdditionalLinks
+  & > div > nav > div > ul {
+    display: flex;
+    flex-direction: column;
+  }
 `;
+
+const AdditionalLink = styled(Link)`
+  align-items: center;
+  display: flex;
+  letter-spacing: 0;
+  margin-bottom: ${theme.size.default};
+  padding: 0 ${theme.size.medium};
+`;
+
+const AdditionalLinksContainer = styled('div')`
+  margin-top: ${theme.size.large};
+`;
+
+const LinkTitle = styled('span')`
+  color: ${uiColors.gray.dark3};
+  line-height: 20px;
+  padding-left: ${theme.size.default};
+`;
+
+// Allows AdditionalLinks to always be at the bottom of the SideNav
+const Spaceholder = styled('div')`
+  flex-grow: 1;
+`;
+
+const StyledIcon = styled(Icon)`
+  color: ${uiColors.black};
+  height: ${theme.size.default};
+  width: ${theme.size.default};
+`;
+
+const additionalLinks = [
+  { glyph: 'Support', title: 'Contact Support', url: 'https://support.mongodb.com/welcome' },
+  { glyph: 'Person', title: 'Join our community', url: 'https://developer.mongodb.com/' },
+  { glyph: 'University', title: 'Register for Courses', url: 'https://university.mongodb.com/' },
+];
 
 const Sidenav = ({ page }) => {
   const showAllProducts = page?.options?.['nav-show-all-products'];
@@ -15,6 +60,17 @@ const Sidenav = ({ page }) => {
   return (
     <StyledLeafygreenSideNav aria-label="Side navigation">
       {showAllProducts && <ProductsList />}
+      <Spaceholder />
+      <AdditionalLinksContainer>
+        {additionalLinks.map(({ glyph, title, url }) => {
+          return (
+            <AdditionalLink to={url} key={title}>
+              <StyledIcon glyph={glyph} />
+              <LinkTitle>{title}</LinkTitle>
+            </AdditionalLink>
+          );
+        })}
+      </AdditionalLinksContainer>
     </StyledLeafygreenSideNav>
   );
 };


### PR DESCRIPTION
### Stories/Links:

DOP-2115

### Staging Links:

[Landing Staging](https://docs-mongodborg-staging.corp.mongodb.com/docs-nav/landing/raymundrodriguez/DOP-2115/
)

### Notes:
* Added additional links to the bottom of the new SideNav.
* I set one of the elements of LG SideNav to be a flex item so that we can have a child flex grow. Open to any better alternatives so that we don't have to modify the css of the SideNav!