### PR TITLE
DOP-2104: Remove Drivers 404s

### DIFF
--- a/src/components/EcosystemHomepageTiles.js
+++ b/src/components/EcosystemHomepageTiles.js
@@ -46,7 +46,7 @@ const EcosystemHomepageTiles = () => {
       icon: <IconJava />,
     },
     {
-      slug: '/node/',
+      slug: 'https://docs.mongodb.com/drivers/node/current/',
       title: 'Node.js',
       icon: <IconNode />,
     },
@@ -61,7 +61,7 @@ const EcosystemHomepageTiles = () => {
       icon: <IconPython />,
     },
     {
-      slug: '/ruby/',
+      slug: 'https://docs.mongodb.com/ruby-driver/current/',
       title: 'Ruby',
       icon: <IconRuby />,
     },


### PR DESCRIPTION
### Stories/Links:

DOP-2104

### Staging Links:

[Drivers Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/drivers/sophstad/DOP-2104/)

### Notes:

- Convert Ruby and Node from paths to absolute URLs, as these pages are not contained within the `docs-ecosystem` property