### PR TITLE
DOP-2138: Add padding for additional levels of TOC

### DIFF
--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -11993,6 +11993,12 @@ div.sphinxsidebar li.toctree-l4 > a {
 div.sphinxsidebar li.toctree-l5 > a {
   padding-left: 130px;
 }
+div.sphinxsidebar li.toctree-l6 > a {
+  padding-left: 156px;
+}
+div.sphinxsidebar li.toctree-l7 > a {
+  padding-left: 182px;
+}
 div.sphinxsidebar p {
   color: #333;
   margin: 12px 0 5px 12px;


### PR DESCRIPTION
### Stories/Links:

DOP-2138

### Staging Links:

[BI-Connector](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-2138/bi-connector/raymundrodriguez/DOP-2138/reference/known-issues/)

### Notes:
* Added padding for a couple of extra levels in the old TOC.
* Stand by for related docs-tools PR to keep the css as similar as possible, and in case something like this were to happen with legacy or old gen docs. (https://github.com/mongodb/docs-tools/pull/506)