### PR TITLE
DOP-2380: Add mobile support for the side nav with consistent nav enabled

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import SiteBanner from './SiteBanner';
+import { UnifiedNav } from '@mdb/consistent-nav';
 import Navbar from './Navbar';
+import { SidenavMobileMenuDropdown } from './Sidenav';
+import SiteBanner from './SiteBanner';
 
 const StyledHeaderContainer = styled.header`
   grid-area: header;
@@ -12,7 +14,16 @@ const Header = () => {
   return (
     <StyledHeaderContainer>
       <SiteBanner />
-      <Navbar />
+      {/* TODO: Remove this flag after consistent-nav is officially released */}
+      {process.env.FEATURE_FLAG_CONSISTENT_NAVIGATION ? (
+        <>
+          {/* UnifiedNav currently looks wonky on grid layout; this should be changed in a future update */}
+          <UnifiedNav position="relative" />
+          <SidenavMobileMenuDropdown />
+        </>
+      ) : (
+        <Navbar />
+      )}
     </StyledHeaderContainer>
   );
 };

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -51,6 +51,7 @@ const NavLabel = styled('div')`
   user-select: none;
 `;
 
+// TODO: Remove this component after consistent-nav is officially released
 const Navbar = () => {
   // We want to expand the searchbar on default when it won't collide with any other nav elements
   // Specifically, the upper limit works around the Get MongoDB link

--- a/src/components/Sidenav/SidenavMobileMenuButton.js
+++ b/src/components/Sidenav/SidenavMobileMenuButton.js
@@ -22,6 +22,7 @@ const MenuButton = styled(IconButton)`
   }
 `;
 
+// TODO: Remove this component after consistent-nav is officially released
 const SidenavMobileMenuButton = ({ className }) => {
   const { hideMobile, setHideMobile } = useContext(SidenavContext);
 

--- a/src/components/Sidenav/SidenavMobileMenuDropdown.js
+++ b/src/components/Sidenav/SidenavMobileMenuDropdown.js
@@ -1,0 +1,45 @@
+import React, { useCallback, useContext } from 'react';
+import styled from '@emotion/styled';
+import Icon from '@leafygreen-ui/icon';
+import { uiColors } from '@leafygreen-ui/palette';
+import { SidenavContext } from './sidenav-context';
+import { theme } from '../../theme/docsTheme';
+import { displayNone } from '../../utils/display-none';
+
+const Container = styled('div')`
+  align-items: center;
+  background-color: ${uiColors.gray.light3};
+  border-bottom: 1px solid ${uiColors.gray.light2};
+  display: flex;
+  height: 52px;
+  justify-content: space-between;
+  width: 100vw;
+
+  ${displayNone.onLargerThanMobile}
+`;
+
+const Text = styled('div')`
+  color: ${uiColors.black};
+  margin-left: ${theme.size.large};
+`;
+
+const StyledIcon = styled(Icon)`
+  margin-right: ${theme.size.medium};
+`;
+
+const SidenavMobileMenuDropdown = () => {
+  const { hideMobile, setHideMobile } = useContext(SidenavContext);
+
+  const clickDropdown = useCallback(() => {
+    setHideMobile((state) => !state);
+  }, [setHideMobile]);
+
+  return (
+    <Container onClick={clickDropdown}>
+      <Text>Docs Menu</Text>
+      <StyledIcon glyph={hideMobile ? 'ChevronDown' : 'ChevronUp'} />
+    </Container>
+  );
+};
+
+export default SidenavMobileMenuDropdown;

--- a/src/components/Sidenav/index.js
+++ b/src/components/Sidenav/index.js
@@ -1,6 +1,14 @@
 import Sidenav from './Sidenav';
 import SidenavBackButton from './SidenavBackButton';
 import SidenavMobileMenuButton from './SidenavMobileMenuButton';
+import SidenavMobileMenuDropdown from './SidenavMobileMenuDropdown';
 import { SidenavContext, SidenavContextProvider } from './sidenav-context';
 
-export { Sidenav, SidenavBackButton, SidenavContext, SidenavContextProvider, SidenavMobileMenuButton };
+export {
+  Sidenav,
+  SidenavBackButton,
+  SidenavContext,
+  SidenavContextProvider,
+  SidenavMobileMenuButton,
+  SidenavMobileMenuDropdown,
+};


### PR DESCRIPTION
### Stories/Links:

DOP-2380

### Staging Links:

[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2380/) - with consistent nav feature flag
[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2380-flag-off/) - with feature flag off

### Notes:
* Added a new component `SidenavMobileMenuDropdown` to allow users to open the new side nav with the new consistent nav
* The current implementation of the consistent nav on the new docs-nav layout isn't perfect at the moment because of its compatibility with our grid layout. There should be an upcoming update to the consistent nav package that fixes this