### PR TITLE
Dop 2298

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,10 +5,10 @@ import { UserProvider } from './src/contexts/user-context';
 import { theme } from './src/theme/docsTheme';
 import './src/styles/mongodb-docs.css';
 
+export const wrapPageElement = ({ element }) => <UserProvider>{element}</UserProvider>;
+
 export const wrapRootElement = ({ element }) => (
   <ThemeProvider theme={theme}>
-    <LeafyGreenProvider baseFontSize={16}>
-      <UserProvider>{element}</UserProvider>
-    </LeafyGreenProvider>
+    <LeafyGreenProvider baseFontSize={16}>{element}</LeafyGreenProvider>
   </ThemeProvider>
 );

--- a/src/contexts/user-context.js
+++ b/src/contexts/user-context.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { getUserProfileFromJWT } from '../clients/auth.js';
+import { getUserProfileFromJWT } from '../services/auth.js';
+import { useLocation } from '@reach/router';
 // import { isBrowser } from '../utils/is-browser';
 
 const defaultContextValue = {
@@ -11,13 +12,16 @@ const UserContext = React.createContext(defaultContextValue);
 
 const UserProvider = ({ children = {} }) => {
   const [userData, setUserData] = useState();
+
+  const location = useLocation();
+
   useEffect(() => {
     (async () => {
       const userProfile = await getUserProfileFromJWT();
       setUserData(userProfile);
       console.log(userProfile);
     })();
-  }, []);
+  }, [location]);
   return <UserContext.Provider value={{ userData, setUserData }}>{children}</UserContext.Provider>;
 };
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -55,18 +55,27 @@ const authorize = async () => {
   });
 };
 
+const clearApplicationSession = async () => {
+  await authClient.tokenManager.remove('idToken');
+};
+
+//Checks for an existing IDP session and attempts to retrieve idToken.
+//If no idToken is set but an IDP session is present, attempts to ensure
+//that we can instantatiate a new token for the application session
 const checkOktaSession = async () => {
   return authClient.session.exists().then(async (exists) => {
     if (exists) {
       const idToken = await authClient.tokenManager.get('idToken');
-      return idToken ? idToken : ensureOktaApplicationSession();
+      return idToken ? idToken : await ensureOktaApplicationSession();
     } else {
       console.log('logged out - clear tokens after this message');
-      // TODO: Add a call to clear tokens here, when we're certain that all other logic is valid.
+      await clearApplicationSession();
+      return {};
     }
   });
 };
 
+//Entry point to get a user's profile data from a JWT.
 export const getUserProfileFromJWT = async () => {
   if (isBrowser && authClient) {
     if (authClient.isLoginRedirect()) {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -66,7 +66,9 @@ const checkOktaSession = async () => {
   return authClient.session.exists().then(async (exists) => {
     if (exists) {
       const idToken = await authClient.tokenManager.get('idToken');
-      return idToken ? idToken : await ensureOktaApplicationSession();
+      if (idToken) return idToken;
+      await ensureOktaApplicationSession();
+      return authClient.tokenManager.get('idToken');
     } else {
       console.log('logged out - clear tokens after this message');
       await clearApplicationSession();


### PR DESCRIPTION
### Stories/Links:

DOP-2298

### Staging Links:

N/A - only configured for localhost

### Notes:

- Adds application session invalidation logic and id token clearing on an invalid Okta IDP session.
- Fixes a bug where a user could log in and establish an IDP session, but we never surfaced idToken profile data to the UserProvider after handling the valid IDP session and missing idToken 
- moves UserProvider to a per page level. A little unorthodox, but the most suitable option for checking authentication status on a per page basis