### PR TITLE
Fix back button appearance on landing

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -143,6 +143,7 @@ const Sidenav = ({ page, pageTitle, publishedBranches, siteTitle, slug, toctree 
   const { isTablet } = useScreenSize();
   const viewportSize = useViewportSize();
   const isMobile = viewportSize?.width <= 420;
+  const showDocsLogo = process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && !isMobile;
 
   // Checks if user is navigating back to the homepage on docs landing
   const [back, setBack] = React.useState(null);
@@ -176,29 +177,22 @@ const Sidenav = ({ page, pageTitle, publishedBranches, siteTitle, slug, toctree 
             <IATransition back={back} hasIA={!!ia} slug={slug} isMobile={isMobile}>
               <NavTopContainer>
                 <ArtificialPadding />
-                {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && !isMobile && (
-                  <>
-                    <SidenavDocsLogo border={<Border />} />
-                    {/* Instead of extra flag logic in the button, we add another spacer div as the border 
-                        to ensure proper spacing in placeholder + rendered back target
-                        TODO: Strongly consider removing this spacer div and adding a 16px margin + placeholder offset
-                        in the SidenavBackButton component
-                        as part of PROCESS.ENV.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION cleanup
-                      */}
-                    <SidenavBackButton
-                      handleClick={() => {
-                        setBack(true);
-                        hideMobileSidenav();
-                      }}
-                      project={project}
-                      currentSlug={slug}
-                      border={<ArtificialPadding />}
-                    />
-                  </>
-                )}
-                {(!process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION || isMobile) && (
-                  <SidenavBackButton border={<Border />} />
-                )}
+                {showDocsLogo && <SidenavDocsLogo border={<Border />} />}
+                {/* Instead of extra flag logic in the button, we add another spacer div as the border 
+                    to ensure proper spacing in placeholder + rendered back target
+                    TODO: Strongly consider removing this spacer div and adding a 16px margin + placeholder offset
+                    in the SidenavBackButton component
+                    as part of PROCESS.ENV.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION cleanup
+                */}
+                <SidenavBackButton
+                  handleClick={() => {
+                    setBack(true);
+                    hideMobileSidenav();
+                  }}
+                  project={project}
+                  currentSlug={slug}
+                  border={showDocsLogo ? <ArtificialPadding /> : <Border />}
+                />
                 {ia && (
                   <IA
                     header={<span className={cx(titleStyle)}>{formatText(pageTitle)}</span>}


### PR DESCRIPTION
### Staging Links:

[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/upstream-nav/landing/raymundrodriguez/fix-back-button/) - consistent nav off
[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/upstream-nav/landing/raymundrodriguez/fix-back-button-con-nav/) - consistent nav on

### Notes:
* The back button currently requires to pass in `project` and `slug` props since the back button has different behavior on docs-landing than other sites. However, the back button appears on the docs homepage as if this is a different docs site. Use this [staging link built on master](https://docs-mongodbcom-staging.corp.mongodb.com/upstream-nav/landing/raymundrodriguez/master/) for comparison with the staging links above.
* Included screenshots below of the docs-node site to validate that behavior is acceptable on non-landing sites with these changes.

### Screenshots:
Node - consistent nav on
<img width="800" alt="Screen Shot 2021-09-14 at 12 11 00 PM" src="https://user-images.githubusercontent.com/27821750/133298488-92cd8b66-d071-449a-987f-d6d2287bf844.png">
<img width="405" alt="Screen Shot 2021-09-14 at 12 11 17 PM" src="https://user-images.githubusercontent.com/27821750/133298497-236bb38c-0d68-4770-80c7-f05bce4dae3a.png">

Node - consistent nav off
<img width="407" alt="Screen Shot 2021-09-14 at 12 14 21 PM" src="https://user-images.githubusercontent.com/27821750/133298574-234d0d03-1687-4c7b-bf5f-1963b5960676.png">
<img width="775" alt="Screen Shot 2021-09-14 at 12 14 35 PM" src="https://user-images.githubusercontent.com/27821750/133298583-6a20b7c3-a226-440a-b541-67bef5e699d4.png">
