### PR TITLE
DOP-2650: The great url accommodation roundup

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { transformBreadcrumbs } = require('./src/utils/setup/transform-breadcrumbs.js');
 const { initStitch } = require('./src/utils/setup/init-stitch');
+const { isDotCom, dotcomifyUrl } = require('./src/utils/dotcom');
 const { saveAssetFiles, saveStaticFiles } = require('./src/utils/setup/save-asset-files');
 const { validateEnvVariables } = require('./src/utils/setup/validate-env-variables');
 const { getNestedValue } = require('./src/utils/get-nested-value');
@@ -80,6 +81,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
   // Get all MongoDB products for the sidenav
   const products = await stitchClient.callFunction('fetchAllProducts', [siteMetadata.database]);
   products.forEach((product) => {
+    // TODO: REMOVE AFTER DOP 2705
+    let url = product.baseUrl + product.slug;
+    if (isDotCom()) url = dotcomifyUrl(url, true);
+
     createNode({
       children: [],
       id: createNodeId(`Product-${product.title}`),
@@ -89,7 +94,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       },
       parent: null,
       title: product.title,
-      url: product.baseUrl + product.slug,
+      url,
     });
   });
 };

--- a/src/components/BreadcrumbSchema.js
+++ b/src/components/BreadcrumbSchema.js
@@ -4,6 +4,7 @@ import { withPrefix } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { assertTrailingSlash } from '../utils/assert-trailing-slash';
+import { baseUrl } from '../utils/dotcom';
 
 const getBreadcrumbList = (breadcrumb, siteUrl) =>
   breadcrumb.map(({ path, plaintext }, index) => ({
@@ -20,7 +21,7 @@ const BreadcrumbSchema = ({ breadcrumb = [], siteTitle, slug }) => {
       '@type': 'ListItem',
       position: 1,
       name: 'MongoDB Documentation',
-      item: 'https://docs.mongodb.com/',
+      item: assertTrailingSlash(baseUrl(true)),
     },
     ...getBreadcrumbList(
       [...(slug !== '/' && project !== 'landing' ? [{ path: '/', plaintext: siteTitle }] : []), ...breadcrumb],

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -5,6 +5,7 @@ import { uiColors } from '@leafygreen-ui/palette';
 import BreadcrumbSchema from './BreadcrumbSchema';
 import { theme } from '../theme/docsTheme';
 import BreadcrumbContainer from './BreadcrumbContainer';
+import { baseUrl } from '../utils/dotcom';
 
 const Wrapper = styled('nav')`
   font-size: ${theme.fontSize.small};
@@ -23,7 +24,7 @@ const Wrapper = styled('nav')`
 const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle, slug }) => {
   const homeCrumb = {
     title: 'Docs Home',
-    url: homeUrl || 'https://docs.mongodb.com/',
+    url: homeUrl || baseUrl(true),
   };
   // If a pageTitle prop is passed, use that as the last breadcrumb instead
   const lastCrumb = {

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -6,6 +6,7 @@ import BreadcrumbSchema from './BreadcrumbSchema';
 import { theme } from '../theme/docsTheme';
 import BreadcrumbContainer from './BreadcrumbContainer';
 import { baseUrl } from '../utils/dotcom';
+import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 
 const Wrapper = styled('nav')`
   font-size: ${theme.fontSize.small};
@@ -24,7 +25,7 @@ const Wrapper = styled('nav')`
 const Breadcrumbs = ({ homeUrl = null, pageTitle = null, parentPaths, siteTitle, slug }) => {
   const homeCrumb = {
     title: 'Docs Home',
-    url: homeUrl || baseUrl(true),
+    url: homeUrl || assertTrailingSlash(baseUrl(true)),
   };
   // If a pageTitle prop is passed, use that as the last breadcrumb instead
   const lastCrumb = {

--- a/src/components/DriversIndexTiles.js
+++ b/src/components/DriversIndexTiles.js
@@ -4,6 +4,7 @@ import { uiColors } from '@leafygreen-ui/palette';
 import LeafyGreenCard from '@leafygreen-ui/card';
 import Link from './Link';
 import { theme } from '../theme/docsTheme';
+import { baseUrl } from '../utils/dotcom';
 
 import IconC from './icons/C';
 import IconCpp from './icons/Cpp';
@@ -18,7 +19,7 @@ import IconRust from './icons/Rust';
 import IconScala from './icons/Scala';
 import IconSwift from './icons/Swift';
 
-// DriversIndexTiles is used to display the drivers as Cards on docs.mongodb.com/drivers
+// DriversIndexTiles is used to display the drivers as Cards on drivers landing page
 
 // TODO: Unhardcode this. Ideally, the SVG resources would just be plain SVG, not components
 const tiles = [
@@ -38,7 +39,7 @@ const tiles = [
     icon: <IconCsharp />,
   },
   {
-    slug: 'https://docs.mongodb.com/drivers/go/current/',
+    slug: `${baseUrl(true)}/drivers/go/current/`,
     title: 'Go',
     icon: <IconGo />,
   },
@@ -48,7 +49,7 @@ const tiles = [
     icon: <IconJava />,
   },
   {
-    slug: 'https://docs.mongodb.com/drivers/node/current/',
+    slug: `${baseUrl(true)}/drivers/node/current/`,
     title: 'Node.js',
     icon: <IconNode />,
   },
@@ -63,7 +64,7 @@ const tiles = [
     icon: <IconPython />,
   },
   {
-    slug: 'https://docs.mongodb.com/ruby-driver/current/',
+    slug: `${baseUrl(true)}/ruby-driver/current/`,
     title: 'Ruby',
     icon: <IconRuby />,
   },

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
+import { baseUrl } from '../utils/dotcom';
 
 const DEFAULT_TWITTER_SITE = '@mongodb';
+const metaUrl = `${baseUrl(true)}/assets/meta_generic.png`;
 
 const SEO = ({ pageTitle, siteTitle }) => (
   <Helmet>
@@ -14,11 +16,8 @@ const SEO = ({ pageTitle, siteTitle }) => (
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content={DEFAULT_TWITTER_SITE} />
     <meta property="twitter:title" content={pageTitle} />
-    <meta name="twitter:image" content="http://docs.mongodb.com/assets/meta_generic.png" />
-    <meta
-      name="twitter:image:alt"
-      content="MongoDB logo featuring a green leaf on a dark gray background. Slogan reads 'For giant ideas'."
-    />
+    <meta name="twitter:image" content={metaUrl} />
+    <meta name="twitter:image:alt" content="MongoDB logo featuring a green leaf on a dark green background." />
   </Helmet>
 );
 

--- a/src/components/VersionDropdown.js
+++ b/src/components/VersionDropdown.js
@@ -8,6 +8,7 @@ import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { theme } from '../theme/docsTheme';
 import { generatePathPrefix } from '../utils/generate-path-prefix';
 import { normalizePath } from '../utils/normalize-path';
+import { baseUrl } from '../utils/dotcom';
 
 const zip = (a, b) => {
   // Zip arrays a and b into an object where a is used for keys and b for values
@@ -89,7 +90,7 @@ const VersionDropdown = ({
   };
 
   const getUrl = (value) => {
-    const legacyDocsURL = `https://docs.mongodb.com/legacy/?site=${project}`;
+    const legacyDocsURL = `${baseUrl(true)}/legacy/?site=${project}`;
     return value === 'legacy' ? legacyDocsURL : normalizePath(`${generatePrefix(value)}/${slug}`);
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+import { baseUrl, dotcomifyUrl, isDotCom } from './utils/dotcom';
+
 export const DEPLOYMENTS = ['cloud', 'local'];
 
 export const PLATFORMS = ['windows', 'macos', 'linux', 'debian', 'rhel'];
@@ -34,7 +36,7 @@ export const stringifyTab = (tabName) => {
 
 // hardcoded for now because this target lookup will be complex
 // as it relies on other sites (e.g. manual) cc. Andrew
-export const REF_TARGETS = {
+const dotcomHandlingForREF_TARGETS = {
   'compass-index': 'https://docs.mongodb.com/compass/current/#compass-index',
   'document-dot-notation': 'https://docs.mongodb.com/manual/core/document/#document-dot-notation',
   glossary: 'https://docs.mongodb.com/manual/reference/glossary',
@@ -48,7 +50,16 @@ export const REF_TARGETS = {
   'configuration-options': 'https://docs.mongodb.com/manual/reference/configuration-options/#configuration-options',
 };
 
-export const DOCS_URL = 'https://docs.mongodb.com';
+// Changed to apply dotcom logic across each ref target, conditionally if we determine that we are building for dotcom.
+// TODO: remove after dotcom go live and update hardcoded links.
+export const REF_TARGETS = Object.fromEntries(
+  Object.entries(dotcomHandlingForREF_TARGETS).map(([key, value]) => {
+    if (isDotCom()) value = dotcomifyUrl(value, true);
+    return [key, value];
+  })
+);
+
+export const DOCS_URL = baseUrl(true);
 export const MARIAN_URL = 'https://docs-search-transport.mongodb.com';
 
 export const SECTION_NAME_MAPPING = {

--- a/src/html.js
+++ b/src/html.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { baseUrl } from './utils/dotcom';
 
-const metaUrl = `${baseUrl(true)}/assets/meta_generic.png`;
-const metaSecureUrl = `http://${baseUrl()}/assets/meta_generic.png`;
+const metaUrl = `http://${baseUrl()}/assets/meta_generic.png`;
+const metaSecureUrl = `${baseUrl(true)}/assets/meta_generic.png`;
 const faviconUrl = `${baseUrl(true)}/assets/favicon.ico`;
 const osdUrl = `${baseUrl(true)}/osd.xml`;
 

--- a/src/html.js
+++ b/src/html.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { baseUrl } from './utils/dotcom';
+
+const metaUrl = `${baseUrl(true)}/assets/meta_generic.png`;
+const metaSecureUrl = `http://${baseUrl()}/assets/meta_generic.png`;
+const faviconUrl = `${baseUrl(true)}/assets/favicon.ico`;
+const osdUrl = `${baseUrl(true)}/osd.xml`;
 
 const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyComponents, postBodyComponents }) => (
   <html lang="en" {...htmlAttributes}>
@@ -12,16 +18,11 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
       <meta name="release" content="1.0" />
       <meta name="version" content="master" />
       <meta name="DC.Source" content="https://github.com/mongodb/docs-bi-connector/blob/DOCSP-3279/source/index.txt" />
-      <meta property="og:image" content="http://docs.mongodb.com/assets/meta_generic.png" />
-      <meta property="og:image:secure_url" content="https://docs.mongodb.com/assets/meta_generic.png" />
+      <meta property="og:image" content={metaUrl} />
+      <meta property="og:image:secure_url" content={metaSecureUrl} />
       <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
-      <link rel="shortcut icon" href="https://docs.mongodb.com/assets/favicon.ico" />
-      <link
-        rel="search"
-        type="application/opensearchdescription+xml"
-        href="https://docs.mongodb.com/osd.xml"
-        title="MongoDB Help"
-      />
+      <link rel="shortcut icon" href={faviconUrl} />
+      <link rel="search" type="application/opensearchdescription+xml" href={osdUrl} title="MongoDB Help" />
       {headComponents}
     </head>
     <body {...bodyAttributes}>

--- a/src/templates/NotFound.js
+++ b/src/templates/NotFound.js
@@ -6,6 +6,7 @@ import Button from '@leafygreen-ui/button';
 import { uiColors } from '@leafygreen-ui/palette';
 import Footer from '../components/Footer';
 import { theme } from '../theme/docsTheme';
+import { baseUrl } from '../utils/dotcom';
 
 const ErrorBox = styled('div')`
   padding: 0px ${theme.size.default};
@@ -87,7 +88,7 @@ const ErrorBoxContainer = () => {
         `}
       >
         <Button
-          href="https://docs.mongodb.com"
+          href={baseUrl(true)}
           variant="primary"
           css={css`
             @media ${theme.screenSize.upToSmall} {

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -6,6 +6,7 @@ import { useTheme } from 'emotion-theming';
 import { uiColors } from '@leafygreen-ui/palette';
 import PropTypes from 'prop-types';
 import { baseUrl } from '../utils/dotcom';
+import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 
 const CONTENT_MAX_WIDTH = 1440;
 
@@ -59,7 +60,7 @@ const Landing = ({ children }) => {
             '@context': 'http://schema.org',
             '@type': 'WebSite',
             name: 'MongoDB Documentation',
-            url: baseUrl(true),
+            url: assertTrailingSlash(baseUrl(true)),
             publisher: {
               '@type': 'Organization',
               name: 'MongoDB',

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -5,6 +5,7 @@ import { Global, css } from '@emotion/core';
 import { useTheme } from 'emotion-theming';
 import { uiColors } from '@leafygreen-ui/palette';
 import PropTypes from 'prop-types';
+import { baseUrl } from '../utils/dotcom';
 
 const CONTENT_MAX_WIDTH = 1440;
 
@@ -58,7 +59,7 @@ const Landing = ({ children }) => {
             '@context': 'http://schema.org',
             '@type': 'WebSite',
             name: 'MongoDB Documentation',
-            url: 'https://docs.mongodb.com/',
+            url: baseUrl(true),
             publisher: {
               '@type': 'Organization',
               name: 'MongoDB',

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -1,0 +1,35 @@
+import { isBrowser } from './is-browser';
+
+// Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
+// this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari
+// with relevant string split-slice-join logic turned into URL.pathname, and etc.
+export const dotcomifyUrl = (url, needsProtocol = false) => {
+  const decomposedUrl = url.split('.');
+  const subdomainProduct = decomposedUrl[1] !== 'mongodb' ? decomposedUrl[1] : '';
+  let pathname = url.split('.mongodb.com')[1];
+  let dotcomBaseUrl = `www.mongodb.com/docs`;
+
+  if (needsProtocol) dotcomBaseUrl = `https://${dotcomBaseUrl}`;
+  if (subdomainProduct) {
+    dotcomBaseUrl = `${dotcomBaseUrl}/${subdomainProduct}`;
+  }
+
+  pathname = pathname.split('/').slice(1).join('/');
+  return pathname.length >= 1 ? `${dotcomBaseUrl}/${pathname}` : `${dotcomBaseUrl}`;
+};
+
+export const isDotCom = () => {
+  if (!isBrowser) return !!process.env.GATSBY_BASE_URL?.includes('www');
+  return window.location.hostname.split('.')[0] === 'www';
+};
+
+// Used for accessing what our base url should be, differentiating between environs
+// and adding sensible defaults in the event the base variable is not present.
+export const baseUrl = (needsProtocol = false) => {
+  if (process.env.GATSBY_BASE_URL) return process.env.GATSBY_BASE_URL;
+
+  const intendedFallback = isDotCom()
+    ? dotcomifyUrl(window.location.hostname, needsProtocol)
+    : `${needsProtocol ? 'https://' : ''}docs.mongodb.com`;
+  return intendedFallback;
+};

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -1,9 +1,11 @@
-import { isBrowser } from './is-browser';
+// Why duplicate this from utils/isBrowser? ES imports vs. requires impacting usage in gatsby-node.js
+// Contents of this file are temporal regardless, and logic is somewhat universal regardless.
+const isBrowser = typeof window !== 'undefined';
 
 // Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
 // this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari
 // with relevant string split-slice-join logic turned into URL.pathname, and etc.
-export const dotcomifyUrl = (url, needsProtocol = false) => {
+const dotcomifyUrl = (url, needsProtocol = false) => {
   const decomposedUrl = url.split('.');
   const subdomainProduct = decomposedUrl[1] !== 'mongodb' ? decomposedUrl[1] : '';
   let pathname = url.split('.mongodb.com')[1];
@@ -18,14 +20,14 @@ export const dotcomifyUrl = (url, needsProtocol = false) => {
   return pathname.length >= 1 ? `${dotcomBaseUrl}/${pathname}` : `${dotcomBaseUrl}`;
 };
 
-export const isDotCom = () => {
+const isDotCom = () => {
   if (!isBrowser) return !!process.env.GATSBY_BASE_URL?.includes('www');
   return window.location.hostname.split('.')[0] === 'www';
 };
 
 // Used for accessing what our base url should be, differentiating between environs
 // and adding sensible defaults in the event the base variable is not present.
-export const baseUrl = (needsProtocol = false) => {
+const baseUrl = (needsProtocol = false) => {
   if (process.env.GATSBY_BASE_URL) return process.env.GATSBY_BASE_URL;
 
   const intendedFallback = isDotCom()
@@ -33,3 +35,5 @@ export const baseUrl = (needsProtocol = false) => {
     : `${needsProtocol ? 'https://' : ''}docs.mongodb.com`;
   return intendedFallback;
 };
+
+module.exports = { dotcomifyUrl, isDotCom, baseUrl };

--- a/src/utils/get-site-url.js
+++ b/src/utils/get-site-url.js
@@ -1,13 +1,18 @@
+const { isDotCom, dotcomifyUrl } = require('./dotcom');
+
 // Given a project's `name`, return its base URL.
 const getSiteUrl = (project) => {
+  let url = 'https://docs.mongodb.com';
   switch (project) {
     case 'cloud-docs':
-      return 'https://docs.atlas.mongodb.com';
+      url = 'https://docs.atlas.mongodb.com';
+      break;
     case 'mms':
-      return 'https://docs.opsmanager.mongodb.com';
+      url = 'https://docs.opsmanager.mongodb.com';
+      break;
     default:
-      return 'https://docs.mongodb.com';
   }
+  return isDotCom() ? dotcomifyUrl(url, true) : url;
 };
 
 module.exports.getSiteUrl = getSiteUrl;

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -45,7 +45,7 @@ exports[`renders correctly with pageTitle 1`] = `
     <p>
       <a
         class="emotion-0 emotion-1"
-        href="https://docs.mongodb.com/"
+        href="https://docs.mongodb.com"
       >
         Docs Home
       </a>
@@ -110,7 +110,7 @@ exports[`renders correctly with siteTitle 1`] = `
     <p>
       <a
         class="emotion-0 emotion-1"
-        href="https://docs.mongodb.com/"
+        href="https://docs.mongodb.com"
       >
         Docs Home
       </a>

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -45,7 +45,7 @@ exports[`renders correctly with pageTitle 1`] = `
     <p>
       <a
         class="emotion-0 emotion-1"
-        href="https://docs.mongodb.com"
+        href="https://docs.mongodb.com/"
       >
         Docs Home
       </a>
@@ -110,7 +110,7 @@ exports[`renders correctly with siteTitle 1`] = `
     <p>
       <a
         class="emotion-0 emotion-1"
-        href="https://docs.mongodb.com"
+        href="https://docs.mongodb.com/"
       >
         Docs Home
       </a>

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -1,0 +1,132 @@
+import { dotcomifyUrl, isDotCom, baseUrl } from '../../../src/utils/dotcom';
+
+describe('dotcomifyUrl', () => {
+  it('by default does not return a url with protocols', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs');
+  });
+
+  it('supports adding https:// protocol to url when given boolean flag', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com', true)).toBe('https://www.mongodb.com/docs');
+  });
+
+  it('supports both regular subdomain and product subdomain conversions', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('www.mongodb.com/docs/opsmanager');
+    expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('www.mongodb.com/docs/atlas');
+  });
+
+  it('supports conversions with pathname combinations, and handles `com` in pathname', () => {
+    // single level subdomain
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs');
+    expect(dotcomifyUrl('https://docs.mongodb.com/long-path/name/divided/by-many-paths')).toBe(
+      'www.mongodb.com/docs/long-path/name/divided/by-many-paths'
+    );
+    expect(dotcomifyUrl('https://docs.mongodb.com/compound-indexes')).toBe('www.mongodb.com/docs/compound-indexes');
+
+    // product subdomains
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('www.mongodb.com/docs/opsmanager');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/this-is/a-long/pathname')).toBe(
+      'www.mongodb.com/docs/opsmanager/this-is/a-long/pathname'
+    );
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/combine-results')).toBe(
+      'www.mongodb.com/docs/opsmanager/combine-results'
+    );
+  });
+
+  it('supports conversions with versions and aliases', () => {
+    // single level subdomain
+    expect(dotcomifyUrl('https://docs.mongodb.com/v1.2.3/compound-indexes')).toBe(
+      'www.mongodb.com/docs/v1.2.3/compound-indexes'
+    );
+    expect(dotcomifyUrl('https://docs.mongodb.com/upcoming/compound-indexes')).toBe(
+      'www.mongodb.com/docs/upcoming/compound-indexes'
+    );
+
+    // product subdomains
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/upcoming/compound-indexes')).toBe(
+      'www.mongodb.com/docs/opsmanager/upcoming/compound-indexes'
+    );
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/v1.5/compound-indexes')).toBe(
+      'www.mongodb.com/docs/opsmanager/v1.5/compound-indexes'
+    );
+  });
+});
+
+describe('isDotCom', () => {
+  global.window = Object.create(window);
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: 'docs.mongodb.com',
+    },
+    writable: true,
+  });
+
+  describe('attempts to assert state on whether a property is a dotCom instance', () => {
+    it('returns false in docs.*.mongodb.com instances', () => {
+      expect(isDotCom()).not.toBeTruthy();
+    });
+
+    it('returns true when invoked on ANY www. subdomain, not just /docs routes', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: 'www.mongodb.com',
+        },
+        writeable: true,
+      });
+      expect(isDotCom()).toBeTruthy();
+    });
+  });
+});
+
+describe('baseUrl', () => {
+  global.window = Object.create(window);
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: 'docs.mongodb.com',
+    },
+    writable: true,
+  });
+
+  describe('is a function which attempts return an appropriate baseUrl at invocation time based on environment state.', () => {
+    it('always prefers process.env.GATSBY_BASE_URL if present', () => {
+      process.env.GATSBY_BASE_URL = 'www.mongodb.com';
+      expect(baseUrl()).toBe('www.mongodb.com');
+    });
+
+    it('determines dotcom vs. docs. based on subdomain when invoked, if no process.env.GATSBY_BASE_URL is present', () => {
+      process.env = {};
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: 'www.mongodb.com',
+        },
+        writeable: true,
+      });
+
+      expect(baseUrl()).toBe('www.mongodb.com/docs');
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: 'docs.mongodb.com',
+        },
+        writable: true,
+      });
+      expect(baseUrl()).toBe('docs.mongodb.com');
+    });
+
+    it('supports a protocol boolean flag', () => {
+      process.env = {};
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: 'docs.mongodb.com',
+        },
+        writable: true,
+      });
+      expect(baseUrl(true)).toBe('https://docs.mongodb.com');
+    });
+
+    it('ignores the protocol flag if process.env.GATSBY_BASE_URL is defined', () => {
+      process.env.GATSBY_BASE_URL = 'www.mongodb.com';
+      expect(baseUrl(true)).toBe('www.mongodb.com');
+    });
+  });
+});


### PR DESCRIPTION
### Stories/Links:

DOP-2650

### Staging Links:

_Put a link to your staging environment(s), if applicable_

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/cassidy.schaufele/DOP-2650/index.html)

[Realm](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/realm/cassidy.schaufele/DOP-2650/index.html)

### Notes:

This changeset adds a series of helpers for determining the `base url` that a front end website is deployed with.
It also utilizes these helpers throughout the frontend to ensure compatibility with tandem `dotcom` url scheme deployments, e.g. properties following `www.mongodb.com/docs` url patterns instead of `docs.*.mongodb.com` patterns.

This is implemented by first preferring the presence of a `GATSBY_BASE_URL` environment variable, then otherwise falling back on logic to determine if the site uses `www` or `docs` subdomain patterns.

#### How do we test this?
![image](https://user-images.githubusercontent.com/3813528/152010794-7780d981-37e6-4cfc-8cb6-0e15499937b8.png)

Well, at least we don't manually test this with the `www` logic, on account of that logic being intrinsically coupled to being hosted on a `www` site. The conceit of this change is that it's backwards and forwards compatible, and works with both current and dotcom instanced sites. Smoke testing in staging links should give us enough confidence that everything 'works' as intended, combined with unit tests present.