### PR TITLE
DOP-2402: Add default side nav back button target

### DIFF
--- a/src/components/Sidenav/SidenavBackButton.js
+++ b/src/components/Sidenav/SidenavBackButton.js
@@ -5,6 +5,7 @@ import Icon from '@leafygreen-ui/icon';
 import { SideNavItem } from '@leafygreen-ui/side-nav';
 import Link from '../Link';
 import { NavigationContext } from '../navigation-context';
+import { DOCS_URL } from '../../constants';
 import { formatText } from '../../utils/format-text';
 
 // Empty SideNavItem used as a placeholder while parent category page is fetched.
@@ -18,7 +19,7 @@ const Placeholder = styled(SideNavItem)`
 `;
 
 const SidenavBackButton = ({ border, currentSlug, handleClick, project, target, titleOverride, ...props }) => {
-  const { parents } = useContext(NavigationContext);
+  const { completedFetch, parents } = useContext(NavigationContext);
   let title = titleOverride;
   let url = target;
 
@@ -36,6 +37,9 @@ const SidenavBackButton = ({ border, currentSlug, handleClick, project, target, 
       url = '/';
     } else if (parents.length) {
       [{ title, url }] = parents.slice(-1);
+    } else if (completedFetch) {
+      title = 'docs home';
+      url = DOCS_URL;
     } else {
       // Show placeholder since the data is likely being fetched
       return (

--- a/src/components/navigation-context.js
+++ b/src/components/navigation-context.js
@@ -5,14 +5,16 @@ import { fetchProjectParents } from '../utils/realm';
 
 const NavigationContext = React.createContext({
   parents: [],
+  completedFetch: false,
 });
 
 const NavigationProvider = ({ children }) => {
   const { database, project } = useSiteMetadata();
   const [parents, setParents] = useState([]);
+  const [completedFetch, setCompletedFetch] = useState(false);
 
   useEffect(() => {
-    const fetchBreadcrumbData = async () => {
+    const fetchData = async () => {
       try {
         const parents = await fetchProjectParents(database, project);
         setParents(parents);
@@ -21,11 +23,12 @@ const NavigationProvider = ({ children }) => {
       }
     };
     if (isBrowser) {
-      fetchBreadcrumbData();
+      fetchData();
+      setCompletedFetch(true);
     }
   }, [database, project]);
 
-  return <NavigationContext.Provider value={{ parents }}>{children}</NavigationContext.Provider>;
+  return <NavigationContext.Provider value={{ completedFetch, parents }}>{children}</NavigationContext.Provider>;
 };
 
 export { NavigationContext, NavigationProvider };


### PR DESCRIPTION
### Stories/Links:

DOP-2402

### Staging Links:

[Node staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/node/raymundrodriguez/DOP-2402/)

### Notes:
* The Node docs should have their side nav back button point to the Drivers site but is not being included here for the purpose of the PR (will update the navigation accordingly after this PR is merged).