### PR TITLE
Update Makefile to use new S3 staging bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
-STAGING_BUCKET=docs-mongodb-org-staging
+STAGING_BUCKET=docs-mongodb-org-stg
 -include .env.production
 
 .PHONY: stage static


### PR DESCRIPTION
### Stories/Links:

Not a ticket

### Staging Links:

[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/raymundrodriguez/update-makefile/)
[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/update-makefile/)

### Notes:
* Updates the S3 bucket we use for staging. I left 2 staging links just to double-check.
* Snooty devs should use the updated AWS credentials so mut can publish to the new bucket