### PR TITLE
DOP-2210: Match legacy sidebar breakpoint with snooty's

### DIFF
--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -11993,26 +11993,15 @@ div.admonition {
     margin-left: 25px;
   }
 }
-@media (max-width: 1120px) {
-  .expand-toc-icon {
+@media (max-width: 1024px) {
+  #showNav {
+    cursor: pointer;
+    position: fixed;
     display: block;
-    padding-top: 10px;
-    padding-right: 10px;
-    color: #fff;
   }
-  .expand-toc-icon:active,
-  .expand-toc-icon:hover {
-    color: #fff;
-    text-decoration: none;
-  }
-  #header-db .header-content {
-    width: 1093px;
-    padding-left: 30px;
-    float: none;
-  }
-  #header-db .nav-items {
-    margin-right: 15px;
-    float: none;
+  #left-column,
+  .sphinxsidebar {
+    display: none;
   }
   .document {
     margin-left: 25px;
@@ -12143,17 +12132,6 @@ table.compatibility-large td,
 table.compatibility-large th {
   border: 1px solid #f5f6f7;
   vertical-align: middle;
-}
-@media (max-width: 1024px) {
-  #left-column,
-  .sphinxsidebar {
-    display: none;
-  }
-  #showNav {
-    cursor: pointer;
-    position: fixed;
-    display: block;
-  }
 }
 @media print {
   #left-column,

--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -12014,15 +12014,6 @@ div.admonition {
     margin-right: 15px;
     float: none;
   }
-  #showNav {
-    cursor: pointer;
-    position: fixed;
-    display: block;
-  }
-  #left-column,
-  .sphinxsidebar {
-    display: none;
-  }
   .document {
     margin-left: 25px;
   }
@@ -12152,6 +12143,17 @@ table.compatibility-large td,
 table.compatibility-large th {
   border: 1px solid #f5f6f7;
   vertical-align: middle;
+}
+@media (max-width: 1024px) {
+  #left-column,
+  .sphinxsidebar {
+    display: none;
+  }
+  #showNav {
+    cursor: pointer;
+    position: fixed;
+    display: block;
+  }
 }
 @media print {
   #left-column,


### PR DESCRIPTION
### Stories/Links:

DOP-2210

### Staging Links:

[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2210/)

### Notes:
* Legacy css for the sidebar had the component's breakpoint at 1120px while [snooty's is 1024px](https://github.com/mongodb/snooty/blob/master/src/templates/document.js#L22). Changing the legacy css to match 1024px seems to solve this issue.
* To test, resize viewport to be between 1024px and 1120px. The left nav should be visible by default. Compare with the current live site for drivers ([link](https://docs.mongodb.com/drivers/c/)) and note that the sidebar no longer disappears.