### PR TITLE
DOP-2780: Update filter to account for shared project name

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,12 +12,12 @@ const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { DOCUMENTS_COLLECTION, METADATA_COLLECTION, BRANCHES_COLLECTION } = require('./src/build-constants');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
 const { constructBuildFilter } = require('./src/utils/setup/construct-build-filter');
+const { constructReposFilter } = require('./src/utils/setup/construct-repos-filter.js');
 
 const DB = siteMetadata.database;
 const reposDB = siteMetadata.reposDatabase;
 
-const reposFilter = { project: siteMetadata.project };
-
+const reposFilter = constructReposFilter(siteMetadata.project);
 const buildFilter = constructBuildFilter(siteMetadata);
 
 // different types of references

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,7 +12,7 @@ const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { DOCUMENTS_COLLECTION, METADATA_COLLECTION, BRANCHES_COLLECTION } = require('./src/build-constants');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
 const { constructBuildFilter } = require('./src/utils/setup/construct-build-filter');
-const { constructReposFilter } = require('./src/utils/setup/construct-repos-filter.js');
+const { constructReposFilter } = require('./src/utils/setup/construct-repos-filter');
 
 const DB = siteMetadata.database;
 const reposDB = siteMetadata.reposDatabase;

--- a/src/utils/setup/construct-repos-filter.js
+++ b/src/utils/setup/construct-repos-filter.js
@@ -1,8 +1,6 @@
 // Returns the filter to use when querying for a site's versions/branches.
 const constructReposFilter = (project) => {
-  const filter = {
-    project: project,
-  };
+  const filter = { project };
 
   // Handles case where public and internal docs share the same project name.
   // REPO_NAME should be passed in by the autobuilder as an env variable

--- a/src/utils/setup/construct-repos-filter.js
+++ b/src/utils/setup/construct-repos-filter.js
@@ -1,0 +1,16 @@
+// Returns the filter to use when querying for a site's versions/branches.
+const constructReposFilter = (project) => {
+  const filter = {
+    project: project,
+  };
+
+  // Handles case where public and internal docs share the same project name.
+  // REPO_NAME should be passed in by the autobuilder as an env variable
+  if (process.env.REPO_NAME) {
+    filter['repoName'] = process.env.REPO_NAME;
+  }
+
+  return filter;
+};
+
+module.exports = { constructReposFilter };


### PR DESCRIPTION
### Stories/Links:

DOP-2780

### Staging Links:

[Server docs](https://docs-mongodbcom-integration.corp.mongodb.com/v5.0/docs/raymundrodriguez/DOP-2780/)

### Notes:
* For context: The internal docs repo may not be able to update the project name in their `snooty.toml` due to a script that syncs changes between the public and internal repos. This means that changing the project name for the internal docs will automatically change the project name for the public docs too, or else merge conflicts may occur.
* This solution adds an additional optional field to the filter when searching for branches. This will require the autobuilder Makefiles for `docs` and `docs-mongodb-internal` to pass in a new `REPO_NAME` env variable to the frontend's `.env.production` file to differentiate between two repos that share the same project name.