### PR TITLE
DOP-2233: Make all text and components within tables 14px

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -45,7 +45,6 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
           className={cx(css`
             overflow-wrap: anywhere;
             word-break: break-word;
-            font-size: 14px;
 
             /* Force top alignment rather than LeafyGreen default middle (PD-1217) */
             vertical-align: top;
@@ -53,17 +52,12 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
             /* Apply grey background to stub <th> cells (PD-1216) */
             ${isStub && `background-clip: padding-box; background-color: ${uiColors.gray.light3};`}
 
+            * {
+              font-size: 14px !important;
+            }
+
             & > div > span > * {
               margin: 0 0 12px;
-              font-size: 14px;
-            }
-
-            & > div > span > div > * {
-              font-size: 14px;
-            }
-
-            & > div > span > div > div > * {
-              font-size: 14px;
             }
 
             /* Prevent extra margin below last element */

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -117,7 +117,7 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
             return (
               <TableHeader
                 className={cx(css`
-                  > * {
+                  * {
                     font-size: 14px;
                   }
                   ${widths && `width: ${widths[colIndex]}%`}

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -45,6 +45,7 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
           className={cx(css`
             overflow-wrap: anywhere;
             word-break: break-word;
+            font-size: 14px;
 
             /* Force top alignment rather than LeafyGreen default middle (PD-1217) */
             vertical-align: top;
@@ -54,6 +55,15 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
 
             & > div > span > * {
               margin: 0 0 12px;
+              font-size: 14px;
+            }
+
+            & > div > span > div > * {
+              font-size: 14px;
+            }
+
+            & > div > span > div > div > * {
+              font-size: 14px;
             }
 
             /* Prevent extra margin below last element */
@@ -113,6 +123,9 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
             return (
               <TableHeader
                 className={cx(css`
+                  > * {
+                    font-size: 14px;
+                  }
                   ${widths && `width: ${widths[colIndex]}%`}
                 `)}
                 key={`${rowIndex}-${colIndex}`}

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Table, Row, Cell, TableHeader, HeaderRow } from '@leafygreen-ui/table';
 import { uiColors } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
+import { theme } from '../theme/docsTheme';
 import ComponentFactory from './ComponentFactory';
 
 const align = (key) => {
@@ -53,7 +54,7 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
             ${isStub && `background-clip: padding-box; background-color: ${uiColors.gray.light3};`}
 
             * {
-              font-size: 14px !important;
+              font-size: ${theme.fontSize.small} !important;
             }
 
             & > div > span > * {
@@ -118,7 +119,7 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
               <TableHeader
                 className={cx(css`
                   * {
-                    font-size: 14px;
+                    font-size: ${theme.fontSize.small};
                   }
                   ${widths && `width: ${widths[colIndex]}%`}
                 `)}

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -206,7 +206,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 5%;
 }
 
-.emotion-4 > * {
+.emotion-4 * {
   font-size: 14px;
 }
 
@@ -223,7 +223,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 10%;
 }
 
-.emotion-7 > * {
+.emotion-7 * {
   font-size: 14px;
 }
 
@@ -240,7 +240,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 15%;
 }
 
-.emotion-10 > * {
+.emotion-10 * {
   font-size: 14px;
 }
 
@@ -257,7 +257,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 20%;
 }
 
-.emotion-13 > * {
+.emotion-13 * {
   font-size: 14px;
 }
 
@@ -274,7 +274,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 30%;
 }
 
-.emotion-16 > * {
+.emotion-16 * {
   font-size: 14px;
 }
 
@@ -583,7 +583,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   border-color: #E7EEEC;
 }
 
-.emotion-4 > * {
+.emotion-4 * {
   font-size: 14px;
 }
 

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -121,11 +121,21 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   position: relative;
   overflow-wrap: anywhere;
   word-break: break-word;
+  font-size: 14px;
   vertical-align: top;
 }
 
 .emotion-22 > div > span > * {
   margin: 0 0 12px;
+  font-size: 14px;
+}
+
+.emotion-22 > div > span > div > * {
+  font-size: 14px;
+}
+
+.emotion-22 > div > span > div > div > * {
+  font-size: 14px;
 }
 
 .emotion-22 > div > span > *:last-child {
@@ -202,6 +212,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 5%;
 }
 
+.emotion-4 > * {
+  font-size: 14px;
+}
+
 .emotion-7 {
   border-width: 0px 1px 3px 1px;
   border-style: solid;
@@ -213,6 +227,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   line-height: 20px;
   border-color: #E7EEEC;
   width: 10%;
+}
+
+.emotion-7 > * {
+  font-size: 14px;
 }
 
 .emotion-10 {
@@ -228,6 +246,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 15%;
 }
 
+.emotion-10 > * {
+  font-size: 14px;
+}
+
 .emotion-13 {
   border-width: 0px 1px 3px 1px;
   border-style: solid;
@@ -241,6 +263,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 20%;
 }
 
+.emotion-13 > * {
+  font-size: 14px;
+}
+
 .emotion-16 {
   border-width: 0px 1px 3px 1px;
   border-style: solid;
@@ -252,6 +278,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   line-height: 20px;
   border-color: #E7EEEC;
   width: 30%;
+}
+
+.emotion-16 > * {
+  font-size: 14px;
 }
 
 <div
@@ -559,6 +589,10 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   border-color: #E7EEEC;
 }
 
+.emotion-4 > * {
+  font-size: 14px;
+}
+
 .emotion-2 {
   padding-right: 4px;
   color: #3D4F58;
@@ -576,6 +610,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   font-weight: bold;
   overflow-wrap: anywhere;
   word-break: break-word;
+  font-size: 14px;
   vertical-align: top;
   background-clip: padding-box;
   background-color: #F9FBFA;
@@ -583,6 +618,15 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 
 .emotion-21 > div > span > * {
   margin: 0 0 12px;
+  font-size: 14px;
+}
+
+.emotion-21 > div > span > div > * {
+  font-size: 14px;
+}
+
+.emotion-21 > div > span > div > div > * {
+  font-size: 14px;
 }
 
 .emotion-21 > div > span > *:last-child {
@@ -600,11 +644,21 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   position: relative;
   overflow-wrap: anywhere;
   word-break: break-word;
+  font-size: 14px;
   vertical-align: top;
 }
 
 .emotion-23 > div > span > * {
   margin: 0 0 12px;
+  font-size: 14px;
+}
+
+.emotion-23 > div > span > div > * {
+  font-size: 14px;
+}
+
+.emotion-23 > div > span > div > div > * {
+  font-size: 14px;
 }
 
 .emotion-23 > div > span > *:last-child {

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -121,21 +121,15 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   position: relative;
   overflow-wrap: anywhere;
   word-break: break-word;
-  font-size: 14px;
   vertical-align: top;
+}
+
+.emotion-22 * {
+  font-size: 14px !important;
 }
 
 .emotion-22 > div > span > * {
   margin: 0 0 12px;
-  font-size: 14px;
-}
-
-.emotion-22 > div > span > div > * {
-  font-size: 14px;
-}
-
-.emotion-22 > div > span > div > div > * {
-  font-size: 14px;
 }
 
 .emotion-22 > div > span > *:last-child {
@@ -610,23 +604,17 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   font-weight: bold;
   overflow-wrap: anywhere;
   word-break: break-word;
-  font-size: 14px;
   vertical-align: top;
   background-clip: padding-box;
   background-color: #F9FBFA;
 }
 
+.emotion-21 * {
+  font-size: 14px !important;
+}
+
 .emotion-21 > div > span > * {
   margin: 0 0 12px;
-  font-size: 14px;
-}
-
-.emotion-21 > div > span > div > * {
-  font-size: 14px;
-}
-
-.emotion-21 > div > span > div > div > * {
-  font-size: 14px;
 }
 
 .emotion-21 > div > span > *:last-child {
@@ -644,21 +632,15 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   position: relative;
   overflow-wrap: anywhere;
   word-break: break-word;
-  font-size: 14px;
   vertical-align: top;
+}
+
+.emotion-23 * {
+  font-size: 14px !important;
 }
 
 .emotion-23 > div > span > * {
   margin: 0 0 12px;
-  font-size: 14px;
-}
-
-.emotion-23 > div > span > div > * {
-  font-size: 14px;
-}
-
-.emotion-23 > div > span > div > div > * {
-  font-size: 14px;
 }
 
 .emotion-23 > div > span > *:last-child {


### PR DESCRIPTION
### Stories/Links:

[DOP-2233](https://jira.mongodb.org/browse/DOP-2233)

### Staging Links:

[Compass Staging Link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/compass/grace.chong/DOP-2233/indexes/index.html#optional-specify-the-index-options)

### Notes:

This change makes the text in Tables 14px, including nested components. 