### PR TITLE
DOP-2450: Fix spacing between content and TOC

### DIFF
--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -8,7 +8,7 @@ const MainColumn = ({ children, className }) => (
     className={className}
     css={css`
       margin: ${theme.size.default} ${theme.size.xlarge} ${theme.size.xlarge};
-      max-width: 775px;
+      max-width: 800px;
       min-height: 600px;
 
       @media ${theme.screenSize.upToXSmall} {

--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -8,7 +8,7 @@ const MainColumn = ({ children, className }) => (
     className={className}
     css={css`
       margin: ${theme.size.default} ${theme.size.xlarge} ${theme.size.xlarge};
-      max-width: 800px;
+      max-width: 775px;
       min-height: 600px;
 
       @media ${theme.screenSize.upToXSmall} {

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
-import { Logo } from '@leafygreen-ui/logo';
 import { uiColors } from '@leafygreen-ui/palette';
+import Link from './Link';
 import Searchbar from './Searchbar';
 import { SidenavContext, SidenavMobileMenuButton } from './Sidenav';
+import DocsLogo from './SVGs/DocsLogo';
+import { DOCS_URL } from '../constants';
 import useMedia from '../hooks/use-media';
 import { theme } from '../theme/docsTheme';
 import { getSearchbarResultsFromJSON } from '../utils/get-searchbar-results-from-json';
@@ -83,16 +84,9 @@ const Navbar = () => {
     <NavbarContainer tabIndex="0" isTransparent={isTransparent}>
       {isSidenavEnabled && <SidenavMobileMenuButton />}
       <NavbarLeft isTransparent={isTransparent}>
-        <a
-          css={css`
-            height: ${logoHeight}px;
-          `}
-          href="https://mongodb.com"
-        >
-          <Logo height={logoHeight} />
-        </a>
-        <NavSeparator></NavSeparator>
-        <NavLabel>Documentation</NavLabel>
+        <Link to={`${DOCS_URL}/`}>
+          <DocsLogo />
+        </Link>
       </NavbarLeft>
       <Searchbar
         getResultsFromJSON={getSearchbarResultsFromJSON}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
 import styled from '@emotion/styled';
-import { uiColors } from '@leafygreen-ui/palette';
 import Link from './Link';
 import Searchbar from './Searchbar';
 import { SidenavContext, SidenavMobileMenuButton } from './Sidenav';
@@ -36,22 +35,6 @@ const NavbarLeft = styled('div')`
   ${(props) => props.isTransparent && 'opacity: 0.2;'}
 `;
 
-const NavSeparator = styled('span')`
-  background-color: #616161;
-  display: inline-block;
-  height: ${theme.size.default};
-  margin: 0 6px;
-  width: 1px;
-`;
-
-const NavLabel = styled('div')`
-  color: ${uiColors.gray.dark3}
-  display: inline-block;
-  font-family: Akzidenz;
-  font-size: ${theme.fontSize.default};
-  user-select: none;
-`;
-
 // TODO: Remove this component after consistent-nav is officially released
 const Navbar = () => {
   // We want to expand the searchbar on default when it won't collide with any other nav elements
@@ -60,7 +43,6 @@ const Navbar = () => {
   const { isSidenavEnabled } = useContext(SidenavContext);
   const [isSearchbarExpanded, setIsSearchbarExpanded] = useState(isSearchbarDefaultExpanded);
   const [isTransparent, setIsTransparent] = useState(false);
-  const logoHeight = 22;
 
   const onSearchbarExpand = useCallback(
     (isExpanded) => {

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -8,7 +8,7 @@ const RightColumn = ({ children, className }) => (
   <div
     className={className}
     css={css`
-      margin: 70px 24px 40px 54px;
+      margin: 70px 24px 40px 5px;
       min-width: 180px;
 
       ${displayNone.onMobileAndTablet};

--- a/src/components/Sidenav/SidenavDocsLogo.js
+++ b/src/components/Sidenav/SidenavDocsLogo.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { DOCS_URL } from '../../constants';
 import { theme } from '../../theme/docsTheme';
 
 import DocsLogo from '../SVGs/DocsLogo';
+import Link from '../Link';
 
 const PaddedDocsLogo = styled(DocsLogo)`
   margin: 0px ${theme.size.medium};
@@ -12,7 +14,9 @@ const PaddedDocsLogo = styled(DocsLogo)`
 const SidenavDocsLogo = ({ border, ...props }) => {
   return (
     <>
-      <PaddedDocsLogo height={20} width={184} {...props} />
+      <Link to={`${DOCS_URL}/`}>
+        <PaddedDocsLogo height={20} width={184} {...props} />
+      </Link>
       {border}
     </>
   );

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -11,6 +11,17 @@ import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
 
+// TODO: Delete this as a part of the css cleanup
+// Currently used to preserve behavior and stop legacy css
+// from overriding specified styles in imported footer
+const footerOverrides = css`
+  footer {
+    a:hover {
+      color: currentColor;
+    }
+  }
+`;
+
 const globalCSS = css`
   html {
     overflow: hidden;
@@ -49,6 +60,8 @@ const globalCSS = css`
       display: none !important;
     }
   }
+
+  ${footerOverrides}
 `;
 
 const GlobalGrid = styled('div')`

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -18,6 +18,7 @@ const DocumentContainer = styled('div')`
 
 const StyledMainColumn = styled(MainColumn)`
   grid-area: main;
+  max-width: 775px;
   overflow-x: scroll;
 `;
 

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -13,10 +13,12 @@ import { getNestedValue } from '../utils/get-nested-value';
 const DocumentContainer = styled('div')`
   display: grid;
   grid-template-areas: 'main right';
+  grid-template-columns: minmax(0, auto) 1fr;
 `;
 
 const StyledMainColumn = styled(MainColumn)`
   grid-area: main;
+  overflow-x: scroll;
 `;
 
 const StyledRightColumn = styled(RightColumn)`


### PR DESCRIPTION
### Stories/Links:

DOP-2450

### Staging Links:

[Docs Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/raymundrodriguez/DOP-2450/installation/)
[Drivers Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/drivers/raymundrodriguez/DOP-2450/) - without consistent nav, for comparison

### Notes:
* Changes max width of content's main column div from 800px to 775px to match current production content width.
* Fixes spacing between the content column and the righthand TOC / `Contents` component for very large screens.
* Makes the docs logo clickable on the sidenav and on the (non-consistent nav) navbar.
* Re-adds footer overrides for `UnifiedFooter` that weren't merged in properly before.