### PR TITLE
DOP-1840: Add Sidebar back link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
         "react-loadable": "^5.5.0",
+        "realm-web": "^1.2.1",
         "redoc": "^2.0.0-rc.48",
         "sanitize-html": "^2.2.0",
         "styled-components": "^5.2.1"
@@ -4290,6 +4291,18 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -9942,6 +9955,15 @@
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.22.tgz",
       "integrity": "sha512-Fnk9E2p4rkZ3eJGBn2HDeZoBTpyjPxj8RX/whdr4Pm5622xYgYo1k48SUD649Xlo6nnoKRr2WwcUlneil/AZ8g=="
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -17023,6 +17045,11 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -22431,6 +22458,36 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/realm-web": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/realm-web/-/realm-web-1.2.1.tgz",
+      "integrity": "sha512-bKMiaRhXGY/QXZqffnUNH0EYyFhkviPGVUVuu8RuPB3HJN3DqjlwqmUZghqqw67YH0gWXj1Fgt4JQkY+MIjrdg==",
+      "dependencies": {
+        "bson": "^4.2.0",
+        "detect-browser": "^5.1.1",
+        "js-base64": "^2.6.3"
+      },
+      "optionalDependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node_modules/realm-web/node_modules/bson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/realm-web/node_modules/detect-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.1",
@@ -32434,6 +32491,15 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -37243,6 +37309,12 @@
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.22.tgz",
       "integrity": "sha512-Fnk9E2p4rkZ3eJGBn2HDeZoBTpyjPxj8RX/whdr4Pm5622xYgYo1k48SUD649Xlo6nnoKRr2WwcUlneil/AZ8g=="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -43020,6 +43092,11 @@
         }
       }
     },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -47560,6 +47637,33 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        }
+      }
+    },
+    "realm-web": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/realm-web/-/realm-web-1.2.1.tgz",
+      "integrity": "sha512-bKMiaRhXGY/QXZqffnUNH0EYyFhkviPGVUVuu8RuPB3HJN3DqjlwqmUZghqqw67YH0gWXj1Fgt4JQkY+MIjrdg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "bson": "^4.2.0",
+        "detect-browser": "^5.1.1",
+        "js-base64": "^2.6.3",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+          "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "detect-browser": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+          "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
     "react-loadable": "^5.5.0",
+    "realm-web": "^1.2.1",
     "redoc": "^2.0.0-rc.48",
     "sanitize-html": "^2.2.0",
     "styled-components": "^5.2.1"

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { HeaderContext } from './header-context';
 import { SNOOTY_STITCH_ID } from '../build-constants';
 import { theme } from '../theme/docsTheme';
+import { isBrowser } from '../utils/is-browser';
 import { normalizePath } from '../utils/normalize-path';
 import { fetchBanner } from '../utils/realm';
 
@@ -42,7 +43,9 @@ const Banner = () => {
         console.error(err);
       }
     };
-    fetchBannerContent();
+    if (isBrowser) {
+      fetchBannerContent();
+    }
   }, [setBannerContent]);
 
   if (bannerContent == null) {

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -4,7 +4,7 @@ import { HeaderContext } from './header-context';
 import { SNOOTY_STITCH_ID } from '../build-constants';
 import { theme } from '../theme/docsTheme';
 import { normalizePath } from '../utils/normalize-path';
-import { fetchBanner } from '../utils/stitch';
+import { fetchBanner } from '../utils/realm';
 
 const getBannerSource = (src) => {
   if (src == null || src === '') return null;
@@ -36,7 +36,11 @@ const Banner = () => {
 
   useEffect(() => {
     const fetchBannerContent = async () => {
-      setBannerContent(await fetchBanner(SNOOTY_STITCH_ID));
+      try {
+        setBannerContent(await fetchBanner());
+      } catch (err) {
+        console.error(err);
+      }
     };
     fetchBannerContent();
   }, [setBannerContent]);

--- a/src/components/BreadcrumbContainer.js
+++ b/src/components/BreadcrumbContainer.js
@@ -1,14 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import { css } from '@emotion/core';
 import Link from './Link';
-import { SNOOTY_STITCH_ID } from '../build-constants';
-import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { NavigationContext } from './navigation-context';
 import { formatText } from '../utils/format-text';
 import { reportAnalytics } from '../utils/report-analytics';
-import { fetchProjectParents } from '../utils/stitch';
 
 const activeColor = css`
   color: ${uiColors.gray.dark3};
@@ -38,17 +36,8 @@ const StyledLink = styled(Link)`
 `;
 
 const BreadcrumbContainer = ({ homeCrumb, lastCrumb }) => {
-  const { database, project } = useSiteMetadata();
-  const [breadcrumbs, setBreadcrumbs] = useState([]);
-
-  useEffect(() => {
-    const fetchBreadcrumbData = async () => {
-      let parentCrumbs = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
-      const breadcrumbs = [homeCrumb, ...parentCrumbs, lastCrumb];
-      setBreadcrumbs(breadcrumbs);
-    };
-    fetchBreadcrumbData();
-  }, [database, homeCrumb, lastCrumb, project]);
+  const { parents } = useContext(NavigationContext);
+  const breadcrumbs = React.useMemo(() => [homeCrumb, ...parents, lastCrumb], [homeCrumb, parents, lastCrumb]);
 
   return (
     <>

--- a/src/components/BreadcrumbSchema.js
+++ b/src/components/BreadcrumbSchema.js
@@ -48,7 +48,7 @@ BreadcrumbSchema.propTypes = {
       path: PropTypes.string,
       plaintext: PropTypes.string,
     })
-  ).isRequired,
+  ),
   siteTitle: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
 };

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -2,11 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
-import Loadable from '@loadable/component';
 import BreadcrumbSchema from './BreadcrumbSchema';
 import { theme } from '../theme/docsTheme';
-
-const BreadcrumbContainer = Loadable(() => import('./BreadcrumbContainer'));
+import BreadcrumbContainer from './BreadcrumbContainer';
 
 const Wrapper = styled('nav')`
   font-size: ${theme.fontSize.small};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import Loadable from '@loadable/component';
+import Banner from './Banner';
 import Navbar from './Navbar';
-
-// Prevents Stitch functions in Banner from erroring when starting local development
-const Banner = Loadable(() => import('./Banner'));
 
 const StyledHeaderContainer = styled.header`
   grid-area: header;

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import loadable from '@loadable/component';
+import PropTypes from 'prop-types';
+import { HeaderContextProvider } from './header-context';
+import { ContentsProvider } from './contents-context';
+import { SidebarContextProvider } from './sidebar-context';
+import { TabProvider } from './tab-context';
+
+const NavigationProvider = loadable(() => import('./navigation-context'), {
+  resolveComponent: (components) => components.NavigationProvider,
+});
+
+const RootProvider = ({ children, headingNodes, isSidebarEnabled, selectors, siteTitle }) => (
+  <TabProvider selectors={selectors}>
+    <ContentsProvider headingNodes={headingNodes}>
+      <HeaderContextProvider>
+        <NavigationProvider siteTitle={siteTitle}>
+          <SidebarContextProvider isSidebarEnabled={isSidebarEnabled}>{children}</SidebarContextProvider>
+        </NavigationProvider>
+      </HeaderContextProvider>
+    </ContentsProvider>
+  </TabProvider>
+);
+
+RootProvider.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  headingNodes: PropTypes.arrayOf(PropTypes.object),
+  isSidebarEnabled: PropTypes.bool,
+  selectors: PropTypes.object,
+  siteTitle: PropTypes.string,
+};
+
+export default RootProvider;

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -1,14 +1,10 @@
 import React from 'react';
-import loadable from '@loadable/component';
 import PropTypes from 'prop-types';
-import { HeaderContextProvider } from './header-context';
 import { ContentsProvider } from './contents-context';
+import { HeaderContextProvider } from './header-context';
+import { NavigationProvider } from './navigation-context';
 import { SidebarContextProvider } from './sidebar-context';
 import { TabProvider } from './tab-context';
-
-const NavigationProvider = loadable(() => import('./navigation-context'), {
-  resolveComponent: (components) => components.NavigationProvider,
-});
 
 const RootProvider = ({ children, headingNodes, isSidebarEnabled, selectors, siteTitle }) => (
   <TabProvider selectors={selectors}>

--- a/src/components/SidebarBack.js
+++ b/src/components/SidebarBack.js
@@ -1,27 +1,44 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import Icon from '@leafygreen-ui/icon';
-import { SideNavItem } from '@leafygreen-ui/side-nav';
 import ComponentFactory from './ComponentFactory';
 import { NavigationContext } from './navigation-context';
 
-const SidebarBack = () => {
+const SidebarBack = ({ Wrapper }) => {
+  const Placeholder = () => (
+    <Wrapper
+      as="div"
+      css={css`
+        cursor: unset;
+        :hover {
+          background-color: unset;
+        }
+      `}
+    />
+  );
+
   const { parents } = useContext(NavigationContext);
 
   if (parents.length === 0) {
-    return <SideNavItem />;
+    return <Placeholder />;
   }
 
   const [{ title, url }] = parents.slice(-1);
   if (!title || title.length === 0 || !url) {
-    return <SideNavItem />;
+    return <Placeholder />;
   }
 
   const titleNodes = title.map((child, i) => <ComponentFactory key={i} nodeData={child} />);
   return (
-    <SideNavItem as="a" href={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
+    <Wrapper as="a" href={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
       Back to {titleNodes}
-    </SideNavItem>
+    </Wrapper>
   );
+};
+
+SidebarBack.propTypes = {
+  Wrapper: PropTypes.elementType,
 };
 
 export default SidebarBack;

--- a/src/components/SidebarBack.js
+++ b/src/components/SidebarBack.js
@@ -2,10 +2,15 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import Icon from '@leafygreen-ui/icon';
-import ComponentFactory from './ComponentFactory';
+import Link from './Link';
 import { NavigationContext } from './navigation-context';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { formatText } from '../utils/format-text';
 
-const SidebarBack = ({ Wrapper }) => {
+const SidebarBack = ({ slug, Wrapper }) => {
+  const { parents } = useContext(NavigationContext);
+  const { project } = useSiteMetadata();
+
   const Placeholder = () => (
     <Wrapper
       as="div"
@@ -18,21 +23,25 @@ const SidebarBack = ({ Wrapper }) => {
     />
   );
 
-  const { parents } = useContext(NavigationContext);
+  let title = null,
+    url = null;
 
-  if (!parents.length) {
+  if (project === 'landing' && slug !== '/') {
+    title = 'home';
+    url = '/';
+  } else if (parents.length) {
+    [{ title, url }] = parents.slice(-1);
+  } else {
     return <Placeholder />;
   }
 
-  const [{ title, url }] = parents.slice(-1);
   if (!title || !title.length || !url) {
     return <Placeholder />;
   }
 
-  const titleNodes = title.map((child, i) => <ComponentFactory key={i} nodeData={child} />);
   return (
-    <Wrapper as="a" href={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
-      Back to {titleNodes}
+    <Wrapper as={Link} to={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
+      Back to {formatText(title)}
     </Wrapper>
   );
 };

--- a/src/components/SidebarBack.js
+++ b/src/components/SidebarBack.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import Icon from '@leafygreen-ui/icon';
+import { SideNavItem } from '@leafygreen-ui/side-nav';
+import ComponentFactory from './ComponentFactory';
+import { NavigationContext } from './navigation-context';
+
+const SidebarBack = () => {
+  const { parents } = useContext(NavigationContext);
+
+  if (parents.length === 0) {
+    return <SideNavItem />;
+  }
+
+  const [{ title, url }] = parents.slice(-1);
+  if (!title || title.length === 0 || !url) {
+    return <SideNavItem />;
+  }
+
+  const titleNodes = title.map((child, i) => <ComponentFactory key={i} nodeData={child} />);
+  return (
+    <SideNavItem as="a" href={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
+      Back to {titleNodes}
+    </SideNavItem>
+  );
+};
+
+export default SidebarBack;

--- a/src/components/SidebarBack.js
+++ b/src/components/SidebarBack.js
@@ -20,12 +20,12 @@ const SidebarBack = ({ Wrapper }) => {
 
   const { parents } = useContext(NavigationContext);
 
-  if (parents.length === 0) {
+  if (!parents.length) {
     return <Placeholder />;
   }
 
   const [{ title, url }] = parents.slice(-1);
-  if (!title || title.length === 0 || !url) {
+  if (!title || !title.length || !url) {
     return <Placeholder />;
   }
 

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -43,12 +43,12 @@ const Sidenav = ({ page }) => {
   return (
     <StyledLeafygreenSideNav aria-label="Side navigation">
       <SideNavGroup>
-        <SidebarBack />
+        <SidebarBack Wrapper={StyledSideNavItem} />
       </SideNavGroup>
       {showAllProducts && <ProductsList />}
       <Spaceholder />
       {additionalLinks.map(({ glyph, title, url }) => (
-        <StyledSideNavItem glyph={<Icon glyph={glyph} />} href={url}>
+        <StyledSideNavItem key={url} glyph={<Icon glyph={glyph} />} href={url}>
           {title}
         </StyledSideNavItem>
       ))}

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { SideNav as LeafygreenSideNav } from '@leafygreen-ui/side-nav';
+import { SideNav as LeafygreenSideNav, SideNavGroup } from '@leafygreen-ui/side-nav';
 import ProductsList from './ProductsList';
+import SidebarBack from './SidebarBack';
 
 const StyledLeafygreenSideNav = styled(LeafygreenSideNav)`
   grid-area: sidebar;
@@ -14,6 +15,9 @@ const Sidenav = ({ page }) => {
 
   return (
     <StyledLeafygreenSideNav aria-label="Side navigation">
+      <SideNavGroup>
+        <SidebarBack />
+      </SideNavGroup>
       {showAllProducts && <ProductsList />}
     </StyledLeafygreenSideNav>
   );

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
-import { SideNav as LeafygreenSideNav, SideNavGroup, SideNavItem } from '@leafygreen-ui/side-nav';
+import { SideNav as LeafygreenSideNav, SideNavItem } from '@leafygreen-ui/side-nav';
 import ProductsList from './ProductsList';
 import SidebarBack from './SidebarBack';
 
@@ -37,14 +37,12 @@ const additionalLinks = [
   { glyph: 'University', title: 'Register for Courses', url: 'https://university.mongodb.com/' },
 ];
 
-const Sidenav = ({ page }) => {
+const Sidenav = ({ page, slug }) => {
   const showAllProducts = page?.options?.['nav-show-all-products'];
 
   return (
     <StyledLeafygreenSideNav aria-label="Side navigation">
-      <SideNavGroup>
-        <SidebarBack Wrapper={StyledSideNavItem} />
-      </SideNavGroup>
+      <SidebarBack slug={slug} Wrapper={StyledSideNavItem} />
       {showAllProducts && <ProductsList />}
       <Spaceholder />
       {additionalLinks.map(({ glyph, title, url }) => (
@@ -60,6 +58,7 @@ Sidenav.propTypes = {
   page: PropTypes.shape({
     options: PropTypes.object,
   }).isRequired,
+  slug: PropTypes.string.isRequired,
 };
 
 export default Sidenav;

--- a/src/components/navigation-context.js
+++ b/src/components/navigation-context.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { isBrowser } from '../utils/is-browser';
 import { fetchProjectParents } from '../utils/realm';
 
 const NavigationContext = React.createContext(null);
@@ -17,7 +18,9 @@ const NavigationProvider = ({ children }) => {
         console.error(err);
       }
     };
-    fetchBreadcrumbData();
+    if (isBrowser) {
+      fetchBreadcrumbData();
+    }
   }, [database, project]);
 
   return <NavigationContext.Provider value={{ parents }}>{children}</NavigationContext.Provider>;

--- a/src/components/navigation-context.js
+++ b/src/components/navigation-context.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import { SNOOTY_STITCH_ID } from '../build-constants';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { fetchProjectParents } from '../utils/stitch';
+
+const NavigationContext = React.createContext(null);
+
+const NavigationProvider = ({ children }) => {
+  const { database, project } = useSiteMetadata();
+  const [parents, setParents] = useState([]);
+
+  useEffect(() => {
+    const fetchBreadcrumbData = async () => {
+      const parents = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
+      setParents(parents);
+    };
+    fetchBreadcrumbData();
+  }, [database, project]);
+
+  return <NavigationContext.Provider value={{ parents }}>{children}</NavigationContext.Provider>;
+};
+
+export { NavigationContext, NavigationProvider };

--- a/src/components/navigation-context.js
+++ b/src/components/navigation-context.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { SNOOTY_STITCH_ID } from '../build-constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { fetchProjectParents } from '../utils/stitch';
+import { fetchProjectParents } from '../utils/realm';
 
 const NavigationContext = React.createContext(null);
 
@@ -11,8 +10,12 @@ const NavigationProvider = ({ children }) => {
 
   useEffect(() => {
     const fetchBreadcrumbData = async () => {
-      const parents = await fetchProjectParents(SNOOTY_STITCH_ID, database, project);
-      setParents(parents);
+      try {
+        const parents = await fetchProjectParents(database, project);
+        setParents(parents);
+      } catch (err) {
+        console.error(err);
+      }
     };
     fetchBreadcrumbData();
   }, [database, project]);

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { HeaderContextProvider } from '../components/header-context';
-import { ContentsProvider } from '../components/contents-context';
 import Header from '../components/Header';
 import SiteMetadata from '../components/site-metadata';
-import { SidebarContextProvider } from '../components/sidebar-context';
-import { TabProvider } from '../components/tab-context';
+import RootProvider from '../components/RootProvider';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
@@ -79,27 +76,26 @@ const DefaultLayout = (props) => {
     <>
       <Global styles={globalCSS} />
       <SiteMetadata siteTitle={title} />
-      <TabProvider selectors={page?.options?.selectors}>
-        <ContentsProvider headingNodes={page?.options?.headings}>
-          <HeaderContextProvider>
-            <GlobalGrid>
-              <SidebarContextProvider isSidebarEnabled={isSidebarEnabled}>
-                <Header />
-                <Template
-                  css={css`
-                    grid-area: contents;
-                    margin: 0px;
-                    overflow-y: auto;
-                  `}
-                  {...props}
-                >
-                  {template === 'landing' ? [children] : children}
-                </Template>
-              </SidebarContextProvider>
-            </GlobalGrid>
-          </HeaderContextProvider>
-        </ContentsProvider>
-      </TabProvider>
+      <RootProvider
+        headingNodes={page?.options?.headings}
+        isSidebarEnabled={isSidebarEnabled}
+        selectors={page?.options?.selectors}
+        siteTitle={title}
+      >
+        <GlobalGrid>
+          <Header />
+          <Template
+            css={css`
+              grid-area: contents;
+              margin: 0px;
+              overflow-y: auto;
+            `}
+            {...props}
+          >
+            {template === 'landing' ? [children] : children}
+          </Template>
+        </GlobalGrid>
+      </RootProvider>
     </>
   );
 };

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -48,7 +48,7 @@ const Document = ({
 
   return (
     <>
-      <Sidenav page={page} />
+      <Sidenav page={page} slug={slug} />
       <DocumentContainer className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <StyledMainColumn>
           <MainBody className="body">

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -17,7 +17,7 @@ const EcosystemIndex = ({
   },
 }) => (
   <>
-    <Sidenav page={page} />
+    <Sidenav page={page} slug={slug} />
     <div className={`${TEMPLATE_CLASSNAME} ${className}`}>
       <MainColumn className={EcosystemHomepageStyles.fullWidth}>
         <div

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -29,7 +29,7 @@ const Wrapper = styled('main')`
   }
 `;
 
-const Landing = ({ children, className, pageContext: { page } }) => {
+const Landing = ({ children, className, pageContext: { slug, page } }) => {
   const { fontSize, screenSize, size } = useTheme();
   return (
     <>
@@ -54,7 +54,7 @@ const Landing = ({ children, className, pageContext: { page } }) => {
           })}
         </script>
       </Helmet>
-      <Sidenav page={page} />
+      <Sidenav page={page} slug={slug} />
       <div className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <Wrapper>{children}</Wrapper>
       </div>

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -1,0 +1,32 @@
+import * as Realm from 'realm-web';
+import { SNOOTY_STITCH_ID } from '../build-constants';
+
+const config = {
+  id: SNOOTY_STITCH_ID,
+};
+const app = new Realm.App(config);
+
+const loginAnonymous = async () => {
+  const credentials = Realm.Credentials.anonymous();
+  try {
+    const user = await app.logIn(credentials);
+    return user;
+  } catch (err) {
+    console.error('Failed to log in', err);
+  }
+};
+
+const fetchData = async (funcName, ...argsList) => {
+  if (!app.currentUser) {
+    await loginAnonymous();
+  }
+  return await app.currentUser.callFunction(funcName, ...argsList);
+};
+
+export const fetchBanner = async () => {
+  return await fetchData('getBanner');
+};
+
+export const fetchProjectParents = async (database, project) => {
+  return await fetchData('fetchProjectParents', database, project);
+};

--- a/src/utils/stitch.js
+++ b/src/utils/stitch.js
@@ -2,19 +2,3 @@ import { Stitch, AnonymousCredential } from 'mongodb-stitch-browser-sdk';
 
 export const getStitchClient = (appId) =>
   Stitch.hasAppClient(appId) ? Stitch.getAppClient(appId) : Stitch.initializeAppClient(appId);
-
-const fetchData = async (appId, funcName, argsList = []) => {
-  const client = getStitchClient(appId);
-  if (!client.auth.isLoggedIn) {
-    await client.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
-  }
-  return await client.callFunction(funcName, argsList);
-};
-
-export const fetchBanner = async (appId) => {
-  return await fetchData(appId, 'getBanner', []);
-};
-
-export const fetchProjectParents = async (appId, database, project) => {
-  return await fetchData(appId, 'fetchProjectParents', [database, project]);
-};

--- a/src/utils/stitch.js
+++ b/src/utils/stitch.js
@@ -1,4 +1,4 @@
-import { Stitch, AnonymousCredential } from 'mongodb-stitch-browser-sdk';
+import { Stitch } from 'mongodb-stitch-browser-sdk';
 
 export const getStitchClient = (appId) =>
   Stitch.hasAppClient(appId) ? Stitch.getAppClient(appId) : Stitch.initializeAppClient(appId);

--- a/tests/unit/Banner.test.js
+++ b/tests/unit/Banner.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import * as StitchUtil from '../../src/utils/stitch';
+import * as RealmUtil from '../../src/utils/realm';
 import Banner from '../../src/components/Banner';
 import { HeaderContext } from '../../src/components/header-context';
 import { tick } from '../utils';
@@ -21,7 +21,7 @@ describe('Banner component', () => {
 
   it('renders with a banner image', async () => {
     jest.useFakeTimers();
-    jest.spyOn(StitchUtil, 'fetchBanner').mockImplementation(() => mockBannerContent);
+    jest.spyOn(RealmUtil, 'fetchBanner').mockImplementation(() => mockBannerContent);
     const setBannerContent = jest.fn();
     const wrapper = mount(
       <HeaderContext.Provider value={{ bannerContent: mockBannerContent, setBannerContent: setBannerContent }}>

--- a/tests/unit/BreadcrumbContainer.test.js
+++ b/tests/unit/BreadcrumbContainer.test.js
@@ -1,50 +1,45 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import BreadcrumbContainer from '../../src/components/BreadcrumbContainer';
-import * as StitchUtil from '../../src/utils/stitch';
-import { tick } from '../utils';
+import { NavigationContext } from '../../src/components/navigation-context';
 
-jest.mock('../../src/hooks/use-site-metadata', () => ({
-  useSiteMetadata: () => ({
-    database: 'snooty_dev',
-    project: 'test',
-  }),
-}));
+const mountBreadcrumbContainer = (homeCrumb, lastCrumb, parents) =>
+  mount(
+    <NavigationContext.Provider value={{ parents }}>
+      <BreadcrumbContainer homeCrumb={homeCrumb} lastCrumb={lastCrumb} />
+    </NavigationContext.Provider>
+  );
 
 describe('BreadcrumbContainer', () => {
-  jest.useFakeTimers();
-
   const mockHomeCrumb = {
     title: 'Docs Home',
     url: 'https://docs.mongodb.com/',
   };
 
-  it('renders correctly with project parent', async () => {
+  it('renders correctly with project parent', () => {
     const mockLastCrumb = {
       title: 'MongoDB Compass',
       url: 'documents/view',
     };
-    jest.spyOn(StitchUtil, 'fetchProjectParents').mockImplementation(() => [
+
+    const mockParents = [
       {
         title: 'View & Analyze',
         url: 'https://docs.mongodb.com/view-analyze',
       },
-    ]);
+    ];
 
-    const tree = mount(<BreadcrumbContainer homeCrumb={mockHomeCrumb} lastCrumb={mockLastCrumb} />);
-    await tick({ wrapper: tree });
+    const tree = mountBreadcrumbContainer(mockHomeCrumb, mockLastCrumb, mockParents);
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly without project parent', async () => {
+  it('renders correctly without project parent', () => {
     const mockLastCrumb = {
       title: 'View & Analyze Data',
       url: 'view-analyze',
     };
-    jest.spyOn(StitchUtil, 'fetchProjectParents').mockImplementation(() => []);
 
-    const tree = mount(<BreadcrumbContainer homeCrumb={mockHomeCrumb} lastCrumb={mockLastCrumb} />);
-    await tick({ wrapper: tree });
+    const tree = mountBreadcrumbContainer(mockHomeCrumb, mockLastCrumb, []);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders correctly with pageTitle 1`] = `
   />
   <Wrapper>
     <p>
-      <ForwardRef
+      <BreadcrumbContainer
         homeCrumb={
           Object {
             "title": "Docs Home",
@@ -70,7 +70,7 @@ exports[`renders correctly with siteTitle 1`] = `
   />
   <Wrapper>
     <p>
-      <ForwardRef
+      <BreadcrumbContainer
         homeCrumb={
           Object {
             "title": "Docs Home",


### PR DESCRIPTION
### Stories/Links:

DOP-1840

### Staging Links:

- [BI Connector](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/sophstad/DOP-1840/)
- [Landing](https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-1840/)

### Notes:

- Use `realm-web` rather than `mongodb-stitch-browser-core` because the latter package was exhibiting some bugs when used with `@loadable/component`. Switching over was easy enough!
- Lift Realm `fetchProjectParents` call into context so that results are accessible to breadcrumbs and sidenav
- Move all providers into one component for the sake of tidiness