### PR TITLE
DOP-2092: Upgrade LG button to version 12.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "snooty",
       "version": "0.11.13",
       "dependencies": {
         "@emotion/core": "^10.1.1",
@@ -12,7 +13,7 @@
         "@leafygreen-ui/badge": "^4.0.3",
         "@leafygreen-ui/banner": "^3.0.6",
         "@leafygreen-ui/box": "^3.0.3",
-        "@leafygreen-ui/button": "^8.0.1",
+        "@leafygreen-ui/button": "^12.0.2",
         "@leafygreen-ui/callout": "^2.1.2",
         "@leafygreen-ui/card": "^5.1.1",
         "@leafygreen-ui/checkbox": "^6.0.3",
@@ -2771,17 +2772,35 @@
       }
     },
     "node_modules/@leafygreen-ui/button": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-8.0.1.tgz",
-      "integrity": "sha512-3yIi1QHITOHc1w4jWb1TVS3ZpqiQP99IyjJOUGOFMwUV8xOW/qBOAneWu2MLIA1MHDMZIod1GQNvugagfTWztQ==",
+      "version": "12.0.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.2.tgz",
+      "integrity": "sha1-2HwaePbv10CEv6/FeI063eOF76w=",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.0.1",
-        "@leafygreen-ui/lib": "^6.0.1",
-        "@leafygreen-ui/palette": "^3.0.1",
-        "lodash": "^4.17.20"
+        "@leafygreen-ui/box": "^3.0.4",
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/palette": "^3.2.1",
+        "@leafygreen-ui/ripple": "^1.1.1",
+        "@leafygreen-ui/tokens": "^0.5.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.0.1"
+        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/lib": {
+      "version": "7.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
+      "integrity": "sha1-Yv8uwR3VA+F+W8Mc3AU+fy9cWVQ=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "facepaint": "^1.2.1",
+        "polished": "^2.3.0",
+        "prop-types": "^15.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
       }
     },
     "node_modules/@leafygreen-ui/callout": {
@@ -3363,22 +3382,6 @@
         "@types/react-is": "^17.0.0",
         "polished": "^4.0.3",
         "react-is": "^17.0.1"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.1.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/button": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-12.0.2.tgz",
-      "integrity": "sha512-PGo//TaHFLsm/2MM49woCfYXGyE3M2YQ6p12n3wNTW2YyxtQBNoL3/51VVQi7/rnrrv4ynMfDdSWQsRq9W6fww==",
-      "dependencies": {
-        "@leafygreen-ui/box": "^3.0.4",
-        "@leafygreen-ui/emotion": "^3.0.1",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1",
-        "@leafygreen-ui/ripple": "^1.1.1",
-        "@leafygreen-ui/tokens": "^0.5.1"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^2.1.0"
@@ -32199,14 +32202,29 @@
       }
     },
     "@leafygreen-ui/button": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-8.0.1.tgz",
-      "integrity": "sha512-3yIi1QHITOHc1w4jWb1TVS3ZpqiQP99IyjJOUGOFMwUV8xOW/qBOAneWu2MLIA1MHDMZIod1GQNvugagfTWztQ==",
+      "version": "12.0.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.2.tgz",
+      "integrity": "sha1-2HwaePbv10CEv6/FeI063eOF76w=",
       "requires": {
-        "@leafygreen-ui/box": "^3.0.1",
-        "@leafygreen-ui/lib": "^6.0.1",
-        "@leafygreen-ui/palette": "^3.0.1",
-        "lodash": "^4.17.20"
+        "@leafygreen-ui/box": "^3.0.4",
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/palette": "^3.2.1",
+        "@leafygreen-ui/ripple": "^1.1.1",
+        "@leafygreen-ui/tokens": "^0.5.1"
+      },
+      "dependencies": {
+        "@leafygreen-ui/lib": {
+          "version": "7.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
+          "integrity": "sha1-Yv8uwR3VA+F+W8Mc3AU+fy9cWVQ=",
+          "requires": {
+            "@leafygreen-ui/emotion": "^3.0.1",
+            "facepaint": "^1.2.1",
+            "polished": "^2.3.0",
+            "prop-types": "^15.0.0"
+          }
+        }
       }
     },
     "@leafygreen-ui/callout": {
@@ -32744,19 +32762,6 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "@leafygreen-ui/button": {
-          "version": "12.0.2",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-12.0.2.tgz",
-          "integrity": "sha512-PGo//TaHFLsm/2MM49woCfYXGyE3M2YQ6p12n3wNTW2YyxtQBNoL3/51VVQi7/rnrrv4ynMfDdSWQsRq9W6fww==",
-          "requires": {
-            "@leafygreen-ui/box": "^3.0.4",
-            "@leafygreen-ui/emotion": "^3.0.1",
-            "@leafygreen-ui/lib": "^7.0.0",
-            "@leafygreen-ui/palette": "^3.2.1",
-            "@leafygreen-ui/ripple": "^1.1.1",
-            "@leafygreen-ui/tokens": "^0.5.1"
-          }
-        },
         "@leafygreen-ui/lib": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@leafygreen-ui/badge": "^4.0.3",
     "@leafygreen-ui/banner": "^3.0.6",
     "@leafygreen-ui/box": "^3.0.3",
-    "@leafygreen-ui/button": "^8.0.1",
+    "@leafygreen-ui/button": "^12.0.2",
     "@leafygreen-ui/callout": "^2.1.2",
     "@leafygreen-ui/card": "^5.1.1",
     "@leafygreen-ui/checkbox": "^6.0.3",

--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -58,6 +58,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
     setVersion('');
   }, []);
   const updateVersion = useCallback(({ value }) => setVersion(value), []);
+  const buttonDisabled = !(product && version);
 
   useEffect(() => {
     if (isBrowser) {
@@ -70,6 +71,12 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
   }, [deprecatedVersions]);
 
   const generateUrl = () => {
+    // Our current LG button version has a bug where a disabled button with an href allows the disabled
+    // button to be clickable. This logic can be removed when LG button is version >= 12.0.4.
+    if (buttonDisabled) {
+      return null;
+    }
+
     const hostName = getSiteUrl(product);
     return ['docs', 'mms', 'cloud-docs'].includes(product)
       ? `${hostName}/${version}`
@@ -107,13 +114,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
         onChange={updateVersion}
         value={version}
       />
-      <Button
-        variant="primary"
-        title="View Documentation"
-        size="large"
-        href={generateUrl()}
-        disabled={!(product && version)}
-      >
+      <Button variant="primary" title="View Documentation" size="large" href={generateUrl()} disabled={buttonDisabled}>
         View Documentation
       </Button>
     </>

--- a/src/components/Introduction.js
+++ b/src/components/Introduction.js
@@ -7,7 +7,6 @@ import ComponentFactory from './ComponentFactory';
 const StyledIntroduction = styled('div')`
   .button {
     font-size: ${theme.fontSize.default};
-    height: unset;
     margin: ${theme.size.medium} ${theme.size.default} ${theme.size.default} 0;
     min-height: ${theme.size.large};
   }


### PR DESCRIPTION
### Stories/Links:

DOP-2092

### Staging Links:

[Compass](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/raymundrodriguez/DOP-2092/)
[Landing - Legacy page](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/raymundrodriguez/DOP-2092/legacy/)

### Notes:
* Upgrades LG button to version 12.0.2 in hopes of resolving button/selector styling when working on DOP-2136.
* 12.0.2 is the version chosen for the LG button since versions 12.0.3+ use upgraded dependencies that require React 17.
* We only use disabled buttons in one place (the legacy docs landing page). I incorporated a workaround for the disabled button bug that is fixed in future versions of the LG button (see comment regarding the change).