### PR TITLE
DOP-2190: support user-specified canonical URLs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-sitemap',
     {
-      resolve: 'gatsby-plugin-canonical-urls',
+      resolve: 'gatsby-plugin-react-helmet-canonical-urls',
       options: {
         siteUrl: `${siteMetadata.siteUrl}${pathPrefix}`,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "gatsby-plugin-google-tagmanager": "^2.8.0",
         "gatsby-plugin-layout": "^1.7.0",
         "gatsby-plugin-react-helmet": "^3.7.0",
+        "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
         "gatsby-plugin-sitemap": "^2.11.0",
         "highlight.js": "~10.6.0",
         "html-screen-capture-js": "^1.0.50",
@@ -306,9 +307,8 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha1-bRpE32o4yVeqfDEtoHZCnxG0IvM=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -391,10 +391,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-      "integrity": "sha1-0PDid8US4Mk4J3+qhaOWjJpEwOg=",
-      "license": "MIT",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -629,9 +628,8 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha1-AA4uJdhnPM5JMAUXo+2kTCY+QgE=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -644,9 +642,8 @@
     },
     "node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
       "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha1-WsgizpfuxGdBq3ClF5ceRDpwxak=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1265,12 +1262,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha1-O7mXuoKaIQTO2yBonEpbgSHTg/8=",
-      "license": "MIT",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1301,9 +1297,8 @@
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.3.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
-      "integrity": "sha1-OhaFC6BNjZZR8H8/tnSzQ2pPudc=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
+      "integrity": "sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/plugin-syntax-jsx": "^7.12.13",
@@ -1332,21 +1327,18 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
       "version": "0.8.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
       "version": "0.7.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha1-LED4FEmk5VTp/GOWkQ7UhD7CvlA=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
       "version": "1.0.2",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/serialize/-/serialize-1.0.2.tgz",
-      "integrity": "sha1-d8shoFccn2jrZgh3VKZfqXv82WU=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
       "dependencies": {
         "@emotion/hash": "^0.8.0",
         "@emotion/memoize": "^0.7.4",
@@ -1357,21 +1349,18 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
       "version": "1.0.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha1-q+BqgxYLEFcIFskTmQJFgTov1q8=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/csstype": {
       "version": "3.0.8",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -1445,9 +1434,8 @@
     },
     "node_modules/@emotion/react": {
       "version": "11.4.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/react/-/react-11.4.0.tgz",
-      "integrity": "sha1-JGWtewc6aRQJuI39ltwXCX3a2bc=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.0.tgz",
+      "integrity": "sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.4.0",
@@ -1472,9 +1460,8 @@
     },
     "node_modules/@emotion/react/node_modules/@emotion/cache": {
       "version": "11.4.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/cache/-/cache-11.4.0.tgz",
-      "integrity": "sha1-KT/J2aeji5qtjpM35QFDZsOwmsA=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+      "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
       "dependencies": {
         "@emotion/memoize": "^0.7.4",
         "@emotion/sheet": "^1.0.0",
@@ -1485,15 +1472,13 @@
     },
     "node_modules/@emotion/react/node_modules/@emotion/hash": {
       "version": "0.8.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/react/node_modules/@emotion/serialize": {
       "version": "1.0.2",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/serialize/-/serialize-1.0.2.tgz",
-      "integrity": "sha1-d8shoFccn2jrZgh3VKZfqXv82WU=",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
       "dependencies": {
         "@emotion/hash": "^0.8.0",
         "@emotion/memoize": "^0.7.4",
@@ -1504,21 +1489,18 @@
     },
     "node_modules/@emotion/react/node_modules/@emotion/sheet": {
       "version": "1.0.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/sheet/-/sheet-1.0.1.tgz",
-      "integrity": "sha1-JF9Uq7At/YIybihonzTCeqmyppg=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+      "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
     },
     "node_modules/@emotion/react/node_modules/@emotion/utils": {
       "version": "1.0.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha1-q+BqgxYLEFcIFskTmQJFgTov1q8=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
     },
     "node_modules/@emotion/react/node_modules/csstype": {
       "version": "3.0.8",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@emotion/serialize": {
       "version": "0.11.15",
@@ -2641,18 +2623,27 @@
       }
     },
     "node_modules/@leafygreen-ui/a11y": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.2.0.tgz",
-      "integrity": "sha512-9iUFvnWXIGTpuS6x7S0yZnmluBxwMJsLhfoeUuEqZGzXMFTDHQW/C60gGRqpZXkm47pUHuypZZG1ocaBdq9bhw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.2.1.tgz",
+      "integrity": "sha512-bcWJdyUUcimheVwaWTjz8aQZibXzDCTOQBlGtJ/HwJIil3zaEDivHERPfcBR0bMd/EpO0Szc0aS6vIjvcL5/LA==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+      "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -2681,57 +2672,165 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/banner": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-3.0.6.tgz",
-      "integrity": "sha512-2e6eXqeT96JbK4fpZzxUvhbFqQ/0GpvNXcchAggyJO8T0VVIDut8+wh9yrIqRt1LDiVo7A/bc9bnI9fAFN+CNw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-3.0.9.tgz",
+      "integrity": "sha512-siSNSgeW/zhqNaD+Dldv+CiWJ7fUdsaH8JsV++m3e8NX9ZxSurWFl5BVODwWxm1Wu50j/KMpDuVxAvcodZJ5xw==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/icon": "^10.2.1",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1"
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/icon": "^11.3.0",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.2.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+      "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/sheet": "^1.0.0",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "stylis": "^4.0.3"
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/css": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+      "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.0.0",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/sheet": "^1.0.0",
+        "@emotion/utils": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/serialize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+      "dependencies": {
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/unitless": "^0.7.5",
+        "@emotion/utils": "^1.0.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/server": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.4.0.tgz",
+      "integrity": "sha512-IHovdWA3V0DokzxLtUNDx4+hQI82zUXqQFcVz/om2t44O0YSc+NHB+qifnyAOoQwt3SXcBTgaSntobwUI9gnfA==",
+      "dependencies": {
+        "@emotion/utils": "^1.0.0",
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
+      },
+      "peerDependencies": {
+        "@emotion/css": "^11.0.0-rc.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/css": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/sheet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+      "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@emotion/utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/emotion": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+      "integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+      "dependencies": {
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.4.0",
+        "@emotion/server": "^11.4.0"
       }
     },
     "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/icon": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-      "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-11.4.0.tgz",
+      "integrity": "sha512-Ogm9LKuq2e0kfSscmXqRchA5jMoqKg3pkYfnOdE8lcC9556S9cQy2DTzEOo5SCUUdLW8mgzbTl6BHX32WCMkjA==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/lib": "^9.0.0"
       }
     },
     "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.0.0.tgz",
+      "integrity": "sha512-Uo2tOfkhCYiSKrYCi8+CrTEcyPhf+iczNP+wPKlQjKOLa+6zJaWX/0AXLiQX1CuO0MXdYgNvsB5510q7hDiqdg==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/emotion": "^4.0.0",
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/palette": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.2.2.tgz",
+      "integrity": "sha512-Oqjz6Qfapm8jB9rw4r9C1yq5XFJRSZ6xSCCGu6Oz8nR0o66xzCxsp0h96tPcrSFWwOrJJxYsQPSGHVsUmTJDzw=="
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+    },
+    "node_modules/@leafygreen-ui/banner/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@leafygreen-ui/box": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.4.tgz",
-      "integrity": "sha512-/qMa1zPvsUBwtLfmpHy5WLAL5gfYs6Kh4ynnHV6Pd4lmcHQFAI44C3s/8/QSmsO1GZXcAWQuW31dvZCqoexyqg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.5.tgz",
+      "integrity": "sha512-cdiXfmyUsAWwJUZR4V47+5OLhfBwVKkXxqP3tT9W7SOheL939AynIBSFuXFHVlmiU3Nu6b7j3BBYmtlZVu+2Zw==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/box/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -2751,9 +2850,6 @@
         "@leafygreen-ui/lib": "^6.0.1",
         "@leafygreen-ui/palette": "^3.0.1",
         "lodash": "^4.17.20"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.0.1"
       }
     },
     "node_modules/@leafygreen-ui/callout": {
@@ -2767,9 +2863,6 @@
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/typography": "^7.6.0",
         "polished": "^3.6.5"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.0.3"
       }
     },
     "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/icon": {
@@ -2789,16 +2882,12 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/lib/node_modules/polished": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
       "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
-      "deprecated": "polished@2.X is no longer supported. Please upgrade to @latest for important bug and security fixes.",
       "dependencies": {
         "@babel/runtime": "^7.2.0"
       }
@@ -2833,9 +2922,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/checkbox": {
@@ -2855,9 +2941,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/code": {
@@ -2894,9 +2977,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/emotion": {
@@ -2926,21 +3006,21 @@
       }
     },
     "node_modules/@leafygreen-ui/icon-button": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.1.3.tgz",
-      "integrity": "sha512-qWDRTpEbtoGlcX3ZjIr++e7EGitOKDBN/0viVP2SGlcpt7AHBF2SVleR5rq9GjBjWJM2J/znmFa9A/+LLAu75g==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.1.5.tgz",
+      "integrity": "sha512-XKCbjNjR2jNi/D4M6gxZPd9r7yD903Igsj++Tnt8E/8fqs8IALB8mh20a0S3r054aYXdu5rneH/bhn86SoVupA==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.2.0",
-        "@leafygreen-ui/box": "^3.0.4",
+        "@leafygreen-ui/a11y": "^1.2.1",
+        "@leafygreen-ui/box": "^3.0.5",
         "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0",
         "@leafygreen-ui/palette": "^3.2.1"
       }
     },
     "node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -2983,24 +3063,29 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.0.tgz",
-      "integrity": "sha512-GEEH8IFJvEc9zXTjVouFjbEZPdiF1ZNb0hI0P5bE1f8pRoIStbvuHEAZNoGdCRU27hgn7DbREqoyp9J05ewUEw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.2.tgz",
+      "integrity": "sha512-JSC81/PSivqasTbw63wLPG3Uw4GRoul9HJDdFmurQU1oVAHdjo2HNQ5W1GkEbFVqXSd56tLMAOepHkTmjbpfag==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+      "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -3020,40 +3105,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-10.0.2.tgz",
-      "integrity": "sha512-+Qhgxnnwgboj7ERtm/wUgC9oBMOn4h2LYKERB5+DWJc/GTlUSCHCkoSA+8avfxuaM5dU5HVIH6ggFLtruB1+qA==",
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.0.4",
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1",
-        "@leafygreen-ui/popover": "^7.2.0",
-        "react-transition-group": "^4.4.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^3.0.1",
-        "facepaint": "^1.2.1",
-        "polished": "^2.3.0",
-        "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/modal": {
@@ -3088,9 +3139,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/palette": {
@@ -3099,22 +3147,30 @@
       "integrity": "sha512-E7gAN6eEWqsNIQrySABesXckJDJMLnzr3Z0BDQOBEmUdnYzXefvBY1e/zhHE6jb4rxwiOWnzwi1Zb2me50nOmQ=="
     },
     "node_modules/@leafygreen-ui/popover": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-7.2.0.tgz",
-      "integrity": "sha512-FHWr8f04B8thhVwJ6yqD0KKsWqwmupDN+hCD0AExYaVLxeANhrjnPtkkiAc174HG3zencrlsR4kZexCxDCKXfQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-7.2.1.tgz",
+      "integrity": "sha512-LZ7oafgfjD9e9ReMS0W1ObKY37q7QTVs3SoJfQJPVXPHGgLHuSuZGOU8ai++ebxb6isMUBR/DTi9LpldmQThLg==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^6.0.1",
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/portal": "^3.1.2",
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/leafygreen-provider": "^2.1.2",
+        "@leafygreen-ui/lib": "^8.0.0",
+        "@leafygreen-ui/portal": "^3.1.3",
         "lodash": "^4.17.21",
         "react-transition-group": "^4.4.1"
       }
     },
-    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+      "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -3126,20 +3182,20 @@
       }
     },
     "node_modules/@leafygreen-ui/portal": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-3.1.2.tgz",
-      "integrity": "sha512-AcpDz3iKcZ1+IdClyAO0f5z0m+1PBCQyvkC5kckqbhgZNi4QX0v6chFp7l7EvaW1hXyyPSDP1SQcBwlvHMqKhQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-3.1.3.tgz",
+      "integrity": "sha512-yAYdYyjzaTu46+NHRqC6OKnfu6HeRRMsQNuz7EtDszu71YVlJPUMUCSUr9k1DArPAXxDaCWmTJsHpxIM3uaIag==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/lib": "^8.0.0"
       },
       "peerDependencies": {
         "react-dom": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -3186,9 +3242,6 @@
         "@types/react-is": "^17.0.0",
         "polished": "^4.0.3",
         "react-is": "^17.0.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/button": {
@@ -3202,9 +3255,6 @@
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/ripple": "^1.1.1",
         "@leafygreen-ui/tokens": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/icon": {
@@ -3224,16 +3274,12 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/lib/node_modules/polished": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
       "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
-      "deprecated": "polished@2.X is no longer supported. Please upgrade to @latest for important bug and security fixes.",
       "dependencies": {
         "@babel/runtime": "^7.2.0"
       }
@@ -3269,9 +3315,6 @@
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/portal": "^3.1.2",
         "@leafygreen-ui/tooltip": "^6.2.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/side-nav/node_modules/@leafygreen-ui/icon": {
@@ -3286,6 +3329,42 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
       "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "facepaint": "^1.2.1",
+        "polished": "^2.3.0",
+        "prop-types": "^15.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/side-nav/node_modules/@leafygreen-ui/menu": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-10.0.3.tgz",
+      "integrity": "sha512-TphJLZegaam7leTXYgnpyIXW6H8H2oP8EhXPXWSafIBsDIo9OFKOOA2BfcK2zhwpm0zVtjPfcR0NM8Pr/IQLpw==",
+      "dependencies": {
+        "@leafygreen-ui/box": "^3.0.5",
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/icon-button": "^9.1.5",
+        "@leafygreen-ui/lib": "^8.0.0",
+        "@leafygreen-ui/palette": "^3.2.1",
+        "@leafygreen-ui/popover": "^7.2.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.1.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/side-nav/node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+      "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/side-nav/node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/lib": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+      "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -3311,9 +3390,6 @@
         "lodash": "^4.17.21",
         "react-transition-group": "^4.4.1",
         "use-ssr": "^1.0.23"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/icon": {
@@ -3333,9 +3409,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/tabs": {
@@ -3361,9 +3434,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/text-input": {
@@ -3376,9 +3446,6 @@
         "@leafygreen-ui/lib": "^7.0.0",
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/typography": "^8.0.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/icon": {
@@ -3398,9 +3465,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/typography": {
@@ -3413,9 +3477,6 @@
         "@leafygreen-ui/lib": "^7.0.0",
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/tokens": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
@@ -3435,9 +3496,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/tooltip": {
@@ -3471,9 +3529,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/typography": {
@@ -3486,9 +3541,6 @@
         "@leafygreen-ui/lib": "^7.0.0",
         "@leafygreen-ui/palette": "^3.2.1",
         "@leafygreen-ui/tokens": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.0.3"
       }
     },
     "node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/icon": {
@@ -3508,9 +3560,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
       }
     },
     "node_modules/@loadable/component": {
@@ -3527,12 +3576,12 @@
       }
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.0.0-rc.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.1.tgz",
-      "integrity": "sha1-uoyjNI6TBd1eibWRwAb8K0HtmLs=",
+      "version": "1.0.0-rc.5",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.5.tgz",
+      "integrity": "sha1-aiMVa38OWwZN4gojx19FQav75fs=",
       "license": "ISC",
       "peerDependencies": {
-        "@mdb/flora": ">= 0.3.8",
+        "@mdb/flora": ">= 0.3.11",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
         "styled-components": ">= 4.4.1",
@@ -3540,9 +3589,9 @@
       }
     },
     "node_modules/@mdb/flora": {
-      "version": "0.3.9",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.9.tgz",
-      "integrity": "sha1-ShnLe8CYFoFV7qik3jhj9l8mOyI=",
+      "version": "0.3.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.11.tgz",
+      "integrity": "sha1-mKrIXIYUhq2Au8qIUeSBVSIy/1U=",
       "license": "ISC",
       "peerDependencies": {
         "react": ">= 16.8",
@@ -6019,7 +6068,6 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6227,9 +6275,6 @@
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "lodash": "^4.17.11"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-plugin-syntax-jsx": {
@@ -11277,11 +11322,6 @@
       "integrity": "sha512-yuItOIwgriOBMrbHDqbWMpQjGVs9SbtugYrT0vs0yPjHiPKja3NZ9dBMxDQrV1JhyojGK5d6j7ayqBS7Kcm9xQ==",
       "dependencies": {
         "focus-trap": "^6.3.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.7.2",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -11831,6 +11871,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gatsby-plugin-react-helmet-canonical-urls": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz",
+      "integrity": "sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1"
+      },
+      "peerDependencies": {
+        "gatsby-plugin-react-helmet": "*",
+        "react-helmet": "*"
       }
     },
     "node_modules/gatsby-plugin-sitemap": {
@@ -13935,17 +13987,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.1.tgz",
       "integrity": "sha512-80LZ736V0Nr4/st0c2COYaMbEQhHNmAbLMN8J/kLk7/mo0QdUkUGNDjv/7jVkhug377Wh8wfbWyaVXEJ/h2B/Q==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/typicode"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/husky"
-        }
-      ],
-      "hasInstallScript": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -18029,9 +18070,6 @@
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
       }
     },
     "node_modules/lint-staged/node_modules/ansi-styles": {
@@ -19357,11 +19395,7 @@
     "node_modules/mobx": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.1.5.tgz",
-      "integrity": "sha512-BsVAHEk/Ty+6BmCis0CUvA7E9u5aJpUkdRM91YwBt4lVha4heDLjRT43z2pqENeFuVZPfA1RRaf7sRcqRB2i4Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      }
+      "integrity": "sha512-BsVAHEk/Ty+6BmCis0CUvA7E9u5aJpUkdRM91YwBt4lVha4heDLjRT43z2pqENeFuVZPfA1RRaf7sRcqRB2i4Q=="
     },
     "node_modules/mobx-react": {
       "version": "7.1.0",
@@ -25154,6 +25188,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25732,15 +25771,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
       }
     },
     "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
@@ -25800,9 +25830,8 @@
     },
     "node_modules/stylis": {
       "version": "4.0.10",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/stylis/-/stylis-4.0.10.tgz",
-      "integrity": "sha1-RGUS0Qlxl6s/Avs8JYNYw/ehQkA=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
     },
     "node_modules/sudo-prompt": {
       "version": "8.2.5",
@@ -27136,11 +27165,7 @@
     "node_modules/use-ssr": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.23.tgz",
-      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA==",
-      "peerDependencies": {
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1"
-      }
+      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA=="
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -27513,7 +27538,6 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -27905,7 +27929,6 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -29366,8 +29389,8 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha1-bRpE32o4yVeqfDEtoHZCnxG0IvM=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -29447,9 +29470,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-      "integrity": "sha1-0PDid8US4Mk4J3+qhaOWjJpEwOg="
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.1",
@@ -29672,16 +29695,16 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha1-AA4uJdhnPM5JMAUXo+2kTCY+QgE=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
           "version": "7.14.5",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha1-WsgizpfuxGdBq3ClF5ceRDpwxak="
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
         }
       }
     },
@@ -30303,11 +30326,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha1-O7mXuoKaIQTO2yBonEpbgSHTg/8=",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -30329,8 +30352,8 @@
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
-      "integrity": "sha1-OhaFC6BNjZZR8H8/tnSzQ2pPudc=",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
+      "integrity": "sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==",
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/plugin-syntax-jsx": "^7.12.13",
@@ -30348,18 +30371,18 @@
       "dependencies": {
         "@emotion/hash": {
           "version": "0.8.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/hash/-/hash-0.8.0.tgz",
-          "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM="
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
         },
         "@emotion/memoize": {
           "version": "0.7.5",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/memoize/-/memoize-0.7.5.tgz",
-          "integrity": "sha1-LED4FEmk5VTp/GOWkQ7UhD7CvlA="
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
         },
         "@emotion/serialize": {
           "version": "1.0.2",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/serialize/-/serialize-1.0.2.tgz",
-          "integrity": "sha1-d8shoFccn2jrZgh3VKZfqXv82WU=",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+          "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
           "requires": {
             "@emotion/hash": "^0.8.0",
             "@emotion/memoize": "^0.7.4",
@@ -30370,18 +30393,18 @@
         },
         "@emotion/utils": {
           "version": "1.0.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/utils/-/utils-1.0.0.tgz",
-          "integrity": "sha1-q+BqgxYLEFcIFskTmQJFgTov1q8="
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
         },
         "csstype": {
           "version": "3.0.8",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A="
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         },
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
@@ -30459,8 +30482,8 @@
     },
     "@emotion/react": {
       "version": "11.4.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/react/-/react-11.4.0.tgz",
-      "integrity": "sha1-JGWtewc6aRQJuI39ltwXCX3a2bc=",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.0.tgz",
+      "integrity": "sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.4.0",
@@ -30473,8 +30496,8 @@
       "dependencies": {
         "@emotion/cache": {
           "version": "11.4.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/cache/-/cache-11.4.0.tgz",
-          "integrity": "sha1-KT/J2aeji5qtjpM35QFDZsOwmsA=",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+          "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
           "requires": {
             "@emotion/memoize": "^0.7.4",
             "@emotion/sheet": "^1.0.0",
@@ -30485,13 +30508,13 @@
         },
         "@emotion/hash": {
           "version": "0.8.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/hash/-/hash-0.8.0.tgz",
-          "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM="
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
         },
         "@emotion/serialize": {
           "version": "1.0.2",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/serialize/-/serialize-1.0.2.tgz",
-          "integrity": "sha1-d8shoFccn2jrZgh3VKZfqXv82WU=",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+          "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
           "requires": {
             "@emotion/hash": "^0.8.0",
             "@emotion/memoize": "^0.7.4",
@@ -30502,18 +30525,18 @@
         },
         "@emotion/sheet": {
           "version": "1.0.1",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/sheet/-/sheet-1.0.1.tgz",
-          "integrity": "sha1-JF9Uq7At/YIybihonzTCeqmyppg="
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+          "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
         },
         "@emotion/utils": {
           "version": "1.0.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/utils/-/utils-1.0.0.tgz",
-          "integrity": "sha1-q+BqgxYLEFcIFskTmQJFgTov1q8="
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
         },
         "csstype": {
           "version": "3.0.8",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A="
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         }
       }
     },
@@ -31528,18 +31551,27 @@
       }
     },
     "@leafygreen-ui/a11y": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.2.0.tgz",
-      "integrity": "sha512-9iUFvnWXIGTpuS6x7S0yZnmluBxwMJsLhfoeUuEqZGzXMFTDHQW/C60gGRqpZXkm47pUHuypZZG1ocaBdq9bhw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.2.1.tgz",
+      "integrity": "sha512-bcWJdyUUcimheVwaWTjz8aQZibXzDCTOQBlGtJ/HwJIil3zaEDivHERPfcBR0bMd/EpO0Szc0aS6vIjvcL5/LA==",
       "requires": {
         "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0"
       },
       "dependencies": {
-        "@leafygreen-ui/lib": {
+        "@leafygreen-ui/hooks": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+          "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -31572,50 +31604,142 @@
       }
     },
     "@leafygreen-ui/banner": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-3.0.6.tgz",
-      "integrity": "sha512-2e6eXqeT96JbK4fpZzxUvhbFqQ/0GpvNXcchAggyJO8T0VVIDut8+wh9yrIqRt1LDiVo7A/bc9bnI9fAFN+CNw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/banner/-/banner-3.0.9.tgz",
+      "integrity": "sha512-siSNSgeW/zhqNaD+Dldv+CiWJ7fUdsaH8JsV++m3e8NX9ZxSurWFl5BVODwWxm1Wu50j/KMpDuVxAvcodZJ5xw==",
       "requires": {
-        "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/icon": "^10.2.1",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1"
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/icon": "^11.3.0",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.2.2"
       },
       "dependencies": {
-        "@leafygreen-ui/icon": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-          "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
+        "@emotion/cache": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+          "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
           "requires": {
-            "@leafygreen-ui/lib": "^7.0.0"
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/sheet": "^1.0.0",
+            "@emotion/utils": "^1.0.0",
+            "@emotion/weak-memoize": "^0.2.5",
+            "stylis": "^4.0.3"
+          }
+        },
+        "@emotion/css": {
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+          "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+          "requires": {
+            "@emotion/babel-plugin": "^11.0.0",
+            "@emotion/cache": "^11.1.3",
+            "@emotion/serialize": "^1.0.0",
+            "@emotion/sheet": "^1.0.0",
+            "@emotion/utils": "^1.0.0"
+          }
+        },
+        "@emotion/hash": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "@emotion/serialize": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+          "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/server": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.4.0.tgz",
+          "integrity": "sha512-IHovdWA3V0DokzxLtUNDx4+hQI82zUXqQFcVz/om2t44O0YSc+NHB+qifnyAOoQwt3SXcBTgaSntobwUI9gnfA==",
+          "requires": {
+            "@emotion/utils": "^1.0.0",
+            "html-tokenize": "^2.0.0",
+            "multipipe": "^1.0.2",
+            "through": "^2.3.8"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+          "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "@leafygreen-ui/emotion": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+          "integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+          "requires": {
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.4.0",
+            "@emotion/server": "^11.4.0"
+          }
+        },
+        "@leafygreen-ui/icon": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-11.4.0.tgz",
+          "integrity": "sha512-Ogm9LKuq2e0kfSscmXqRchA5jMoqKg3pkYfnOdE8lcC9556S9cQy2DTzEOo5SCUUdLW8mgzbTl6BHX32WCMkjA==",
+          "requires": {
+            "@leafygreen-ui/lib": "^9.0.0"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.0.0.tgz",
+          "integrity": "sha512-Uo2tOfkhCYiSKrYCi8+CrTEcyPhf+iczNP+wPKlQjKOLa+6zJaWX/0AXLiQX1CuO0MXdYgNvsB5510q7hDiqdg==",
           "requires": {
-            "@leafygreen-ui/emotion": "^3.0.1",
+            "@leafygreen-ui/emotion": "^4.0.0",
             "facepaint": "^1.2.1",
             "polished": "^2.3.0",
             "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.2.2.tgz",
+          "integrity": "sha512-Oqjz6Qfapm8jB9rw4r9C1yq5XFJRSZ6xSCCGu6Oz8nR0o66xzCxsp0h96tPcrSFWwOrJJxYsQPSGHVsUmTJDzw=="
+        },
+        "csstype": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
           }
         }
       }
     },
     "@leafygreen-ui/box": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.4.tgz",
-      "integrity": "sha512-/qMa1zPvsUBwtLfmpHy5WLAL5gfYs6Kh4ynnHV6Pd4lmcHQFAI44C3s/8/QSmsO1GZXcAWQuW31dvZCqoexyqg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.5.tgz",
+      "integrity": "sha512-cdiXfmyUsAWwJUZR4V47+5OLhfBwVKkXxqP3tT9W7SOheL939AynIBSFuXFHVlmiU3Nu6b7j3BBYmtlZVu+2Zw==",
       "requires": {
-        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0",
         "lodash": "^4.17.21"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -31797,21 +31921,21 @@
       }
     },
     "@leafygreen-ui/icon-button": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.1.3.tgz",
-      "integrity": "sha512-qWDRTpEbtoGlcX3ZjIr++e7EGitOKDBN/0viVP2SGlcpt7AHBF2SVleR5rq9GjBjWJM2J/znmFa9A/+LLAu75g==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.1.5.tgz",
+      "integrity": "sha512-XKCbjNjR2jNi/D4M6gxZPd9r7yD903Igsj++Tnt8E/8fqs8IALB8mh20a0S3r054aYXdu5rneH/bhn86SoVupA==",
       "requires": {
-        "@leafygreen-ui/a11y": "^1.2.0",
-        "@leafygreen-ui/box": "^3.0.4",
+        "@leafygreen-ui/a11y": "^1.2.1",
+        "@leafygreen-ui/box": "^3.0.5",
         "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0",
         "@leafygreen-ui/palette": "^3.2.1"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -31858,18 +31982,26 @@
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.0.tgz",
-      "integrity": "sha512-GEEH8IFJvEc9zXTjVouFjbEZPdiF1ZNb0hI0P5bE1f8pRoIStbvuHEAZNoGdCRU27hgn7DbREqoyp9J05ewUEw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.2.tgz",
+      "integrity": "sha512-JSC81/PSivqasTbw63wLPG3Uw4GRoul9HJDdFmurQU1oVAHdjo2HNQ5W1GkEbFVqXSd56tLMAOepHkTmjbpfag==",
       "requires": {
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/lib": "^8.0.0"
       },
       "dependencies": {
-        "@leafygreen-ui/lib": {
+        "@leafygreen-ui/hooks": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+          "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -31888,33 +32020,6 @@
         "facepaint": "^1.2.1",
         "polished": "^2.3.0",
         "prop-types": "^15.0.0"
-      }
-    },
-    "@leafygreen-ui/menu": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-10.0.2.tgz",
-      "integrity": "sha512-+Qhgxnnwgboj7ERtm/wUgC9oBMOn4h2LYKERB5+DWJc/GTlUSCHCkoSA+8avfxuaM5dU5HVIH6ggFLtruB1+qA==",
-      "requires": {
-        "@leafygreen-ui/box": "^3.0.4",
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1",
-        "@leafygreen-ui/popover": "^7.2.0",
-        "react-transition-group": "^4.4.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
-          "requires": {
-            "@leafygreen-ui/emotion": "^3.0.1",
-            "facepaint": "^1.2.1",
-            "polished": "^2.3.0",
-            "prop-types": "^15.0.0"
-          }
-        }
       }
     },
     "@leafygreen-ui/modal": {
@@ -31959,22 +32064,30 @@
       "integrity": "sha512-E7gAN6eEWqsNIQrySABesXckJDJMLnzr3Z0BDQOBEmUdnYzXefvBY1e/zhHE6jb4rxwiOWnzwi1Zb2me50nOmQ=="
     },
     "@leafygreen-ui/popover": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-7.2.0.tgz",
-      "integrity": "sha512-FHWr8f04B8thhVwJ6yqD0KKsWqwmupDN+hCD0AExYaVLxeANhrjnPtkkiAc174HG3zencrlsR4kZexCxDCKXfQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-7.2.1.tgz",
+      "integrity": "sha512-LZ7oafgfjD9e9ReMS0W1ObKY37q7QTVs3SoJfQJPVXPHGgLHuSuZGOU8ai++ebxb6isMUBR/DTi9LpldmQThLg==",
       "requires": {
-        "@leafygreen-ui/hooks": "^6.0.1",
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/portal": "^3.1.2",
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/leafygreen-provider": "^2.1.2",
+        "@leafygreen-ui/lib": "^8.0.0",
+        "@leafygreen-ui/portal": "^3.1.3",
         "lodash": "^4.17.21",
         "react-transition-group": "^4.4.1"
       },
       "dependencies": {
-        "@leafygreen-ui/lib": {
+        "@leafygreen-ui/hooks": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+          "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -31985,17 +32098,17 @@
       }
     },
     "@leafygreen-ui/portal": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-3.1.2.tgz",
-      "integrity": "sha512-AcpDz3iKcZ1+IdClyAO0f5z0m+1PBCQyvkC5kckqbhgZNi4QX0v6chFp7l7EvaW1hXyyPSDP1SQcBwlvHMqKhQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-3.1.3.tgz",
+      "integrity": "sha512-yAYdYyjzaTu46+NHRqC6OKnfu6HeRRMsQNuz7EtDszu71YVlJPUMUCSUr9k1DArPAXxDaCWmTJsHpxIM3uaIag==",
       "requires": {
-        "@leafygreen-ui/lib": "^7.0.0"
+        "@leafygreen-ui/lib": "^8.0.0"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+          "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
@@ -32133,6 +32246,41 @@
             "facepaint": "^1.2.1",
             "polished": "^2.3.0",
             "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/menu": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/menu/-/menu-10.0.3.tgz",
+          "integrity": "sha512-TphJLZegaam7leTXYgnpyIXW6H8H2oP8EhXPXWSafIBsDIo9OFKOOA2BfcK2zhwpm0zVtjPfcR0NM8Pr/IQLpw==",
+          "requires": {
+            "@leafygreen-ui/box": "^3.0.5",
+            "@leafygreen-ui/hooks": "^7.0.0",
+            "@leafygreen-ui/icon-button": "^9.1.5",
+            "@leafygreen-ui/lib": "^8.0.0",
+            "@leafygreen-ui/palette": "^3.2.1",
+            "@leafygreen-ui/popover": "^7.2.1",
+            "react-transition-group": "^4.4.1"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.0.0.tgz",
+              "integrity": "sha512-/UDdinXJbHcNvqodfY+5Ej4auxKdzbljJx0PkLy+bAUI0/P9W4xlYb2N0LZTIZBmKj4SUSQX3O/G7fvtSqJW7A==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-8.0.0.tgz",
+              "integrity": "sha512-Iku3DfYHteSzl2oRdUkejn1h0gr0YC5d3kWfmeIFcpLvuUxLYROVd53EjlANqpP8ZHTZAAmQzi37GomrTwImcQ==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^3.0.1",
+                "facepaint": "^1.2.1",
+                "polished": "^2.3.0",
+                "prop-types": "^15.0.0"
+              }
+            }
           }
         }
       }
@@ -32347,15 +32495,15 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "1.0.0-rc.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.1.tgz",
-      "integrity": "sha1-uoyjNI6TBd1eibWRwAb8K0HtmLs=",
+      "version": "1.0.0-rc.5",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.5.tgz",
+      "integrity": "sha1-aiMVa38OWwZN4gojx19FQav75fs=",
       "requires": {}
     },
     "@mdb/flora": {
-      "version": "0.3.9",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.9.tgz",
-      "integrity": "sha1-ShnLe8CYFoFV7qik3jhj9l8mOyI=",
+      "version": "0.3.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.11.tgz",
+      "integrity": "sha1-mKrIXIYUhq2Au8qIUeSBVSIy/1U=",
       "requires": {}
     },
     "@mdx-js/react": {
@@ -39861,6 +40009,14 @@
       "integrity": "sha512-vynqIMOUR/sOfM2eXpZiECuEZ6G/97ic+ulkyCVw7CjHNTQCW2evzJKNbHQrBYgmQCGXzQJuyGf1F5khLm8H7g==",
       "requires": {
         "@babel/runtime": "^7.12.5"
+      }
+    },
+    "gatsby-plugin-react-helmet-canonical-urls": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz",
+      "integrity": "sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
       }
     },
     "gatsby-plugin-sitemap": {
@@ -51077,8 +51233,8 @@
     },
     "stylis": {
       "version": "4.0.10",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/stylis/-/stylis-4.0.10.tgz",
-      "integrity": "sha1-RGUS0Qlxl6s/Avs8JYNYw/ehQkA="
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
     },
     "sudo-prompt": {
       "version": "8.2.5",
@@ -52165,8 +52321,7 @@
     "use-ssr": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.23.tgz",
-      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA==",
-      "requires": {}
+      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "gatsby-plugin-google-tagmanager": "^2.8.0",
     "gatsby-plugin-layout": "^1.7.0",
     "gatsby-plugin-react-helmet": "^3.7.0",
+    "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
     "gatsby-plugin-sitemap": "^2.11.0",
     "highlight.js": "~10.6.0",
     "html-screen-capture-js": "^1.0.50",

--- a/src/components/Meta.js
+++ b/src/components/Meta.js
@@ -4,9 +4,9 @@ import { Helmet } from 'react-helmet';
 
 const Meta = ({ nodeData: { options } }) => (
   <Helmet>
-    {Object.entries(options).map(([key, value]) => (
-      <meta key={key} name={key} content={value} />
-    ))}
+    {Object.entries(options).map(([key, value]) =>
+      key === 'canonical' ? <link rel={key} href={value} /> : <meta key={key} name={key} content={value} />
+    )}
   </Helmet>
 );
 


### PR DESCRIPTION
### Stories/Links:

DOP-2190: supports overwriting default canonical link for a page (as specified using the `.. meta::` directive in the parser).

### Staging Links:

[Compass](https://docs-mongodbcom-staging.corp.mongodb.com/canonical/compass/allison/DOP-2190/aggregation-pipeline-builder/) - search the page source for:
```
<link data-react-helmet="true" rel="canonical" href="https://docs.mongodb.com/compass/foo/aggregation-pipeline-builder/"/>
```
and confirm there isn't another canonical link specified.

### Notes:
This ensures we don't have duplicate canonical links; it does not address the duplication of `robots` meta directives between src/html.js and whatever the writer specifies in the `.. meta::` directive.

**I have no idea why it changed most of the registries.**