### PR TITLE
no-unset: Remove unnecessary unset

### DIFF
--- a/src/components/landing/CardGroup.js
+++ b/src/components/landing/CardGroup.js
@@ -31,9 +31,6 @@ const verticalStyling = css`
   grid-column-gap: ${theme.size.default};
   grid-template-columns: 'auto';
   grid-row-gap: '${theme.size.default}';
-  &:before {
-    content: 'unset';
-  }
 `;
 
 // StyledGrid behavior on medium and small screens is determined by 'isCarousel'


### PR DESCRIPTION
### Stories/Links:

N/A

### Staging Links:

[Docs-compass](https://docs-mongodborg-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/no-unset/).

### Notes

Since `verticalStyling` no longer inherits from `carouselStyling`, the `unset` became vestigial. 
