### PR TITLE
DOP-2720: Improve useActiveHeading hook accuracy

### DIFF
--- a/src/components/Chapters/RightColumn.js
+++ b/src/components/Chapters/RightColumn.js
@@ -98,7 +98,7 @@ const RightColumn = ({ chapters = {} }) => {
   const isVisible = useVisibleOnScroll('.hero-img');
   const chapterEntries = Object.entries(chapters || {});
   const chapterValues = Object.values(chapters || {});
-  const activeChapterId = useActiveHeading(chapterValues);
+  const activeChapterId = useActiveHeading(chapterValues, 0.6);
 
   return (
     <Container isSidenavCollapsed={isCollapsed} isVisible={isVisible}>

--- a/src/components/Chapters/RightColumn.js
+++ b/src/components/Chapters/RightColumn.js
@@ -98,7 +98,10 @@ const RightColumn = ({ chapters = {} }) => {
   const isVisible = useVisibleOnScroll('.hero-img');
   const chapterEntries = Object.entries(chapters || {});
   const chapterValues = Object.values(chapters || {});
-  const activeChapterId = useActiveHeading(chapterValues, 0.6);
+  // Set active chapter id if its chapter card is more than 60% visible on the page to account for
+  // top nav and chapters/gallery view controller
+  const targetIntersectionRatio = 0.6;
+  const activeChapterId = useActiveHeading(chapterValues, targetIntersectionRatio);
 
   return (
     <Container isSidenavCollapsed={isCollapsed} isVisible={isVisible}>

--- a/src/components/Permalink.js
+++ b/src/components/Permalink.js
@@ -27,6 +27,8 @@ const LinkIcon = styled.img`
 const HeaderBuffer = styled.div`
   margin-top: ${({ bufferSpace }) => bufferSpace};
   position: absolute;
+  // Add a bit of padding to help headings be more accurately set as "active" on FF and Safari
+  padding-bottom: 2px;
 `;
 
 const headingStyle = (copied) => css`

--- a/src/hooks/useActiveHeading.js
+++ b/src/hooks/useActiveHeading.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
 const observeHeadings = (headingNodes, observer) =>
   headingNodes.flatMap((heading) => {
@@ -16,22 +16,26 @@ const unobserveHeadings = (headings, observer) => {
   });
 };
 
-// Returns the id of the first (topmost) heading that is in the viewport.
+/**
+ * Returns the id of the first (topmost) heading that is in the viewport.
+ * @param headingNodes An array of headings nodes to be observed. Headings are typically
+ * expected to be AST nodes or objects with an id field.
+ * @param intersectionRatio The ratio to compare element intersection visibility with. If the element
+ * is observed to be above this ratio, it will be eligible as active.
+ */
 const useActiveHeading = (headingNodes, intersectionRatio) => {
   const [activeHeadingId, setActiveHeadingId] = useState(headingNodes?.[0]?.id);
 
-  // Create map to keep track of all headings and if they are currently seen within the viewport.
-  const headingsMap = useMemo(() => {
-    const map = new Map();
-    headingNodes.forEach(({ id }) => {
-      map.set(id, false);
-    });
-    return map;
-  }, [headingNodes]);
-  const targetRatio = intersectionRatio >= 0 ? intersectionRatio : 0;
-
   useEffect(() => {
+    // Create map to keep track of all headings and if they are currently seen within the viewport.
+    const headingsMap = new Map();
+    headingNodes.forEach(({ id }) => {
+      headingsMap.set(id, false);
+    });
+    const targetRatio = intersectionRatio >= 0 ? intersectionRatio : 0;
+
     const options = {
+      // Check elements after every 25% of visibility, if possible
       threshold: [0, 0.25, 0.5, 0.75, 1.0],
     };
 
@@ -58,7 +62,7 @@ const useActiveHeading = (headingNodes, intersectionRatio) => {
     return () => {
       unobserveHeadings(headings, observer);
     };
-  }, [headingNodes, headingsMap, targetRatio]);
+  }, [headingNodes, intersectionRatio]);
 
   return activeHeadingId;
 };

--- a/src/hooks/useActiveHeading.js
+++ b/src/hooks/useActiveHeading.js
@@ -17,12 +17,13 @@ const unobserveHeadings = (headings, observer) => {
 };
 
 // Returns the id of the first (topmost) heading that is in the viewport.
-const useActiveHeading = (headingNodes) => {
+const useActiveHeading = (headingNodes, intersectionRatio) => {
   const [activeHeadingId, setActiveHeadingId] = useState(headingNodes?.[0]?.id);
 
   // Create array to keep track of all headings and if they are currently seen within the viewport.
   // The order of the headings matter.
   const headingsMemo = useMemo(() => headingNodes.map(({ id }) => ({ id, isInViewport: false })), [headingNodes]);
+  const targetRatio = intersectionRatio >= 0 ? intersectionRatio : 0;
 
   useEffect(() => {
     const options = {
@@ -35,7 +36,7 @@ const useActiveHeading = (headingNodes) => {
         if (!heading) {
           continue;
         }
-        heading.isInViewport = entry.intersectionRatio > 0;
+        heading.isInViewport = entry.intersectionRatio > targetRatio;
       }
 
       // Find first heading that is in the viewport
@@ -50,7 +51,7 @@ const useActiveHeading = (headingNodes) => {
     return () => {
       unobserveHeadings(headings, observer);
     };
-  }, [headingNodes, headingsMemo]);
+  }, [headingNodes, headingsMemo, targetRatio]);
 
   return activeHeadingId;
 };

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -18,6 +18,7 @@ exports[`renders correctly 1`] = `
 .emotion-3 {
   margin-top: -175px;
   position: absolute;
+  padding-bottom: 2px;
 }
 
 <h3

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -18,6 +18,7 @@ exports[`renders correctly 1`] = `
 .emotion-3 {
   margin-top: -175px;
   position: absolute;
+  padding-bottom: 2px;
 }
 
 <section>

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -44,6 +44,7 @@ exports[`renders correctly with a directive_argument node 1`] = `
 .emotion-6 {
   margin-top: -150px;
   position: absolute;
+  padding-bottom: 2px;
 }
 
 <dl


### PR DESCRIPTION
### Stories/Links:

DOP-2720

### Staging Links:

[Guides Staging](https://docs-mongodbcom-integration.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2720/cloud/account/)
[Server Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/raymundrodriguez/DOP-2720/core/sharding-reshard-a-collection/) (ensure that the "On This Page" component more or less works the same on staging).
Compare the "On This Page" component here: server [staging page](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/raymundrodriguez/DOP-2720/tutorial/model-embedded-one-to-one-relationships-between-documents/) with [prod page](https://docs.mongodb.com/manual/tutorial/model-embedded-one-to-one-relationships-between-documents/).

### Notes:
The original problem was that if multiple headings were in the viewport at the same time, we would only track the first one seen, but disregard the second one. The second one would be completely ignored and a new active heading won't be set until a third heading is seen by the `IntersectionObserver`.

The approach that I went with is to have the `useActiveHeading` hook keep track of all of the headings on the page and track if they're in the viewport. We'll only set the topmost heading (based on array order) that is in the viewport as *the* active heading. When the `IntersectionObserver` sees that the first heading is no longer seen, the second heading will still be tracked and set as the new active heading.