### PR TITLE
DOP-2752: Move metadata out of page context

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -99,10 +99,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       url,
     });
   });
-};
 
-exports.createPages = async ({ actions }) => {
-  const { createPage } = actions;
   const [, { static_files: staticFiles, ...metadataMinusStatic }] = await Promise.all([
     saveAssetFiles(assets, stitchClient),
     stitchClient.callFunction('fetchDocument', [DB, METADATA_COLLECTION, buildFilter]),
@@ -112,6 +109,26 @@ exports.createPages = async ({ actions }) => {
   if (parentPaths) {
     transformBreadcrumbs(parentPaths, slugToTitle);
   }
+
+  //Save files in the static_files field of metadata document, including intersphinx inventories
+  if (staticFiles) {
+    await saveStaticFiles(staticFiles);
+  }
+
+  createNode({
+    children: [],
+    id: createNodeId('metadata'),
+    internal: {
+      contentDigest: createContentDigest(metadataMinusStatic),
+      type: 'SnootyMetadata',
+    },
+    parent: null,
+    metadata: metadataMinusStatic,
+  });
+};
+
+exports.createPages = async ({ actions }) => {
+  const { createPage } = actions;
 
   let repoBranches = null;
   try {
@@ -125,11 +142,6 @@ exports.createPages = async ({ actions }) => {
     console.error('No version information found for', siteMetadata.project);
   }
 
-  //Save files in the static_files field of metadata document, including intersphinx inventories
-  if (staticFiles) {
-    await saveStaticFiles(staticFiles);
-  }
-
   return new Promise((resolve, reject) => {
     PAGES.forEach((page) => {
       const pageNodes = RESOLVED_REF_DOC_MAPPING[page]?.ast;
@@ -141,7 +153,6 @@ exports.createPages = async ({ actions }) => {
           component: path.resolve(__dirname, './src/components/DocumentBody.js'),
           context: {
             slug,
-            metadata: metadataMinusStatic,
             repoBranches: repoBranches,
             template: pageNodes?.options?.template,
             page: pageNodes,
@@ -176,6 +187,10 @@ exports.createSchemaCustomization = ({ actions }) => {
   actions.createTypes(`
     type SitePage implements Node @dontInfer {
       path: String!
+    }
+
+    type SnootyMetadata implements Node @dontInfer {
+        metadata: JSON!
     }
   `);
 };

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import RootProvider from '../components/RootProvider';
 import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
 import { theme } from '../theme/docsTheme';
+import useSnootyMetadata from '../utils/use-snooty-metadata';
 
 // TODO: Delete this as a part of the css cleanup
 // Currently used to preserve behavior and stop legacy css
@@ -81,17 +82,11 @@ const GlobalGrid = styled('div')`
   grid-template-rows: auto 1fr;
 `;
 
-const DefaultLayout = ({
-  children,
-  pageContext: {
-    metadata: { chapters, guides, publishedBranches, slugToTitle, title, toctree },
-    page,
-    slug,
-    repoBranches,
-    template,
-  },
-}) => {
+const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, template } }) => {
   const { sidenav } = getTemplate(template);
+
+  const { chapters, guides, publishedBranches, slugToTitle, title, toctree } = useSnootyMetadata();
+
   const pageTitle = React.useMemo(() => page?.options?.title || slugToTitle?.[slug === '/' ? 'index' : slug], [slug]); // eslint-disable-line react-hooks/exhaustive-deps
   useDelightedSurvey(slug);
 

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -9,6 +9,7 @@ import RightColumn from '../components/RightColumn';
 import TabSelectors from '../components/TabSelectors';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getNestedValue } from '../utils/get-nested-value';
+import useSnootyMetadata from '../utils/use-snooty-metadata';
 
 const DocumentContainer = styled('div')`
   display: grid;
@@ -26,15 +27,9 @@ const StyledRightColumn = styled(RightColumn)`
   grid-area: right;
 `;
 
-const Document = ({
-  children,
-  pageContext: {
-    slug,
-    page,
-    metadata: { parentPaths, slugToTitle: slugTitleMapping, title, toctreeOrder },
-  },
-}) => {
+const Document = ({ children, pageContext: { slug, page } }) => {
   const { project } = useSiteMetadata();
+  const { parentPaths, slugTitleMapping, title, toctreeOrder } = useSnootyMetadata();
   const pageOptions = page?.options;
   const showPrevNext = !(pageOptions?.noprevnext === '' || pageOptions?.template === 'guide');
   const isLanding = project === 'landing';
@@ -72,13 +67,7 @@ Document.propTypes = {
       children: PropTypes.array,
       options: PropTypes.object,
     }).isRequired,
-    parentPaths: PropTypes.object,
     slug: PropTypes.string.isRequired,
-    slugTitleMapping: PropTypes.shape({
-      [PropTypes.string]: PropTypes.string,
-    }),
-    toctree: PropTypes.object,
-    toctreeOrder: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/src/utils/use-snooty-metadata.js
+++ b/src/utils/use-snooty-metadata.js
@@ -1,0 +1,15 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+export default function useSnootyMetadata() {
+  const data = useStaticQuery(graphql`
+    query Metadata {
+      allSnootyMetadata {
+        nodes {
+          metadata
+        }
+      }
+    }
+  `);
+
+  return data.allSnootyMetadata.nodes[0].metadata;
+}


### PR DESCRIPTION
### Stories/Links:

DOP-2752

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

This shrinks `page-data.json` considerably; a typical size decrease is going from 1015K to 6K by making metadata lookups a StaticQuery.

As part of the process of using `useStaticQuery()`, I had to transform `DocumentBody` into a function component.