### PR TITLE
DOP-2383: Use snootyEnv as a flag for Realm banner function

### DIFF
--- a/src/components/SiteBanner.js
+++ b/src/components/SiteBanner.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { HeaderContext } from './header-context';
 import { SNOOTY_STITCH_ID } from '../build-constants';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { theme } from '../theme/docsTheme';
 import { isBrowser } from '../utils/is-browser';
 import { normalizePath } from '../utils/normalize-path';
@@ -34,11 +35,12 @@ const StyledBannerContent = styled.div(
 
 const SiteBanner = () => {
   const { bannerContent, setBannerContent } = useContext(HeaderContext);
+  const { snootyEnv } = useSiteMetadata();
 
   useEffect(() => {
     const fetchBannerContent = async () => {
       try {
-        setBannerContent(await fetchBanner());
+        setBannerContent(await fetchBanner(snootyEnv));
       } catch (err) {
         console.error(err);
       }
@@ -46,7 +48,7 @@ const SiteBanner = () => {
     if (isBrowser) {
       fetchBannerContent();
     }
-  }, [setBannerContent]);
+  }, [setBannerContent, snootyEnv]);
 
   if (bannerContent == null) {
     return null;

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -23,8 +23,8 @@ const fetchData = async (funcName, ...argsList) => {
   return await app.currentUser.callFunction(funcName, ...argsList);
 };
 
-export const fetchBanner = async () => {
-  return await fetchData('getBanner');
+export const fetchBanner = async (snootyEnv) => {
+  return await fetchData('getBanner', snootyEnv === 'development');
 };
 
 export const fetchProjectParents = async (database, project) => {

--- a/tests/unit/SiteBanner.test.js
+++ b/tests/unit/SiteBanner.test.js
@@ -1,9 +1,21 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import * as Gatsby from 'gatsby';
 import * as RealmUtil from '../../src/utils/realm';
 import SiteBanner from '../../src/components/SiteBanner';
 import { HeaderContext } from '../../src/components/header-context';
 import { tick } from '../utils';
+
+const useStaticQuery = jest.spyOn(Gatsby, 'useStaticQuery');
+const mockSnootyEnv = (snootyEnv) => {
+  useStaticQuery.mockImplementation(() => ({
+    site: {
+      siteMetadata: {
+        snootyEnv,
+      },
+    },
+  }));
+};
 
 const mockBannerContent = {
   altText: 'Test',
@@ -13,6 +25,10 @@ const mockBannerContent = {
 };
 
 describe('Banner component', () => {
+  beforeAll(() => {
+    mockSnootyEnv('development');
+  });
+
   it('renders without a banner image', () => {
     // bannerContent state should remain null
     const wrapper = mount(<SiteBanner />);


### PR DESCRIPTION
### Stories/Links:

DOP-2383

### Staging Links:

[Realm staging with site banner](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2383/) - regular build meant for snooty devs (no `SNOOTY_ENV` set)
[Realm staging without site banner](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2383-not-develop/) - with `SNOOTY_ENV !== 'development'` (emulates the autobuilder)

### Notes:
* More context on the issue could be found in the ticket description! Relevant Realm code can be found in our Realm `snooty` app's `getBanner` function, and `banner` value. For this PR, the `banner` value is set to have its new `isDev` bool set to true. This should allow the banner to be seen with local builds on snooty, but shouldn't be shown when using the autobuilder.
* `SNOOTY_ENV` is an env var that is omitted locally but is used by the autobuilder to determine environment (prod, staging). I decided to pass this env variable up to our Realm function (`getBanner`) that returns the site banner content (for .Live and such).