### PR TITLE
DOP-2461: Whitespace possible below Unified Footer

### DIFF
--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -51,7 +51,7 @@ const ContentTransition = ({ children, slug }) => (
       >
         <div
           css={css`
-            min-height: fill-available;
+            min-height: 100%;
             display: flex;
             flex-direction: column;
             justify-content: space-between;

--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -49,7 +49,16 @@ const ContentTransition = ({ children, slug }) => (
         classNames="fade"
         key={slug}
       >
-        <div>{children}</div>
+        <div
+          css={css`
+            min-height: fill-available;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+          `}
+        >
+          {children}
+        </div>
       </CSSTransition>
     </TransitionGroup>
   </>

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -5,7 +5,6 @@ import { UnifiedFooter } from '@mdb/consistent-nav';
 import ComponentFactory from './ComponentFactory';
 import { ContentsProvider } from './contents-context';
 import FootnoteContext from './footnote-context';
-import Footer from './Footer';
 import SEO from './SEO';
 import Widgets from './Widgets';
 import { findAllKeyValuePairs } from '../utils/find-all-key-value-pairs';
@@ -131,12 +130,11 @@ export default class DocumentBody extends Component {
                       {this.pageNodes.map((child, index) => (
                         <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
                       ))}
-                      {!process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <Footer />}
                     </Template>
                   </ContentsProvider>
                 </FootnoteContext.Provider>
               </Widgets>
-              {process.env.GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION && <UnifiedFooter hideLocale={true} />}
+              <UnifiedFooter hideLocale={true} />
             </>
           );
         }}

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -19,7 +19,7 @@ const DocumentContainer = styled('div')`
 const StyledMainColumn = styled(MainColumn)`
   grid-area: main;
   max-width: 775px;
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 const StyledRightColumn = styled(RightColumn)`

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -10,7 +10,7 @@ const Wrapper = styled('main')`
   color: ${uiColors.black};
   margin: 0 auto ${theme.size.xlarge} auto;
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 
   h1,
   h2,


### PR DESCRIPTION
### Stories/Links:

DOP-2461

### Staging Links:

**Landing:**
https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2461/develop-applications/

### Notes:

- Adds basic flexbox styles to our main `content` column, to ensure that any content (footer) is spaced to fill available screen space.
- Changes `overflow-x: scroll` to `auto` to remove empty horizontal scrollbars on non OSX devices.

**Production, portrait viewport**
<img width="764" alt="dop2461prod" src="https://user-images.githubusercontent.com/3813528/135471982-8f37ee4f-7cb5-492e-85db-d59dfb09a891.PNG">

**Staging, portrait viewport**
<img width="764" alt="dop2461change" src="https://user-images.githubusercontent.com/3813528/135472038-79af265e-e365-473e-95f7-b2dd999a41a4.PNG">
t