### PR TITLE
DOP-2485: Add support for scrolling content container with keyboard

### DIFF
--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { css, Global } from '@emotion/core';
 import { CONTENT_CONTAINER_CLASSNAME } from '../constants';
 import { theme } from '../theme/docsTheme';
+import { isBrowser } from '../utils/is-browser';
 
 const fadeOut = css`
   .fade-exit {
@@ -33,36 +34,50 @@ const fadeInOut = css`
   ${fadeIn}
 `;
 
-const ContentTransition = ({ children, slug }) => (
-  <>
-    <Global styles={fadeInOut} />
-    <TransitionGroup
-      className={CONTENT_CONTAINER_CLASSNAME}
-      css={css`
-        grid-area: contents;
-        margin: 0px;
-        overflow-y: auto;
-      `}
-    >
-      <CSSTransition
-        addEndListener={(node, done) => node.addEventListener('transitionend', done, false)}
-        classNames="fade"
-        key={slug}
+const ContentTransition = ({ children, slug }) => {
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    if (isBrowser) {
+      // Focus on the page's content first by default to allow page scroll navigation for keyboard
+      contentRef.current.focus();
+    }
+  }, [slug]);
+
+  return (
+    <>
+      <Global styles={fadeInOut} />
+      <TransitionGroup
+        className={CONTENT_CONTAINER_CLASSNAME}
+        css={css`
+          grid-area: contents;
+          margin: 0px;
+          overflow-y: auto;
+        `}
       >
-        <div
-          css={css`
-            min-height: 100%;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-          `}
+        <CSSTransition
+          addEndListener={(node, done) => node.addEventListener('transitionend', done, false)}
+          classNames="fade"
+          key={slug}
         >
-          {children}
-        </div>
-      </CSSTransition>
-    </TransitionGroup>
-  </>
-);
+          <div
+            css={css`
+              min-height: 100%;
+              display: flex;
+              flex-direction: column;
+              justify-content: space-between;
+              outline: none;
+            `}
+            tabIndex="-1"
+            ref={contentRef}
+          >
+            {children}
+          </div>
+        </CSSTransition>
+      </TransitionGroup>
+    </>
+  );
+};
 
 ContentTransition.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,


### PR DESCRIPTION
### Stories/Links:

DOP-2485

### Staging Links:

[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2485/)

### Notes:
* Scroll navigation using arrow keys and spacebar should work again with our current layout. This was tested on Chrome, FF, and Safari. Please feel free to double-check on these browsers!
* Another possible approach to fix this issue may be to change our top nav and side nav components to be positioned `sticky`, and change the [overflow](https://github.com/mongodb/snooty/blob/d317db5c8f3f917b087bd2b382ad2c63551e8935/src/layouts/index.js#L26) and [scroll behavior](https://github.com/mongodb/snooty/blob/d317db5c8f3f917b087bd2b382ad2c63551e8935/gatsby-browser.js#L15) to be on the whole page instead of our current content container (similar to how we had our layout prior to the docs nav IA update). 
However, this caused me to once again run into the mysterious issue with ref links not scrolling to the correct location on the new page when they are clicked. (Actually, this issue could probably be worked around by reworking some logic in `gatsby-browser.js`)