### PR TITLE
DOP-2211: Fix floating version selector

### DIFF
--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -95,6 +95,7 @@ const VersionDropdown = ({
       onChange={navigate}
       placeholder={null}
       size={Size.Large}
+      usePortal={false}
       value={parserBranch}
     >
       {Object.entries(gitNamedMapping).map(([branch, name]) => {


### PR DESCRIPTION
### Stories/Links:

DOP-2211

### Staging Links:

_Put a link to your staging environment(s), if applicable_
*in progress*
### Notes:
Looks like this regression was caused by a [change](https://github.com/mongodb/leafygreen-ui/commit/857a680a03d3523aafcc8773c6a23ca0cc1422a7#) in leafygreen that changed default value for the `usePortal` prop on the `Select`, which changed default behavior for the `Select` component.