### PR TITLE
DOP-2392: Add UnifiedFooter to docs-nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@leafygreen-ui/tooltip": "^6.1.7",
         "@leafygreen-ui/typography": "^7.5.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^1.0.0-rc.1",
+        "@mdb/consistent-nav": "^1.0.0-rc.8",
         "@mdb/flora": "^0.3.9",
         "clipboard": "^2.0.8",
         "dotenv": "^8.2.0",
@@ -3669,12 +3669,12 @@
       }
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.0.0-rc.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.1.tgz",
-      "integrity": "sha1-uoyjNI6TBd1eibWRwAb8K0HtmLs=",
+      "version": "1.0.0-rc.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.8.tgz",
+      "integrity": "sha1-q8FMUNg5syc9VsXbjHUGxD5Rmds=",
       "license": "ISC",
       "peerDependencies": {
-        "@mdb/flora": ">= 0.3.8",
+        "@mdb/flora": ">= 0.3.11",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
         "styled-components": ">= 4.4.1",
@@ -3682,9 +3682,9 @@
       }
     },
     "node_modules/@mdb/flora": {
-      "version": "0.3.9",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.9.tgz",
-      "integrity": "sha1-ShnLe8CYFoFV7qik3jhj9l8mOyI=",
+      "version": "0.3.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.11.tgz",
+      "integrity": "sha1-mKrIXIYUhq2Au8qIUeSBVSIy/1U=",
       "license": "ISC",
       "peerDependencies": {
         "react": ">= 16.8",
@@ -32605,15 +32605,15 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "1.0.0-rc.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.1.tgz",
-      "integrity": "sha1-uoyjNI6TBd1eibWRwAb8K0HtmLs=",
+      "version": "1.0.0-rc.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.0.0-rc.8.tgz",
+      "integrity": "sha1-q8FMUNg5syc9VsXbjHUGxD5Rmds=",
       "requires": {}
     },
     "@mdb/flora": {
-      "version": "0.3.9",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.9.tgz",
-      "integrity": "sha1-ShnLe8CYFoFV7qik3jhj9l8mOyI=",
+      "version": "0.3.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.3.11.tgz",
+      "integrity": "sha1-mKrIXIYUhq2Au8qIUeSBVSIy/1U=",
       "requires": {}
     },
     "@mdx-js/react": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@leafygreen-ui/tooltip": "^6.1.7",
     "@leafygreen-ui/typography": "^7.5.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^1.0.0-rc.1",
+    "@mdb/consistent-nav": "^1.0.0-rc.8",
     "@mdb/flora": "^0.3.9",
     "clipboard": "^2.0.8",
     "dotenv": "^8.2.0",

--- a/src/components/Contents.js
+++ b/src/components/Contents.js
@@ -17,6 +17,14 @@ const activeBorderLeftCSS = css`
 const listItemColor = uiColors.black;
 
 const ListItem = styled('li')`
+  padding: 6px 0 6px 1px;
+  width: ${(props) => props.figwidth};
+
+  &:hover,
+  &:active {
+    padding-left: 4px;
+  }
+
   @media ${theme.screenSize.largeAndUp} {
     ${(props) => (props.isActive ? activeBorderLeftCSS : `border-left: 1px solid ${uiColors.gray.light2};`)}
 
@@ -24,14 +32,6 @@ const ListItem = styled('li')`
     &:active {
       ${activeBorderLeftCSS}
     }
-  }
-
-  padding: 6px 0 6px 1px;
-  width: ${(props) => props.figwidth};
-
-  &:hover,
-  &:active {
-    padding-left: 4px;
   }
 `;
 
@@ -61,7 +61,7 @@ const StyledContents = styled('div')`
 `;
 const ContentsListItem = ({ children, depth, id, isActive }) => (
   <ListItem isActive={isActive}>
-    <StyledLink to={`#${id}`} isActive={isActive} depth={depth}>
+    <StyledLink to={`#${id}`} depth={depth}>
       {children}
     </StyledLink>
   </ListItem>

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -136,7 +136,7 @@ export default class DocumentBody extends Component {
                   </ContentsProvider>
                 </FootnoteContext.Provider>
               </Widgets>
-              {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <UnifiedFooter />}
+              {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <UnifiedFooter hideLocale={true} />}
             </>
           );
         }}

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
+import { UnifiedFooter } from '@mdb/consistent-nav';
 import ComponentFactory from './ComponentFactory';
 import { ContentsProvider } from './contents-context';
 import FootnoteContext from './footnote-context';
@@ -130,11 +131,12 @@ export default class DocumentBody extends Component {
                       {this.pageNodes.map((child, index) => (
                         <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
                       ))}
-                      <Footer />
+                      {!process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <Footer />}
                     </Template>
                   </ContentsProvider>
                 </FootnoteContext.Provider>
               </Widgets>
+              {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <UnifiedFooter />}
             </>
           );
         }}

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { displayNone } from '../utils/display-none';
+import { theme } from '../theme/docsTheme';
 
 const RightColumn = ({ children, className }) => (
   <div
@@ -18,7 +19,8 @@ const RightColumn = ({ children, className }) => (
         height: 100%;
         max-height: calc(100vh - 120px);
         overflow: auto;
-        position: fixed;
+        position: sticky;
+        top: ${theme.size.medium};
 
         & > * {
           margin-bottom: 30px;

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FeedbackProvider, FeedbackForm, FeedbackTab, useFeedbackData } from './FeedbackWidget';
 import { isBrowser } from '../../utils/is-browser';
 
-const Widgets = ({ children, location, pageOptions, pageTitle, publishedBranches, slug }) => {
+const Widgets = ({ children, pageOptions, pageTitle, publishedBranches, slug }) => {
   const url = isBrowser ? window.location.href : null;
   const hideFeedbackHeader = pageOptions.hidefeedback === 'header';
   const feedbackData = useFeedbackData({
@@ -31,7 +31,7 @@ Widgets.propTypes = {
     hideFeedback: PropTypes.string,
   }),
   pageTitle: PropTypes.string.isRequired,
-  publishedBranches: PropTypes.object.isRequired,
+  publishedBranches: PropTypes.object,
   slug: PropTypes.string.isRequired,
 };
 

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -24,9 +24,6 @@ const Widgets = ({ children, pageOptions, pageTitle, publishedBranches, slug }) 
 
 Widgets.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
-  location: PropTypes.shape({
-    href: PropTypes.string.isRequired,
-  }).isRequired,
   pageOptions: PropTypes.shape({
     hideFeedback: PropTypes.string,
   }),


### PR DESCRIPTION
### Stories/Links:

DOP-2392

### Staging Links:

[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2392/) - with consistent nav feature flag on
[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2392-con-nav-off/) - without feature flag

### Notes:
* Adds `UnifiedFooter` to `DocumentBody`.
* Had to update the positioning of our `RightColumn` that hosts the "On This Page"/`Contents` component to avoid the component from overlapping with the new footer.
* Also updated some props for the `Contents` and `Widgets` files to avoid unnecessary prop errors.