### PR TITLE
DOP-1798 - 'Click to enlarge' doesn't enlarge the image

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -39,7 +39,7 @@ export default class Image extends Component {
   };
 
   render() {
-    const { className, nodeData, isOpen } = this.props;
+    const { className, nodeData, isLightboxOpen } = this.props;
     const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
     const altText = getNestedValue(['options', 'alt'], nodeData) || imgSrc;
     const customAlign = getNestedValue(['options', 'align'], nodeData)
@@ -75,7 +75,7 @@ export default class Image extends Component {
         ref={this.imgRef}
         css={css`
           ${hasBorder ? borderStyling : ''}
-          ${isOpen ? enlargedImg : ''}
+          ${isLightboxOpen ? enlargedImg : ''}
           max-width: 100%;
         `}
       />

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -16,8 +16,7 @@ export default class Image extends Component {
   }
 
   handleLoad = ({ target: img }) => {
-    const { handleImageLoaded, nodeData } = this.props;
-
+    const { handleImageLoaded, nodeData, isOpen } = this.props;
     handleImageLoaded(this.imgRef.current);
 
     const scale = getNestedValue(['options', 'scale'], nodeData);
@@ -40,7 +39,7 @@ export default class Image extends Component {
   };
 
   render() {
-    const { className, nodeData } = this.props;
+    const { className, nodeData, isOpen } = this.props;
     const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
     const altText = getNestedValue(['options', 'alt'], nodeData) || imgSrc;
     const customAlign = getNestedValue(['options', 'align'], nodeData)
@@ -52,6 +51,9 @@ export default class Image extends Component {
       border: 0.5px solid ${uiColors.gray.light1};
       width: 100%;
       border-radius: 4px;
+    `;
+    const enlargedImg = css`
+      width: 80%;
     `;
 
     const buildStyles = () => {
@@ -73,7 +75,7 @@ export default class Image extends Component {
         ref={this.imgRef}
         css={css`
           ${hasBorder ? borderStyling : ''}
-          max-width: 100%;
+          ${isOpen ? enlargedImg : ''}
         `}
       />
     );
@@ -83,6 +85,7 @@ export default class Image extends Component {
 Image.propTypes = {
   className: PropTypes.string,
   handleImageLoaded: PropTypes.func,
+  isOpen: PropTypes.bool,
   nodeData: PropTypes.shape({
     argument: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -16,7 +16,7 @@ export default class Image extends Component {
   }
 
   handleLoad = ({ target: img }) => {
-    const { handleImageLoaded, nodeData, isOpen } = this.props;
+    const { handleImageLoaded, nodeData } = this.props;
     handleImageLoaded(this.imgRef.current);
 
     const scale = getNestedValue(['options', 'scale'], nodeData);
@@ -76,6 +76,7 @@ export default class Image extends Component {
         css={css`
           ${hasBorder ? borderStyling : ''}
           ${isOpen ? enlargedImg : ''}
+          max-width: 100%;
         `}
       />
     );

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -34,7 +34,7 @@ const Lightbox = ({ nodeData, ...rest }) => {
     <React.Fragment>
       <div className="figure lightbox" style={{ width: getNestedValue(['options', 'figwidth'], nodeData) || 'auto' }}>
         <div className="lightbox__imageWrapper" onClick={toggleShowModal} role="button" tabIndex="-1">
-          <Image nodeData={nodeData} />
+          <Image nodeData={nodeData} isOpen={false} />
           <div className="lightbox__caption">{CAPTION_TEXT}</div>
         </div>
         <CaptionLegend {...rest} nodeData={nodeData} />
@@ -51,6 +51,7 @@ const Lightbox = ({ nodeData, ...rest }) => {
         >
           <Image
             nodeData={nodeData}
+            isOpen={true}
             className={`lightbox__content lightbox__content--activated ${
               isSvg(imgSrc) ? 'lightbox__content--scalable' : ''
             }`}

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -34,7 +34,7 @@ const Lightbox = ({ nodeData, ...rest }) => {
     <React.Fragment>
       <div className="figure lightbox" style={{ width: getNestedValue(['options', 'figwidth'], nodeData) || 'auto' }}>
         <div className="lightbox__imageWrapper" onClick={toggleShowModal} role="button" tabIndex="-1">
-          <Image nodeData={nodeData} isOpen={false} />
+          <Image nodeData={nodeData} isLightboxOpen={false} />
           <div className="lightbox__caption">{CAPTION_TEXT}</div>
         </div>
         <CaptionLegend {...rest} nodeData={nodeData} />
@@ -51,7 +51,7 @@ const Lightbox = ({ nodeData, ...rest }) => {
         >
           <Image
             nodeData={nodeData}
-            isOpen={true}
+            isLightboxOpen={true}
             className={`lightbox__content lightbox__content--activated ${
               isSvg(imgSrc) ? 'lightbox__content--scalable' : ''
             }`}

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -19,6 +19,7 @@ exports[`Lightbox renders correctly 1`] = `
       <Image
         className=""
         handleImageLoaded={[Function]}
+        isOpen={false}
         nodeData={
           Object {
             "argument": Array [

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -19,7 +19,7 @@ exports[`Lightbox renders correctly 1`] = `
       <Image
         className=""
         handleImageLoaded={[Function]}
-        isOpen={false}
+        isLightboxOpen={false}
         nodeData={
           Object {
             "argument": Array [


### PR DESCRIPTION
### Stories/Links:

DOP-1798

### Staging Links:

[Docs Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/carolinao/DOP-1798/core/databases-and-collections/)

For some reason if you go directly to a page that has images you can click to enlarge, you can’t click on them. But if you’re on a different page, and then you go to a page with an image you can click, you can click on it (previous bug from the way it's in production right now) So to test it, it's needed to go to previous page and go to next one

### Notes:
- Problem was images weren't changing size after clicking on "Click to Enlarge". 
- Solved it by adding a new `isOpen` boolean prop in `Image` component that sets `width : 100%` if true