### PR TITLE
DOP-2782: Remove passthrough of GATSBY_BASE_URL

### DIFF
--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -28,12 +28,9 @@ const isDotCom = () => {
 // Used for accessing what our base url should be, differentiating between environs
 // and adding sensible defaults in the event the base variable is not present.
 const baseUrl = (needsProtocol = false) => {
-  if (process.env.GATSBY_BASE_URL) return process.env.GATSBY_BASE_URL;
-
-  const intendedFallback = isDotCom()
+  return isDotCom()
     ? dotcomifyUrl(window.location.hostname, needsProtocol)
     : `${needsProtocol ? 'https://' : ''}docs.mongodb.com`;
-  return intendedFallback;
 };
 
 module.exports = { dotcomifyUrl, isDotCom, baseUrl };

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -88,12 +88,7 @@ describe('baseUrl', () => {
   });
 
   describe('is a function which attempts return an appropriate baseUrl at invocation time based on environment state.', () => {
-    it('always prefers process.env.GATSBY_BASE_URL if present', () => {
-      process.env.GATSBY_BASE_URL = 'www.mongodb.com';
-      expect(baseUrl()).toBe('www.mongodb.com');
-    });
-
-    it('determines dotcom vs. docs. based on subdomain when invoked, if no process.env.GATSBY_BASE_URL is present', () => {
+    it('determines dotcom vs. docs. based on subdomain when invoked', () => {
       process.env = {};
       Object.defineProperty(window, 'location', {
         value: {
@@ -122,11 +117,6 @@ describe('baseUrl', () => {
         writable: true,
       });
       expect(baseUrl(true)).toBe('https://docs.mongodb.com');
-    });
-
-    it('ignores the protocol flag if process.env.GATSBY_BASE_URL is defined', () => {
-      process.env.GATSBY_BASE_URL = 'www.mongodb.com';
-      expect(baseUrl(true)).toBe('www.mongodb.com');
     });
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-2782

### Staging Links:

_Put a link to your staging environment(s), if applicable_
Mostly N/A - dependent on a variable which was never defined being undefined
https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2782/

### Notes:
This removes the ability to 'passthrough' the `GATSBY_BASE_URL` env var - on second thought, this is too vulnerable to passing garbage data directly throughout the frontend, and doesn't adequately account for `docs.mongodb`, `docs.atlas.mongodb`, etc. cases for pre-consolidated instances. 
