### PR TITLE
DOP-2790: Fix connected steps from being disconnected

### DIFF
--- a/src/components/Procedure/Procedure.js
+++ b/src/components/Procedure/Procedure.js
@@ -49,14 +49,7 @@ const Procedure = ({ nodeData: { children, options }, ...rest }) => {
   return (
     <StyledProcedure procedureStyle={style}>
       {steps.map((child, i) => (
-        <Step
-          {...rest}
-          nodeData={child}
-          stepNumber={i + 1}
-          stepStyle={style}
-          isLastStep={i === children.length - 1}
-          key={i}
-        />
+        <Step {...rest} nodeData={child} stepNumber={i + 1} stepStyle={style} key={i} />
       ))}
     </StyledProcedure>
   );

--- a/src/components/Procedure/Step.js
+++ b/src/components/Procedure/Step.js
@@ -33,21 +33,6 @@ const Content = styled.div`
   }
 `;
 
-const stepBlockStyles = {
-  connected: css`
-    :after {
-      content: '';
-      border-left: 2px dashed ${uiColors.gray.light2};
-      bottom: 0;
-      left: calc(50% - 1px);
-      position: absolute;
-      top: 0;
-      z-index: -1;
-    }
-  `,
-  normal: null,
-};
-
 const circleStyles = {
   connected: css`
     background-color: ${uiColors.green.light3};
@@ -65,7 +50,18 @@ const circleStyles = {
 
 const landingStepStyles = {
   connected: css`
+    position: relative;
     gap: 33px;
+
+    :not(:last-child):after {
+      content: '';
+      border-left: 2px dashed ${uiColors.gray.light2};
+      bottom: 0;
+      left: 16px;
+      position: absolute;
+      top: 0;
+      z-index: -1;
+    }
   `,
   normal: css`
     gap: ${theme.size.default};
@@ -88,10 +84,10 @@ const contentStyles = {
   `,
 };
 
-const Step = ({ nodeData: { children }, isLastStep, stepNumber, stepStyle = 'connected', ...rest }) => {
+const Step = ({ nodeData: { children }, stepNumber, stepStyle = 'connected', ...rest }) => {
   return (
     <StyledStep css={landingStepStyles[stepStyle]}>
-      <StepBlock css={!isLastStep && stepBlockStyles[stepStyle]}>
+      <StepBlock>
         <Circle css={circleStyles[stepStyle]}>{stepNumber}</Circle>
       </StepBlock>
       <Content css={contentStyles[stepStyle]}>
@@ -108,9 +104,8 @@ Step.propTypes = {
     argument: PropTypes.arrayOf(PropTypes.object).isRequired,
     children: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
-  isLastStep: PropTypes.bool,
   stepNumber: PropTypes.number.isRequired,
-  stepStyle: PropTypes.string.isRequired,
+  stepStyle: PropTypes.string,
 };
 
 export default Step;

--- a/tests/unit/Procedure.test.js
+++ b/tests/unit/Procedure.test.js
@@ -22,4 +22,5 @@ it('renders with "normal" or YAML steps styling', () => {
 it('renders steps nested in include nodes', () => {
   const tree = render(<Procedure nodeData={mockData.nestedSteps} />);
   expect(tree.asFragment()).toMatchSnapshot();
+  expect(tree.getAllByText(/Step/)).toHaveLength(7);
 });

--- a/tests/unit/Step.test.js
+++ b/tests/unit/Step.test.js
@@ -6,16 +6,16 @@ import Step from '../../src/components/Procedure/Step';
 import mockData from './data/Step.test.json';
 
 it('renders with "connected" styling by default', () => {
-  const tree = render(<Step nodeData={mockData} isLastStep={false} stepNumber={1} />);
+  const tree = render(<Step nodeData={mockData} stepNumber={1} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
 
 it('renders with "connected" styling', () => {
-  const tree = render(<Step nodeData={mockData} stepStyle="connected" isLastStep={false} stepNumber={1} />);
+  const tree = render(<Step nodeData={mockData} stepStyle="connected" stepNumber={1} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
 
 it('renders with "normal" or YAML steps styling', () => {
-  const tree = render(<Step nodeData={mockData} stepStyle="normal" isLastStep={false} stepNumber={1} />);
+  const tree = render(<Step nodeData={mockData} stepStyle="normal" stepNumber={1} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -19,6 +19,7 @@ exports[`renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   gap: 33px;
 }
 
@@ -26,18 +27,18 @@ exports[`renders correctly 1`] = `
   font-weight: 600;
 }
 
-.emotion-2 {
-  position: relative;
-}
-
-.emotion-2:after {
+.emotion-6:not(:last-child):after {
   content: '';
   border-left: 2px dashed #E7EEEC;
   bottom: 0;
-  left: calc(50% - 1px);
+  left: 16px;
   position: absolute;
   top: 0;
   z-index: -1;
+}
+
+.emotion-2 {
+  position: relative;
 }
 
 .emotion-0 {
@@ -82,10 +83,6 @@ exports[`renders correctly 1`] = `
   }
 }
 
-.emotion-10 {
-  position: relative;
-}
-
 <div
     class="emotion-16 emotion-17"
   >
@@ -120,7 +117,7 @@ exports[`renders correctly 1`] = `
       class="emotion-6 emotion-7"
     >
       <div
-        class="emotion-10 emotion-3"
+        class="emotion-2 emotion-3"
       >
         <div
           class="emotion-0 emotion-1"
@@ -149,8 +146,16 @@ exports[`renders correctly 1`] = `
 
 exports[`renders steps nested in include nodes 1`] = `
 <DocumentFragment>
-  .emotion-2 {
-  position: relative;
+  @media only screen and (max-width:1023px) {
+  .emotion-91 {
+    padding-bottom: 32px;
+  }
+}
+
+@media only screen and (max-width:480px) {
+  .emotion-91 {
+    padding-bottom: 24px;
+  }
 }
 
 .emotion-11 {
@@ -158,11 +163,26 @@ exports[`renders steps nested in include nodes 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 16px;
+  position: relative;
+  gap: 33px;
 }
 
 .emotion-11 section > p > a {
   font-weight: 600;
+}
+
+.emotion-11:not(:last-child):after {
+  content: '';
+  border-left: 2px dashed #E7EEEC;
+  bottom: 0;
+  left: 16px;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+}
+
+.emotion-2 {
+  position: relative;
 }
 
 .emotion-0 {
@@ -180,18 +200,31 @@ exports[`renders steps nested in include nodes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  background-color: #333;
-  color: #FFFFFF;
-  height: 24px;
-  width: 24px;
+  background-color: #E4F4E4;
+  color: #116149;
+  height: 34px;
+  width: 34px;
 }
 
 .emotion-9 {
-  margin-bottom: 24px;
+  margin-top: 5px;
+  padding-bottom: 64px;
 }
 
 .emotion-9 > section >:first-of-type {
   margin-top: 0;
+}
+
+@media only screen and (max-width:767px) {
+  .emotion-9 {
+    padding-bottom: 40px;
+  }
+}
+
+@media only screen and (max-width:480px) {
+  .emotion-9 {
+    padding-bottom: 32px;
+  }
 }
 
 .emotion-6 {

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders with "connected" styling 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   gap: 33px;
 }
 
@@ -14,18 +15,18 @@ exports[`renders with "connected" styling 1`] = `
   font-weight: 600;
 }
 
-.emotion-2 {
-  position: relative;
-}
-
-.emotion-2:after {
+.emotion-6:not(:last-child):after {
   content: '';
   border-left: 2px dashed #E7EEEC;
   bottom: 0;
-  left: calc(50% - 1px);
+  left: 16px;
   position: absolute;
   top: 0;
   z-index: -1;
+}
+
+.emotion-2 {
+  position: relative;
 }
 
 .emotion-0 {
@@ -107,6 +108,7 @@ exports[`renders with "connected" styling by default 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  position: relative;
   gap: 33px;
 }
 
@@ -114,18 +116,18 @@ exports[`renders with "connected" styling by default 1`] = `
   font-weight: 600;
 }
 
-.emotion-2 {
-  position: relative;
-}
-
-.emotion-2:after {
+.emotion-6:not(:last-child):after {
   content: '';
   border-left: 2px dashed #E7EEEC;
   bottom: 0;
-  left: calc(50% - 1px);
+  left: 16px;
   position: absolute;
   top: 0;
   z-index: -1;
+}
+
+.emotion-2 {
+  position: relative;
 }
 
 .emotion-0 {
@@ -202,7 +204,11 @@ exports[`renders with "connected" styling by default 1`] = `
 
 exports[`renders with "normal" or YAML steps styling 1`] = `
 <DocumentFragment>
-  .emotion-6 {
+  .emotion-2 {
+  position: relative;
+}
+
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -212,10 +218,6 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 
 .emotion-6 section > p > a {
   font-weight: 600;
-}
-
-.emotion-2 {
-  position: relative;
 }
 
 .emotion-0 {

--- a/tests/unit/data/Procedure.test.json
+++ b/tests/unit/data/Procedure.test.json
@@ -789,7 +789,7 @@
     "name": "procedure",
     "argument": [],
     "options": {
-      "style": "normal"
+      "style": "connected"
     }
   }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-2790

### Staging Links:

[Guide staging](https://docs-mongodbcom-integration.corp.mongodb.com/connected-steps-includes-fix/guides/raymundrodriguez/DOP-2790/cloud/account/#connected-steps-with-include-test)

### Notes:
* The main change is that we're removing a prop to indicate the last step, and we'll instead handle that through CSS. The CSS was moved around accordingly to facilitate this.