### PR TITLE
readme-update: Update README.md to expand on release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ make stage
 
 We have configured an automatic release process using [GitHub Actions](https://github.com/features/actions) that is triggered by [npm-version](https://docs.npmjs.com/cli/version). To release a version, you must have admin privileges in this repo. Then proceed as follows:
 
-1. Run `npm version [major | minor | patch]`, using [Semantic Versioning](https://semver.org) guidelines to correctly increment the version number. GitHub Actions will create a new git tag and push it to GitHub.
-2. Update the release draft found [here](https://github.com/mongodb/snooty/releases) using the automatically generated [CHANGELOG.md](https://github.com/mongodb/snooty/blob/master/CHANGELOG.md) and publish the release.
+1. On the `master` branch, run `git pull` followed by `npm ci`.
+2. Run `npm version [major | minor | patch]`, using [Semantic Versioning](https://semver.org) guidelines to correctly increment the version number. Keep the minor version consistent with [snooty-parser versioning](https://github.com/mongodb/snooty-parser/tags). GitHub Actions will create a new git tag and push it to GitHub.
+3. Update the release draft found [here](https://github.com/mongodb/snooty/releases) using the automatically generated [CHANGELOG.md](https://github.com/mongodb/snooty/blob/master/CHANGELOG.md) and publish the release. Keep "pre-release" checked until version 1.0.0.
 
 :warning: This process cannot be completed if the releaser's `origin` points to a fork.
 


### PR DESCRIPTION
Added the following to help standardize + document release process:

- Be on master branch & run npm ci
- Keep snooty + snooty-parser minor versions consistent
- Keep pre-release checked until 1.0.0