### PR TITLE
DOP-2411: Fix content margins for Unified Navigation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .cache
+CHANGELOG.md
 docs-tools
 package.json
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "gatsby build --prefix-paths",
     "build:clean": "npm run clean && npm run build",
+    "build:clean:stage": "npm run build:clean && make stage",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
     "ensure-master": "node scripts/ensure-master.js",

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -33,8 +33,16 @@ const Document = ({
     setShowLeftColumn(!isTabletOrMobile);
   }, [isTabletOrMobile]);
 
+  //TODO: When cleaning up the feature flag from code, replace the existing margin in the .content class in the legacy css.
+  let consistentNavHeightOffset;
+  if (process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION) {
+    consistentNavHeightOffset = {
+      margin: '87px auto 0',
+    };
+  }
+
   return (
-    <div className="content">
+    <div className="content" style={consistentNavHeightOffset}>
       {/* TODO: If not removed during docs nav rework, move this inline style elsewhere */}
       <div style={{ display: 'flex' }}>
         {(!isBrowser || showLeftColumn) && (


### PR DESCRIPTION
### Stories/Links:

DOP-2411

### Staging Links:

#### Built with unified nav:
https://docs-mongodborg-staging.corp.mongodb.com/master/realm/cassidy.schaufele/DOP-2411/

#### Built with current nav:
https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/cassidy.schaufele/DOP-2411

### Notes:
- Adds a conditional style to our page layout to adjust top margins when the unified nav is turned on. This resolves a number of layout issues (sidnav having underflow when body content is shorter, improper spacing between top breadcrumbs, etc.)
- Ridealong that brokers a peace treaty between our warring `auto-semver` and `prettier`
- Ridealong that adds `build:clean:stage` for a single routine to build and stage after cleaning local artifacts
