### PR TITLE
DOP-2160: Add IA sidebar transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
         "react-loadable": "^5.5.0",
+        "react-transition-group": "^4.4.1",
         "realm-web": "^1.2.1",
         "redoc": "^2.0.0-rc.48",
         "sanitize-html": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
     "react-loadable": "^5.5.0",
+    "react-transition-group": "^4.4.1",
     "realm-web": "^1.2.1",
     "redoc": "^2.0.0-rc.48",
     "sanitize-html": "^2.2.0",

--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SwitchTransition, CSSTransition } from 'react-transition-group';
+import { css, Global } from '@emotion/core';
+
+const fadeOut = css`
+  .fade-exit {
+    opacity: 1;
+  }
+  .fade-exit-active {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
+`;
+
+const fadeIn = css`
+  .fade-enter {
+    opacity: 0;
+  }
+  .fade-enter-active {
+    opacity: 1;
+    transition: opacity 300ms;
+  }
+`;
+
+const fadeInOut = css`
+  ${fadeOut}
+  ${fadeIn}
+`;
+
+const ContentTransition = ({ children, slug }) => (
+  <>
+    <Global styles={fadeInOut} />
+    <SwitchTransition>
+      <CSSTransition
+        addEndListener={(node, done) => node.addEventListener('transitionend', done, false)}
+        classNames="fade"
+        key={slug}
+      >
+        <div>{children}</div>
+      </CSSTransition>
+    </SwitchTransition>
+  </>
+);
+
+ContentTransition.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  slug: PropTypes.string,
+};
+
+export default ContentTransition;

--- a/src/components/IA.js
+++ b/src/components/IA.js
@@ -4,12 +4,12 @@ import { SideNavGroup, SideNavItem } from '@leafygreen-ui/side-nav';
 import Link from './Link';
 import { formatText } from '../utils/format-text';
 
-const IA = ({ header, ia }) => (
+const IA = ({ handleClick, header, ia }) => (
   <SideNavGroup header={header}>
     {ia.map(({ title, slug, url }) => {
       const target = slug || url;
       return (
-        <SideNavItem key={target} as={Link} to={target}>
+        <SideNavItem key={target} as={Link} onClick={handleClick} to={target}>
           {formatText(title)}
         </SideNavItem>
       );
@@ -18,6 +18,7 @@ const IA = ({ header, ia }) => (
 );
 
 IA.propTypes = {
+  handleClick: PropTypes.func,
   header: PropTypes.element,
   ia: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/IATransition.js
+++ b/src/components/IATransition.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SwitchTransition, CSSTransition } from 'react-transition-group';
+import { css, Global } from '@emotion/core';
+import ConditionalWrapper from './ConditionalWrapper';
+
+const fadeOut = css`
+  .slide-exit {
+    opacity: 1;
+  }
+  .slide-exit-active {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
+`;
+
+const backStyle = css`
+  ${fadeOut}
+
+  .slide-enter {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  .slide-enter-active {
+    opacity: 1;
+    transform: translateX(0%);
+    transition: opacity 300ms, transform 300ms;
+  }
+`;
+
+const forwardStyle = css`
+  ${fadeOut}
+
+  .slide-enter {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+  .slide-enter-active {
+    opacity: 1;
+    transform: translateX(0%);
+  }
+  .slide-enter-active {
+    transition: opacity 300ms, transform 300ms;
+  }
+`;
+
+const IATransition = ({ back, children, hasIA, slug }) => (
+  <ConditionalWrapper
+    condition={hasIA}
+    wrapper={(kids) => (
+      <>
+        <Global styles={back ? backStyle : forwardStyle} />
+        <SwitchTransition>
+          <CSSTransition
+            addEndListener={(node, done) => node.addEventListener('transitionend', done, false)}
+            classNames="slide"
+            key={slug}
+          >
+            <div>{kids}</div>
+          </CSSTransition>
+        </SwitchTransition>
+      </>
+    )}
+  >
+    {children}
+  </ConditionalWrapper>
+);
+
+IATransition.propTypes = {
+  back: PropTypes.bool,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  hasIA: PropTypes.bool,
+  slug: PropTypes.string,
+};
+
+export default IATransition;

--- a/src/components/IATransition.js
+++ b/src/components/IATransition.js
@@ -38,8 +38,6 @@ const forwardStyle = css`
   .slide-enter-active {
     opacity: 1;
     transform: translateX(0%);
-  }
-  .slide-enter-active {
     transition: opacity 300ms, transform 300ms;
   }
 `;

--- a/src/components/SidebarBack.js
+++ b/src/components/SidebarBack.js
@@ -21,7 +21,7 @@ const Placeholder = () => (
   />
 );
 
-const SidebarBack = ({ border, slug }) => {
+const SidebarBack = ({ border, handleClick, slug }) => {
   const { parents } = useContext(NavigationContext);
   const { project } = useSiteMetadata();
 
@@ -48,7 +48,7 @@ const SidebarBack = ({ border, slug }) => {
 
   return (
     <>
-      <SideNavItem as={Link} to={url} glyph={<Icon glyph="ArrowLeft" size="small" />}>
+      <SideNavItem as={Link} to={url} glyph={<Icon glyph="ArrowLeft" size="small" />} onClick={handleClick}>
         Back to {formatText(title)}
       </SideNavItem>
       {border}

--- a/src/components/Sidenav.js
+++ b/src/components/Sidenav.js
@@ -6,6 +6,7 @@ import Icon from '@leafygreen-ui/icon';
 import { SideNav as LeafygreenSideNav, SideNavItem } from '@leafygreen-ui/side-nav';
 import { uiColors } from '@leafygreen-ui/palette';
 import IA from './IA';
+import IATransition from './IATransition';
 import { NavigationContext } from './navigation-context.js';
 import ProductsList from './ProductsList';
 import SidebarBack from './SidebarBack';
@@ -60,11 +61,28 @@ const Sidenav = ({ page, slug }) => {
   const showAllProducts = page?.options?.['nav-show-all-products'];
   const ia = page?.options?.ia;
   const { pageTitle } = useContext(NavigationContext);
+  const [back, setBack] = React.useState(null);
 
   return (
     <StyledLeafygreenSideNav aria-label="Side navigation">
-      <SidebarBack border={<Border />} slug={slug} />
-      {ia && <IA header={<span css={titleStyle}>{formatText(pageTitle)}</span>} ia={ia} />}
+      <IATransition back={back} hasIA={!!ia.length} slug={slug}>
+        <SidebarBack
+          border={<Border />}
+          handleClick={() => {
+            setBack(true);
+          }}
+          slug={slug}
+        />
+        {ia && (
+          <IA
+            header={<span css={titleStyle}>{formatText(pageTitle)}</span>}
+            handleClick={() => {
+              setBack(false);
+            }}
+            ia={ia}
+          />
+        )}
+      </IATransition>
       {showAllProducts && <ProductsList />}
       <Spaceholder />
       {additionalLinks.map(({ glyph, title, url }) => (

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
+import ContentTransition from '../components/ContentTransition';
 import Header from '../components/Header';
 import Sidenav from '../components/Sidenav';
 import SiteMetadata from '../components/site-metadata';
@@ -87,16 +88,18 @@ const DefaultLayout = (props) => {
         <GlobalGrid>
           <Header />
           {sidebar && <Sidenav page={page} slug={slug} />}
-          <Template
-            css={css`
-              grid-area: contents;
-              margin: 0px;
-              overflow-y: auto;
-            `}
-            {...props}
-          >
-            {children}
-          </Template>
+          <ContentTransition slug={slug}>
+            <Template
+              css={css`
+                grid-area: contents;
+                margin: 0px;
+                overflow-y: auto;
+              `}
+              {...props}
+            >
+              {children}
+            </Template>
+          </ContentTransition>
         </GlobalGrid>
       </RootProvider>
     </>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Header from '../components/Header';
+import Sidenav from '../components/Sidenav';
 import SiteMetadata from '../components/site-metadata';
 import RootProvider from '../components/RootProvider';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
@@ -68,7 +69,7 @@ const DefaultLayout = (props) => {
     slug,
     template,
   } = pageContext;
-  const Template = getTemplate(project, slug, template);
+  const { Template, sidebar } = getTemplate(project, slug, template);
   const isSidebarEnabled = template !== 'blank';
   const pageTitle = React.useMemo(() => page?.options?.title || slugToTitle[slug === '/' ? 'index' : slug], [slug]); // eslint-disable-line react-hooks/exhaustive-deps
   useDelightedSurvey(slug);
@@ -85,6 +86,7 @@ const DefaultLayout = (props) => {
       >
         <GlobalGrid>
           <Header />
+          {sidebar && <Sidenav page={page} slug={slug} />}
           <Template
             css={css`
               grid-area: contents;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -6,7 +6,6 @@ import Contents from '../components/Contents';
 import InternalPageNav from '../components/InternalPageNav';
 import MainColumn from '../components/MainColumn';
 import RightColumn from '../components/RightColumn';
-import Sidenav from '../components/Sidenav';
 import TabSelectors from '../components/TabSelectors';
 import { TEMPLATE_CLASSNAME } from '../constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
@@ -48,7 +47,6 @@ const Document = ({
 
   return (
     <>
-      <Sidenav page={page} slug={slug} />
       <DocumentContainer className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <StyledMainColumn>
           <MainBody className="body">

--- a/src/templates/ecosystem-index.js
+++ b/src/templates/ecosystem-index.js
@@ -4,7 +4,6 @@ import { css } from '@emotion/core';
 import Breadcrumbs from '../components/Breadcrumbs';
 import EcosystemHomepageTiles from '../components/EcosystemHomepageTiles';
 import MainColumn from '../components/MainColumn';
-import Sidenav from '../components/Sidenav';
 import { TEMPLATE_CLASSNAME } from '../constants';
 import EcosystemHomepageStyles from '../styles/ecosystem-homepage.module.css';
 
@@ -17,7 +16,6 @@ const EcosystemIndex = ({
   },
 }) => (
   <>
-    <Sidenav page={page} slug={slug} />
     <div className={`${TEMPLATE_CLASSNAME} ${className}`}>
       <MainColumn className={EcosystemHomepageStyles.fullWidth}>
         <div

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -5,7 +5,6 @@ import { Global, css } from '@emotion/core';
 import { useTheme } from 'emotion-theming';
 import { uiColors } from '@leafygreen-ui/palette';
 import PropTypes from 'prop-types';
-import Sidenav from '../components/Sidenav';
 import { TEMPLATE_CLASSNAME } from '../constants';
 
 const Wrapper = styled('main')`
@@ -54,7 +53,6 @@ const Landing = ({ children, className, pageContext: { slug, page } }) => {
           })}
         </script>
       </Helmet>
-      <Sidenav page={page} slug={slug} />
       <div className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <Wrapper>{children}</Wrapper>
       </div>

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -1,26 +1,40 @@
 import { Blank, Document, DriversIndex, Guide, GuidesIndex, Landing, OpenAPITemplate, NotFound } from '../templates';
 
-const getTemplate = (project, slug, template) => {
-  switch (template) {
+const getTemplate = (project, slug, templateName) => {
+  let template;
+  let sidebar;
+  switch (templateName) {
     case 'blank':
-      return Blank;
+      template = Blank;
+      break;
     case 'landing':
-      return Landing;
+      template = Landing;
+      sidebar = true;
+      break;
     case 'openapi':
-      return OpenAPITemplate;
+      template = OpenAPITemplate;
+      break;
     case 'errorpage':
-      return NotFound;
+      template = NotFound;
+      break;
     default:
       const isIndex = slug === '/';
       switch (project) {
         case 'guides':
-          return isIndex ? GuidesIndex : Guide;
+          template = isIndex ? GuidesIndex : Guide;
+          break;
         case 'drivers':
-          return isIndex ? DriversIndex : Document;
+          template = isIndex ? DriversIndex : Document;
+          sidebar = true;
+          break;
         default:
-          return Document;
+          template = Document;
+          sidebar = true;
       }
+      break;
   }
+
+  return { Template: template, sidebar };
 };
 
 export { getTemplate };


### PR DESCRIPTION
### Stories/Links:

DOP-2160

### Staging Links:

- [Landing](https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/DOP-2160/)
- [Drivers](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/DOP-2160/) (sidebar still rendering correctly in ecosystem-index template)

### Notes:

- @allisonmui9 adding you for UAT for transition animations!
- Add sidebar to shared layout component
- Add content animation (fade out-in) to all page transitions