### PR TITLE
Append GATSBY_ prefix to existing nav feature flag

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -104,7 +104,7 @@ const Navbar = () => {
 
   return (
     <>
-      {process.env.FEATURE_FLAG_CONSISTENT_NAVIGATION ? (
+      {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION ? (
         <div
           css={css`
             position: fixed;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -18,7 +18,7 @@ const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => 
   }, []);
 
   const consistentNavHeightOffset =
-    process.env.FEATURE_FLAG_CONSISTENT_NAVIGATION &&
+    process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION &&
     css`
       top: 56px !important;
       @media ${theme.screenSize.largeAndUp} {


### PR DESCRIPTION
### Stories/Links:

DOP-2385

### Staging Links:

N/A, meant to interact with autobuilder

related PR:
https://github.com/mongodb/docs-worker-pool/pull/475

### Notes:
Observed that feature flag wasn't functional in environments built with autobuilder (flag is additive - no regressions, only causes the old nav to render, which is desired production behavior currently). 

Cause seems isolated to the autobuilder itself (see related pr) but this is a precaution after referencing https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/.

Changes the feature flag in use to have `GATSBY_` as a prefix. 

