### PR TITLE
DOP-2764: Re-render GuideNext component with localStorage

### DIFF
--- a/src/components/GuideNext/read-guides-context.js
+++ b/src/components/GuideNext/read-guides-context.js
@@ -7,7 +7,11 @@ const ReadGuidesContext = createContext({
 
 const ReadGuidesContextProvider = ({ children, slug }) => {
   const localStorageKey = 'readGuides';
-  const [readGuides, setReadGuides] = useState(getLocalValue(localStorageKey) || {});
+  const [readGuides, setReadGuides] = useState({});
+
+  useEffect(() => {
+    setReadGuides(getLocalValue(localStorageKey));
+  }, []);
 
   useEffect(() => {
     if (!readGuides[slug]) {


### PR DESCRIPTION
### Stories/Links:

DOP-2764

### Staging Links:

[Guides staging](https://docs-mongodbcom-integration.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2764/cloud/account/)

### Notes:
* Feel free to compare above staging link with this [older staging link](https://docs-mongodbcom-integration.corp.mongodb.com/test-guides/guides/raymundrodriguez/master/cloud/account/). When clicking directly on the older staging link, the list of guides in the "What's Next" component at the bottom may not have the correct states from `localStorage`. The new staging link above should show the correct states (even if with a short delay)