### PR TITLE
DOP-2174: Card-ref styling

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -42,7 +42,7 @@ const cardRefStyling = css`
     font-size: ${theme.fontSize.small} !important;
     font-weight: 600;
     margin-bottom: ${theme.size.small};
-    margin-right: ${theme.size.small};
+    margin-right: ${theme.size.tiny};
     padding: ${theme.size.tiny};
 
     &:after {
@@ -59,7 +59,7 @@ const H4 = styled('h4')`
 
 const CTA = styled('p')`
   font-weight: bold;
-  margin-top: auto;
+  margin-top: ${theme.size.default};
   & > a:hover {
     color: ${uiColors.blue.dark2};
   }
@@ -125,7 +125,6 @@ const Card = ({
             }
           : undefined
       }
-      url={url}
     >
       {icon && (
         <ConditionalWrapper

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -41,7 +41,7 @@ const cardRefStyling = css`
     display: inline-block;
     font-size: ${theme.fontSize.small} !important;
     font-weight: 600;
-    margin-bottom: ${theme.size.small};
+    margin-bottom: ${theme.size.tiny};
     margin-right: ${theme.size.tiny};
     padding: ${theme.size.tiny};
 
@@ -59,7 +59,7 @@ const H4 = styled('h4')`
 
 const CTA = styled('p')`
   font-weight: bold;
-  margin-top: ${theme.size.default};
+  margin-top: ${theme.size.small};
   & > a:hover {
     color: ${uiColors.blue.dark2};
   }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -22,7 +22,7 @@ const StyledCard = styled(LeafyGreenCard)`
   }
 
   &:hover {
-    box-shadow: ${({ url }) => (url ? `` : `0 4px 10px -4px rgba(6,22,33,0.3)`)};
+    box-shadow: ${({ url }) => (!url ? `` : `0 4px 10px -4px rgba(6,22,33,0.3)`)};
   }
 `;
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import LeafyGreenCard from '@leafygreen-ui/card';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme';
 import ComponentFactory from './ComponentFactory';
@@ -19,10 +20,35 @@ const StyledCard = styled(LeafyGreenCard)`
   p:last-of-type {
     margin-bottom: 0;
   }
+
+  &:hover {
+    box-shadow: ${({ url }) => (url ? `` : `0 4px 10px -4px rgba(6,22,33,0.3)`)};
+  }
 `;
 
 const CardIcon = styled('img')`
   width: ${theme.size.medium};
+`;
+
+// Applied when no URL option is specified for the card, because the card-ref
+// and ref directives are currently indistinguishable in the AST
+const cardRefStyling = css`
+  a {
+    background: ${uiColors.gray.light3};
+    border-radius: ${theme.size.tiny};
+    border: 1px solid rgba(184, 196, 194, 0.48);
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: ${theme.fontSize.small} !important;
+    font-weight: 600;
+    margin-bottom: ${theme.size.small};
+    margin-right: ${theme.size.small};
+    padding: ${theme.size.tiny};
+
+    &:after {
+      content: ' ➔';
+    }
+  }
 `;
 
 const H4 = styled('h4')`
@@ -92,9 +118,14 @@ const Card = ({
   const Icon = isCompact ? CompactIcon : CardIcon;
   return (
     <Card
-      onClick={() => {
-        window.location.href = url;
-      }}
+      onClick={
+        url
+          ? () => {
+              window.location.href = url;
+            }
+          : undefined
+      }
+      url={url}
     >
       {icon && (
         <ConditionalWrapper
@@ -106,7 +137,9 @@ const Card = ({
       )}
       <ConditionalWrapper
         condition={isCompact || isExtraCompact}
-        wrapper={(children) => <CompactTextWrapper>{children}</CompactTextWrapper>}
+        wrapper={(children) => (
+          <CompactTextWrapper className={!url && cx(cardRefStyling)}>{children}</CompactTextWrapper>
+        )}
       >
         {tag && <FlexTag text={tag} />}
         <H4 compact={isCompact || isExtraCompact}>{headline}</H4>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -20,10 +20,6 @@ const StyledCard = styled(LeafyGreenCard)`
   p:last-of-type {
     margin-bottom: 0;
   }
-
-  &:hover {
-    box-shadow: ${({ url }) => (!url ? `` : `0 4px 10px -4px rgba(6,22,33,0.3)`)};
-  }
 `;
 
 const CardIcon = styled('img')`

--- a/src/components/CardGroup.js
+++ b/src/components/CardGroup.js
@@ -43,7 +43,7 @@ const StyledGrid = styled('div')`
   grid-template-columns: ${(props) => `repeat(${getColumnValue(props)}, 1fr)`};
   margin: ${theme.size.large} 0;
 
-  @media ${theme.screenSize.upToLarge} {
+  @media ${theme.screenSize.upToXLarge} {
     grid-template-columns: repeat(2, 1fr);
   }
 

--- a/src/components/CardGroup.js
+++ b/src/components/CardGroup.js
@@ -71,7 +71,7 @@ const CardGroup = ({
   const isExtraCompact = style === 'extra-compact';
   const isCarousel = layout === 'carousel';
   return (
-    <StyledGrid columns={columns} noMargin={true} isCarousel={isCarousel}>
+    <StyledGrid className="card-group" columns={columns} noMargin={true} isCarousel={isCarousel}>
       {children.map((child, i) => (
         <ComponentFactory {...rest} key={i} nodeData={child} isCompact={isCompact} isExtraCompact={isExtraCompact} />
       ))}

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -51,6 +51,7 @@ const landingTabStyling = css`
   display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
+  margin-top: unset !important;
 
   img {
     border-radius: ${theme.size.small};

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -115,13 +115,15 @@ const Wrapper = styled('main')`
       grid-row: 2;
     }
 
-    // Sub-sections should use all but the outer columns. Card-groups may
-    // occasionally not be nested within sections (see: Realm PLP)
-    // but should be constrained to the inner columns regardless
-    & > section,
-    .card-group {
+    // Sub-sections should use all but the outer columns.
+    & > section {
       grid-column: 2 / -2 !important;
       overflow: hidden;
+    }
+    // Card-groups may occasionally not be nested within sections (see: Realm
+    // PLP) but should be constrained to the inner columns regardless
+    .card-group {
+      grid-column: 2 / -2 !important;
     }
   }
 `;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -115,9 +115,12 @@ const Wrapper = styled('main')`
       grid-row: 2;
     }
 
-    /* Sub-sections should take up the full width of the main section */
-    & > section {
-      grid-column: 2 / -2;
+    // Sub-sections should use all but the outer columns. Card-groups may
+    // occasionally not be nested within sections (see: Realm PLP)
+    // but should be constrained to the inner columns regardless
+    & > section,
+    .card-group {
+      grid-column: 2 / -2 !important;
       overflow: hidden;
     }
   }

--- a/tests/unit/CardRef.test.js
+++ b/tests/unit/CardRef.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { ThemeProvider } from 'emotion-theming';
-import Card from '../../src/components/Card';
+import CardGroup from '../../src/components/CardGroup';
 import { theme } from '../../src/theme/docsTheme';
 
 // data for this component
@@ -9,19 +9,10 @@ import mockData from './data/CardRef.test.json';
 
 // Since there isn't a proper CardRef component, test that card-ref styling
 // is applied appropriately (i.e., only when a Card :url: is not specified)
-it('renders correctly without url', () => {
+it('card correctly with and without url', () => {
   const tree = mount(
     <ThemeProvider theme={theme}>
-      <Card nodeData={mockData} />
-    </ThemeProvider>
-  ).childAt(0);
-  expect(tree).toMatchSnapshot();
-});
-
-it('renders correctly with url', () => {
-  const tree = mount(
-    <ThemeProvider theme={theme}>
-      <Card url="testdata.com" nodeData={mockData} />
+      <CardGroup nodeData={mockData} />
     </ThemeProvider>
   ).childAt(0);
   expect(tree).toMatchSnapshot();

--- a/tests/unit/CardRef.test.js
+++ b/tests/unit/CardRef.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ThemeProvider } from 'emotion-theming';
+import Card from '../../src/components/Card';
+import { theme } from '../../src/theme/docsTheme';
+
+// data for this component
+import mockData from './data/CardRef.test.json';
+
+// Since there isn't a proper CardRef component, test that card-ref styling
+// is applied appropriately (i.e., only when a Card :url: is not specified)
+it('renders correctly without url', () => {
+  const tree = mount(
+    <ThemeProvider theme={theme}>
+      <Card nodeData={mockData} />
+    </ThemeProvider>
+  ).childAt(0);
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders correctly with url', () => {
+  const tree = mount(
+    <ThemeProvider theme={theme}>
+      <Card url="testdata.com" nodeData={mockData} />
+    </ThemeProvider>
+  ).childAt(0);
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders correctly 1`] = `
 <StyledCard
   onClick={[Function]}
+  url="https://university.mongodb.com/courses/M001/about"
 >
   <ConditionalWrapper
     wrapper={[Function]}

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -3,7 +3,6 @@
 exports[`renders correctly 1`] = `
 <StyledCard
   onClick={[Function]}
-  url="https://university.mongodb.com/courses/M001/about"
 >
   <ConditionalWrapper
     wrapper={[Function]}

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <StyledGrid
+  className="card-group"
   columns={3}
   isCarousel={true}
   noMargin={true}

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -1,7 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly with url 1`] = `
-.emotion-6 {
+exports[`card correctly with and without url 1`] = `
+.emotion-4 a {
+  background: #F9FBFA;
+  border-radius: 4px;
+  border: 1px solid rgba(184,196,194,0.48);
+  box-sizing: border-box;
+  display: inline-block;
+  font-size: 14px !important;
+  font-weight: 600;
+  margin-bottom: 4px;
+  margin-right: 4px;
+  padding: 4px;
+}
+
+.emotion-4 a:after {
+  content: ' ➔';
+}
+
+.emotion-10 {
   position: relative;
   border-radius: 7px;
   -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
@@ -12,7 +29,67 @@ exports[`renders correctly with url 1`] = `
   color: #21313C;
 }
 
-.emotion-4 {
+.emotion-26 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
+  cursor: pointer;
+}
+
+.emotion-26:focus {
+  outline: none;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
+}
+
+.emotion-26:hover {
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
+}
+
+.emotion-26:hover:focus {
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
+}
+
+.emotion-32 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: grid;
+  grid-column: 1 / -1 !important;
+  grid-column-gap: 24px;
+  grid-row-gap: 24px;
+  grid-template-columns: repeat(3,1fr);
+  margin: 32px 0;
+}
+
+@media only screen and (max-width:1200px) {
+  .emotion-32 {
+    grid-template-columns: repeat(2,1fr);
+  }
+}
+
+@media only screen and (max-width:767px) {
+  .emotion-32 {
+    grid-template-columns: repeat(1,1fr);
+    grid-column-gap: 16px;
+  }
+}
+
+@media only screen and (max-width:420px) {
+  .emotion-32 {
+    grid-column-gap: 16px;
+    grid-template-columns: 'auto';
+    grid-row-gap: '16px';
+  }
+}
+
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22,18 +99,40 @@ exports[`renders correctly with url 1`] = `
   flex-direction: column;
   height: 100%;
   padding: 32px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 32px 24px;
 }
 
-.emotion-4 p:last-of-type {
+.emotion-8 p:last-of-type {
   margin-bottom: 0;
-}
-
-.emotion-4:hover {
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
 }
 
 .emotion-0 {
   width: 24px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  margin-left: 24px;
+}
+
+@media only screen and (max-width:420px) {
+  .emotion-5 {
+    margin-left: 16px;
+  }
 }
 
 .emotion-2 {
@@ -41,308 +140,619 @@ exports[`renders correctly with url 1`] = `
   -moz-letter-spacing: 0.5px;
   -ms-letter-spacing: 0.5px;
   letter-spacing: 0.5px;
-  margin: 24px 0 8px 0;
+  margin: 0 0 8px;
 }
 
-<Card
+.emotion-20 {
+  font-weight: bold;
+  margin-top: 8px;
+}
+
+.emotion-20 > a:hover {
+  color: #1A567E;
+}
+
+<CardGroup
   nodeData={
     Object {
       "argument": Array [],
       "children": Array [
         Object {
+          "argument": Array [],
           "children": Array [
             Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 50,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                },
+              ],
               "position": Object {
                 "start": Object {
                   "line": 50,
                 },
               },
-              "type": "text",
-              "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+              "type": "paragraph",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "Android",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "sdk/android",
+                    "std-label-android-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "android-intro",
+                  "type": "ref_role",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "
+",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "iOS",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "sdk/ios",
+                    "std-label-ios-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "ios-intro",
+                  "type": "ref_role",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "
+",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": ".Net",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "sdk/dotnet",
+                    "std-label-dotnet-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "dotnet-intro",
+                  "type": "ref_role",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "
+",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "Web",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "web",
+                    "std-label-web-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "web-intro",
+                  "type": "ref_role",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "
+",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "React Native",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "sdk/react-native",
+                    "std-label-react-native-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "react-native-intro",
+                  "type": "ref_role",
+                },
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "
+",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "Node.js",
+                    },
+                  ],
+                  "domain": "std",
+                  "fileid": Array [
+                    "sdk/node",
+                    "std-label-node-intro",
+                  ],
+                  "flag": "",
+                  "name": "label",
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "target": "node-intro",
+                  "type": "ref_role",
+                },
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "paragraph",
             },
           ],
+          "domain": "mongodb",
+          "name": "card",
+          "options": Object {
+            "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
+            "headline": "Realm SDKs",
+            "icon": "/images/icons/realm_sdk.svg",
+          },
           "position": Object {
             "start": Object {
-              "line": 50,
+              "line": 46,
             },
           },
-          "type": "paragraph",
+          "type": "directive",
         },
         Object {
+          "argument": Array [],
           "children": Array [
             Object {
               "children": Array [
                 Object {
                   "position": Object {
                     "start": Object {
-                      "line": 52,
+                      "line": 65,
                     },
                   },
                   "type": "text",
-                  "value": "Android",
+                  "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
                 },
               ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/android",
-                "std-label-android-intro",
-              ],
-              "flag": "",
-              "name": "label",
               "position": Object {
                 "start": Object {
-                  "line": 52,
+                  "line": 65,
                 },
               },
-              "target": "android-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "iOS",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/ios",
-                "std-label-ios-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "ios-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": ".Net",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/dotnet",
-                "std-label-dotnet-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "dotnet-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Web",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "web",
-                "std-label-web-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "web-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "React Native",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/react-native",
-                "std-label-react-native-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "react-native-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Node.js",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/node",
-                "std-label-node-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "node-intro",
-              "type": "ref_role",
+              "type": "paragraph",
             },
           ],
+          "domain": "mongodb",
+          "name": "card",
+          "options": Object {
+            "checksum": "a75dde0c71beef8015b5546c7402cb9f9f1e8738823e90617fd7582940a832a0",
+            "cta": "Learn more about MongoDB Realm Application Services",
+            "headline": "MongoDB Realm",
+            "icon": "/images/icons/realm.svg",
+            "url": "https://docs.mongodb.com/realm/services/",
+          },
           "position": Object {
             "start": Object {
-              "line": 52,
+              "line": 59,
             },
           },
-          "type": "paragraph",
+          "type": "directive",
         },
       ],
       "domain": "mongodb",
-      "name": "card",
+      "name": "card-group",
       "options": Object {
-        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
-        "headline": "Realm SDKs",
-        "icon": "/images/icons/realm_sdk.svg",
+        "columns": 3,
+        "style": "extra-compact",
       },
       "position": Object {
         "start": Object {
-          "line": 46,
+          "line": 42,
         },
       },
       "type": "directive",
     }
   }
-  url="testdata.com"
 >
-  <StyledCard>
-    <Card
-      className="emotion-4 emotion-5"
+  <StyledGrid
+    className="card-group"
+    columns={3}
+    isCarousel={false}
+    noMargin={true}
+  >
+    <div
+      className="card-group emotion-32 emotion-33"
     >
-      <Box
-        className="emotion-4 emotion-5 emotion-6"
+      <ComponentFactory
+        isCompact={false}
+        isExtraCompact={true}
+        key="0"
+        nodeData={
+          Object {
+            "argument": Array [],
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 50,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                  },
+                ],
+                "position": Object {
+                  "start": Object {
+                    "line": 50,
+                  },
+                },
+                "type": "paragraph",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Android",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "sdk/android",
+                      "std-label-android-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "android-intro",
+                    "type": "ref_role",
+                  },
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "text",
+                    "value": "
+",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "iOS",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "sdk/ios",
+                      "std-label-ios-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "ios-intro",
+                    "type": "ref_role",
+                  },
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "text",
+                    "value": "
+",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": ".Net",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "sdk/dotnet",
+                      "std-label-dotnet-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "dotnet-intro",
+                    "type": "ref_role",
+                  },
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "text",
+                    "value": "
+",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Web",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "web",
+                      "std-label-web-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "web-intro",
+                    "type": "ref_role",
+                  },
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "text",
+                    "value": "
+",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "React Native",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "sdk/react-native",
+                      "std-label-react-native-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "react-native-intro",
+                    "type": "ref_role",
+                  },
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "text",
+                    "value": "
+",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Node.js",
+                      },
+                    ],
+                    "domain": "std",
+                    "fileid": Array [
+                      "sdk/node",
+                      "std-label-node-intro",
+                    ],
+                    "flag": "",
+                    "name": "label",
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "target": "node-intro",
+                    "type": "ref_role",
+                  },
+                ],
+                "position": Object {
+                  "start": Object {
+                    "line": 52,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "domain": "mongodb",
+            "name": "card",
+            "options": Object {
+              "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
+              "headline": "Realm SDKs",
+              "icon": "/images/icons/realm_sdk.svg",
+            },
+            "position": Object {
+              "start": Object {
+                "line": 46,
+              },
+            },
+            "type": "directive",
+          }
+        }
       >
-        <div
-          className="emotion-4 emotion-5 emotion-6"
-        >
-          <ConditionalWrapper
-            wrapper={[Function]}
-          >
-            <CardIcon
-              src="/images/icons/realm_sdk.svg"
-            >
-              <img
-                className="emotion-0 emotion-1"
-                src="/images/icons/realm_sdk.svg"
-              />
-            </CardIcon>
-          </ConditionalWrapper>
-          <ConditionalWrapper
-            wrapper={[Function]}
-          >
-            <H4>
-              <h4
-                className="emotion-2 emotion-3"
-              >
-                Realm SDKs
-              </h4>
-            </H4>
-            <ComponentFactory
-              key="0"
-              nodeData={
+        <Card
+          isCompact={false}
+          isExtraCompact={true}
+          nodeData={
+            Object {
+              "argument": Array [],
+              "children": Array [
                 Object {
                   "children": Array [
                     Object {
@@ -361,69 +771,7 @@ exports[`renders correctly with url 1`] = `
                     },
                   },
                   "type": "paragraph",
-                }
-              }
-            >
-              <Paragraph
-                nodeData={
-                  Object {
-                    "children": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 50,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                      },
-                    ],
-                    "position": Object {
-                      "start": Object {
-                        "line": 50,
-                      },
-                    },
-                    "type": "paragraph",
-                  }
-                }
-              >
-                <p>
-                  <ComponentFactory
-                    key="0"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 50,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 50,
-                            },
-                          },
-                          "type": "text",
-                          "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                        }
-                      }
-                    >
-                      Use platform-specific libraries to include and work with the Realm database in your application.
-                    </Text>
-                  </ComponentFactory>
-                </p>
-              </Paragraph>
-            </ComponentFactory>
-            <ComponentFactory
-              key="1"
-              nodeData={
+                },
                 Object {
                   "children": Array [
                     Object {
@@ -645,2742 +993,1664 @@ exports[`renders correctly with url 1`] = `
                     },
                   },
                   "type": "paragraph",
-                }
-              }
-            >
-              <Paragraph
-                nodeData={
-                  Object {
-                    "children": Array [
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Android",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/android",
-                          "std-label-android-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "android-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "iOS",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/ios",
-                          "std-label-ios-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "ios-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": ".Net",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/dotnet",
-                          "std-label-dotnet-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "dotnet-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Web",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "web",
-                          "std-label-web-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "web-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "React Native",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/react-native",
-                          "std-label-react-native-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "react-native-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Node.js",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/node",
-                          "std-label-node-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "node-intro",
-                        "type": "ref_role",
-                      },
-                    ],
-                    "position": Object {
-                      "start": Object {
-                        "line": 52,
-                      },
-                    },
-                    "type": "paragraph",
-                  }
-                }
-              >
-                <p>
-                  <ComponentFactory
-                    key="0"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Android",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/android",
-                          "std-label-android-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "android-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Android",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/android",
-                            "std-label-android-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "android-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/android/#std-label-android-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/android/#std-label-android-intro"
-                        >
-                          <a
-                            href="/sdk/android/#std-label-android-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "Android",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Android",
-                                  }
-                                }
-                              >
-                                Android
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="1"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="2"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "iOS",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/ios",
-                          "std-label-ios-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "ios-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "iOS",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/ios",
-                            "std-label-ios-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "ios-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/ios/#std-label-ios-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/ios/#std-label-ios-intro"
-                        >
-                          <a
-                            href="/sdk/ios/#std-label-ios-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "iOS",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "iOS",
-                                  }
-                                }
-                              >
-                                iOS
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="3"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="4"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": ".Net",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/dotnet",
-                          "std-label-dotnet-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "dotnet-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": ".Net",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/dotnet",
-                            "std-label-dotnet-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "dotnet-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/dotnet/#std-label-dotnet-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/dotnet/#std-label-dotnet-intro"
-                        >
-                          <a
-                            href="/sdk/dotnet/#std-label-dotnet-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": ".Net",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": ".Net",
-                                  }
-                                }
-                              >
-                                .Net
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="5"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="6"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Web",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "web",
-                          "std-label-web-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "web-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Web",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "web",
-                            "std-label-web-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "web-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="web/#std-label-web-intro"
-                      >
-                        <mockConstructor
-                          to="/web/#std-label-web-intro"
-                        >
-                          <a
-                            href="/web/#std-label-web-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "Web",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Web",
-                                  }
-                                }
-                              >
-                                Web
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="7"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="8"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "React Native",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/react-native",
-                          "std-label-react-native-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "react-native-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "React Native",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/react-native",
-                            "std-label-react-native-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "react-native-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/react-native/#std-label-react-native-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/react-native/#std-label-react-native-intro"
-                        >
-                          <a
-                            href="/sdk/react-native/#std-label-react-native-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "React Native",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "React Native",
-                                  }
-                                }
-                              >
-                                React Native
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="9"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="10"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Node.js",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/node",
-                          "std-label-node-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "node-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Node.js",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/node",
-                            "std-label-node-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "node-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/node/#std-label-node-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/node/#std-label-node-intro"
-                        >
-                          <a
-                            href="/sdk/node/#std-label-node-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "Node.js",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Node.js",
-                                  }
-                                }
-                              >
-                                Node.js
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                </p>
-              </Paragraph>
-            </ComponentFactory>
-          </ConditionalWrapper>
-        </div>
-      </Box>
-    </Card>
-  </StyledCard>
-</Card>
-`;
-
-exports[`renders correctly without url 1`] = `
-.emotion-6 {
-  position: relative;
-  border-radius: 7px;
-  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-  background-color: white;
-  color: #21313C;
-}
-
-.emotion-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
-  padding: 32px;
-}
-
-.emotion-4 p:last-of-type {
-  margin-bottom: 0;
-}
-
-.emotion-4:hover {
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-}
-
-.emotion-0 {
-  width: 24px;
-}
-
-.emotion-2 {
-  -webkit-letter-spacing: 0.5px;
-  -moz-letter-spacing: 0.5px;
-  -ms-letter-spacing: 0.5px;
-  letter-spacing: 0.5px;
-  margin: 24px 0 8px 0;
-}
-
-<Card
-  nodeData={
-    Object {
-      "argument": Array [],
-      "children": Array [
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 50,
-                },
-              },
-              "type": "text",
-              "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 50,
-            },
-          },
-          "type": "paragraph",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Android",
                 },
               ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/android",
-                "std-label-android-intro",
-              ],
-              "flag": "",
-              "name": "label",
+              "domain": "mongodb",
+              "name": "card",
+              "options": Object {
+                "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
+                "headline": "Realm SDKs",
+                "icon": "/images/icons/realm_sdk.svg",
+              },
               "position": Object {
                 "start": Object {
-                  "line": 52,
+                  "line": 46,
                 },
               },
-              "target": "android-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "iOS",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/ios",
-                "std-label-ios-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "ios-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": ".Net",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/dotnet",
-                "std-label-dotnet-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "dotnet-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Web",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "web",
-                "std-label-web-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "web-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "React Native",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/react-native",
-                "std-label-react-native-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "react-native-intro",
-              "type": "ref_role",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "type": "text",
-              "value": "
-",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Node.js",
-                },
-              ],
-              "domain": "std",
-              "fileid": Array [
-                "sdk/node",
-                "std-label-node-intro",
-              ],
-              "flag": "",
-              "name": "label",
-              "position": Object {
-                "start": Object {
-                  "line": 52,
-                },
-              },
-              "target": "node-intro",
-              "type": "ref_role",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 52,
-            },
-          },
-          "type": "paragraph",
-        },
-      ],
-      "domain": "mongodb",
-      "name": "card",
-      "options": Object {
-        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
-        "headline": "Realm SDKs",
-        "icon": "/images/icons/realm_sdk.svg",
-      },
-      "position": Object {
-        "start": Object {
-          "line": 46,
-        },
-      },
-      "type": "directive",
-    }
-  }
->
-  <StyledCard>
-    <Card
-      className="emotion-4 emotion-5"
-    >
-      <Box
-        className="emotion-4 emotion-5 emotion-6"
-      >
-        <div
-          className="emotion-4 emotion-5 emotion-6"
+              "type": "directive",
+            }
+          }
         >
-          <ConditionalWrapper
-            wrapper={[Function]}
-          >
-            <CardIcon
-              src="/images/icons/realm_sdk.svg"
+          <CompactCard>
+            <Card
+              className="emotion-8 emotion-9"
             >
-              <img
-                className="emotion-0 emotion-1"
-                src="/images/icons/realm_sdk.svg"
-              />
-            </CardIcon>
-          </ConditionalWrapper>
-          <ConditionalWrapper
-            wrapper={[Function]}
-          >
-            <H4>
-              <h4
-                className="emotion-2 emotion-3"
+              <Box
+                className="emotion-8 emotion-9 emotion-10"
               >
-                Realm SDKs
-              </h4>
-            </H4>
-            <ComponentFactory
-              key="0"
-              nodeData={
+                <div
+                  className="emotion-8 emotion-9 emotion-10"
+                >
+                  <ConditionalWrapper
+                    condition={false}
+                    wrapper={[Function]}
+                  >
+                    <CardIcon
+                      src="/images/icons/realm_sdk.svg"
+                    >
+                      <img
+                        className="emotion-0 emotion-1"
+                        src="/images/icons/realm_sdk.svg"
+                      />
+                    </CardIcon>
+                  </ConditionalWrapper>
+                  <ConditionalWrapper
+                    condition={true}
+                    wrapper={[Function]}
+                  >
+                    <CompactTextWrapper
+                      className="emotion-4"
+                    >
+                      <div
+                        className="emotion-4 emotion-5 emotion-6"
+                      >
+                        <H4
+                          compact={true}
+                        >
+                          <h4
+                            className="emotion-2 emotion-3"
+                          >
+                            Realm SDKs
+                          </h4>
+                        </H4>
+                        <ComponentFactory
+                          key="0"
+                          nodeData={
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 50,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                                },
+                              ],
+                              "position": Object {
+                                "start": Object {
+                                  "line": 50,
+                                },
+                              },
+                              "type": "paragraph",
+                            }
+                          }
+                        >
+                          <Paragraph
+                            nodeData={
+                              Object {
+                                "children": Array [
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 50,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                                  },
+                                ],
+                                "position": Object {
+                                  "start": Object {
+                                    "line": 50,
+                                  },
+                                },
+                                "type": "paragraph",
+                              }
+                            }
+                          >
+                            <p>
+                              <ComponentFactory
+                                key="0"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 50,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 50,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                                    }
+                                  }
+                                >
+                                  Use platform-specific libraries to include and work with the Realm database in your application.
+                                </Text>
+                              </ComponentFactory>
+                            </p>
+                          </Paragraph>
+                        </ComponentFactory>
+                        <ComponentFactory
+                          key="1"
+                          nodeData={
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "Android",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "sdk/android",
+                                    "std-label-android-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "android-intro",
+                                  "type": "ref_role",
+                                },
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "
+",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "iOS",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "sdk/ios",
+                                    "std-label-ios-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "ios-intro",
+                                  "type": "ref_role",
+                                },
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "
+",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": ".Net",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "sdk/dotnet",
+                                    "std-label-dotnet-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "dotnet-intro",
+                                  "type": "ref_role",
+                                },
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "
+",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "Web",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "web",
+                                    "std-label-web-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "web-intro",
+                                  "type": "ref_role",
+                                },
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "
+",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "React Native",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "sdk/react-native",
+                                    "std-label-react-native-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "react-native-intro",
+                                  "type": "ref_role",
+                                },
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "
+",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "Node.js",
+                                    },
+                                  ],
+                                  "domain": "std",
+                                  "fileid": Array [
+                                    "sdk/node",
+                                    "std-label-node-intro",
+                                  ],
+                                  "flag": "",
+                                  "name": "label",
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "target": "node-intro",
+                                  "type": "ref_role",
+                                },
+                              ],
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "paragraph",
+                            }
+                          }
+                        >
+                          <Paragraph
+                            nodeData={
+                              Object {
+                                "children": Array [
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Android",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/android",
+                                      "std-label-android-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "android-intro",
+                                    "type": "ref_role",
+                                  },
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  },
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "iOS",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/ios",
+                                      "std-label-ios-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "ios-intro",
+                                    "type": "ref_role",
+                                  },
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  },
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": ".Net",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/dotnet",
+                                      "std-label-dotnet-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "dotnet-intro",
+                                    "type": "ref_role",
+                                  },
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  },
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Web",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "web",
+                                      "std-label-web-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "web-intro",
+                                    "type": "ref_role",
+                                  },
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  },
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "React Native",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/react-native",
+                                      "std-label-react-native-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "react-native-intro",
+                                    "type": "ref_role",
+                                  },
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  },
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Node.js",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/node",
+                                      "std-label-node-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "node-intro",
+                                    "type": "ref_role",
+                                  },
+                                ],
+                                "position": Object {
+                                  "start": Object {
+                                    "line": 52,
+                                  },
+                                },
+                                "type": "paragraph",
+                              }
+                            }
+                          >
+                            <p>
+                              <ComponentFactory
+                                key="0"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Android",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/android",
+                                      "std-label-android-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "android-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": "Android",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "sdk/android",
+                                        "std-label-android-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "android-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="sdk/android/#std-label-android-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/sdk/android/#std-label-android-intro"
+                                    >
+                                      <a
+                                        href="/sdk/android/#std-label-android-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": "Android",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": "Android",
+                                              }
+                                            }
+                                          >
+                                            Android
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="1"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "
+",
+                                    }
+                                  }
+                                >
+                                  
+
+                                </Text>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="2"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "iOS",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/ios",
+                                      "std-label-ios-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "ios-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": "iOS",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "sdk/ios",
+                                        "std-label-ios-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "ios-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="sdk/ios/#std-label-ios-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/sdk/ios/#std-label-ios-intro"
+                                    >
+                                      <a
+                                        href="/sdk/ios/#std-label-ios-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": "iOS",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": "iOS",
+                                              }
+                                            }
+                                          >
+                                            iOS
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="3"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "
+",
+                                    }
+                                  }
+                                >
+                                  
+
+                                </Text>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="4"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": ".Net",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/dotnet",
+                                      "std-label-dotnet-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "dotnet-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": ".Net",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "sdk/dotnet",
+                                        "std-label-dotnet-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "dotnet-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="sdk/dotnet/#std-label-dotnet-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/sdk/dotnet/#std-label-dotnet-intro"
+                                    >
+                                      <a
+                                        href="/sdk/dotnet/#std-label-dotnet-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": ".Net",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": ".Net",
+                                              }
+                                            }
+                                          >
+                                            .Net
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="5"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "
+",
+                                    }
+                                  }
+                                >
+                                  
+
+                                </Text>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="6"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Web",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "web",
+                                      "std-label-web-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "web-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": "Web",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "web",
+                                        "std-label-web-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "web-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="web/#std-label-web-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/web/#std-label-web-intro"
+                                    >
+                                      <a
+                                        href="/web/#std-label-web-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": "Web",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": "Web",
+                                              }
+                                            }
+                                          >
+                                            Web
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="7"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "
+",
+                                    }
+                                  }
+                                >
+                                  
+
+                                </Text>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="8"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "React Native",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/react-native",
+                                      "std-label-react-native-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "react-native-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": "React Native",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "sdk/react-native",
+                                        "std-label-react-native-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "react-native-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="sdk/react-native/#std-label-react-native-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/sdk/react-native/#std-label-react-native-intro"
+                                    >
+                                      <a
+                                        href="/sdk/react-native/#std-label-react-native-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": "React Native",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": "React Native",
+                                              }
+                                            }
+                                          >
+                                            React Native
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="9"
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "
+",
+                                  }
+                                }
+                              >
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "
+",
+                                    }
+                                  }
+                                >
+                                  
+
+                                </Text>
+                              </ComponentFactory>
+                              <ComponentFactory
+                                key="10"
+                                nodeData={
+                                  Object {
+                                    "children": Array [
+                                      Object {
+                                        "position": Object {
+                                          "start": Object {
+                                            "line": 52,
+                                          },
+                                        },
+                                        "type": "text",
+                                        "value": "Node.js",
+                                      },
+                                    ],
+                                    "domain": "std",
+                                    "fileid": Array [
+                                      "sdk/node",
+                                      "std-label-node-intro",
+                                    ],
+                                    "flag": "",
+                                    "name": "label",
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "target": "node-intro",
+                                    "type": "ref_role",
+                                  }
+                                }
+                              >
+                                <RefRole
+                                  nodeData={
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "position": Object {
+                                            "start": Object {
+                                              "line": 52,
+                                            },
+                                          },
+                                          "type": "text",
+                                          "value": "Node.js",
+                                        },
+                                      ],
+                                      "domain": "std",
+                                      "fileid": Array [
+                                        "sdk/node",
+                                        "std-label-node-intro",
+                                      ],
+                                      "flag": "",
+                                      "name": "label",
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 52,
+                                        },
+                                      },
+                                      "target": "node-intro",
+                                      "type": "ref_role",
+                                    }
+                                  }
+                                >
+                                  <Link
+                                    to="sdk/node/#std-label-node-intro"
+                                  >
+                                    <mockConstructor
+                                      to="/sdk/node/#std-label-node-intro"
+                                    >
+                                      <a
+                                        href="/sdk/node/#std-label-node-intro"
+                                      >
+                                        <ComponentFactory
+                                          key="0"
+                                          nodeData={
+                                            Object {
+                                              "position": Object {
+                                                "start": Object {
+                                                  "line": 52,
+                                                },
+                                              },
+                                              "type": "text",
+                                              "value": "Node.js",
+                                            }
+                                          }
+                                        >
+                                          <Text
+                                            nodeData={
+                                              Object {
+                                                "position": Object {
+                                                  "start": Object {
+                                                    "line": 52,
+                                                  },
+                                                },
+                                                "type": "text",
+                                                "value": "Node.js",
+                                              }
+                                            }
+                                          >
+                                            Node.js
+                                          </Text>
+                                        </ComponentFactory>
+                                      </a>
+                                    </mockConstructor>
+                                  </Link>
+                                </RefRole>
+                              </ComponentFactory>
+                            </p>
+                          </Paragraph>
+                        </ComponentFactory>
+                      </div>
+                    </CompactTextWrapper>
+                  </ConditionalWrapper>
+                </div>
+              </Box>
+            </Card>
+          </CompactCard>
+        </Card>
+      </ComponentFactory>
+      <ComponentFactory
+        isCompact={false}
+        isExtraCompact={true}
+        key="1"
+        nodeData={
+          Object {
+            "argument": Array [],
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 65,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
+                  },
+                ],
+                "position": Object {
+                  "start": Object {
+                    "line": 65,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "domain": "mongodb",
+            "name": "card",
+            "options": Object {
+              "checksum": "a75dde0c71beef8015b5546c7402cb9f9f1e8738823e90617fd7582940a832a0",
+              "cta": "Learn more about MongoDB Realm Application Services",
+              "headline": "MongoDB Realm",
+              "icon": "/images/icons/realm.svg",
+              "url": "https://docs.mongodb.com/realm/services/",
+            },
+            "position": Object {
+              "start": Object {
+                "line": 59,
+              },
+            },
+            "type": "directive",
+          }
+        }
+      >
+        <Card
+          isCompact={false}
+          isExtraCompact={true}
+          nodeData={
+            Object {
+              "argument": Array [],
+              "children": Array [
                 Object {
                   "children": Array [
                     Object {
                       "position": Object {
                         "start": Object {
-                          "line": 50,
+                          "line": 65,
                         },
                       },
                       "type": "text",
-                      "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                      "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
                     },
                   ],
                   "position": Object {
                     "start": Object {
-                      "line": 50,
+                      "line": 65,
                     },
                   },
                   "type": "paragraph",
-                }
-              }
+                },
+              ],
+              "domain": "mongodb",
+              "name": "card",
+              "options": Object {
+                "checksum": "a75dde0c71beef8015b5546c7402cb9f9f1e8738823e90617fd7582940a832a0",
+                "cta": "Learn more about MongoDB Realm Application Services",
+                "headline": "MongoDB Realm",
+                "icon": "/images/icons/realm.svg",
+                "url": "https://docs.mongodb.com/realm/services/",
+              },
+              "position": Object {
+                "start": Object {
+                  "line": 59,
+                },
+              },
+              "type": "directive",
+            }
+          }
+        >
+          <CompactCard
+            onClick={[Function]}
+          >
+            <Card
+              className="emotion-8 emotion-9"
+              onClick={[Function]}
             >
-              <Paragraph
-                nodeData={
-                  Object {
-                    "children": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 50,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                      },
-                    ],
-                    "position": Object {
-                      "start": Object {
-                        "line": 50,
-                      },
-                    },
-                    "type": "paragraph",
-                  }
-                }
+              <Box
+                className="emotion-8 emotion-9 emotion-26"
+                onClick={[Function]}
               >
-                <p>
-                  <ComponentFactory
-                    key="0"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 50,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                      }
-                    }
+                <div
+                  className="emotion-8 emotion-9 emotion-26"
+                  onClick={[Function]}
+                >
+                  <ConditionalWrapper
+                    condition={false}
+                    wrapper={[Function]}
                   >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 50,
-                            },
-                          },
-                          "type": "text",
-                          "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
-                        }
-                      }
+                    <CardIcon
+                      src="/images/icons/realm.svg"
                     >
-                      Use platform-specific libraries to include and work with the Realm database in your application.
-                    </Text>
-                  </ComponentFactory>
-                </p>
-              </Paragraph>
-            </ComponentFactory>
-            <ComponentFactory
-              key="1"
-              nodeData={
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "Android",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "sdk/android",
-                        "std-label-android-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "android-intro",
-                      "type": "ref_role",
-                    },
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "text",
-                      "value": "
-",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "iOS",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "sdk/ios",
-                        "std-label-ios-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "ios-intro",
-                      "type": "ref_role",
-                    },
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "text",
-                      "value": "
-",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": ".Net",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "sdk/dotnet",
-                        "std-label-dotnet-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "dotnet-intro",
-                      "type": "ref_role",
-                    },
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "text",
-                      "value": "
-",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "Web",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "web",
-                        "std-label-web-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "web-intro",
-                      "type": "ref_role",
-                    },
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "text",
-                      "value": "
-",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "React Native",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "sdk/react-native",
-                        "std-label-react-native-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "react-native-intro",
-                      "type": "ref_role",
-                    },
-                    Object {
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "type": "text",
-                      "value": "
-",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "Node.js",
-                        },
-                      ],
-                      "domain": "std",
-                      "fileid": Array [
-                        "sdk/node",
-                        "std-label-node-intro",
-                      ],
-                      "flag": "",
-                      "name": "label",
-                      "position": Object {
-                        "start": Object {
-                          "line": 52,
-                        },
-                      },
-                      "target": "node-intro",
-                      "type": "ref_role",
-                    },
-                  ],
-                  "position": Object {
-                    "start": Object {
-                      "line": 52,
-                    },
-                  },
-                  "type": "paragraph",
-                }
-              }
-            >
-              <Paragraph
-                nodeData={
-                  Object {
-                    "children": Array [
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Android",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/android",
-                          "std-label-android-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "android-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "iOS",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/ios",
-                          "std-label-ios-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "ios-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": ".Net",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/dotnet",
-                          "std-label-dotnet-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "dotnet-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Web",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "web",
-                          "std-label-web-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "web-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "React Native",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/react-native",
-                          "std-label-react-native-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "react-native-intro",
-                        "type": "ref_role",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Node.js",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/node",
-                          "std-label-node-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "node-intro",
-                        "type": "ref_role",
-                      },
-                    ],
-                    "position": Object {
-                      "start": Object {
-                        "line": 52,
-                      },
-                    },
-                    "type": "paragraph",
-                  }
-                }
-              >
-                <p>
-                  <ComponentFactory
-                    key="0"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Android",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/android",
-                          "std-label-android-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "android-intro",
-                        "type": "ref_role",
-                      }
-                    }
+                      <img
+                        className="emotion-0 emotion-1"
+                        src="/images/icons/realm.svg"
+                      />
+                    </CardIcon>
+                  </ConditionalWrapper>
+                  <ConditionalWrapper
+                    condition={true}
+                    wrapper={[Function]}
                   >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Android",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/android",
-                            "std-label-android-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "android-intro",
-                          "type": "ref_role",
-                        }
-                      }
+                    <CompactTextWrapper
+                      className={false}
                     >
-                      <Link
-                        to="sdk/android/#std-label-android-intro"
+                      <div
+                        className="false emotion-5 emotion-6"
                       >
-                        <mockConstructor
-                          to="/sdk/android/#std-label-android-intro"
+                        <H4
+                          compact={true}
                         >
-                          <a
-                            href="/sdk/android/#std-label-android-intro"
+                          <h4
+                            className="emotion-2 emotion-3"
                           >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
+                            MongoDB Realm
+                          </h4>
+                        </H4>
+                        <ComponentFactory
+                          key="0"
+                          nodeData={
+                            Object {
+                              "children": Array [
                                 Object {
                                   "position": Object {
                                     "start": Object {
-                                      "line": 52,
+                                      "line": 65,
                                     },
                                   },
                                   "type": "text",
-                                  "value": "Android",
-                                }
+                                  "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
+                                },
+                              ],
+                              "position": Object {
+                                "start": Object {
+                                  "line": 65,
+                                },
+                              },
+                              "type": "paragraph",
+                            }
+                          }
+                        >
+                          <Paragraph
+                            nodeData={
+                              Object {
+                                "children": Array [
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 65,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
+                                  },
+                                ],
+                                "position": Object {
+                                  "start": Object {
+                                    "line": 65,
+                                  },
+                                },
+                                "type": "paragraph",
                               }
-                            >
-                              <Text
+                            }
+                          >
+                            <p>
+                              <ComponentFactory
+                                key="0"
                                 nodeData={
                                   Object {
                                     "position": Object {
                                       "start": Object {
-                                        "line": 52,
+                                        "line": 65,
                                       },
                                     },
                                     "type": "text",
-                                    "value": "Android",
+                                    "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
                                   }
                                 }
                               >
-                                Android
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="1"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="2"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "iOS",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/ios",
-                          "std-label-ios-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "ios-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "iOS",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/ios",
-                            "std-label-ios-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "ios-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/ios/#std-label-ios-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/ios/#std-label-ios-intro"
-                        >
-                          <a
-                            href="/sdk/ios/#std-label-ios-intro"
+                                <Text
+                                  nodeData={
+                                    Object {
+                                      "position": Object {
+                                        "start": Object {
+                                          "line": 65,
+                                        },
+                                      },
+                                      "type": "text",
+                                      "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.",
+                                    }
+                                  }
+                                >
+                                  Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.
+                                </Text>
+                              </ComponentFactory>
+                            </p>
+                          </Paragraph>
+                        </ComponentFactory>
+                        <CTA>
+                          <p
+                            className="emotion-20 emotion-21"
                           >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "iOS",
-                                }
-                              }
+                            <Link
+                              to="https://docs.mongodb.com/realm/services/"
                             >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "iOS",
-                                  }
-                                }
+                              <a
+                                href="https://docs.mongodb.com/realm/services/"
                               >
-                                iOS
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="3"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="4"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": ".Net",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/dotnet",
-                          "std-label-dotnet-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "dotnet-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": ".Net",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/dotnet",
-                            "std-label-dotnet-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "dotnet-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/dotnet/#std-label-dotnet-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/dotnet/#std-label-dotnet-intro"
-                        >
-                          <a
-                            href="/sdk/dotnet/#std-label-dotnet-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": ".Net",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": ".Net",
-                                  }
-                                }
-                              >
-                                .Net
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="5"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="6"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Web",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "web",
-                          "std-label-web-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "web-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Web",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "web",
-                            "std-label-web-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "web-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="web/#std-label-web-intro"
-                      >
-                        <mockConstructor
-                          to="/web/#std-label-web-intro"
-                        >
-                          <a
-                            href="/web/#std-label-web-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "Web",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Web",
-                                  }
-                                }
-                              >
-                                Web
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="7"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="8"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "React Native",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/react-native",
-                          "std-label-react-native-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "react-native-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "React Native",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/react-native",
-                            "std-label-react-native-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "react-native-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/react-native/#std-label-react-native-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/react-native/#std-label-react-native-intro"
-                        >
-                          <a
-                            href="/sdk/react-native/#std-label-react-native-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "React Native",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "React Native",
-                                  }
-                                }
-                              >
-                                React Native
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="9"
-                    nodeData={
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "type": "text",
-                        "value": "
-",
-                      }
-                    }
-                  >
-                    <Text
-                      nodeData={
-                        Object {
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "type": "text",
-                          "value": "
-",
-                        }
-                      }
-                    >
-                      
-
-                    </Text>
-                  </ComponentFactory>
-                  <ComponentFactory
-                    key="10"
-                    nodeData={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 52,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Node.js",
-                          },
-                        ],
-                        "domain": "std",
-                        "fileid": Array [
-                          "sdk/node",
-                          "std-label-node-intro",
-                        ],
-                        "flag": "",
-                        "name": "label",
-                        "position": Object {
-                          "start": Object {
-                            "line": 52,
-                          },
-                        },
-                        "target": "node-intro",
-                        "type": "ref_role",
-                      }
-                    }
-                  >
-                    <RefRole
-                      nodeData={
-                        Object {
-                          "children": Array [
-                            Object {
-                              "position": Object {
-                                "start": Object {
-                                  "line": 52,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Node.js",
-                            },
-                          ],
-                          "domain": "std",
-                          "fileid": Array [
-                            "sdk/node",
-                            "std-label-node-intro",
-                          ],
-                          "flag": "",
-                          "name": "label",
-                          "position": Object {
-                            "start": Object {
-                              "line": 52,
-                            },
-                          },
-                          "target": "node-intro",
-                          "type": "ref_role",
-                        }
-                      }
-                    >
-                      <Link
-                        to="sdk/node/#std-label-node-intro"
-                      >
-                        <mockConstructor
-                          to="/sdk/node/#std-label-node-intro"
-                        >
-                          <a
-                            href="/sdk/node/#std-label-node-intro"
-                          >
-                            <ComponentFactory
-                              key="0"
-                              nodeData={
-                                Object {
-                                  "position": Object {
-                                    "start": Object {
-                                      "line": 52,
-                                    },
-                                  },
-                                  "type": "text",
-                                  "value": "Node.js",
-                                }
-                              }
-                            >
-                              <Text
-                                nodeData={
-                                  Object {
-                                    "position": Object {
-                                      "start": Object {
-                                        "line": 52,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Node.js",
-                                  }
-                                }
-                              >
-                                Node.js
-                              </Text>
-                            </ComponentFactory>
-                          </a>
-                        </mockConstructor>
-                      </Link>
-                    </RefRole>
-                  </ComponentFactory>
-                </p>
-              </Paragraph>
-            </ComponentFactory>
-          </ConditionalWrapper>
-        </div>
-      </Box>
-    </Card>
-  </StyledCard>
-</Card>
+                                Learn more about MongoDB Realm Application Services
+                              </a>
+                            </Link>
+                          </p>
+                        </CTA>
+                      </div>
+                    </CompactTextWrapper>
+                  </ConditionalWrapper>
+                </div>
+              </Box>
+            </Card>
+          </CompactCard>
+        </Card>
+      </ComponentFactory>
+    </div>
+  </StyledGrid>
+</CardGroup>
 `;

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -1,0 +1,3386 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with url 1`] = `
+.emotion-6 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 32px;
+}
+
+.emotion-4 p:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-4:hover {
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+}
+
+.emotion-0 {
+  width: 24px;
+}
+
+.emotion-2 {
+  -webkit-letter-spacing: 0.5px;
+  -moz-letter-spacing: 0.5px;
+  -ms-letter-spacing: 0.5px;
+  letter-spacing: 0.5px;
+  margin: 24px 0 8px 0;
+}
+
+<Card
+  nodeData={
+    Object {
+      "argument": Array [],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 50,
+                },
+              },
+              "type": "text",
+              "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 50,
+            },
+          },
+          "type": "paragraph",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Android",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/android",
+                "std-label-android-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "android-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "iOS",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/ios",
+                "std-label-ios-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "ios-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": ".Net",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/dotnet",
+                "std-label-dotnet-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "dotnet-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Web",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "web",
+                "std-label-web-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "web-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "React Native",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/react-native",
+                "std-label-react-native-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "react-native-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Node.js",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/node",
+                "std-label-node-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "node-intro",
+              "type": "ref_role",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 52,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "domain": "mongodb",
+      "name": "card",
+      "options": Object {
+        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
+        "headline": "Realm SDKs",
+        "icon": "/images/icons/realm_sdk.svg",
+      },
+      "position": Object {
+        "start": Object {
+          "line": 46,
+        },
+      },
+      "type": "directive",
+    }
+  }
+  url="testdata.com"
+>
+  <StyledCard>
+    <Card
+      className="emotion-4 emotion-5"
+    >
+      <Box
+        className="emotion-4 emotion-5 emotion-6"
+      >
+        <div
+          className="emotion-4 emotion-5 emotion-6"
+        >
+          <ConditionalWrapper
+            wrapper={[Function]}
+          >
+            <CardIcon
+              src="/images/icons/realm_sdk.svg"
+            >
+              <img
+                className="emotion-0 emotion-1"
+                src="/images/icons/realm_sdk.svg"
+              />
+            </CardIcon>
+          </ConditionalWrapper>
+          <ConditionalWrapper
+            wrapper={[Function]}
+          >
+            <H4>
+              <h4
+                className="emotion-2 emotion-3"
+              >
+                Realm SDKs
+              </h4>
+            </H4>
+            <ComponentFactory
+              key="0"
+              nodeData={
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 50,
+                        },
+                      },
+                      "type": "text",
+                      "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                    },
+                  ],
+                  "position": Object {
+                    "start": Object {
+                      "line": 50,
+                    },
+                  },
+                  "type": "paragraph",
+                }
+              }
+            >
+              <Paragraph
+                nodeData={
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 50,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                      },
+                    ],
+                    "position": Object {
+                      "start": Object {
+                        "line": 50,
+                      },
+                    },
+                    "type": "paragraph",
+                  }
+                }
+              >
+                <p>
+                  <ComponentFactory
+                    key="0"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 50,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 50,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                        }
+                      }
+                    >
+                      Use platform-specific libraries to include and work with the Realm database in your application.
+                    </Text>
+                  </ComponentFactory>
+                </p>
+              </Paragraph>
+            </ComponentFactory>
+            <ComponentFactory
+              key="1"
+              nodeData={
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Android",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/android",
+                        "std-label-android-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "android-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "iOS",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/ios",
+                        "std-label-ios-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "ios-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": ".Net",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/dotnet",
+                        "std-label-dotnet-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "dotnet-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Web",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "web",
+                        "std-label-web-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "web-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "React Native",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/react-native",
+                        "std-label-react-native-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "react-native-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Node.js",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/node",
+                        "std-label-node-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "node-intro",
+                      "type": "ref_role",
+                    },
+                  ],
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "paragraph",
+                }
+              }
+            >
+              <Paragraph
+                nodeData={
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Android",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/android",
+                          "std-label-android-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "android-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "iOS",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/ios",
+                          "std-label-ios-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "ios-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": ".Net",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/dotnet",
+                          "std-label-dotnet-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "dotnet-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Web",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "web",
+                          "std-label-web-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "web-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "React Native",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/react-native",
+                          "std-label-react-native-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "react-native-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Node.js",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/node",
+                          "std-label-node-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "node-intro",
+                        "type": "ref_role",
+                      },
+                    ],
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "paragraph",
+                  }
+                }
+              >
+                <p>
+                  <ComponentFactory
+                    key="0"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Android",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/android",
+                          "std-label-android-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "android-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Android",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/android",
+                            "std-label-android-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "android-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/android/#std-label-android-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/android/#std-label-android-intro"
+                        >
+                          <a
+                            href="/sdk/android/#std-label-android-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Android",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Android",
+                                  }
+                                }
+                              >
+                                Android
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="1"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="2"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "iOS",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/ios",
+                          "std-label-ios-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "ios-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "iOS",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/ios",
+                            "std-label-ios-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "ios-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/ios/#std-label-ios-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/ios/#std-label-ios-intro"
+                        >
+                          <a
+                            href="/sdk/ios/#std-label-ios-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "iOS",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "iOS",
+                                  }
+                                }
+                              >
+                                iOS
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="3"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="4"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": ".Net",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/dotnet",
+                          "std-label-dotnet-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "dotnet-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": ".Net",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/dotnet",
+                            "std-label-dotnet-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "dotnet-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/dotnet/#std-label-dotnet-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/dotnet/#std-label-dotnet-intro"
+                        >
+                          <a
+                            href="/sdk/dotnet/#std-label-dotnet-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": ".Net",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": ".Net",
+                                  }
+                                }
+                              >
+                                .Net
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="5"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="6"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Web",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "web",
+                          "std-label-web-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "web-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Web",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "web",
+                            "std-label-web-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "web-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="web/#std-label-web-intro"
+                      >
+                        <mockConstructor
+                          to="/web/#std-label-web-intro"
+                        >
+                          <a
+                            href="/web/#std-label-web-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Web",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Web",
+                                  }
+                                }
+                              >
+                                Web
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="7"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="8"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "React Native",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/react-native",
+                          "std-label-react-native-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "react-native-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "React Native",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/react-native",
+                            "std-label-react-native-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "react-native-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/react-native/#std-label-react-native-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/react-native/#std-label-react-native-intro"
+                        >
+                          <a
+                            href="/sdk/react-native/#std-label-react-native-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "React Native",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "React Native",
+                                  }
+                                }
+                              >
+                                React Native
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="9"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="10"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Node.js",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/node",
+                          "std-label-node-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "node-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Node.js",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/node",
+                            "std-label-node-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "node-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/node/#std-label-node-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/node/#std-label-node-intro"
+                        >
+                          <a
+                            href="/sdk/node/#std-label-node-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Node.js",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Node.js",
+                                  }
+                                }
+                              >
+                                Node.js
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                </p>
+              </Paragraph>
+            </ComponentFactory>
+          </ConditionalWrapper>
+        </div>
+      </Box>
+    </Card>
+  </StyledCard>
+</Card>
+`;
+
+exports[`renders correctly without url 1`] = `
+.emotion-6 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 32px;
+}
+
+.emotion-4 p:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-4:hover {
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+}
+
+.emotion-0 {
+  width: 24px;
+}
+
+.emotion-2 {
+  -webkit-letter-spacing: 0.5px;
+  -moz-letter-spacing: 0.5px;
+  -ms-letter-spacing: 0.5px;
+  letter-spacing: 0.5px;
+  margin: 24px 0 8px 0;
+}
+
+<Card
+  nodeData={
+    Object {
+      "argument": Array [],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 50,
+                },
+              },
+              "type": "text",
+              "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 50,
+            },
+          },
+          "type": "paragraph",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Android",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/android",
+                "std-label-android-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "android-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "iOS",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/ios",
+                "std-label-ios-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "ios-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": ".Net",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/dotnet",
+                "std-label-dotnet-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "dotnet-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Web",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "web",
+                "std-label-web-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "web-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "React Native",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/react-native",
+                "std-label-react-native-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "react-native-intro",
+              "type": "ref_role",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "type": "text",
+              "value": "
+",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Node.js",
+                },
+              ],
+              "domain": "std",
+              "fileid": Array [
+                "sdk/node",
+                "std-label-node-intro",
+              ],
+              "flag": "",
+              "name": "label",
+              "position": Object {
+                "start": Object {
+                  "line": 52,
+                },
+              },
+              "target": "node-intro",
+              "type": "ref_role",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 52,
+            },
+          },
+          "type": "paragraph",
+        },
+      ],
+      "domain": "mongodb",
+      "name": "card",
+      "options": Object {
+        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f",
+        "headline": "Realm SDKs",
+        "icon": "/images/icons/realm_sdk.svg",
+      },
+      "position": Object {
+        "start": Object {
+          "line": 46,
+        },
+      },
+      "type": "directive",
+    }
+  }
+>
+  <StyledCard>
+    <Card
+      className="emotion-4 emotion-5"
+    >
+      <Box
+        className="emotion-4 emotion-5 emotion-6"
+      >
+        <div
+          className="emotion-4 emotion-5 emotion-6"
+        >
+          <ConditionalWrapper
+            wrapper={[Function]}
+          >
+            <CardIcon
+              src="/images/icons/realm_sdk.svg"
+            >
+              <img
+                className="emotion-0 emotion-1"
+                src="/images/icons/realm_sdk.svg"
+              />
+            </CardIcon>
+          </ConditionalWrapper>
+          <ConditionalWrapper
+            wrapper={[Function]}
+          >
+            <H4>
+              <h4
+                className="emotion-2 emotion-3"
+              >
+                Realm SDKs
+              </h4>
+            </H4>
+            <ComponentFactory
+              key="0"
+              nodeData={
+                Object {
+                  "children": Array [
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 50,
+                        },
+                      },
+                      "type": "text",
+                      "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                    },
+                  ],
+                  "position": Object {
+                    "start": Object {
+                      "line": 50,
+                    },
+                  },
+                  "type": "paragraph",
+                }
+              }
+            >
+              <Paragraph
+                nodeData={
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 50,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                      },
+                    ],
+                    "position": Object {
+                      "start": Object {
+                        "line": 50,
+                      },
+                    },
+                    "type": "paragraph",
+                  }
+                }
+              >
+                <p>
+                  <ComponentFactory
+                    key="0"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 50,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 50,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Use platform-specific libraries to include and work with the Realm database in your application.",
+                        }
+                      }
+                    >
+                      Use platform-specific libraries to include and work with the Realm database in your application.
+                    </Text>
+                  </ComponentFactory>
+                </p>
+              </Paragraph>
+            </ComponentFactory>
+            <ComponentFactory
+              key="1"
+              nodeData={
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Android",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/android",
+                        "std-label-android-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "android-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "iOS",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/ios",
+                        "std-label-ios-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "ios-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": ".Net",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/dotnet",
+                        "std-label-dotnet-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "dotnet-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Web",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "web",
+                        "std-label-web-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "web-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "React Native",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/react-native",
+                        "std-label-react-native-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "react-native-intro",
+                      "type": "ref_role",
+                    },
+                    Object {
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "type": "text",
+                      "value": "
+",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "Node.js",
+                        },
+                      ],
+                      "domain": "std",
+                      "fileid": Array [
+                        "sdk/node",
+                        "std-label-node-intro",
+                      ],
+                      "flag": "",
+                      "name": "label",
+                      "position": Object {
+                        "start": Object {
+                          "line": 52,
+                        },
+                      },
+                      "target": "node-intro",
+                      "type": "ref_role",
+                    },
+                  ],
+                  "position": Object {
+                    "start": Object {
+                      "line": 52,
+                    },
+                  },
+                  "type": "paragraph",
+                }
+              }
+            >
+              <Paragraph
+                nodeData={
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Android",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/android",
+                          "std-label-android-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "android-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "iOS",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/ios",
+                          "std-label-ios-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "ios-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": ".Net",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/dotnet",
+                          "std-label-dotnet-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "dotnet-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Web",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "web",
+                          "std-label-web-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "web-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "React Native",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/react-native",
+                          "std-label-react-native-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "react-native-intro",
+                        "type": "ref_role",
+                      },
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Node.js",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/node",
+                          "std-label-node-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "node-intro",
+                        "type": "ref_role",
+                      },
+                    ],
+                    "position": Object {
+                      "start": Object {
+                        "line": 52,
+                      },
+                    },
+                    "type": "paragraph",
+                  }
+                }
+              >
+                <p>
+                  <ComponentFactory
+                    key="0"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Android",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/android",
+                          "std-label-android-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "android-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Android",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/android",
+                            "std-label-android-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "android-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/android/#std-label-android-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/android/#std-label-android-intro"
+                        >
+                          <a
+                            href="/sdk/android/#std-label-android-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Android",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Android",
+                                  }
+                                }
+                              >
+                                Android
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="1"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="2"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "iOS",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/ios",
+                          "std-label-ios-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "ios-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "iOS",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/ios",
+                            "std-label-ios-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "ios-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/ios/#std-label-ios-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/ios/#std-label-ios-intro"
+                        >
+                          <a
+                            href="/sdk/ios/#std-label-ios-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "iOS",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "iOS",
+                                  }
+                                }
+                              >
+                                iOS
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="3"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="4"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": ".Net",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/dotnet",
+                          "std-label-dotnet-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "dotnet-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": ".Net",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/dotnet",
+                            "std-label-dotnet-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "dotnet-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/dotnet/#std-label-dotnet-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/dotnet/#std-label-dotnet-intro"
+                        >
+                          <a
+                            href="/sdk/dotnet/#std-label-dotnet-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": ".Net",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": ".Net",
+                                  }
+                                }
+                              >
+                                .Net
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="5"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="6"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Web",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "web",
+                          "std-label-web-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "web-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Web",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "web",
+                            "std-label-web-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "web-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="web/#std-label-web-intro"
+                      >
+                        <mockConstructor
+                          to="/web/#std-label-web-intro"
+                        >
+                          <a
+                            href="/web/#std-label-web-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Web",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Web",
+                                  }
+                                }
+                              >
+                                Web
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="7"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="8"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "React Native",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/react-native",
+                          "std-label-react-native-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "react-native-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "React Native",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/react-native",
+                            "std-label-react-native-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "react-native-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/react-native/#std-label-react-native-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/react-native/#std-label-react-native-intro"
+                        >
+                          <a
+                            href="/sdk/react-native/#std-label-react-native-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "React Native",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "React Native",
+                                  }
+                                }
+                              >
+                                React Native
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="9"
+                    nodeData={
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "type": "text",
+                        "value": "
+",
+                      }
+                    }
+                  >
+                    <Text
+                      nodeData={
+                        Object {
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "type": "text",
+                          "value": "
+",
+                        }
+                      }
+                    >
+                      
+
+                    </Text>
+                  </ComponentFactory>
+                  <ComponentFactory
+                    key="10"
+                    nodeData={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "position": Object {
+                              "start": Object {
+                                "line": 52,
+                              },
+                            },
+                            "type": "text",
+                            "value": "Node.js",
+                          },
+                        ],
+                        "domain": "std",
+                        "fileid": Array [
+                          "sdk/node",
+                          "std-label-node-intro",
+                        ],
+                        "flag": "",
+                        "name": "label",
+                        "position": Object {
+                          "start": Object {
+                            "line": 52,
+                          },
+                        },
+                        "target": "node-intro",
+                        "type": "ref_role",
+                      }
+                    }
+                  >
+                    <RefRole
+                      nodeData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "position": Object {
+                                "start": Object {
+                                  "line": 52,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Node.js",
+                            },
+                          ],
+                          "domain": "std",
+                          "fileid": Array [
+                            "sdk/node",
+                            "std-label-node-intro",
+                          ],
+                          "flag": "",
+                          "name": "label",
+                          "position": Object {
+                            "start": Object {
+                              "line": 52,
+                            },
+                          },
+                          "target": "node-intro",
+                          "type": "ref_role",
+                        }
+                      }
+                    >
+                      <Link
+                        to="sdk/node/#std-label-node-intro"
+                      >
+                        <mockConstructor
+                          to="/sdk/node/#std-label-node-intro"
+                        >
+                          <a
+                            href="/sdk/node/#std-label-node-intro"
+                          >
+                            <ComponentFactory
+                              key="0"
+                              nodeData={
+                                Object {
+                                  "position": Object {
+                                    "start": Object {
+                                      "line": 52,
+                                    },
+                                  },
+                                  "type": "text",
+                                  "value": "Node.js",
+                                }
+                              }
+                            >
+                              <Text
+                                nodeData={
+                                  Object {
+                                    "position": Object {
+                                      "start": Object {
+                                        "line": 52,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Node.js",
+                                  }
+                                }
+                              >
+                                Node.js
+                              </Text>
+                            </ComponentFactory>
+                          </a>
+                        </mockConstructor>
+                      </Link>
+                    </RefRole>
+                  </ComponentFactory>
+                </p>
+              </Paragraph>
+            </ComponentFactory>
+          </ConditionalWrapper>
+        </div>
+      </Box>
+    </Card>
+  </StyledCard>
+</Card>
+`;

--- a/tests/unit/data/CardRef.test.json
+++ b/tests/unit/data/CardRef.test.json
@@ -1,0 +1,313 @@
+{
+    "type": "directive",
+    "position":
+    {
+        "start":
+        {
+            "line": 46
+        }
+    },
+    "children":
+    [
+        {
+            "type": "paragraph",
+            "position":
+            {
+                "start":
+                {
+                    "line": 50
+                }
+            },
+            "children":
+            [
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 50
+                        }
+                    },
+                    "value": "Use platform-specific libraries to include and work with the Realm database in your application."
+                }
+            ]
+        },
+        {
+            "type": "paragraph",
+            "position":
+            {
+                "start":
+                {
+                    "line": 52
+                }
+            },
+            "children":
+            [
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "Android"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "android-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "sdk/android",
+                        "std-label-android-intro"
+                    ]
+                },
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "iOS"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "ios-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "sdk/ios",
+                        "std-label-ios-intro"
+                    ]
+                },
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": ".Net"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "dotnet-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "sdk/dotnet",
+                        "std-label-dotnet-intro"
+                    ]
+                },
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "Web"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "web-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "web",
+                        "std-label-web-intro"
+                    ]
+                },
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "React Native"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "react-native-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "sdk/react-native",
+                        "std-label-react-native-intro"
+                    ]
+                },
+                {
+                    "type": "text",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "ref_role",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "Node.js"
+                        }
+                    ],
+                    "domain": "std",
+                    "name": "label",
+                    "target": "node-intro",
+                    "flag": "",
+                    "fileid":
+                    [
+                        "sdk/node",
+                        "std-label-node-intro"
+                    ]
+                }
+            ]
+        }
+    ],
+    "domain": "mongodb",
+    "name": "card",
+    "argument":
+    [],
+    "options":
+    {
+        "headline": "Realm SDKs",
+        "icon": "/images/icons/realm_sdk.svg",
+        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f"
+    }
+}

--- a/tests/unit/data/CardRef.test.json
+++ b/tests/unit/data/CardRef.test.json
@@ -4,24 +4,24 @@
     {
         "start":
         {
-            "line": 46
+            "line": 42
         }
     },
     "children":
     [
         {
-            "type": "paragraph",
+            "type": "directive",
             "position":
             {
                 "start":
                 {
-                    "line": 50
+                    "line": 46
                 }
             },
             "children":
             [
                 {
-                    "type": "text",
+                    "type": "paragraph",
                     "position":
                     {
                         "start":
@@ -29,28 +29,317 @@
                             "line": 50
                         }
                     },
-                    "value": "Use platform-specific libraries to include and work with the Realm database in your application."
+                    "children":
+                    [
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 50
+                                }
+                            },
+                            "value": "Use platform-specific libraries to include and work with the Realm database in your application."
+                        }
+                    ]
+                },
+                {
+                    "type": "paragraph",
+                    "position":
+                    {
+                        "start":
+                        {
+                            "line": 52
+                        }
+                    },
+                    "children":
+                    [
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": "Android"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "android-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "sdk/android",
+                                "std-label-android-intro"
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "\n"
+                        },
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": "iOS"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "ios-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "sdk/ios",
+                                "std-label-ios-intro"
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "\n"
+                        },
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": ".Net"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "dotnet-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "sdk/dotnet",
+                                "std-label-dotnet-intro"
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "\n"
+                        },
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": "Web"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "web-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "web",
+                                "std-label-web-intro"
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "\n"
+                        },
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": "React Native"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "react-native-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "sdk/react-native",
+                                "std-label-react-native-intro"
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "value": "\n"
+                        },
+                        {
+                            "type": "ref_role",
+                            "position":
+                            {
+                                "start":
+                                {
+                                    "line": 52
+                                }
+                            },
+                            "children":
+                            [
+                                {
+                                    "type": "text",
+                                    "position":
+                                    {
+                                        "start":
+                                        {
+                                            "line": 52
+                                        }
+                                    },
+                                    "value": "Node.js"
+                                }
+                            ],
+                            "domain": "std",
+                            "name": "label",
+                            "target": "node-intro",
+                            "flag": "",
+                            "fileid":
+                            [
+                                "sdk/node",
+                                "std-label-node-intro"
+                            ]
+                        }
+                    ]
                 }
-            ]
+            ],
+            "domain": "mongodb",
+            "name": "card",
+            "argument":
+            [],
+            "options":
+            {
+                "headline": "Realm SDKs",
+                "icon": "/images/icons/realm_sdk.svg",
+                "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f"
+            }
         },
         {
-            "type": "paragraph",
+            "type": "directive",
             "position":
             {
                 "start":
                 {
-                    "line": 52
+                    "line": 59
                 }
             },
             "children":
             [
                 {
-                    "type": "ref_role",
+                    "type": "paragraph",
                     "position":
                     {
                         "start":
                         {
-                            "line": 52
+                            "line": 65
                         }
                     },
                     "children":
@@ -61,253 +350,35 @@
                             {
                                 "start":
                                 {
-                                    "line": 52
+                                    "line": 65
                                 }
                             },
-                            "value": "Android"
+                            "value": "Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas."
                         }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "android-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "sdk/android",
-                        "std-label-android-intro"
-                    ]
-                },
-                {
-                    "type": "text",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "value": "\n"
-                },
-                {
-                    "type": "ref_role",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "children":
-                    [
-                        {
-                            "type": "text",
-                            "position":
-                            {
-                                "start":
-                                {
-                                    "line": 52
-                                }
-                            },
-                            "value": "iOS"
-                        }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "ios-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "sdk/ios",
-                        "std-label-ios-intro"
-                    ]
-                },
-                {
-                    "type": "text",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "value": "\n"
-                },
-                {
-                    "type": "ref_role",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "children":
-                    [
-                        {
-                            "type": "text",
-                            "position":
-                            {
-                                "start":
-                                {
-                                    "line": 52
-                                }
-                            },
-                            "value": ".Net"
-                        }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "dotnet-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "sdk/dotnet",
-                        "std-label-dotnet-intro"
-                    ]
-                },
-                {
-                    "type": "text",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "value": "\n"
-                },
-                {
-                    "type": "ref_role",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "children":
-                    [
-                        {
-                            "type": "text",
-                            "position":
-                            {
-                                "start":
-                                {
-                                    "line": 52
-                                }
-                            },
-                            "value": "Web"
-                        }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "web-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "web",
-                        "std-label-web-intro"
-                    ]
-                },
-                {
-                    "type": "text",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "value": "\n"
-                },
-                {
-                    "type": "ref_role",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "children":
-                    [
-                        {
-                            "type": "text",
-                            "position":
-                            {
-                                "start":
-                                {
-                                    "line": 52
-                                }
-                            },
-                            "value": "React Native"
-                        }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "react-native-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "sdk/react-native",
-                        "std-label-react-native-intro"
-                    ]
-                },
-                {
-                    "type": "text",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "value": "\n"
-                },
-                {
-                    "type": "ref_role",
-                    "position":
-                    {
-                        "start":
-                        {
-                            "line": 52
-                        }
-                    },
-                    "children":
-                    [
-                        {
-                            "type": "text",
-                            "position":
-                            {
-                                "start":
-                                {
-                                    "line": 52
-                                }
-                            },
-                            "value": "Node.js"
-                        }
-                    ],
-                    "domain": "std",
-                    "name": "label",
-                    "target": "node-intro",
-                    "flag": "",
-                    "fileid":
-                    [
-                        "sdk/node",
-                        "std-label-node-intro"
                     ]
                 }
-            ]
+            ],
+            "domain": "mongodb",
+            "name": "card",
+            "argument":
+            [],
+            "options":
+            {
+                "cta": "Learn more about MongoDB Realm Application Services",
+                "headline": "MongoDB Realm",
+                "icon": "/images/icons/realm.svg",
+                "url": "https://docs.mongodb.com/realm/services/",
+                "checksum": "a75dde0c71beef8015b5546c7402cb9f9f1e8738823e90617fd7582940a832a0"
+            }
         }
     ],
     "domain": "mongodb",
-    "name": "card",
+    "name": "card-group",
     "argument":
     [],
     "options":
     {
-        "headline": "Realm SDKs",
-        "icon": "/images/icons/realm_sdk.svg",
-        "checksum": "6ab1b6f350784c7f0de16ea79adb40b6c08ee0482a508d7b6a274597d4be6d7f"
+        "columns": 3,
+        "style": "extra-compact"
     }
 }


### PR DESCRIPTION
### Stories/Links:

[DOP-2174](https://jira.mongodb.org/browse/DOP-2174)
[index.txt rST](https://github.com/mango-db/docs-realm/blob/master/source/index.txt)
[Figma](https://www.figma.com/file/hPTwMb9uHOypYLckYDg072/Realm-PLP?node-id=0%3A1)

### Staging Links:

[Docs-realm](https://docs-mongodborg-staging.corp.mongodb.com/master/realm/cgoecknerwald/DOP-2174/)
[Docs-compass](https://docs-mongodborg-staging.corp.mongodb.com/master/compass/cgoecknerwald/DOP-2174/
) for sanity check <- nothing should break, though the breakpoint for cards to switch to 2 columns is bumped up to ~1200px

#### Tabs margin change

[Cloud-docs 1](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/cgoecknerwald/DOP-2174/security-add-mongodb-users/#open-the-add-new-database-user-dialog) <- no changes expected
[Cloud-docs 2](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/carolinao/DOP-1728/security-multi-factor-authentication/#set-up-an-authentication-method) <- no changes expected

### Notes:
- Hero image [handled separately](https://github.com/mongodb/snooty/pull/438)