### PR TITLE
DOP-2117: Use layout option for isCarousel

### DIFF
--- a/src/components/landing/CardGroup.js
+++ b/src/components/landing/CardGroup.js
@@ -44,13 +44,13 @@ const StyledGrid = styled('div')`
 const CardGroup = ({
   nodeData: {
     children,
-    options: { columns, style },
+    options: { columns, layout, style },
   },
   ...rest
 }) => {
   const isCompact = style === 'compact';
   const isExtraCompact = style === 'extra-compact';
-  const isCarousel = !(isCompact || isExtraCompact);
+  const isCarousel = layout === 'carousel';
   return (
     <StyledGrid columns={columns} noMargin={true} isCarousel={isCarousel}>
       {children.map((child, i) => (


### PR DESCRIPTION
### Stories/Links:

[JIRA](https://jira.mongodb.org/browse/DOP-2117).

[Docs-landing PR](https://github.com/mongodb/docs-landing/pull/70).
[Snooty-parser PR](https://github.com/mongodb/snooty-parser/pull/311). [MERGED]

### Staging Links:

[Docs-landing](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/cgoecknerwald/DOP-2117/), which should perform identically to [docs.mongodb.com](docs.mongodb.com)
