### PR TITLE
DOP-2411: Fix cutoff sidenav

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -17,6 +17,7 @@ const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => 
     setFixedHeight(fixedHeading.current.clientHeight);
   }, []);
 
+  // Replace styling in sidebar.module.css for .sphinxsidebar if flag is removed before Docs IA update
   const consistentNavHeightOffset =
     process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION &&
     css`
@@ -24,6 +25,7 @@ const Sidebar = ({ slug, publishedBranches, toctreeData, toggleLeftColumn }) => 
       @media ${theme.screenSize.largeAndUp} {
         top: 87px !important;
       }
+      height: calc(100vh - 87px) !important;
     `;
 
   return (

--- a/src/styles/sidebar.module.css
+++ b/src/styles/sidebar.module.css
@@ -4,6 +4,6 @@
 .sphinxsidebar {
   display: block !important;
   overflow-y: auto !important;
-  height: calc(100vh -45px);
+  height: calc(100vh - 45px);
   position: sticky !important;
 }

--- a/src/styles/sidebar.module.css
+++ b/src/styles/sidebar.module.css
@@ -4,6 +4,6 @@
 .sphinxsidebar {
   display: block !important;
   overflow-y: auto !important;
-  height: 90vh;
+  height: calc(100vh -45px);
   position: sticky !important;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-2418

### Staging Links:

_Put a link to your staging environment(s), if applicable_
BI Connector (current nav): https://docs-mongodborg-staging.corp.mongodb.com/master/bi-connector/cassidy.schaufele/DOP-2418/

Realm (with new nav): https://docs-mongodborg-staging.corp.mongodb.com/master/realm/cassidy.schaufele/DOP-2418/

### Notes:
Resolves an issue with nav cutoff due to viewport height being constricted.

I had a changeset similar to this that was stashed and never applied in the sticky nav branch - essentially, it just ensures that we set a height for the remaining viewport, offset by the margin that our content body uses to account for our top navbar.