### PR TITLE
DOP-2495: Retain Realm Searchbar Context

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -14,7 +14,10 @@ const StyledHeaderContainer = styled.header`
 
 const Header = ({ sidenav }) => {
   const { project } = useSiteMetadata();
-  const unifiedNavProperty = project === 'realm' ? 'REALM' : 'DOCS';
+
+  const searchProperty = new URL(window.location).searchParams.get('searchProperty');
+  const shouldSearchRealm = project === 'realm' || searchProperty === 'realm-master';
+  const unifiedNavProperty = shouldSearchRealm ? 'REALM' : 'DOCS';
 
   return (
     <StyledHeaderContainer>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { isBrowser } from '../utils/is-browser';
 import { UnifiedNav } from '@mdb/consistent-nav';
 import Navbar from './Navbar';
 import { SidenavMobileMenuDropdown } from './Sidenav';
@@ -15,7 +16,11 @@ const StyledHeaderContainer = styled.header`
 const Header = ({ sidenav }) => {
   const { project } = useSiteMetadata();
 
-  const searchProperty = new URL(window.location).searchParams.get('searchProperty');
+  let searchProperty;
+  if (isBrowser) {
+    searchProperty = new URL(window.location).searchParams.get('searchProperty');
+  }
+
   const shouldSearchRealm = project === 'realm' || searchProperty === 'realm-master';
   const unifiedNavProperty = shouldSearchRealm ? 'REALM' : 'DOCS';
 


### PR DESCRIPTION
### Stories/Links:

DOP-2495

### Staging Links:

_Put a link to your staging environment(s), if applicable_

*Landing, with Realm searchProperty*
https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2495/search/?q=&searchProperty=realm-master

*Landing, default*
https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2495/search

### Notes:
We can be assured that for the version of the consistent navigation component that we utilize, the `searchProperty` will have a value of `realm-master` when a search originates from Realm docs.

This change ensures that we will retain Realm search as the default property for the navigation when originating search from said Realm pages.
