### PR TITLE
DOP-2177: Handle no hero images, and no tab images

### DIFF
--- a/src/components/landing/Kicker.js
+++ b/src/components/landing/Kicker.js
@@ -7,6 +7,7 @@ import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
 
 const StyledKicker = styled(Overline)`
+  grid-column: 1;
   font-size: ${theme.fontSize.small};
   color: ${uiColors.gray.dark1};
   padding-top: 80px;


### PR DESCRIPTION
### Stories/Links:

[JIRA](https://jira.mongodb.org/browse/DOP-2177).

### Staging Links:

[Docs-compass, images removed](https://docs-mongodborg-staging.corp.mongodb.com/DOP-1979/compass/cgoecknerwald/DOP-2177/)

### Notes:

Thankfully a one-liner!