### PR TITLE
Update staging url to use S3 site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
-STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 STAGING_BUCKET=docs-mongodb-org-stg
+STAGING_URL="https://${STAGING_BUCKET}.s3.us-east-2.amazonaws.com"
 -include .env.production
 
 .PHONY: stage static
@@ -25,7 +25,7 @@ stage: prefix
 		echo "To stage changes to the Snooty frontend, ensure that GATSBY_SNOOTY_DEV=true in your production environment."; exit 1; \
 	else \
 		mut-publish public ${STAGING_BUCKET} --prefix=${PREFIX} --stage ${ARGS}; \
-		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/"; \
+		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/index.html"; \
 	fi
 
 static:


### PR DESCRIPTION
### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/compass/raymundrodriguez/update-staging-makefile/index.html

### Notes:
* With the change to our new S3 bucket for docs team staging, the staging site no longer points to our staging bucket. This PR updates the staging url to refer directly to the S3 bucket's url.
* Each page in our S3 bucket site requires `/index.html` to be included in the url when putting it into the address bar. I have included that in the echo of our final staging url.