### PR TITLE
DOP-1728 - [cloud-docs]: Increase padding above ordered lists in tabs

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
 import ComponentFactory from './ComponentFactory';

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
 import ComponentFactory from './ComponentFactory';
@@ -66,6 +67,7 @@ const landingTabStyling = css`
 
 const getTabStyling = ({ isProductLanding }) => css`
   ${isProductLanding && landingTabStyling}
+  margin-top: 24px;
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {


### PR DESCRIPTION
### Stories/Links:

DOP-1728

### Staging Links:

[Ordered list example ](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/carolinao/DOP-1728/security-multi-factor-authentication/)
[Regular text example](https://docs-atlas-staging.mongodb.com/cloud-docs/docsworker-xlarge/snooty-setup/security-add-mongodb-users)

### Notes:
Simple CSS change added to `Tabs` component