### PR TITLE
DOP-2208: Fix missing sidebar and cut-off title heading on mobile

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -57,7 +57,7 @@ const HeadingContainer = styled.div`
 
 const ChildContainer = styled.div(
   ({ isStacked }) => css`
-    margin: ${isStacked ? '4px 0 16px 0' : '-24px 0 0 0'};
+    ${isStacked && 'margin: 4px 0 16px 0;'}
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -11303,7 +11303,6 @@ div.body h1 {
   font-size: 36px;
   line-height: 48px;
   padding: 0;
-  margin: -24px 0 24px;
 }
 div.body h3 {
   font-size: 18px;

--- a/src/styles/sidebar.module.css
+++ b/src/styles/sidebar.module.css
@@ -2,6 +2,6 @@
   display: block;
 }
 .sphinxsidebar {
-  display: block;
+  display: block !important;
   overflow-y: visible !important;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-2208

### Staging Links:

[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2208/)
[BI-Connector Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/raymundrodriguez/DOP-2208/)

### Notes:
* Ever since the mongodb-docs css was forked, it has caused a `display` rule to be applied to our sidebar in a different order. This PR hopes to resolve that issue by making a different display important.
* Title headings seem to be cut off at the top of the page on mobile when there are no breadcrumbs present. Removing the negative top margin fixes this.