### PR TITLE
DOP-2135: Update homepage layout

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -19,9 +19,9 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const isPageTitle = sectionDepth === 1;
   const { isMobile, isTabletOrMobile } = useScreenSize();
   const hidefeedbackheader = page?.options?.hidefeedback === 'header';
-  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile && !hidefeedbackheader;
   const { selectors } = useContext(TabContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
+  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile && (hasSelectors || !hidefeedbackheader);
 
   return (
     <ConditionalWrapper

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -12,13 +12,14 @@ import Contents from './Contents';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
-const Heading = ({ sectionDepth, nodeData, ...rest }) => {
+const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const id = nodeData.id || '';
   const HeadingTag = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
 
   const isPageTitle = sectionDepth === 1;
   const { isMobile, isTabletOrMobile } = useScreenSize();
-  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile;
+  const hidefeedbackheader = page?.options?.hidefeedback === 'header';
+  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile && !hidefeedbackheader;
   const { selectors } = useContext(TabContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
 
@@ -39,7 +40,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
     >
       <HeadingTag className="contains-headerlink" id={id}>
         {nodeData.children.map((element, index) => {
-          return <ComponentFactory {...rest} nodeData={element} key={index} />;
+          return <ComponentFactory {...rest} nodeData={element} page={page} key={index} />;
         })}
         <a className="headerlink" href={`#${id}`} title="Permalink to this headline">
           ¶

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -76,6 +76,7 @@ Heading.propTypes = {
     ).isRequired,
     id: PropTypes.string.isRequired,
   }).isRequired,
+  page: PropTypes.object,
 };
 
 export default Heading;

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -64,6 +64,8 @@ const SearchResultsContainer = styled('div')`
   display: grid;
   grid-template-areas: 'header filter-header' 'results filters';
   grid-template-columns: auto ${FILTER_COLUMN_WIDTH};
+  margin: ${theme.size.large} auto ${theme.size.xlarge} auto;
+  max-width: 1150px;
   row-gap: ${theme.size.large};
   width: 100%;
   @media ${theme.screenSize.upToLarge} {

--- a/src/components/landing/CardGroup.js
+++ b/src/components/landing/CardGroup.js
@@ -52,7 +52,7 @@ const CardGroup = ({
   const isExtraCompact = style === 'extra-compact';
   const isCarousel = !(isCompact || isExtraCompact);
   return (
-    <StyledGrid columns={columns} noMargin={true} isCarousel={isCarousel}>
+    <StyledGrid className="card-group" columns={columns} noMargin={true} isCarousel={isCarousel}>
       {children.map((child, i) => (
         <ComponentFactory {...rest} key={i} nodeData={child} isCompact={isCompact} isExtraCompact={isExtraCompact} />
       ))}

--- a/src/components/landing/CardGroup.js
+++ b/src/components/landing/CardGroup.js
@@ -65,6 +65,7 @@ CardGroup.propTypes = {
     children: PropTypes.arrayOf(PropTypes.object),
     options: PropTypes.shape({
       columns: PropTypes.number,
+      style: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/src/components/landing/Introduction.js
+++ b/src/components/landing/Introduction.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import ComponentFactory from '../ComponentFactory';
 
 const Introduction = ({ nodeData: { children }, ...rest }) => (
-  <>
+  <div className="introduction">
     {children.map((child, i) => (
       <ComponentFactory nodeData={child} key={i} {...rest} />
     ))}
-  </>
+  </div>
 );
 
 Introduction.propTypes = {

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -12,49 +12,30 @@ const Wrapper = styled('main')`
   margin: 0 auto;
   max-width: 1440px;
 
-  & > section {
+  & > section,
+  & > section > section {
     display: grid;
+    grid-column: 1 / -1;
 
     @media ${({ theme }) => theme.screenSize.mediumAndUp} {
-      grid-template-columns: minmax(0, 64px) repeat(12, 1fr) minmax(0, 64px);
+      grid-template-columns: ${({ theme }) => theme.size.xlarge} repeat(12, 1fr) ${({ theme }) => theme.size.xlarge};
     }
 
     @media ${({ theme }) => theme.screenSize.upToMedium} {
-      grid-template-columns: minmax(48px, 1fr) repeat(12, 1fr) minmax(48px, 1fr);
+      grid-template-columns: 48px repeat(12, 1fr) 48px;
     }
 
     @media ${({ theme }) => theme.screenSize.upToSmall} {
-      grid-template-columns: 32px repeat(12, 1fr) 32px;
+      grid-template-columns: ${({ theme }) => theme.size.large} 1fr ${({ theme }) => theme.size.large};
     }
 
-    @media only screen and (max-width: 320px) {
-      grid-template-columns: repeat(14, 1fr);
+    @media ${({ theme }) => theme.screenSize.upToXSmall} {
+      grid-template-columns: ${({ theme }) => theme.size.medium} 1fr ${({ theme }) => theme.size.medium};
     }
 
-    // Select card group
-    & > :nth-child(4) {
+    & > .card-group {
       @media ${({ theme }) => theme.screenSize.mediumAndUp} {
         grid-column: 2 / -2 !important;
-      }
-    }
-  }
-
-  & > section > section {
-    display: grid;
-    grid-template-columns: repeat(12, [col-span] 1fr);
-    grid-column: 2 / -2;
-
-    @media ${({ theme }) => theme.screenSize.upToMedium} {
-      // grid-template-columns: ${({ theme }) => `${theme.size.medium} 1fr ${theme.size.medium}`};
-      grid-template-columns: 1fr;
-    }
-
-    & > * {
-      grid-column-start: 1;
-      grid-column-end: 7;
-
-      @media ${({ theme }) => theme.screenSize.upToMedium} {
-        grid-column: 1/-1;
       }
     }
   }
@@ -134,8 +115,16 @@ const Landing = ({ children, className, pageContext: { slug, page } }) => {
             }
           }
           .span-columns {
-            grid-column: 1 / 12 !important;
+            grid-column: 3 / -3 !important;
             margin: ${size.xlarge} 0;
+          }
+          section > * {
+            grid-column-start: 2;
+            grid-column-end: 8;
+
+            @media ${screenSize.upToMedium} {
+              grid-column: 2 / -2;
+            }
           }
           .hero-img {
             grid-column: 1 / -1;

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -9,22 +9,53 @@ import Sidenav from '../components/Sidenav';
 import { TEMPLATE_CLASSNAME } from '../constants';
 
 const Wrapper = styled('main')`
-  margin: ${({ theme }) => `${theme.size.large} auto ${theme.size.xlarge} auto`};
-  max-width: 1150px;
-  padding: 0 ${({ theme }) => `${theme.size.medium}`};
-  @media ${({ theme }) => theme.screenSize.upToLarge} {
-    max-width: 748px;
+  margin: 0 auto;
+  max-width: 1440px;
+
+  & > section {
+    display: grid;
+
+    @media ${({ theme }) => theme.screenSize.mediumAndUp} {
+      grid-template-columns: minmax(0, 64px) repeat(12, 1fr) minmax(0, 64px);
+    }
+
+    @media ${({ theme }) => theme.screenSize.upToMedium} {
+      grid-template-columns: minmax(48px, 1fr) repeat(12, 1fr) minmax(48px, 1fr);
+    }
+
+    @media ${({ theme }) => theme.screenSize.upToSmall} {
+      grid-template-columns: 32px repeat(12, 1fr) 32px;
+    }
+
+    @media only screen and (max-width: 320px) {
+      grid-template-columns: repeat(14, 1fr);
+    }
+
+    // Select card group
+    & > :nth-child(4) {
+      @media ${({ theme }) => theme.screenSize.mediumAndUp} {
+        grid-column: 2 / -2 !important;
+      }
+    }
   }
-  @media ${({ theme }) => theme.screenSize.upToMedium} {
-    padding: 0;
-  }
-  & > section,
+
   & > section > section {
     display: grid;
     grid-template-columns: repeat(12, [col-span] 1fr);
-    grid-column: 1/-1;
+    grid-column: 2 / -2;
+
     @media ${({ theme }) => theme.screenSize.upToMedium} {
-      grid-template-columns: ${({ theme }) => `${theme.size.medium} 1fr ${theme.size.medium}`};
+      // grid-template-columns: ${({ theme }) => `${theme.size.medium} 1fr ${theme.size.medium}`};
+      grid-template-columns: 1fr;
+    }
+
+    & > * {
+      grid-column-start: 1;
+      grid-column-end: 7;
+
+      @media ${({ theme }) => theme.screenSize.upToMedium} {
+        grid-column: 1/-1;
+      }
     }
   }
 `;
@@ -91,16 +122,53 @@ const Landing = ({ children, className, pageContext: { slug, page } }) => {
           }
           h1 {
             align-self: end;
+            grid-column: 2 / 8;
+            grid-row: 1 / 2;
+
+            @media ${screenSize.upToMedium} {
+              grid-column: 2 / 11;
+            }
+
+            @media ${screenSize.upToSmall} {
+              grid-column: 2 / -2;
+            }
           }
           .span-columns {
-            grid-column: 2 / 11 !important;
+            grid-column: 1 / 12 !important;
             margin: ${size.xlarge} 0;
           }
-          section > * {
-            grid-column-start: 1;
-            grid-column-end: 7;
+          .hero-img {
+            grid-column: 1 / -1;
+            grid-row: 1 / 3;
+            height: 309px;
+            max-width: 100%;
+            object-fit: cover;
+            z-index: -1;
+
             @media ${screenSize.upToMedium} {
-              grid-column: 2/-2;
+              object-position: 35%;
+            }
+
+            @media ${screenSize.upToSmall} {
+              grid-row: unset;
+              height: 200px;
+              object-position: 85%;
+            }
+
+            @media only screen and (max-width: 320px) {
+              object-position: 100%;
+            }
+          }
+          .introduction {
+            grid-column: 2 / 8;
+            grid-row: 2 / 3;
+
+            @media ${screenSize.upToMedium} {
+              grid-column: 2 / 11;
+            }
+
+            @media ${screenSize.upToSmall} {
+              grid-column: 2 / -2;
             }
           }
           @media ${screenSize.upToLarge} {

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -36,8 +36,8 @@ const size = {
  * @type {Object.<string, string>}
  */
 const screenSize = {
-  upToXSmall: 'only screen and (max-width: 374px)',
-  xSmallAndUp: 'not all and (max-width: 374px)',
+  upToXSmall: 'only screen and (max-width: 320px)',
+  xSmallAndUp: 'not all and (max-width: 320px)',
   upToSmall: 'only screen and (max-width: 420px)',
   smallAndUp: 'not all and (max-width: 420px)',
   upToMedium: 'only screen and (max-width: 767px)',


### PR DESCRIPTION
### Stories/Links:

DOP-2135
[docs-landing branch](https://github.com/rayangler/docs-landing/tree/docs-nav)

### Staging Links:

[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/docs-nav/landing/raymundrodriguez/DOP-2135/)

### Notes:
* Added 2 new columns to `landing` template to allow for hero image to expand.
* Added classes to certain components such as `Introduction` and `CardGroup` to allow for landing-specific css.
* Added margins to `SearchResults` component to maintain layout when `search.txt` page has `landing` template.