### PR TITLE
DOP-2722: Fix card URLs in guides gallery view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_BUCKET=docs-mongodb-org-stg
-STAGING_URL="https://${STAGING_BUCKET}.s3.us-east-2.amazonaws.com"
+STAGING_URL="https://docs-mongodbcom-integration.corp.mongodb.com"
 -include .env.production
 
 .PHONY: stage static
@@ -25,7 +25,7 @@ stage: prefix
 		echo "To stage changes to the Snooty frontend, ensure that GATSBY_SNOOTY_DEV=true in your production environment."; exit 1; \
 	else \
 		mut-publish public ${STAGING_BUCKET} --prefix=${PREFIX} --stage ${ARGS}; \
-		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/index.html"; \
+		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
 
 static:

--- a/src/components/Chapters/Chapters.js
+++ b/src/components/Chapters/Chapters.js
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import Icon from '@leafygreen-ui/icon';
 import { css } from '@emotion/core';
@@ -9,6 +8,7 @@ import ComponentFactory from '../ComponentFactory';
 import CardGroup from '../CardGroup';
 import BookIcon from '../icons/Book';
 import { theme } from '../../theme/docsTheme';
+import { assertTrailingSlash } from '../../utils/assert-trailing-slash';
 import { getPlaintext } from '../../utils/get-plaintext';
 import RightColumn from './RightColumn';
 import useStickyTopValues from '../../hooks/useStickyTopValues';
@@ -131,7 +131,7 @@ const getGuidesData = (chapters, guides) => {
         headline: getPlaintext(data['title']),
         icon: chapters[chapterName]?.['icon'],
         'icon-alt': `${chapterName} chapter icon`,
-        url: withPrefix(slug),
+        url: assertTrailingSlash(slug),
       },
     };
   });


### PR DESCRIPTION
### Stories/Links:

DOP-2722

### Staging Links:

[Guides Staging](https://docs-mongodbcom-integration.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2722/)

### Notes:
* Asserts trailing slash on guide slugs to prevent gallery cards from erroring on staging.
* Bonus: Uses old integration site url for S3 staging links.