### PR TITLE
Standardize Margins

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -8,6 +8,7 @@ import BreadcrumbContainer from './BreadcrumbContainer';
 
 const Wrapper = styled('nav')`
   font-size: ${theme.fontSize.small};
+  margin-bottom: ${theme.size.medium};
 
   * {
     color: ${uiColors.gray.dark1};

--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import { theme } from '../theme/docsTheme';
 
 const MainColumn = ({ children, className }) => (
   <main
     className={className}
     css={css`
-      margin: 40px 15px;
+      margin: ${theme.size.xlarge};
       max-width: 800px;
       min-height: 600px;
     `}

--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -11303,7 +11303,6 @@ div.body h1 {
   font-size: 36px;
   line-height: 48px;
   padding: 0;
-  margin: -24px 0 24px;
 }
 div.body h3 {
   font-size: 18px;

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -17,10 +17,6 @@ const DocumentContainer = styled('div')`
   grid-template-columns: minmax(0px, 830px) auto;
 `;
 
-const MainBody = styled('div')`
-  margin-left: 25px;
-`;
-
 const StyledMainColumn = styled(MainColumn)`
   grid-area: main;
 `;
@@ -49,7 +45,7 @@ const Document = ({
     <>
       <DocumentContainer className={`${TEMPLATE_CLASSNAME} ${className}`}>
         <StyledMainColumn>
-          <MainBody className="body">
+          <div className="body">
             <Breadcrumbs
               homeUrl={breadcrumbsHomeUrl}
               pageTitle={breadcrumbsPageTitle}
@@ -61,7 +57,7 @@ const Document = ({
             {showPrevNext && (
               <InternalPageNav slug={slug} slugTitleMapping={slugTitleMapping} toctreeOrder={toctreeOrder} />
             )}
-          </MainBody>
+          </div>
         </StyledMainColumn>
         <StyledRightColumn>
           <TabSelectors />


### PR DESCRIPTION
### Staging Links:

- [Landing](https://docs-mongodbcom-staging.corp.mongodb.com/nav/landing/sophstad/margin-fix/)
- [Drivers](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/margin-fix/)

### Notes:

- Standardizes margins so that `landing`, `document`, and `drivers-index` templates (i.e. all templates with sidebars) according to the docs nav Figma. They'll all have the same positioning in the top-left corner
- Remove `-24px` margin on `<h1>` elements because what was it doing there anyway? This allows breadcrumbs to render with the padding specified in design specs