### PR TITLE
DOP-2198: Update PLP template to accommodate large hero image

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -47,7 +47,7 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
           </a>
         </HeadingTag>
       </ConditionalWrapper>
-      <Contents />
+      {isPageTitle && <Contents />}
     </>
   );
 };

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -12,15 +12,16 @@ import Contents from './Contents';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
-const Heading = ({ sectionDepth, nodeData, ...rest }) => {
+const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const id = nodeData.id || '';
   const HeadingTag = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
 
   const isPageTitle = sectionDepth === 1;
   const { isMobile, isTabletOrMobile } = useScreenSize();
-  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile;
+  const hidefeedbackheader = page?.options?.hidefeedback === 'header';
   const { selectors } = useContext(TabContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
+  const shouldShowMobileHeader = isPageTitle && isTabletOrMobile && (hasSelectors || !hidefeedbackheader);
 
   return (
     <ConditionalWrapper

--- a/src/components/Kicker.js
+++ b/src/components/Kicker.js
@@ -7,7 +7,7 @@ import { theme } from '../theme/docsTheme';
 import ComponentFactory from './ComponentFactory';
 
 const StyledKicker = styled(Overline)`
-  grid-column: 1;
+  grid-column: 2;
   font-size: ${theme.fontSize.small};
   color: ${uiColors.gray.dark1};
   padding-top: 80px;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -8,10 +8,11 @@ import Sidebar from '../components/Sidebar';
 import style from '../styles/navigation.module.css';
 import useScreenSize from '../hooks/useScreenSize.js';
 
+const CONTENT_MAX_WIDTH = 1200;
+
 const Wrapper = styled('main')`
   color: ${uiColors.black};
   margin: 0 auto ${theme.size.xlarge} auto;
-  max-width: 1200px;
   width: 100%;
   overflow-x: scroll;
 
@@ -58,7 +59,13 @@ const Wrapper = styled('main')`
 
   & > section {
     display: grid;
-    grid-template-columns: ${theme.size.xlarge} 1fr 1fr ${theme.size.xlarge};
+    // Create columns such that the 2 outer ones act like margins.
+    // This will allow the hero image to span across the whole content while still being a part
+    // of the DOM flow.
+    grid-template-columns: minmax(${theme.size.xlarge}, 1fr) repeat(2, minmax(0, ${CONTENT_MAX_WIDTH / 2}px)) minmax(
+        ${theme.size.xlarge},
+        1fr
+      );
 
     @media ${theme.screenSize.upToLarge} {
       grid-template-columns: 48px 1fr 48px;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -10,15 +10,10 @@ import useScreenSize from '../hooks/useScreenSize.js';
 
 const Wrapper = styled('main')`
   color: ${uiColors.black};
-  margin: calc(${theme.navbar.height} + ${theme.size.large}) auto ${theme.size.xlarge} auto;
+  margin: 0 auto ${theme.size.xlarge} auto;
   max-width: 1200px;
   width: 100%;
   overflow-x: scroll;
-  padding: 0 ${theme.size.large} 0 ${theme.size.xlarge};
-
-  @media ${theme.screenSize.upToMedium} {
-    padding: 0 ${theme.size.medium} 0 48px;
-  }
 
   h1,
   h2,
@@ -46,6 +41,7 @@ const Wrapper = styled('main')`
 
   section p {
     font-size: ${theme.fontSize.default};
+    grid-column: 2;
     letter-spacing: 0.5px;
     margin-bottom: ${theme.size.small};
     max-width: 500px;
@@ -61,37 +57,78 @@ const Wrapper = styled('main')`
   }
 
   & > section {
+    display: grid;
+    grid-template-columns: ${theme.size.xlarge} 1fr 1fr ${theme.size.xlarge};
+
+    @media ${theme.screenSize.upToLarge} {
+      grid-template-columns: 48px 1fr 48px;
+    }
+
     h1 {
       align-self: end;
+      grid-column: 2;
+      grid-row: 1;
     }
 
     & > img {
       display: block;
+      grid-column: 2;
       margin: auto;
       max-width: 600px;
       width: 100%;
-    }
 
-    ${'' /* Split the content into two columns on large screens. */}
-    @media ${theme.screenSize.largeAndUp} {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-
-      & > h1,
-      & > .introduction {
-        grid-column: 1;
-      }
-
-      & > img {
-        grid-column: 2;
+      @media ${theme.screenSize.largeAndUp} {
+        grid-column: 3;
         grid-row: 1 / span 2;
       }
+    }
 
-      ${'' /* Sub-sections should take up the full width of the main section */}
-      & > section {
-        grid-column: 1 / -1;
+    & > .hero-img {
+      grid-column: 1 / -1;
+      grid-row: 1 / 3;
+      height: 310px;
+      margin-bottom: ${theme.size.large};
+      max-width: 100%;
+      object-fit: cover;
+      z-index: -1;
+
+      @media ${theme.screenSize.upToMedium} {
+        object-position: 100%;
+        grid-row: unset;
+      }
+
+      @media ${theme.screenSize.upToSmall} {
+        grid-row: unset;
+        height: 200px;
       }
     }
+
+    & > .introduction {
+      grid-column: 2;
+      grid-row: 2;
+    }
+
+    /* Sub-sections should take up the full width of the main section */
+    & > section {
+      grid-column: 2 / -2;
+      overflow: hidden;
+    }
+  }
+`;
+
+const ContentContainer = styled('div')`
+  margin-top: ${theme.navbar.height};
+
+  @media ${theme.screenSize.upToMedium} {
+    margin-top: calc(
+      ${theme.bannerContent.enabled ? `${theme.navbar.bannerHeight.medium} +` : ''} ${theme.navbar.baseHeight}
+    );
+  }
+
+  @media not all and (max-width: 1600px) {
+    margin-top: calc(
+      ${theme.bannerContent.enabled && `${theme.navbar.bannerHeight.large} +`} ${theme.navbar.baseHeight}
+    );
   }
 `;
 
@@ -116,7 +153,7 @@ const ProductLanding = ({
   }, [isTabletOrMobile]);
 
   return (
-    <div className="content">
+    <ContentContainer className="content">
       {(!isBrowser || showLeftColumn) && (
         <div className={`left-column ${style.leftColumn} ${renderStatus}`} id="left-column">
           <Sidebar
@@ -135,7 +172,7 @@ const ProductLanding = ({
         )}
         <Wrapper>{children}</Wrapper>
       </>
-    </div>
+    </ContentContainer>
   );
 };
 


### PR DESCRIPTION
### Stories/Links:

DOP-2198
[Realm PLP Design](https://www.figma.com/file/hPTwMb9uHOypYLckYDg072/Realm-PLP?node-id=2%3A965)
[New Realm PLP rst](https://github.com/rayangler/docs-realm/commit/31acd674a51bc12275b59b841a5c9c3676611838)

### Staging Links:

[Realm](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-2198/realm/raymundrodriguez/DOP-2198/)
[Compass](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/raymundrodriguez/DOP-2198/)

### Notes:
* Had to get rid of the padding on the side and add additional grid columns to act as padding. This allows the large hero image to span the whole main column. The grid column for existing components were adjusted to compensate for the new columns. Positioning should be the same overall.
* Added a small fix for the `Contents` component appearing under every heading on mobile/tablet sizes.
* Since the new Realm PLP really uses a layout more similar to the new docs-nav's landing template ([design](https://www.figma.com/file/cGgCI13jIX4XwWwFETopNZ/Docs-Nav-Copy?node-id=116%3A225)), it might be worth either consolidating the `landing` and `product-landing` templates together in the future? Maybe a discussion worth having post-docs-nav / as we add more product landing pages to look for any major differences.