### PR TITLE
DOP-2136: Add LanguageSwitcher to code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@leafygreen-ui/callout": "^2.1.2",
         "@leafygreen-ui/card": "^5.1.1",
         "@leafygreen-ui/checkbox": "^6.0.3",
-        "@leafygreen-ui/code": "^8.0.9",
+        "@leafygreen-ui/code": "^8.1.3",
         "@leafygreen-ui/emotion": "^3.0.1",
         "@leafygreen-ui/hooks": "^6.0.1",
         "@leafygreen-ui/icon": "^11.3.0",
@@ -2908,15 +2908,18 @@
       }
     },
     "node_modules/@leafygreen-ui/code": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-8.0.9.tgz",
-      "integrity": "sha512-ZVJctyeFYXJEMbqczIO+vlHcoBeOMId7ZUYllam6BvtgEKj+ayDfGQOIqZgsCWA5YGxVjHA91WZgOfGJNpLtNw==",
+      "version": "8.1.3",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-8.1.3.tgz",
+      "integrity": "sha1-wX8dn3fS3+4yqLhFXmksQe88tMI=",
+      "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon": "^10.2.1",
+        "@leafygreen-ui/icon": "^11.0.0",
         "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/leafygreen-provider": "^2.0.3",
+        "@leafygreen-ui/leafygreen-provider": "^2.1.0",
         "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/palette": "^3.2.0",
+        "@leafygreen-ui/select": "^3.0.1",
         "@leafygreen-ui/tokens": "^0.5.1",
         "clipboard": "^2.0.6",
         "highlight.js": "^10.0.3",
@@ -2924,18 +2927,11 @@
         "highlightjs-line-numbers.js": "^2.7.0"
       }
     },
-    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/icon": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-      "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0"
-      }
-    },
     "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/lib": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
+      "integrity": "sha1-Yv8uwR3VA+F+W8Mc3AU+fy9cWVQ=",
+      "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/emotion": "^3.0.1",
         "facepaint": "^1.2.1",
@@ -32324,15 +32320,17 @@
       }
     },
     "@leafygreen-ui/code": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-8.0.9.tgz",
-      "integrity": "sha512-ZVJctyeFYXJEMbqczIO+vlHcoBeOMId7ZUYllam6BvtgEKj+ayDfGQOIqZgsCWA5YGxVjHA91WZgOfGJNpLtNw==",
+      "version": "8.1.3",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-8.1.3.tgz",
+      "integrity": "sha1-wX8dn3fS3+4yqLhFXmksQe88tMI=",
       "requires": {
         "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon": "^10.2.1",
+        "@leafygreen-ui/icon": "^11.0.0",
         "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/leafygreen-provider": "^2.0.3",
+        "@leafygreen-ui/leafygreen-provider": "^2.1.0",
         "@leafygreen-ui/lib": "^7.0.0",
+        "@leafygreen-ui/palette": "^3.2.0",
+        "@leafygreen-ui/select": "^3.0.1",
         "@leafygreen-ui/tokens": "^0.5.1",
         "clipboard": "^2.0.6",
         "highlight.js": "^10.0.3",
@@ -32340,18 +32338,10 @@
         "highlightjs-line-numbers.js": "^2.7.0"
       },
       "dependencies": {
-        "@leafygreen-ui/icon": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-          "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
-          "requires": {
-            "@leafygreen-ui/lib": "^7.0.0"
-          }
-        },
         "@leafygreen-ui/lib": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
+          "integrity": "sha1-Yv8uwR3VA+F+W8Mc3AU+fy9cWVQ=",
           "requires": {
             "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@leafygreen-ui/callout": "^2.1.2",
     "@leafygreen-ui/card": "^5.1.1",
     "@leafygreen-ui/checkbox": "^6.0.3",
-    "@leafygreen-ui/code": "^8.0.9",
+    "@leafygreen-ui/code": "^8.1.3",
     "@leafygreen-ui/emotion": "^3.0.1",
     "@leafygreen-ui/hooks": "^6.0.1",
     "@leafygreen-ui/icon": "^11.3.0",

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,7 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { default as CodeBlock, Language } from '@leafygreen-ui/code';
+import { CodeContext } from './code-context';
+import { TabContext } from './tab-context';
 import { theme } from '../theme/docsTheme';
 import { reportAnalytics } from '../utils/report-analytics';
 
@@ -19,7 +21,10 @@ const getLanguage = (lang) => {
 };
 
 const Code = ({ nodeData: { caption, copyable, emphasize_lines: emphasizeLines, lang, linenos, value } }) => {
+  const { setActiveTab } = useContext(TabContext);
+  const { languageOptions, codeBlockLanguage } = useContext(CodeContext);
   const code = value;
+  const language = (languageOptions?.length > 0 && codeBlockLanguage) || getLanguage(lang);
 
   const reportCodeCopied = useCallback(() => {
     reportAnalytics('CodeblockCopied', { code });
@@ -33,13 +38,29 @@ const Code = ({ nodeData: { caption, copyable, emphasize_lines: emphasizeLines, 
         min-width: 150px;
         table-layout: fixed;
         width: 100%;
+
+        // Inner div of LG component has a width set to 700px. Unset this as part of our
+        // override for docs when the language switcher is being used.
+        > div > div {
+          width: unset;
+        }
+
+        // Override default LG Code language switcher font size
+        button > div > div {
+          font-size: ${theme.fontSize.small};
+        }
       `}
     >
       <CodeBlock
         chromeTitle={caption}
         copyable={copyable}
         highlightLines={emphasizeLines}
-        language={getLanguage(lang)}
+        language={language}
+        languageOptions={languageOptions}
+        onChange={(selectedOption) => {
+          const tabsetName = 'drivers';
+          setActiveTab({ name: tabsetName, value: selectedOption.id });
+        }}
         onCopy={reportCodeCopied}
         showLineNumbers={linenos}
         showWindowChrome={caption ? true : false}

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -47,7 +47,7 @@ const Code = ({ nodeData: { caption, copyable, emphasize_lines: emphasizeLines, 
 
         // Override default LG Code language switcher font size
         button > div > div {
-          font-size: ${theme.fontSize.small};
+          font-size: ${theme.fontSize.default};
         }
       `}
     >

--- a/src/components/TabSelectors.js
+++ b/src/components/TabSelectors.js
@@ -6,41 +6,7 @@ import Select from './Select';
 import { getPlaintext } from '../utils/get-plaintext';
 import { reportAnalytics } from '../utils/report-analytics';
 
-import IconC from './icons/C';
-import IconCompass from './icons/Compass';
-import IconCpp from './icons/Cpp';
-import IconCsharp from './icons/Csharp';
-import IconGo from './icons/Go';
-import IconJava from './icons/Java';
-import IconNode from './icons/Node';
-import IconPHP from './icons/Php';
-import IconPython from './icons/Python';
-import IconRuby from './icons/Ruby';
-import IconRust from './icons/Rust';
-import IconScala from './icons/Scala';
-import IconShell from './icons/Shell';
-import IconSwift from './icons/Swift';
-
 const capitalizeFirstLetter = (str) => str.trim().replace(/^\w/, (c) => c.toUpperCase());
-
-const driverIconMap = {
-  c: IconC,
-  compass: IconCompass,
-  cpp: IconCpp,
-  csharp: IconCsharp,
-  go: IconGo,
-  'java-sync': IconJava,
-  'java-async': IconJava,
-  nodejs: IconNode,
-  php: IconPHP,
-  python: IconPython,
-  ruby: IconRuby,
-  rust: IconRust,
-  scala: IconScala,
-  shell: IconShell,
-  'swift-async': IconSwift,
-  'swift-sync': IconSwift,
-};
 
 const getLabel = (name) => {
   switch (name) {
@@ -55,15 +21,15 @@ const getLabel = (name) => {
   }
 };
 
-const makeChoices = ({ name, options }) =>
+const makeChoices = ({ name, iconMapping, options }) =>
   Object.entries(options).map(([tabId, title]) => ({
     text: getPlaintext(title),
     value: tabId,
-    ...(name === 'drivers' && { icon: driverIconMap[tabId] }),
+    ...(name === 'drivers' && { icon: iconMapping[tabId] }),
   }));
 
-const TabSelector = ({ activeTab, handleClick, name, options }) => {
-  const choices = useMemo(() => makeChoices({ name, options }), [name, options]);
+const TabSelector = ({ activeTab, handleClick, iconMapping, name, options }) => {
+  const choices = useMemo(() => makeChoices({ name, iconMapping, options }), [name, iconMapping, options]);
   const { screenSize } = useTheme();
   return (
     <Select
@@ -91,7 +57,7 @@ const TabSelector = ({ activeTab, handleClick, name, options }) => {
 };
 
 const TabSelectors = () => {
-  const { activeTabs, selectors, setActiveTab } = useContext(TabContext);
+  const { activeTabs, driverIconMap, selectors, setActiveTab } = useContext(TabContext);
 
   if (!selectors || Object.keys(selectors).length === 0) {
     return null;
@@ -99,9 +65,23 @@ const TabSelectors = () => {
 
   return (
     <>
-      {Object.entries(selectors).map(([name, options]) => (
-        <TabSelector key={name} activeTab={activeTabs[name]} handleClick={setActiveTab} name={name} options={options} />
-      ))}
+      {Object.entries(selectors).map(([name, options]) => {
+        let iconMapping = {};
+        if (name === 'drivers') {
+          iconMapping = driverIconMap;
+        }
+
+        return (
+          <TabSelector
+            key={name}
+            activeTab={activeTabs[name]}
+            handleClick={setActiveTab}
+            iconMapping={iconMapping}
+            name={name}
+            options={options}
+          />
+        );
+      })}
     </>
   );
 };

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useRef, useState } from 'rea
 import PropTypes from 'prop-types';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
+import { CodeProvider } from './code-context';
 import ComponentFactory from './ComponentFactory';
 import { TabContext } from './tab-context';
 import { theme } from '../theme/docsTheme';
@@ -150,9 +151,11 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
 
           return (
             <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
-              {tab.children.map((child, i) => (
-                <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
-              ))}
+              <CodeProvider>
+                {tab.children.map((child, i) => (
+                  <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
+                ))}
+              </CodeProvider>
             </LeafyTab>
           );
         })}

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -132,34 +132,34 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
   return (
     <>
       <div ref={scrollAnchorRef} aria-hidden="true"></div>
-      <LeafyTabs
-        className={cx(getTabsStyling({ isHidden, isProductLanding }))}
-        aria-label={`Tabs to describe usage of ${tabsetName}`}
-        selected={activeTab}
-        setSelected={handleClick}
-      >
-        {children.map((tab) => {
-          if (tab.name !== 'tab') {
-            return null;
-          }
+      <CodeProvider>
+        <LeafyTabs
+          className={cx(getTabsStyling({ isHidden, isProductLanding }))}
+          aria-label={`Tabs to describe usage of ${tabsetName}`}
+          selected={activeTab}
+          setSelected={handleClick}
+        >
+          {children.map((tab) => {
+            if (tab.name !== 'tab') {
+              return null;
+            }
 
-          const tabId = getTabId(tab);
-          const tabTitle =
-            tab.argument.length > 0
-              ? tab.argument.map((arg, i) => <ComponentFactory {...rest} key={`${tabId}-arg-${i}`} nodeData={arg} />)
-              : tabId;
+            const tabId = getTabId(tab);
+            const tabTitle =
+              tab.argument.length > 0
+                ? tab.argument.map((arg, i) => <ComponentFactory {...rest} key={`${tabId}-arg-${i}`} nodeData={arg} />)
+                : tabId;
 
-          return (
-            <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
-              <CodeProvider>
+            return (
+              <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
                 {tab.children.map((child, i) => (
                   <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
                 ))}
-              </CodeProvider>
-            </LeafyTab>
-          );
-        })}
-      </LeafyTabs>
+              </LeafyTab>
+            );
+          })}
+        </LeafyTabs>
+      </CodeProvider>
     </>
   );
 };

--- a/src/components/code-context.js
+++ b/src/components/code-context.js
@@ -48,18 +48,15 @@ const getDriverImage = (driver, driverIconMap) => {
     return <DriverIcon />;
   }
 
-  // LG Code default file icon; not formally added in their code yet,
-  // but is mentioned in a source code comment
+  // Use LG File icon as our default placeholder for images. This overwrites
+  // LG's Language Switcher current default icon. See:
+  // https://github.com/mongodb/leafygreen-ui/blob/6041b89bf5f9dc1e5ea76018bc2cd84bc1fd6faf/packages/code/src/LanguageSwitcher.tsx#L135-L136
   return <LeafyIcon glyph="File" />;
 };
 
-// Generates language options for code block based on drivers tabset
-const generateLanguageOptions = (selectors, driverIconMap) => {
-  if (!(selectors && Object.keys(selectors).length > 0 && selectors['drivers'])) {
-    return null;
-  }
-
-  const drivers = selectors['drivers'];
+// Generates language options for code block based on drivers tabset on current page
+const generateLanguageOptions = (selectors = {}, driverIconMap) => {
+  const drivers = selectors?.['drivers'];
   const languageOptions = [];
 
   for (const driver in drivers) {
@@ -77,14 +74,13 @@ const generateLanguageOptions = (selectors, driverIconMap) => {
 // Returns the display name of the current driver selected
 const getCurrentLanguageOption = (languageOptions, activeTabs) => {
   const currentTab = activeTabs?.drivers;
-
-  if (!(languageOptions && languageOptions.length > 0 && currentTab)) {
+  if (!currentTab) {
     return null;
   }
 
   const currentLangOption = languageOptions.find((option) => option.id === currentTab);
   // LG Code block's language switcher uses the display name to select the current "language"
-  return currentLangOption?.displayName || null;
+  return currentLangOption?.displayName;
 };
 
 const CodeProvider = ({ children }) => {

--- a/src/components/code-context.js
+++ b/src/components/code-context.js
@@ -1,0 +1,101 @@
+import React, { useContext, useMemo } from 'react';
+import { Language } from '@leafygreen-ui/code';
+import LeafyIcon from '@leafygreen-ui/icon';
+import { TabContext } from './tab-context';
+import { getPlaintext } from '../utils/get-plaintext';
+
+const defaultContextValue = {
+  codeBlockLanguage: null,
+  languageOptions: [],
+};
+
+const CodeContext = React.createContext(defaultContextValue);
+
+const LANGUAGES = new Set(Object.values(Language));
+
+// Custom mapping for unique drivers that don't have an exact 1:1 name to LG language mapping
+const DRIVER_LANGUAGE_MAPPING = {
+  clike: new Set(['c', 'cpp', 'c#']),
+  javascript: new Set(['compass', 'nodejs', 'shell']),
+  python: new Set(['motor']),
+};
+
+// Returns the LG-supported language that corresponds with one of our documented drivers
+const getDriverLanguage = (driverArg) => {
+  // Simplifies driver to language matching for drivers like "java-sync"
+  const driver = driverArg?.split('-')[0];
+
+  for (const language in DRIVER_LANGUAGE_MAPPING) {
+    const driversSet = DRIVER_LANGUAGE_MAPPING[language];
+    if (driversSet.has(driver)) {
+      return language;
+    }
+  }
+
+  if (LANGUAGES.has(driver)) {
+    return driver;
+  }
+
+  // LG Code default language
+  return 'none';
+};
+
+// Returns the icon associated with the driver language that would be
+// shown on our TabSelector component
+const getDriverImage = (driver, driverIconMap) => {
+  const DriverIcon = driverIconMap?.[driver];
+  if (DriverIcon) {
+    return <DriverIcon />;
+  }
+
+  // LG Code default file icon; not formally added in their code yet,
+  // but is mentioned in a source code comment
+  return <LeafyIcon glyph="File" />;
+};
+
+// Generates language options for code block based on drivers tabset
+const generateLanguageOptions = (selectors, driverIconMap) => {
+  if (!(selectors && Object.keys(selectors).length > 0 && selectors['drivers'])) {
+    return null;
+  }
+
+  const drivers = selectors['drivers'];
+  const languageOptions = [];
+
+  for (const driver in drivers) {
+    languageOptions.push({
+      id: driver,
+      displayName: getPlaintext(drivers[driver]),
+      image: getDriverImage(driver, driverIconMap),
+      language: getDriverLanguage(driver),
+    });
+  }
+
+  return languageOptions;
+};
+
+// Returns the display name of the current driver selected
+const getCurrentLanguageOption = (languageOptions, activeTabs) => {
+  const currentTab = activeTabs?.drivers;
+
+  if (!(languageOptions && languageOptions.length > 0 && currentTab)) {
+    return null;
+  }
+
+  const currentLangOption = languageOptions.find((option) => option.id === currentTab);
+  // LG Code block's language switcher uses the display name to select the current "language"
+  return currentLangOption?.displayName || null;
+};
+
+const CodeProvider = ({ children }) => {
+  const { activeTabs, driverIconMap, selectors } = useContext(TabContext);
+  const languageOptions = useMemo(() => generateLanguageOptions(selectors, driverIconMap), [driverIconMap, selectors]);
+  const codeBlockLanguage = useMemo(() => getCurrentLanguageOption(languageOptions, activeTabs), [
+    activeTabs,
+    languageOptions,
+  ]);
+
+  return <CodeContext.Provider value={{ codeBlockLanguage, languageOptions }}>{children}</CodeContext.Provider>;
+};
+
+export { CodeContext, CodeProvider };

--- a/src/components/icons/Shell.js
+++ b/src/components/icons/Shell.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const IconShell = ({ ...styles }) => (
   <svg viewBox="0 0 18 40" xmlns="http://www.w3.org/2000/svg" {...styles}>
-    <g fill-rule="nonzero" fill="none">
+    <g fillRule="nonzero" fill="none">
       <path
         d="M17.607 15.953c-2.1-9.267-6.484-11.735-7.596-13.479C9.406 1.525 8.79.084 8.79.084c-.06.821-.167 1.342-.869 1.966C6.517 3.302.548 8.166.047 18.696c-.468 9.817 7.214 15.872 8.235 16.498.78.383 1.735.007 2.192-.345 3.702-2.542 8.767-9.321 7.129-18.896"
         fill="#10AA50"

--- a/src/components/tab-context.js
+++ b/src/components/tab-context.js
@@ -1,8 +1,42 @@
 import React, { useEffect, useReducer } from 'react';
+import IconC from './icons/C';
+import IconCompass from './icons/Compass';
+import IconCpp from './icons/Cpp';
+import IconCsharp from './icons/Csharp';
+import IconGo from './icons/Go';
+import IconJava from './icons/Java';
+import IconNode from './icons/Node';
+import IconPHP from './icons/Php';
+import IconPython from './icons/Python';
+import IconRuby from './icons/Ruby';
+import IconRust from './icons/Rust';
+import IconScala from './icons/Scala';
+import IconShell from './icons/Shell';
+import IconSwift from './icons/Swift';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
+
+const DRIVER_ICON_MAP = {
+  c: IconC,
+  compass: IconCompass,
+  cpp: IconCpp,
+  csharp: IconCsharp,
+  go: IconGo,
+  'java-sync': IconJava,
+  'java-async': IconJava,
+  nodejs: IconNode,
+  php: IconPHP,
+  python: IconPython,
+  ruby: IconRuby,
+  rust: IconRust,
+  scala: IconScala,
+  shell: IconShell,
+  'swift-async': IconSwift,
+  'swift-sync': IconSwift,
+};
 
 const defaultContextValue = {
   activeTabs: {},
+  driverIconMap: DRIVER_ICON_MAP,
   selectors: {},
   setActiveTab: () => {},
 };
@@ -23,7 +57,11 @@ const TabProvider = ({ children, selectors = {} }) => {
     setLocalValue('activeTabs', activeTabs);
   }, [activeTabs]);
 
-  return <TabContext.Provider value={{ activeTabs, selectors, setActiveTab }}>{children}</TabContext.Provider>;
+  return (
+    <TabContext.Provider value={{ activeTabs, driverIconMap: DRIVER_ICON_MAP, selectors, setActiveTab }}>
+      {children}
+    </TabContext.Provider>
+  );
 };
 
 export { TabContext, TabProvider };

--- a/tests/unit/Code.test.js
+++ b/tests/unit/Code.test.js
@@ -1,25 +1,105 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Code from '../../src/components/Code';
-import { TabContext } from '../../src/components/tab-context';
+import { CodeProvider } from '../../src/components/code-context';
+import { TabProvider } from '../../src/components/tab-context';
+import * as browserStorage from '../../src/utils/browser-storage';
+import { tick } from '../utils';
 
 // data for this component
 import mockData from './data/Code.test.json';
 
-const shallowCode = ({ data, activeTabs }) => {
-  return shallow(
-    <TabContext.Provider value={{ activeTabs }}>
-      <Code nodeData={data} />
-    </TabContext.Provider>
+const mockSelectors = {
+  drivers: {
+    nodejs: [
+      {
+        type: 'text',
+        position: {
+          start: {
+            line: 0,
+          },
+        },
+        value: 'Node.js',
+      },
+    ],
+    python: [
+      {
+        type: 'text',
+        position: {
+          start: {
+            line: 0,
+          },
+        },
+        value: 'Python',
+      },
+    ],
+    shell: [
+      {
+        type: 'text',
+        position: {
+          start: {
+            line: 0,
+          },
+        },
+        value: 'MongoDB Shell',
+      },
+    ],
+  },
+};
+
+const shallowCode = ({ data }) => {
+  return shallow(<Code nodeData={data} />);
+};
+
+const mountCodeWithSelector = ({ data }) => {
+  return mount(
+    <TabProvider selectors={mockSelectors}>
+      <CodeProvider>
+        <Code nodeData={data} />
+      </CodeProvider>
+    </TabProvider>
   );
 };
 
 it('renders correctly', () => {
-  const tree = shallowCode({ data: mockData, activeTabs: { cloud: 'cloud' } });
-  expect(tree).toMatchSnapshot();
+  const wrapper = shallowCode({ data: mockData.testCode, activeTabs: { cloud: 'cloud' } });
+  expect(wrapper).toMatchSnapshot();
+  expect(wrapper.find('LanguageSwitcher').exists()).toBeFalsy();
 });
 
-it('renders with javascript disabled correctly', () => {
-  const tree = shallowCode({ data: mockData, activeTabs: {} });
-  expect(tree).toMatchSnapshot();
+describe('when rendering with selectors', () => {
+  jest.useFakeTimers();
+
+  const testData = mockData.testWithSelectors;
+  let mockGetLocalValue;
+
+  beforeAll(() => {
+    const mockActiveTabs = {
+      drivers: 'shell',
+    };
+    mockGetLocalValue = jest.spyOn(browserStorage, 'getLocalValue').mockImplementation(() => mockActiveTabs);
+  });
+
+  afterAll(() => {
+    mockGetLocalValue.mockClear();
+  });
+
+  it('renders with the correct active tab', () => {
+    const wrapper = mountCodeWithSelector({ data: testData });
+    const codeComponent = wrapper.find('Code').last();
+    expect(codeComponent.props().language).toEqual('MongoDB Shell');
+    expect(wrapper.find('LanguageSwitcher').exists()).toBeTruthy();
+  });
+
+  it('changes the selected driver', async () => {
+    const wrapper = mountCodeWithSelector({ data: testData });
+    let codeComponent = wrapper.find('Code').last();
+    // Assume that the LG component propagates events upwards successfully
+    codeComponent.invoke('onChange')({ id: 'nodejs' });
+
+    await tick({ wrapper });
+
+    codeComponent = wrapper.find('Code').last();
+    expect(codeComponent.props().language).toEqual('Node.js');
+  });
 });

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -2,42 +2,16 @@
 
 exports[`renders correctly 1`] = `
 <Code
-  nodeData={
-    Object {
-      "caption": "Test Caption",
-      "copyable": true,
-      "lang": "javascript",
-      "position": Object {
-        "start": Object {
-          "line": 0,
-        },
-      },
-      "type": "code",
-      "value": "mongoimport --db test --collection inventory ^
-          --authenticationDatabase admin --username <user> --password <password> ^
-          --drop --file ~\\\\downloads\\\\inventory.crud.json",
-    }
-  }
-/>
-`;
-
-exports[`renders with javascript disabled correctly 1`] = `
-<Code
-  nodeData={
-    Object {
-      "caption": "Test Caption",
-      "copyable": true,
-      "lang": "javascript",
-      "position": Object {
-        "start": Object {
-          "line": 0,
-        },
-      },
-      "type": "code",
-      "value": "mongoimport --db test --collection inventory ^
-          --authenticationDatabase admin --username <user> --password <password> ^
-          --drop --file ~\\\\downloads\\\\inventory.crud.json",
-    }
-  }
-/>
+  chromeTitle="Test Caption"
+  copyable={true}
+  language="javascript"
+  languageOptions={Array []}
+  onChange={[Function]}
+  onCopy={[Function]}
+  showWindowChrome={true}
+>
+  mongoimport --db test --collection inventory ^
+          --authenticationDatabase admin --username &lt;user&gt; --password &lt;password&gt; ^
+          --drop --file ~\\downloads\\inventory.crud.json
+</Code>
 `;

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -108,7 +108,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-7 button > div > div {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 <div

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -15,10 +15,10 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-3 {
+  border: 2px solid;
   overflow-x: auto;
   border-radius: 0;
   border: 0;
-  border-left: 2px solid;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
@@ -55,13 +55,13 @@ exports[`renders correctly 1`] = `
   }
 }
 
-.emotion-5 {
+.emotion-6 {
   border: 1px solid #E7EEEC;
   border-radius: 4px;
   overflow: hidden;
 }
 
-.emotion-4 {
+.emotion-5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -73,7 +73,29 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-6 {
+.emotion-4 {
+  width: 38px;
+  border-left: solid 1px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  padding-top: 6px;
+  min-height: 36px;
+  padding-top: 4px;
+  min-height: 36px;
+  padding-top: 4px;
+  border-color: #E7EEEC;
+  background-color: white;
+}
+
+.emotion-7 {
   display: table;
   margin: 16px 0;
   min-width: 150px;
@@ -81,14 +103,22 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
+.emotion-7 > div > div {
+  width: unset;
+}
+
+.emotion-7 button > div > div {
+  font-size: 14px;
+}
+
 <div
-  class="emotion-6"
+  class="emotion-7"
 >
   <div
-    class="emotion-5"
+    class="emotion-6"
   >
     <div
-      class="emotion-4"
+      class="emotion-5"
     >
       <pre
         class="emotion-3"
@@ -114,6 +144,10 @@ exports[`renders correctly 1`] = `
           </table>
         </code>
       </pre>
+      <div
+        class="emotion-4"
+        data-testid="leafygreen-code-panel"
+      />
     </div>
   </div>
 </div>

--- a/tests/unit/data/Code.test.json
+++ b/tests/unit/data/Code.test.json
@@ -1,12 +1,25 @@
 {
-  "type": "code",
-  "position": {
-    "start": {
-      "line": 0
-    }
+  "testCode": {
+    "type": "code",
+    "position": {
+      "start": {
+        "line": 0
+      }
+    },
+    "lang": "javascript",
+    "copyable": true,
+    "caption": "Test Caption",
+    "value": "mongoimport --db test --collection inventory ^\n          --authenticationDatabase admin --username <user> --password <password> ^\n          --drop --file ~\\downloads\\inventory.crud.json"
   },
-  "lang": "javascript",
-  "copyable": true,
-  "caption": "Test Caption",
-  "value": "mongoimport --db test --collection inventory ^\n          --authenticationDatabase admin --username <user> --password <password> ^\n          --drop --file ~\\downloads\\inventory.crud.json"
+  "testWithSelectors": {
+    "type": "code",
+    "position": {
+      "start": {
+        "line": 0
+      }
+    },
+    "lang": "javascript",
+    "copyable": true,
+    "value": "Testing code"
+  }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-2136

### Staging Links:

[Server Docs](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/raymundrodriguez/DOP-2136/indexes/)

### Notes:
* Leverages LG's language switcher for code blocks to work alongside our `TabsSelector` component. If there is no `tabs-selector` directive on the page, and if the code block isn't nested under a tab from the drivers tabset, then the language switcher will not be rendered.