### PR TITLE
DOP-2618: Prevent lint warnings during pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format": "npm run prettier -- --check",
     "format:fix": "npm run prettier -- --write",
     "lint": "eslint --ext .js,.jsx .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "npm run lint -- --fix --max-warnings 0",
     "prepare": "husky install",
     "postversion": "git push origin v$npm_package_version && git push origin master",
     "prettier": "prettier '**/*.{js,jsx,json,md}' '!docs-tools/**'",


### PR DESCRIPTION
### Stories/Links:

DOP-2618

### Notes:
I tested this by importing an unused file inside of a component and committing the change.

```
$ git commit -m "Test pre-commit linting"
✔ Preparing...
⚠ Running tasks...
  ❯ npm run lint:fix [FAILED]
    ✔ npm run format:fix
    ✖ npm run lint:fix [FAILED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ npm run lint:fix:
ESLint found too many warnings (maximum: 0).
```