### PR TITLE
DOP-2485: Fix page scrolling

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
-import { CONTENT_CONTAINER_CLASSNAME } from './src/constants';
 import { theme } from './src/theme/docsTheme';
 import './src/styles/mongodb-docs.css';
 
 // Delay for when page should scroll. Gives time for content in tab components to render
-const contentTransitionDuration = theme.size.stripUnit(theme.transitionSpeed.contentFadeOut);
+const contentTransitionDuration = 500;
 
 // Take control of the scroll for our main content's scroll container when clicking on a Link.
 // By default, Gatsby controls the scroll of the window object, which doesn't work
 // for our use case.
 // https://github.com/gatsbyjs/gatsby/blob/069cb535fa5bf5d2eead31533be18b1fe64c2568/packages/gatsby-react-router-scroll/src/scroll-handler.tsx#L102
-export const shouldUpdateScroll = ({ routerProps: { location } }) => {
+export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPosition }) => {
   const { hash } = location;
-  const scrollContainer = document.querySelector(`.${CONTENT_CONTAINER_CLASSNAME}`);
+  const currentPos = getSavedScrollPosition(location);
 
   const decodeUriAndScroll = () => {
     try {
@@ -25,11 +24,9 @@ export const shouldUpdateScroll = ({ routerProps: { location } }) => {
     }
   };
 
-  if (scrollContainer) {
-    window.setTimeout(() => {
-      hash ? decodeUriAndScroll() : (scrollContainer.scrollTop = 0);
-    }, contentTransitionDuration);
-  }
+  window.setTimeout(() => {
+    hash ? decodeUriAndScroll() : window.scrollTo(...(currentPos || [0, 0]));
+  }, contentTransitionDuration);
 
   // Prevent Gatsby from performing its default scroll behavior after clicking on a link
   return false;

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -7,9 +7,8 @@ import './src/styles/mongodb-docs.css';
 // Delay for when page should scroll. Gives time for content in tab components to render
 const contentTransitionDuration = 500;
 
-// Take control of the scroll for our main content's scroll container when clicking on a Link.
-// By default, Gatsby controls the scroll of the window object, which doesn't work
-// for our use case.
+// Slight modification to the default behavior of Gatsby's shouldUpdateScroll function.
+// We only want to perform scroll location updates through Gatsby Links after the page transitions are over.
 // https://github.com/gatsbyjs/gatsby/blob/069cb535fa5bf5d2eead31533be18b1fe64c2568/packages/gatsby-react-router-scroll/src/scroll-handler.tsx#L102
 export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPosition }) => {
   const { hash } = location;
@@ -18,7 +17,10 @@ export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPo
   const decodeUriAndScroll = () => {
     try {
       const uri = decodeURI(hash);
-      document.getElementById(uri.slice(1)).scrollIntoView(true);
+      const targetEl = document.getElementById(uri.slice(1));
+      if (targetEl) {
+        targetEl.scrollIntoView();
+      }
     } catch (e) {
       console.error(e);
     }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,7 +5,7 @@ import { theme } from './src/theme/docsTheme';
 import './src/styles/mongodb-docs.css';
 
 // Delay for when page should scroll. Gives time for content in tab components to render
-const contentTransitionDuration = 500;
+const contentTransitionDuration = theme.size.stripUnit(theme.transitionSpeed.contentFade);
 
 // Slight modification to the default behavior of Gatsby's shouldUpdateScroll function.
 // We only want to perform scroll location updates through Gatsby Links after the page transitions are over.

--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { css, Global } from '@emotion/core';
-import { CONTENT_CONTAINER_CLASSNAME } from '../constants';
+import { theme } from '../theme/docsTheme';
 
 const fadeOut = css`
   .fade-exit {
@@ -10,7 +10,7 @@ const fadeOut = css`
   }
   .fade-exit-active {
     opacity: 0;
-    transition: opacity 500ms;
+    transition: opacity ${theme.transitionSpeed.contentFade};
   }
 `;
 
@@ -22,7 +22,7 @@ const fadeIn = css`
   .fade-enter-active {
     opacity: 1;
     // Add delay so that fade in transition doesn't begin until the previous page has finished fading out
-    transition: opacity 500ms ease-in-out;
+    transition: opacity ${theme.transitionSpeed.contentFade} ease-in-out;
   }
 `;
 
@@ -35,7 +35,6 @@ const ContentTransition = ({ children, slug }) => (
   <>
     <Global styles={fadeInOut} />
     <TransitionGroup
-      className={CONTENT_CONTAINER_CLASSNAME}
       css={css`
         grid-area: contents;
         margin: 0px;

--- a/src/components/ContentTransition.js
+++ b/src/components/ContentTransition.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { css, Global } from '@emotion/core';
 import { CONTENT_CONTAINER_CLASSNAME } from '../constants';
-import { theme } from '../theme/docsTheme';
 
 const fadeOut = css`
   .fade-exit {
@@ -11,20 +10,19 @@ const fadeOut = css`
   }
   .fade-exit-active {
     opacity: 0;
-    transition: opacity ${theme.transitionSpeed.contentFadeOut};
+    transition: opacity 500ms;
   }
 `;
 
 const fadeIn = css`
   .fade-enter {
     // Set height to 0 to prevent content from jumping
-    height: 0px;
     opacity: 0;
   }
   .fade-enter-active {
     opacity: 1;
     // Add delay so that fade in transition doesn't begin until the previous page has finished fading out
-    transition: opacity ${theme.transitionSpeed.contentFadeIn} ${theme.transitionSpeed.contentFadeOut} ease-out;
+    transition: opacity 500ms ease-in-out;
   }
 `;
 
@@ -41,7 +39,6 @@ const ContentTransition = ({ children, slug }) => (
       css={css`
         grid-area: contents;
         margin: 0px;
-        overflow-y: auto;
       `}
     >
       <CSSTransition
@@ -51,7 +48,7 @@ const ContentTransition = ({ children, slug }) => (
       >
         <div
           css={css`
-            min-height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             justify-content: space-between;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,6 +9,8 @@ import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 const StyledHeaderContainer = styled.header`
   grid-area: header;
+  position: sticky;
+  top: 0;
   z-index: 10;
 `;
 

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -1,38 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import useStickyTopValues from '../hooks/useStickyTopValues';
 import { displayNone } from '../utils/display-none';
 import { theme } from '../theme/docsTheme';
 
-const RightColumn = ({ children, className }) => (
-  <div
-    className={className}
-    css={css`
-      margin: 70px 24px 40px 5px;
-      min-width: 180px;
+const RightColumn = ({ children, className }) => {
+  const { topLarge } = useStickyTopValues();
 
-      ${displayNone.onMobileAndTablet};
-    `}
-  >
-    {/* top: 99px allows a top margin of 12px from Consistent Nav for first element in column*/}
+  return (
     <div
+      className={className}
       css={css`
-        height: 100%;
-        max-height: calc(100vh - 120px);
-        overflow: auto;
-        position: sticky;
-        top: ${theme.size.medium};
+        margin: 70px 24px 40px 5px;
+        min-width: 180px;
 
-        & > * {
-          margin-bottom: 30px;
-          margin-right: 24px;
-        }
+        ${displayNone.onMobileAndTablet};
       `}
     >
-      {children}
+      <div
+        css={css`
+          max-height: calc(100vh - 120px);
+          overflow: auto;
+          position: sticky;
+          top: calc(${topLarge} + ${theme.size.medium});
+
+          & > * {
+            margin-bottom: 30px;
+            margin-right: 24px;
+          }
+        `}
+      >
+        {children}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 RightColumn.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,

--- a/src/components/Sidenav/IATransition.js
+++ b/src/components/Sidenav/IATransition.js
@@ -11,7 +11,7 @@ const fadeOut = css`
   }
   .slide-exit-active {
     opacity: 0;
-    transition: opacity ${theme.transitionSpeed.contentFadeOut};
+    transition: opacity ${theme.transitionSpeed.iaExit};
   }
 `;
 
@@ -25,8 +25,7 @@ const backStyle = css`
   .slide-enter-active {
     opacity: 1;
     transform: translateX(0%);
-    transition: opacity ${theme.transitionSpeed.contentFadeIn},
-      transform ${theme.transitionSpeed.contentFadeIn} ease-out;
+    transition: opacity ${theme.transitionSpeed.iaEnter}, transform ${theme.transitionSpeed.iaEnter} ease-out;
   }
 `;
 
@@ -40,8 +39,7 @@ const forwardStyle = css`
   .slide-enter-active {
     opacity: 1;
     transform: translateX(0%);
-    transition: opacity ${theme.transitionSpeed.contentFadeIn},
-      transform ${theme.transitionSpeed.contentFadeIn} ease-out;
+    transition: opacity ${theme.transitionSpeed.iaEnter}, transform ${theme.transitionSpeed.iaEnter} ease-out;
   }
 `;
 
@@ -54,8 +52,8 @@ const IATransition = ({ back, children, hasIA, slug }) => (
         <SwitchTransition>
           <CSSTransition
             timeout={{
-              enter: theme.size.stripUnit(theme.transitionSpeed.contentFadeIn),
-              exit: theme.size.stripUnit(theme.transitionSpeed.contentFadeOut),
+              enter: theme.size.stripUnit(theme.transitionSpeed.iaEnter),
+              exit: theme.size.stripUnit(theme.transitionSpeed.iaExit),
             }}
             classNames="slide"
             key={slug}

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -81,7 +81,7 @@ const titleStyle = LeafyCss`
 
 // Prevent content scrolling when the side nav is open on mobile and tablet screen sizes
 const disableScroll = (shouldDisableScroll) => css`
-  html {
+  body {
     ${shouldDisableScroll && 'overflow: hidden;'}
   }
 `;
@@ -186,7 +186,9 @@ const Sidenav = ({ page, pageTitle, publishedBranches, siteTitle, slug, toctree 
 
   // CSS top property values for sticky side nav based on header height
   const topLarge = useMemo(() => getSidenavTopValue(isBannerEnabled, [theme.header.navbarHeight]), [isBannerEnabled]);
-  const topMedium = useMemo(() => getSidenavTopValue(isBannerEnabled, [theme.header.navbarMobileHeight]), [isBannerEnabled]);
+  const topMedium = useMemo(() => getSidenavTopValue(isBannerEnabled, [theme.header.navbarMobileHeight]), [
+    isBannerEnabled,
+  ]);
   const topSmall = useMemo(
     () => getSidenavTopValue(isBannerEnabled, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
     [isBannerEnabled]

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -92,7 +92,9 @@ const ContentOverlay = styled('div')`
 
 const SidenavContainer = styled('div')`
   grid-area: sidenav;
-  position: relative;
+  position: sticky;
+  top: 88px;
+  height: calc(100vh - 88px);
   z-index: 2;
 
   // Since we want the SideNav to open on top of the content on medium screen size,

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css, Global } from '@emotion/core';
 import styled from '@emotion/styled';
@@ -7,7 +7,6 @@ import { useViewportSize } from '@leafygreen-ui/hooks';
 import Icon from '@leafygreen-ui/icon';
 import { SideNav as LeafygreenSideNav, SideNavItem } from '@leafygreen-ui/side-nav';
 import { uiColors } from '@leafygreen-ui/palette';
-import { HeaderContext } from '../header-context';
 import IA from './IA';
 import IATransition from './IATransition';
 import Link from '../Link';
@@ -19,6 +18,7 @@ import Toctree from './Toctree';
 import { sideNavItemBasePadding } from './styles/sideNavItem';
 import VersionDropdown from '../VersionDropdown';
 import useScreenSize from '../../hooks/useScreenSize';
+import useStickyTopValues from '../../hooks/useStickyTopValues';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { theme } from '../../theme/docsTheme';
 import { formatText } from '../../utils/format-text';
@@ -98,32 +98,21 @@ const ContentOverlay = styled('div')`
   z-index: 1;
 `;
 
-// Returns the sum of the Header component's children's heights to give the appropriate amount of space for the side nav
-const getSidenavTopValue = (bannerEnabled, heights) => {
-  let topValue = 0;
-  heights.forEach((height) => {
-    topValue += theme.size.stripUnit(height);
-  });
-
-  if (bannerEnabled) {
-    topValue += theme.size.stripUnit(theme.header.bannerHeight);
-  }
-
-  return `${topValue}px`;
-};
+const getTopAndHeight = (topValue) => css`
+  top: ${topValue};
+  height: calc(100vh - ${topValue});
+`;
 
 // Keep the side nav container sticky to allow LG's side nav to push content seemlessly
 const SidenavContainer = styled.div(
   ({ topLarge, topMedium, topSmall }) => css`
     grid-area: sidenav;
-    height: calc(100vh - ${topLarge});
     position: sticky;
-    top: ${topLarge};
     z-index: 2;
+    ${getTopAndHeight(topLarge)};
 
     @media ${theme.screenSize.upToLarge} {
-      top: ${topMedium};
-      height: calc(100vh - ${topMedium});
+      ${getTopAndHeight(topMedium)};
     }
 
     // Since we want the SideNav to open on top of the content on medium screen size,
@@ -133,8 +122,7 @@ const SidenavContainer = styled.div(
     }
 
     @media ${theme.screenSize.upToSmall} {
-      top: ${topSmall};
-      height: calc(100vh - ${topSmall});
+      ${getTopAndHeight(topSmall)};
     }
   `
 );
@@ -175,24 +163,15 @@ const additionalLinks = [
 
 const Sidenav = ({ page, pageTitle, publishedBranches, siteTitle, slug, toctree }) => {
   const { hideMobile, isCollapsed, setCollapsed, setHideMobile } = useContext(SidenavContext);
-  const { bannerContent } = useContext(HeaderContext);
   const { project } = useSiteMetadata();
   const isDocsLanding = project === 'landing';
   const { isTablet } = useScreenSize();
   const viewportSize = useViewportSize();
   const isMobile = viewportSize?.width <= 420;
   const showContentOverlay = isTablet && !isCollapsed;
-  const isBannerEnabled = bannerContent?.isEnabled;
 
   // CSS top property values for sticky side nav based on header height
-  const topLarge = useMemo(() => getSidenavTopValue(isBannerEnabled, [theme.header.navbarHeight]), [isBannerEnabled]);
-  const topMedium = useMemo(() => getSidenavTopValue(isBannerEnabled, [theme.header.navbarMobileHeight]), [
-    isBannerEnabled,
-  ]);
-  const topSmall = useMemo(
-    () => getSidenavTopValue(isBannerEnabled, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
-    [isBannerEnabled]
-  );
+  const topValues = useStickyTopValues();
 
   // Checks if user is navigating back to the homepage on docs landing
   const [back, setBack] = React.useState(null);
@@ -215,7 +194,7 @@ const Sidenav = ({ page, pageTitle, publishedBranches, siteTitle, slug, toctree 
   return (
     <>
       <Global styles={disableScroll(showContentOverlay || !hideMobile)} />
-      <SidenavContainer topLarge={topLarge} topMedium={topMedium} topSmall={topSmall}>
+      <SidenavContainer {...topValues}>
         <SidenavMobileTransition hideMobile={hideMobile} isMobile={isMobile}>
           <LeafygreenSideNav
             aria-label="Side navigation"

--- a/src/components/Sidenav/SidenavMobileMenuDropdown.js
+++ b/src/components/Sidenav/SidenavMobileMenuDropdown.js
@@ -11,7 +11,7 @@ const Container = styled('div')`
   background-color: ${uiColors.gray.light3};
   border-bottom: 1px solid ${uiColors.gray.light2};
   display: flex;
-  height: 52px;
+  height: ${theme.header.docsMobileMenuHeight};
   justify-content: space-between;
   width: 100vw;
 

--- a/src/components/Sidenav/SidenavMobileTransition.js
+++ b/src/components/Sidenav/SidenavMobileTransition.js
@@ -5,8 +5,8 @@ import { css, Global } from '@emotion/core';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { theme } from '../../theme/docsTheme';
 
-const ENTER_DURATION = 200;
-const EXIT_DURATION = theme.size.stripUnit(theme.transitionSpeed.contentFadeOut) + 10;
+const ENTER_DURATION = theme.size.stripUnit(theme.transitionSpeed.iaEnter);
+const EXIT_DURATION = theme.size.stripUnit(theme.transitionSpeed.iaExit) + 10;
 const TRANSITION_NAME = 'sidenav-mobile';
 
 const globalCSS = css`

--- a/src/components/Sidenav/SidenavMobileTransition.js
+++ b/src/components/Sidenav/SidenavMobileTransition.js
@@ -6,7 +6,7 @@ import ConditionalWrapper from '../ConditionalWrapper';
 import { theme } from '../../theme/docsTheme';
 
 const ENTER_DURATION = theme.size.stripUnit(theme.transitionSpeed.iaEnter);
-const EXIT_DURATION = theme.size.stripUnit(theme.transitionSpeed.iaExit) + 10;
+const EXIT_DURATION = theme.size.stripUnit(theme.transitionSpeed.iaExit);
 const TRANSITION_NAME = 'sidenav-mobile';
 
 const globalCSS = css`

--- a/src/components/Target.js
+++ b/src/components/Target.js
@@ -50,7 +50,7 @@ const Target = ({ nodeData: { children, html_id, name }, ...rest }) => {
           </dd>
         </dl>
       ) : (
-        <span id={html_id} />
+        <span className="contains-headerlink" id={html_id} />
       )}
     </React.Fragment>
   );

--- a/src/constants.js
+++ b/src/constants.js
@@ -74,5 +74,3 @@ export const SECTION_NAME_MAPPING = {
     title: 'See Also',
   },
 };
-
-export const CONTENT_CONTAINER_CLASSNAME = 'content-container';

--- a/src/hooks/useStickyTopValues.js
+++ b/src/hooks/useStickyTopValues.js
@@ -1,0 +1,32 @@
+import { useMemo, useContext } from 'react';
+import { HeaderContext } from '../components/header-context';
+import { theme } from '../theme/docsTheme';
+
+// Returns the sum of the Header component's children's heights to give the appropriate amount of space for a component
+const getTopValue = (bannerEnabled, heights) => {
+  let topValue = 0;
+  heights.forEach((height) => {
+    topValue += theme.size.stripUnit(height);
+  });
+
+  if (bannerEnabled) {
+    topValue += theme.size.stripUnit(theme.header.bannerHeight);
+  }
+
+  return `${topValue}px`;
+};
+
+const useStickyTopValues = () => {
+  const { bannerContent } = useContext(HeaderContext);
+  const bannerEnabled = bannerContent?.isEnabled;
+  const topLarge = useMemo(() => getTopValue(bannerEnabled, [theme.header.navbarHeight]), [bannerEnabled]);
+  const topMedium = useMemo(() => getTopValue(bannerEnabled, [theme.header.navbarMobileHeight]), [bannerEnabled]);
+  const topSmall = useMemo(
+    () => getTopValue(bannerEnabled, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
+    [bannerEnabled]
+  );
+
+  return { topLarge, topMedium, topSmall };
+};
+
+export default useStickyTopValues;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -9,6 +9,7 @@ import SiteMetadata from '../components/site-metadata';
 import RootProvider from '../components/RootProvider';
 import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
+import { theme } from '../theme/docsTheme';
 
 // TODO: Delete this as a part of the css cleanup
 // Currently used to preserve behavior and stop legacy css
@@ -34,6 +35,18 @@ const globalCSS = css`
     padding: 0;
     visibility: hidden !important;
     width: 0;
+  }
+
+  .contains-headerlink {
+    scroll-margin-top: ${theme.header.navbarHeight};
+
+    @media ${theme.screenSize.upToLarge} {
+      scroll-margin-top: ${theme.header.navbarMobileHeight};
+    }
+
+    @media ${theme.screenSize.upToSmall} {
+      scroll-margin-top: calc(${theme.header.navbarMobileHeight} + ${theme.header.docsMobileMenuHeight});
+    }
   }
 
   ${'' /* Originally from docs-tools navbar.css */}

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -22,10 +22,6 @@ const footerOverrides = css`
 `;
 
 const globalCSS = css`
-  html {
-    overflow: hidden;
-  }
-
   body {
     font-size: 16px;
     line-height: 24px;
@@ -70,7 +66,6 @@ const GlobalGrid = styled('div')`
     'sidenav contents';
   grid-template-columns: auto 1fr;
   grid-template-rows: auto 1fr;
-  height: 100vh;
 `;
 
 const DefaultLayout = ({

--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -409,10 +409,6 @@ div.highlight,
 div.topic {
   background-color: #fff;
 }
-html {
-  font-size: 62.5%;
-  overflow-x: hidden;
-}
 body {
   font-size: 14px;
 }

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -57,8 +57,9 @@ const header = {
 };
 
 const transitionSpeed = {
-  contentFadeOut: '100ms',
-  contentFadeIn: '200ms',
+  iaExit: '100ms',
+  iaEnter: '200ms',
+  contentFade: '500ms',
 };
 
 export const theme = {

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -51,7 +51,9 @@ const screenSize = {
 
 const header = {
   bannerHeight: '40px',
-  navbarHeight: '45px',
+  navbarHeight: '88px',
+  navbarMobileHeight: '56px',
+  docsMobileMenuHeight: '52px',
 };
 
 const transitionSpeed = {

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -91,6 +91,7 @@ including UTF-8.
 
 exports[`renders correctly with no directive_argument nodes 1`] = `
 <span
+  class="contains-headerlink"
   id="std-label-php-language-center"
 />
 `;

--- a/tests/unit/useStickyTopValues.test.js
+++ b/tests/unit/useStickyTopValues.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import useStickyTopValues from '../../src/hooks/useStickyTopValues';
+import { HeaderContext } from '../../src/components/header-context';
+import { mount } from 'enzyme';
+
+const HelperComponent = () => {
+  const { topLarge, topMedium, topSmall } = useStickyTopValues();
+  return (
+    <>
+      <div className="topLarge">{topLarge}</div>
+      <div className="topMedium">{topMedium}</div>
+      <div className="topSmall">{topSmall}</div>
+    </>
+  );
+};
+
+const TestComponent = ({ mockBannerContent }) => {
+  return (
+    <HeaderContext.Provider value={{ bannerContent: mockBannerContent }}>
+      <HelperComponent />
+    </HeaderContext.Provider>
+  );
+};
+
+describe('useStickyTopValues()', () => {
+  it('provides the correct top values without any banner content', () => {
+    const wrapper = mount(<TestComponent mockBannerContent={null} />);
+    expect(wrapper.find('div.topLarge').text()).toEqual('88px');
+    expect(wrapper.find('div.topMedium').text()).toEqual('56px');
+    expect(wrapper.find('div.topSmall').text()).toEqual('108px');
+  });
+
+  it('provides the correct top values with banner content', () => {
+    const wrapper = mount(<TestComponent mockBannerContent={{ isEnabled: true }} />);
+    expect(wrapper.find('div.topLarge').text()).toEqual('128px');
+    expect(wrapper.find('div.topMedium').text()).toEqual('96px');
+    expect(wrapper.find('div.topSmall').text()).toEqual('148px');
+  });
+});


### PR DESCRIPTION
### Stories/Links:

DOP-2485

### Staging Links:

[Realm Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2485-a/)
[Landing Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/landing/raymundrodriguez/DOP-2485-a/)
[Compass Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/raymundrodriguez/DOP-2485-a/)

### Notes:
* Changes the side nav and header components (unified top nav, mobile docs menu/toctree) to be sticky.
* Brings back page scrolling, replacing the content scroll container.
* Arrow key scrolling works.
* Tab navigation works as expected (starts from the top).