### PR TITLE
DOP-2351: Fix TOC drawers directing to incorrect page

### DIFF
--- a/src/components/TOCNode.js
+++ b/src/components/TOCNode.js
@@ -59,7 +59,7 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
       };
       // TODO: Ideally, this value should be a button, but to keep consistent with CSS render as anchor
       return (
-        <Link // eslint-disable-line jsx-a11y/anchor-is-valid
+        <Link
           onClick={(e) => {
             e.preventDefault();
             setIsOpen(!isOpen);
@@ -69,7 +69,7 @@ const TOCNode = ({ node, level = BASE_NODE_LEVEL }) => {
           aria-expanded={hasChildren ? isActive : undefined}
           role="button"
           tabIndex="0"
-          href={target}
+          to={target}
         >
           {caretIcon}
           {formattedTitle}

--- a/tests/unit/__snapshots__/TableOfContents.test.js.snap
+++ b/tests/unit/__snapshots__/TableOfContents.test.js.snap
@@ -448,23 +448,33 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           <Link
             aria-expanded={false}
             className="reference  internal"
-            href="platforms"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            to="platforms"
           >
-            <a
+            <mockConstructor
               aria-expanded={false}
               className="reference  internal"
-              href="platforms"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"
               tabIndex="0"
+              to="/platforms/"
             >
-              Platforms
-            </a>
+              <a
+                aria-expanded={false}
+                className="reference  internal"
+                href="/platforms/"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex="0"
+              >
+                Platforms
+              </a>
+            </mockConstructor>
           </Link>
         </NodeLink>
       </li>
@@ -529,23 +539,33 @@ exports[`Table of Contents testing Table of Contents unit tests renders correctl
           <Link
             aria-expanded={false}
             className="reference  internal"
-            href="use-cases"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            to="use-cases"
           >
-            <a
+            <mockConstructor
               aria-expanded={false}
               className="reference  internal"
-              href="use-cases"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"
               tabIndex="0"
+              to="/use-cases/"
             >
-              Use Cases
-            </a>
+              <a
+                aria-expanded={false}
+                className="reference  internal"
+                href="/use-cases/"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex="0"
+              >
+                Use Cases
+              </a>
+            </mockConstructor>
           </Link>
         </NodeLink>
       </li>


### PR DESCRIPTION
### Stories/Links:

DOP-2351

### Staging Links:

[Docs staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/raymundrodriguez/DOP-2351/tutorial/getting-started/)

### Notes:
* Use `to` prop instead of `href` to prevent relative path for TOC drawers.
* Go to an arbitrary page on staging and note that drawers now link to its page with the correct site prefix.
* Looked for other `Link` components throughout Snooty that use `href` and could not find any. Other uses of `a` tags use `href`s properly and intentionally, from what I could tell. (There were a lot of entries of both `Link` and `a` so apologies if I missed any 😄)