### PR TITLE
DOP-2440: Fix Document template columns

### DIFF
--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -13,7 +13,6 @@ import { getNestedValue } from '../utils/get-nested-value';
 const DocumentContainer = styled('div')`
   display: grid;
   grid-template-areas: 'main right';
-  grid-template-columns: minmax(0px, 830px) auto;
 `;
 
 const StyledMainColumn = styled(MainColumn)`


### PR DESCRIPTION
### Stories/Links:

DOP-2440

### Staging Links:

[Atlas Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/raymundrodriguez/DOP-2440/connect-to-database-deployment/)

### Notes:
* Removes an unnecessary css rule for grid template columns so that the right column doesn't squish the main column.
* Compare staging link with this [older one](https://docs-mongodbcom-staging.corp.mongodb.com/master/cloud-docs/raymundrodriguez/update-makefile/connect-to-database-deployment/). 