### PR TITLE
DOP-2368: Fix Feedback Container causing CLS

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import Loadable from '@loadable/component';
+import { theme } from '../theme/docsTheme';
 import useScreenSize from '../hooks/useScreenSize';
 import TabSelectors from './TabSelectors';
 import { TabContext } from './tab-context';
@@ -12,23 +12,12 @@ import Contents from './Contents';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
-// Prevent CLS caused by late loading of 'stacked' FeedbackHeadings
-const WrappedFeedbackHeading = ({ isStacked }) => (
-  <div
-    css={css`
-      height: 60px;
-    `}
-  >
-    <FeedbackHeading isStacked={isStacked} />
-  </div>
-);
-
 const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const id = nodeData.id || '';
   const HeadingTag = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
 
   const isPageTitle = sectionDepth === 1;
-  const { isMobile, isTabletOrMobile } = useScreenSize();
+  const { isTabletOrMobile } = useScreenSize();
   const hidefeedbackheader = page?.options?.hidefeedback === 'header';
   const { selectors } = useContext(TabContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
@@ -39,14 +28,10 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
       <ConditionalWrapper
         condition={shouldShowMobileHeader}
         wrapper={(children) => (
-          <>
-            <HeadingContainer stackVertically={isMobile}>
-              {children}
-              <ChildContainer isStacked={isMobile}>
-                {hasSelectors ? <TabSelectors /> : <WrappedFeedbackHeading isStacked={isMobile} />}
-              </ChildContainer>
-            </HeadingContainer>
-          </>
+          <HeadingContainer>
+            {children}
+            <ChildContainer>{hasSelectors ? <TabSelectors /> : <FeedbackHeading />}</ChildContainer>
+          </HeadingContainer>
         )}
       >
         <HeadingTag className="contains-headerlink" id={id}>
@@ -65,19 +50,27 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
 
 const HeadingContainer = styled.div`
   display: flex;
-  flex-direction: ${(props) => (props.stackVertically ? 'column' : 'row')};
+  flex-direction: row;
   justify-content: space-between;
+
+  @media ${theme.screenSize.upToSmall} {
+    border: 1px solid red;
+    flex-direction: column;
+  }
 `;
 
-const ChildContainer = styled.div(
-  ({ isStacked }) => css`
-    ${isStacked && 'margin: 4px 0 16px 0;'}
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: ${isStacked ? 'flex-start' : 'center'};
-  `
-);
+const ChildContainer = styled.div`
+  align-items: 'center';
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  @media ${theme.screenSize.upToSmall} {
+    align-items: 'flex-start';
+    margin: ${theme.size.tiny} 0 ${theme.size.default} 0;
+    min-height: ${theme.size.xLarge};
+  }
+`;
 
 Heading.propTypes = {
   sectionDepth: PropTypes.number.isRequired,

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -11,6 +11,8 @@ import ConditionalWrapper from './ConditionalWrapper';
 import Contents from './Contents';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
+
+// Prevent CLS caused by late loading of 'stacked' FeedbackHeadings
 const WrappedFeedbackHeading = ({ isStacked }) => (
   <div
     css={css`

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -11,6 +11,15 @@ import ConditionalWrapper from './ConditionalWrapper';
 import Contents from './Contents';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
+const WrappedFeedbackHeading = ({ isStacked }) => (
+  <div
+    css={css`
+      height: 60px;
+    `}
+  >
+    <FeedbackHeading isStacked={isStacked} />
+  </div>
+);
 
 const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const id = nodeData.id || '';
@@ -32,7 +41,7 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
             <HeadingContainer stackVertically={isMobile}>
               {children}
               <ChildContainer isStacked={isMobile}>
-                {hasSelectors ? <TabSelectors /> : <FeedbackHeading isStacked={isMobile} />}
+                {hasSelectors ? <TabSelectors /> : <WrappedFeedbackHeading isStacked={isMobile} />}
               </ChildContainer>
             </HeadingContainer>
           </>

--- a/src/components/Widgets/FeedbackWidget/FeedbackForm.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackForm.js
@@ -13,39 +13,40 @@ import SupportView from './views/SupportView';
 import SubmittedView from './views/SubmittedView';
 import CommentView from './views/CommentView';
 
-export function FeedbackContent({ view }) {
-  const View = {
-    rating: RatingView,
-    qualifiers: QualifiersView,
-    comment: CommentView,
-    support: SupportView,
-    submitted: SubmittedView,
-  }[view];
-  return <View className={`view-${view}`} />;
-}
+const getView = (view) => {
+  switch (view) {
+    case 'rating':
+      return RatingView;
+    case 'qualifiers':
+      return QualifiersView;
+    case 'comment':
+      return CommentView;
+    case 'support':
+      return SupportView;
+    case 'submitted':
+      return SubmittedView;
+    default:
+      return RatingView;
+  }
+};
 
-export default function FeedbackForm(props) {
+const FeedbackForm = (props) => {
   const { isMobile, isTabletOrMobile } = useScreenSize();
   const { view } = useFeedbackState();
   const isOpen = view !== 'waiting';
 
-  const displayAs = isMobile ? 'fullscreen' : isTabletOrMobile ? 'modal' : 'floating';
-  const Container = {
-    // If big screen, render a floating card
-    floating: FeedbackCard,
-    // If small screen, render a card in a modal
-    modal: FeedbackModal,
-    // If mini screen, render a full screen app
-    fullscreen: FeedbackFullScreen,
-  }[displayAs];
+  const Container = isMobile ? FeedbackFullScreen : isTabletOrMobile ? FeedbackModal : FeedbackCard;
+  const View = getView(view);
 
   return (
     isOpen && (
       <div className="feedback-form" hidden={!isOpen}>
         <Container isOpen={isOpen}>
-          <FeedbackContent view={view} />
+          <View className={`view-${view}`} />
         </Container>
       </div>
     )
   );
-}
+};
+
+export default FeedbackForm;

--- a/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
@@ -1,26 +1,13 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import StarRating, { StarRatingLabel } from './components/StarRating';
 import { useFeedbackState } from './context';
 
-// Prevent CLS caused by late loading of rating stars
-const WrappedStarRating = ({ size }) => (
-  <div
-    css={css`
-      height: 24px;
-    `}
-  >
-    <StarRating size={size} />
-  </div>
-);
-
-export default function FeedbackHeading({ isVisible = true }) {
+export default function FeedbackHeading() {
   const { hideHeader } = useFeedbackState();
   return (
-    isVisible &&
     !hideHeader && (
       <>
-        <WrappedStarRating size={'lg'} />
+        <StarRating size={'lg'} />
         <StarRatingLabel>Give Feedback</StarRatingLabel>
       </>
     )

--- a/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackHeading.js
@@ -1,6 +1,18 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import StarRating, { StarRatingLabel } from './components/StarRating';
 import { useFeedbackState } from './context';
+
+// Prevent CLS caused by late loading of rating stars
+const WrappedStarRating = ({ size }) => (
+  <div
+    css={css`
+      height: 24px;
+    `}
+  >
+    <StarRating size={size} />
+  </div>
+);
 
 export default function FeedbackHeading({ isVisible = true }) {
   const { hideHeader } = useFeedbackState();
@@ -8,7 +20,7 @@ export default function FeedbackHeading({ isVisible = true }) {
     isVisible &&
     !hideHeader && (
       <>
-        <StarRating size="lg" />
+        <WrappedStarRating size={'lg'} />
         <StarRatingLabel>Give Feedback</StarRatingLabel>
       </>
     )

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -96,6 +96,7 @@ const widthForSize = (size) => {
       return '100%';
   }
 };
+
 const marginForSize = (size) => {
   switch (size) {
     case 'lg':
@@ -108,6 +109,7 @@ const marginForSize = (size) => {
       return '20px 0 20px 0';
   }
 };
+
 const Layout = styled.div(
   (props) => css`
     display: flex;
@@ -115,6 +117,7 @@ const Layout = styled.div(
     width: ${widthForSize(props.size)};
     justify-content: space-between;
     margin: ${marginForSize(props.size)};
+    min-height: 24px;
   `
 );
 


### PR DESCRIPTION
### Stories/Links:

[DOP-2368](https://jira.mongodb.org/browse/DOP-2368)

### Staging Links:

[docs-compass](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/cgoecknerwald/DOP-2368/connect/required-access/) -- Look at mobile/tablet-sized screens to see the `FeedbackHeader` and `StarRatings`

Compare to:
https://docs.mongodb.com/compass/current/connect/required-access/

### Notes:

- Slight rework of code to include default state for `View` + updated / standardized syntax
- Wrap `FeedbackHeader` + `StarRatings` in appropriately-size divs to prevent layout shifts upon load
- CLS is most visible on mobile screens, see JIRA ticket comments for more detail
