### PR TITLE
DOP-2095: Add Sidebar component into PLP

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -59,7 +59,7 @@ const landingTabStyling = css`
     display: block;
   }
 
-  @media ${theme.screenSize.upToMedium} {
+  @media ${theme.screenSize.upToLarge} {
     display: block;
   }
 `;

--- a/src/components/landing/Procedure.js
+++ b/src/components/landing/Procedure.js
@@ -7,7 +7,7 @@ import { theme } from '../../theme/docsTheme';
 const StyledProcedure = styled('div')`
   max-width: 500px;
   padding-left: ${theme.size.large};
-  @media ${theme.screenSize.upToMedium} {
+  @media ${theme.screenSize.upToLarge} {
     padding-bottom: ${theme.size.large};
   }
   @media ${theme.screenSize.upToSmall} {

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
+import { isBrowser } from '../utils/is-browser.js';
 import { theme } from '../theme/docsTheme.js';
+import Sidebar from '../components/Sidebar';
+import style from '../styles/navigation.module.css';
+import useScreenSize from '../hooks/useScreenSize.js';
 
 const Wrapper = styled('main')`
   color: ${uiColors.black};
@@ -65,7 +69,7 @@ const Wrapper = styled('main')`
         grid-column: 1;
       }
 
-      & > .right-column {
+      & > img {
         grid-column: 2;
         grid-row: 1 / span 2;
       }
@@ -78,11 +82,51 @@ const Wrapper = styled('main')`
   }
 `;
 
-const ProductLanding = ({ children }) => (
-  <Wrapper id="main-column" className="main-column">
-    {children}
-  </Wrapper>
-);
+const ProductLanding = ({
+  children,
+  pageContext: {
+    slug,
+    metadata: { publishedBranches, toctree },
+  },
+}) => {
+  const { isTabletOrMobile } = useScreenSize();
+  const [showLeftColumn, setShowLeftColumn] = useState(!isTabletOrMobile);
+  /* Add the postRender CSS class without disturbing pre-render functionality */
+  const renderStatus = isBrowser ? style.postRender : '';
+
+  const toggleLeftColumn = () => {
+    setShowLeftColumn(!showLeftColumn);
+  };
+
+  useEffect(() => {
+    setShowLeftColumn(!isTabletOrMobile);
+  }, [isTabletOrMobile]);
+
+  return (
+    <div className="content">
+      <div>
+        {(!isBrowser || showLeftColumn) && (
+          <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
+            <Sidebar
+              slug={slug}
+              publishedBranches={publishedBranches}
+              toctreeData={toctree}
+              toggleLeftColumn={toggleLeftColumn}
+            />
+          </div>
+        )}
+      </div>
+      <>
+        {(!isBrowser || !showLeftColumn) && (
+          <div className={`showNav ${style.showNav} ${renderStatus}`} id="showNav" onClick={toggleLeftColumn}>
+            Navigation
+          </div>
+        )}
+        <Wrapper>{children}</Wrapper>
+      </>
+    </div>
+  );
+};
 
 ProductLanding.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -12,6 +12,8 @@ const Wrapper = styled('main')`
   color: ${uiColors.black};
   margin: calc(${theme.navbar.height} + ${theme.size.large}) auto ${theme.size.xlarge} auto;
   max-width: 1200px;
+  width: 100%;
+  overflow-x: scroll;
   padding: 0 ${theme.size.large};
 
   h1,
@@ -60,7 +62,7 @@ const Wrapper = styled('main')`
     }
 
     ${'' /* Split the content into two columns on large screens. */}
-    @media ${theme.screenSize.mediumAndUp} {
+    @media ${theme.screenSize.largeAndUp} {
       display: grid;
       grid-template-columns: 1fr 1fr;
 
@@ -104,18 +106,16 @@ const ProductLanding = ({
 
   return (
     <div className="content">
-      <div>
-        {(!isBrowser || showLeftColumn) && (
-          <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
-            <Sidebar
-              slug={slug}
-              publishedBranches={publishedBranches}
-              toctreeData={toctree}
-              toggleLeftColumn={toggleLeftColumn}
-            />
-          </div>
-        )}
-      </div>
+      {(!isBrowser || showLeftColumn) && (
+        <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
+          <Sidebar
+            slug={slug}
+            publishedBranches={publishedBranches}
+            toctreeData={toctree}
+            toggleLeftColumn={toggleLeftColumn}
+          />
+        </div>
+      )}
       <>
         {(!isBrowser || !showLeftColumn) && (
           <div className={`showNav ${style.showNav} ${renderStatus}`} id="showNav" onClick={toggleLeftColumn}>

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -141,6 +141,10 @@ const ProductLanding = ({
 
 ProductLanding.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  pageContext: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    toctree: PropTypes.object,
+  }).isRequired,
 };
 
 export default ProductLanding;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -14,7 +14,11 @@ const Wrapper = styled('main')`
   max-width: 1200px;
   width: 100%;
   overflow-x: scroll;
-  padding: 0 ${theme.size.large};
+  padding: 0 ${theme.size.large} 0 ${theme.size.xlarge};
+
+  @media ${theme.screenSize.upToMedium} {
+    padding: 0 ${theme.size.medium} 0 48px;
+  }
 
   h1,
   h2,
@@ -59,6 +63,13 @@ const Wrapper = styled('main')`
   & > section {
     h1 {
       align-self: end;
+    }
+
+    & > img {
+      display: block;
+      margin: auto;
+      max-width: 600px;
+      width: 100%;
     }
 
     ${'' /* Split the content into two columns on large screens. */}


### PR DESCRIPTION
### Stories/Links:

[DOP-2095](https://jira.mongodb.org/browse/DOP-2095)

### Staging Links:

[Docs-compass](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/DOP-2095/)

### Notes:

There were some interesting design questions arising from the 2-column / 1-column layout boundary. Should the layout switch to 2 columns at **medium** (`max-width: 767px`), **large** (`max-width: 1023px`), or somewhere in-between at **medium-large** (`max-width: 895px`)?

(@allisonmui9: the current layout boundary options are [here](https://github.com/mongodb/snooty/blob/master/src/theme/docsTheme.js#L47-L58). "Medium-large" would need to be added.)

Currently, I have opted to have the layout change to 2 columns at  **large** (`max-width: 1023px`). The downside is that the hero image becomes very massive on slightly-under-large screens (e.g. `1020px`) with a collapsed Sidebar. I opted to constrain the `max-width` of the hero image to `600px`. Here's what that looks like:

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/58707794/117080144-43487680-ad0b-11eb-990b-8a320afce282.png">

Note the copious amounts of whitespace. For comparison, if we constrain the hero image to `800px`:

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/58707794/117080810-97a02600-ad0c-11eb-8c78-bbd57bfa303d.png">

Versus if we don't constrain the `max-width` of the hero image at all:

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/58707794/117080761-7e977500-ad0c-11eb-82b6-8b70f8b08cb8.png">

#### Changing the layout boundary:

If the boundary was reverted to **medium**, and if we expand the sidebar, we get the following result on slightly-under-medium screens (e.g. `770px`):

<img width="829" alt="image" src="https://user-images.githubusercontent.com/58707794/117080307-90c4e380-ad0b-11eb-8088-c097d9cec500.png">

Since the above is so gross, I opted to move the layout boundary to **large** (`max-width: 1023px`). 

Two questions result:

1. Would it be desirable to create a **medium-large** layout boundary at `~895px` (splitting the difference between **medium** and **large**)?
2. If I leave the layout boundary at **large**, what `max-width` should I constrain the hero image to?
