### PR TITLE
Link-hover-fix: Add link hover state to Cards

### DIFF
--- a/src/components/landing/Card.js
+++ b/src/components/landing/Card.js
@@ -34,6 +34,9 @@ const H4 = styled('h4')`
 const CTA = styled('p')`
   font-weight: bold;
   margin-top: auto;
+  & > a:hover {
+    color: ${uiColors.blue.dark2};
+  }
 `;
 
 const FlexTag = styled(Tag)`


### PR DESCRIPTION
### Stories/Links:

N/A - pre-UAT catch.

### Staging Links:

[Docs-compass](https://docs-mongodborg-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/link-hover-fix/)

### Notes:

- This will apply to `extra-compact` Cards as well, which is fine because A) they don't use CTAs, and B) if they did, it's approved behavior
