### PR TITLE
change java slug to /java-drivers/

### DIFF
--- a/src/components/EcosystemHomepageTiles.js
+++ b/src/components/EcosystemHomepageTiles.js
@@ -41,7 +41,7 @@ const EcosystemHomepageTiles = () => {
       icon: <IconGo />,
     },
     {
-      slug: '/java/',
+      slug: '/java-drivers/',
       title: 'Java',
       icon: <IconJava />,
     },


### PR DESCRIPTION
This is part of https://jira.mongodb.org/browse/DOCSP-17578. The Nav links to `/java-drivers/` but the Ecosystem/Drivers homepage links to `/java/`. By updating it to link to the same location as the toolbar, it allows us to remove a temporary workaround and reduce the amount of clicks needed to get to the new documentation for the synchronous Java driver.

### Stories/Links:

DOP-NNNN

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:
