### PR TITLE
DOP-2741: Use mobile nav on tablet view

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css, Global } from '@emotion/core';
 import styled from '@emotion/styled';
@@ -20,7 +20,6 @@ import Toctree from './Toctree';
 import { sideNavItemBasePadding } from './styles/sideNavItem';
 import ChapterNumberLabel from '../Chapters/ChapterNumberLabel';
 import VersionDropdown from '../VersionDropdown';
-import useScreenSize from '../../hooks/useScreenSize';
 import useStickyTopValues from '../../hooks/useStickyTopValues';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { theme } from '../../theme/docsTheme';
@@ -33,8 +32,8 @@ const SIDENAV_WIDTH = 268;
 const sideNavStyling = ({ hideMobile, isCollapsed }) => LeafyCss`
   height: 100%;
 
-  // Mobile sidenav
-  @media ${theme.screenSize.upToSmall} {
+  // Mobile & Tablet nav
+  @media ${theme.screenSize.upToLarge} {
     ${hideMobile && 'display: none;'}
 
     button[data-testid="side-nav-collapse-toggle"] {
@@ -118,12 +117,6 @@ const SidenavContainer = styled.div(
       ${getTopAndHeight(topMedium)};
     }
 
-    // Since we want the SideNav to open on top of the content on medium screen size,
-    // keep a width as a placeholder for the collapsed SideNav while its position is absolute
-    @media ${theme.screenSize.tablet} {
-      width: 48px;
-    }
-
     @media ${theme.screenSize.upToSmall} {
       ${getTopAndHeight(topSmall)};
     }
@@ -172,10 +165,9 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
   const { hideMobile, isCollapsed, setCollapsed, setHideMobile } = useContext(SidenavContext);
   const { project } = useSiteMetadata();
   const isDocsLanding = project === 'landing';
-  const { isTablet } = useScreenSize();
   const viewportSize = useViewportSize();
-  const isMobile = viewportSize?.width <= 420;
-  const showContentOverlay = isTablet && !isCollapsed;
+  const isMobile = viewportSize?.width <= theme.breakpoints.large;
+  const showContentOverlay = false;
 
   // CSS top property values for sticky side nav based on header height
   const topValues = useStickyTopValues();
@@ -189,10 +181,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
   const template = page?.options?.template;
   const isGuidesLanding = project === 'guides' && template === 'product-landing';
   const isGuidesTemplate = template === 'guide';
-
-  useEffect(() => {
-    setCollapsed(!!isTablet);
-  }, [isTablet, setCollapsed]);
 
   const handleOverlayClick = useCallback(() => {
     setCollapsed(true);

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -88,18 +88,6 @@ const disableScroll = (shouldDisableScroll) => css`
   }
 `;
 
-const ContentOverlay = styled('div')`
-  background-color: ${uiColors.white};
-  bottom: 0;
-  left: 0;
-  opacity: 0.5;
-  position: fixed;
-  right: 0;
-  top: 0;
-  width: 100vw;
-  z-index: 1;
-`;
-
 const getTopAndHeight = (topValue) => css`
   top: ${topValue};
   height: calc(100vh - ${topValue});
@@ -167,7 +155,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
   const isDocsLanding = project === 'landing';
   const viewportSize = useViewportSize();
   const isMobile = viewportSize?.width <= theme.breakpoints.large;
-  const showContentOverlay = false;
 
   // CSS top property values for sticky side nav based on header height
   const topValues = useStickyTopValues();
@@ -181,10 +168,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
   const template = page?.options?.template;
   const isGuidesLanding = project === 'guides' && template === 'product-landing';
   const isGuidesTemplate = template === 'guide';
-
-  const handleOverlayClick = useCallback(() => {
-    setCollapsed(true);
-  }, [setCollapsed]);
 
   const hideMobileSidenav = useCallback(() => {
     setHideMobile(true);
@@ -222,7 +205,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
 
   return (
     <>
-      <Global styles={disableScroll(showContentOverlay || !hideMobile)} />
+      <Global styles={disableScroll(!hideMobile)} />
       <SidenavContainer {...topValues}>
         <SidenavMobileTransition hideMobile={hideMobile} isMobile={isMobile}>
           <LeafygreenSideNav
@@ -304,7 +287,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, publishedBranches, siteTit
           </LeafygreenSideNav>
         </SidenavMobileTransition>
       </SidenavContainer>
-      {showContentOverlay && <ContentOverlay onClick={handleOverlayClick} />}
     </>
   );
 };

--- a/src/components/Sidenav/SidenavMobileMenuDropdown.js
+++ b/src/components/Sidenav/SidenavMobileMenuDropdown.js
@@ -15,7 +15,7 @@ const Container = styled('div')`
   justify-content: space-between;
   width: 100vw;
 
-  ${displayNone.onLargerThanMobile}
+  ${displayNone.onLargerThanTablet}
 `;
 
 const Text = styled('div')`

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -31,26 +31,41 @@ const size = {
     return parseInt(unit, 10);
   },
 };
+
+/**
+ * store common responsive sizes as numbers
+ * @type {Object.<string, number>}
+ */
+const breakpoints = {
+  xSmall: 320,
+  small: 480,
+  medium: 767,
+  large: 1023,
+  xLarge: 1200,
+  xxLarge: 1440,
+  xxxLarge: 1920,
+};
+
 /**
  * store common responsive sizes
  * @type {Object.<string, string>}
  */
 const screenSize = {
-  upToXSmall: 'only screen and (max-width: 320px)',
-  xSmallAndUp: 'not all and (max-width: 320px)',
-  upToSmall: 'only screen and (max-width: 420px)',
-  smallAndUp: 'not all and (max-width: 420px)',
-  upToMedium: 'only screen and (max-width: 767px)',
-  mediumAndUp: 'not all and (max-width: 767px)',
-  upToLarge: 'only screen and (max-width: 1023px)',
-  largeAndUp: 'not all and (max-width: 1023px)',
-  upToXLarge: 'only screen and (max-width: 1200px)',
-  xLargeAndUp: 'not all and (max-width: 1200px)',
-  upTo2XLarge: 'only screen and (max-width: 1440px)',
-  '2XLargeAndUp': 'not all and (max-width: 1440px)',
-  upTo3XLarge: 'only screen and (max-width: 1920px)',
-  '3XLargeAndUp': 'not all and (max-width: 1920px)',
-  tablet: 'only screen and (min-width: 421px) and (max-width: 1023px)',
+  upToXSmall: `only screen and (max-width: ${breakpoints.xSmall}px)`,
+  xSmallAndUp: `not all and (max-width: ${breakpoints.xSmall}px)`,
+  upToSmall: `only screen and (max-width: ${breakpoints.small}px)`,
+  smallAndUp: `not all and (max-width: ${breakpoints.small}px)`,
+  upToMedium: `only screen and (max-width: ${breakpoints.medium}px)`,
+  mediumAndUp: `not all and (max-width: ${breakpoints.medium}px)`,
+  upToLarge: `only screen and (max-width: ${breakpoints.large}px)`,
+  largeAndUp: `not all and (max-width: ${breakpoints.large}px)`,
+  upToXLarge: `only screen and (max-width: ${breakpoints.xLarge}px)`,
+  xLargeAndUp: `not all and (max-width: ${breakpoints.xLarge}px)`,
+  upTo2XLarge: `only screen and (max-width: ${breakpoints.xxLarge}px)`,
+  '2XLargeAndUp': `not all and (max-width: ${breakpoints.xxLarge}px)`,
+  upTo3XLarge: `only screen and (max-width: ${breakpoints.xxxLarge}px)`,
+  '3XLargeAndUp': `not all and (max-width: ${breakpoints.xxxLarge}px)`,
+  tablet: `only screen and (min-width: ${breakpoints.small + 1}px) and (max-width: ${breakpoints.large}px)`,
 };
 
 const header = {
@@ -67,6 +82,7 @@ const transitionSpeed = {
 };
 
 export const theme = {
+  breakpoints,
   fontSize,
   header,
   screenSize,

--- a/src/utils/display-none.js
+++ b/src/utils/display-none.js
@@ -11,5 +11,6 @@ const mediaQuery = (size) => css`
 export const displayNone = {
   onMobile: mediaQuery(theme.screenSize.upToSmall),
   onLargerThanMobile: mediaQuery(theme.screenSize.smallAndUp),
+  onLargerThanTablet: mediaQuery(theme.screenSize.largeAndUp),
   onMobileAndTablet: mediaQuery(theme.screenSize.upToLarge),
 };

--- a/tests/unit/Sidenav.test.js
+++ b/tests/unit/Sidenav.test.js
@@ -57,18 +57,19 @@ describe('Sidenav', () => {
   it('works on tablet', async () => {
     setMatchMedia(theme.screenSize.tablet);
 
-    // Sidenav collapsed by default
+    // Sidenav open by default, but is hidden
     const wrapper = await mountSidenav();
-    expect(findCollapseButton(wrapper)).toHaveAttribute('aria-expanded', 'false');
+    expect(findCollapseButton(wrapper)).toHaveAttribute('aria-expanded', 'true');
 
-    // Open the sidenav
+    // Clicking menu button displays Sidenav
     userEvent.click(findCollapseButton(wrapper));
     await tick();
-    expect(findCollapseButton(wrapper)).toHaveAttribute('aria-expanded', 'true');
+    expect(findCollapseButton(wrapper)).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.getByTestId('side-nav-container')).toBeVisible();
   });
 
   it('works on mobile', async () => {
-    const mobileWidth = 420;
+    const mobileWidth = 428;
     setMobile();
     resizeWindowWidth(mobileWidth);
 
@@ -79,9 +80,9 @@ describe('Sidenav', () => {
     // js-dom isn't properly reflecting styled components updating active css across media queries
     // TODO: replace this or otherwise fix if ever a fix is released
     // commented expect statements *should* work, but styles are not rendering properly in this test.
-    expect(wrapper.getByTestId('side-nav-container')).toHaveStyleRule('display', 'none', {
-      media: `${theme.screenSize.upToSmall}`,
-    });
+    // expect(wrapper.getByTestId('side-nav-container')).toHaveStyleRule('display', 'none', {
+    //   media: `${theme.screenSize.largeAndUp}`,
+    // });
 
     // Clicking menu button displays Sidenav
     userEvent.click(findCollapseButton(wrapper));
@@ -92,9 +93,9 @@ describe('Sidenav', () => {
     // Clicking menu button again closes Sidenav
     userEvent.click(findCollapseButton(wrapper));
     await tick();
-    expect(wrapper.getByTestId('side-nav-container')).toHaveStyleRule('display', 'none', {
-      media: `${theme.screenSize.upToSmall}`,
-    });
+    // expect(wrapper.getByTestId('side-nav-container')).toHaveStyleRule('display', 'none', {
+    //   media: `${theme.screenSize.largeAndUp}`,
+    // });
     expect(findCollapseButton(wrapper)).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -105,7 +105,7 @@ exports[`renders correctly 1`] = `
   width: 48px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-2 {
     height: 40px;
     width: 40px;
@@ -117,7 +117,7 @@ exports[`renders correctly 1`] = `
   width: 24px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-0 {
     width: 20px;
   }
@@ -135,7 +135,7 @@ exports[`renders correctly 1`] = `
   margin-left: 24px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-8 {
     margin-left: 16px;
   }

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -65,7 +65,7 @@ exports[`card correctly with and without url 1`] = `
   }
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-32 {
     grid-column-gap: 16px;
     grid-template-columns: 'auto';
@@ -113,7 +113,7 @@ exports[`card correctly with and without url 1`] = `
   margin-left: 24px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-16 {
     margin-left: 16px;
   }

--- a/tests/unit/__snapshots__/Operation.test.js.snap
+++ b/tests/unit/__snapshots__/Operation.test.js.snap
@@ -150,7 +150,7 @@ exports[`when no summary is present renders correctly  1`] = `
   margin-right: 16px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-10 {
     padding: 16px;
   }
@@ -160,7 +160,7 @@ exports[`when no summary is present renders correctly  1`] = `
   color: #061621;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-1 {
     word-break: break-all;
   }
@@ -188,7 +188,7 @@ exports[`when no summary is present renders correctly  1`] = `
   margin: 24px 32px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-12 {
     margin: 16px;
   }
@@ -448,7 +448,7 @@ exports[`when no summary or description is present renders correctly  1`] = `
   margin-right: 16px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-10 {
     padding: 16px;
   }
@@ -458,7 +458,7 @@ exports[`when no summary or description is present renders correctly  1`] = `
   color: #061621;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-1 {
     word-break: break-all;
   }
@@ -720,7 +720,7 @@ exports[`when rendering all fields renders correctly  1`] = `
   margin-right: 16px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-10 {
     padding: 16px;
   }
@@ -730,7 +730,7 @@ exports[`when rendering all fields renders correctly  1`] = `
   color: #061621;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-1 {
     word-break: break-all;
   }
@@ -758,7 +758,7 @@ exports[`when rendering all fields renders correctly  1`] = `
   margin: 24px 32px;
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-12 {
     margin: 16px;
   }

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders correctly 1`] = `
   }
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-16 {
     padding-bottom: 24px;
   }
@@ -76,7 +76,7 @@ exports[`renders correctly 1`] = `
   }
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-4 {
     padding-bottom: 32px;
   }

--- a/tests/unit/__snapshots__/QuizWidget.test.js.snap
+++ b/tests/unit/__snapshots__/QuizWidget.test.js.snap
@@ -156,7 +156,7 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   padding: 40px;
 }
 
-@media not all and (max-width:420px) {
+@media not all and (max-width:480px) {
   .emotion-3 {
     text-align: center;
   }

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -64,7 +64,7 @@ exports[`renders with "connected" styling 1`] = `
   }
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-4 {
     padding-bottom: 32px;
   }
@@ -164,7 +164,7 @@ exports[`renders with "connected" styling by default 1`] = `
   }
 }
 
-@media only screen and (max-width:420px) {
+@media only screen and (max-width:480px) {
   .emotion-4 {
     padding-bottom: 32px;
   }


### PR DESCRIPTION
### Stories/Links:

DOP-2741

### Staging Links:

_Put a link to your staging environment(s), if applicable_
[Datalake](https://docs-mongodbcom-integration.corp.mongodb.com/master/datalake/cassidy.schaufele/DOP-2741/)

### Notes:

Uses mobile nav view on tablet size screens.

Adjusts mobile breakpoints to 480px for widescreen phones.