### PR TITLE
DOP-2819: Remove duplicate prefix from HTML Breadcrumbs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -85,7 +85,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
   products.forEach((product) => {
     // TODO: REMOVE AFTER DOP 2705
     let url = product.baseUrl + product.slug;
-    if (isDotCom()) url = dotcomifyUrl(url, true);
+    if (isDotCom()) url = dotcomifyUrl(url);
 
     createNode({
       children: [],

--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -77,7 +77,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
       return null;
     }
 
-    const hostName = getSiteUrl(product);
+    const hostName = getSiteUrl(product, true);
     return ['docs', 'mms', 'cloud-docs'].includes(product)
       ? `${hostName}/${version}`
       : `${hostName}/${product}/${version}`;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,7 @@ import { UnifiedNav } from '@mdb/consistent-nav';
 import { SidenavMobileMenuDropdown } from './Sidenav';
 import SiteBanner from './Banner/SiteBanner';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { isDotCom, DOTCOM_BASE_URL } from '../utils/dotcom';
+import { isDotCom, DOTCOM_BASE_URL, DOTCOM_BASE_PREFIX } from '../utils/dotcom';
 
 const StyledHeaderContainer = styled.header`
   grid-area: header;
@@ -26,7 +26,7 @@ const Header = ({ sidenav }) => {
   const shouldSearchRealm = project === 'realm' || searchProperty === 'realm-master';
   const unifiedNavProperty = shouldSearchRealm ? 'REALM' : 'DOCS';
 
-  const docsBaseUrl = isDotCom() ? `https://${DOTCOM_BASE_URL}` : null;
+  const docsBaseUrl = isDotCom() ? `https://${DOTCOM_BASE_URL}/${DOTCOM_BASE_PREFIX}` : null;
 
   return (
     <StyledHeaderContainer>

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,7 @@ const dotcomHandlingForREF_TARGETS = {
 // TODO: remove after dotcom go live and update hardcoded links.
 export const REF_TARGETS = Object.fromEntries(
   Object.entries(dotcomHandlingForREF_TARGETS).map(([key, value]) => {
-    if (isDotCom()) value = dotcomifyUrl(value, true);
+    if (isDotCom()) value = dotcomifyUrl(value);
     return [key, value];
   })
 );

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -2,16 +2,18 @@
 // Contents of this file are temporal regardless, and logic is somewhat universal regardless.
 const isBrowser = typeof window !== 'undefined';
 
-const DOTCOM_BASE_URL = 'www.mongodb.com/docs-qa';
+const DOTCOM_BASE_URL = 'www.mongodb.com';
+const DOTCOM_BASE_PREFIX = `docs-qa`;
 
 // Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
 // this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari
 // with relevant string split-slice-join logic turned into URL.pathname, and etc.
-const dotcomifyUrl = (url, needsProtocol = false) => {
+const dotcomifyUrl = (url, options = { needsProtocol: true, needsPrefix: true }) => {
+  const { needsProtocol, needsPrefix } = options;
   const decomposedUrl = url.split('.');
   const subdomainProduct = decomposedUrl[1] !== 'mongodb' ? decomposedUrl[1] : '';
   let pathname = url.split('.mongodb.com')[1];
-  let baseUrl = DOTCOM_BASE_URL;
+  let baseUrl = needsPrefix ? `${DOTCOM_BASE_URL}/${DOTCOM_BASE_PREFIX}` : `${DOTCOM_BASE_URL}`;
 
   if (needsProtocol) baseUrl = `https://${baseUrl}`;
   if (subdomainProduct) {
@@ -31,7 +33,7 @@ const isDotCom = () => {
 // and adding sensible defaults in the event the base variable is not present.
 const baseUrl = (needsProtocol = false) => {
   const url = (isBrowser && window.location.hostname) || 'docs.mongodb.com';
-  return isDotCom() ? dotcomifyUrl(url, needsProtocol) : `${needsProtocol ? 'https://' : ''}${url}`;
+  return isDotCom() ? dotcomifyUrl(url, { needsProtocol }) : `${needsProtocol ? 'https://' : ''}${url}`;
 };
 
-module.exports = { dotcomifyUrl, isDotCom, baseUrl, DOTCOM_BASE_URL };
+module.exports = { dotcomifyUrl, isDotCom, baseUrl, DOTCOM_BASE_URL, DOTCOM_BASE_PREFIX };

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -8,8 +8,8 @@ const DOTCOM_BASE_PREFIX = `docs-qa`;
 // Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
 // this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari
 // with relevant string split-slice-join logic turned into URL.pathname, and etc.
-const dotcomifyUrl = (url, options = { needsProtocol: true, needsPrefix: true }) => {
-  const { needsProtocol, needsPrefix } = options;
+const dotcomifyUrl = (url, options = {}) => {
+  const { needsProtocol = true, needsPrefix = true } = options;
   const decomposedUrl = url.split('.');
   const subdomainProduct = decomposedUrl[1] !== 'mongodb' ? decomposedUrl[1] : '';
   let pathname = url.split('.mongodb.com')[1];

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -16,7 +16,7 @@ const dotcomifyUrl = (url, options = {}) => {
   let baseUrl = needsPrefix ? `${DOTCOM_BASE_URL}/${DOTCOM_BASE_PREFIX}` : `${DOTCOM_BASE_URL}`;
 
   if (needsProtocol) baseUrl = `https://${baseUrl}`;
-  if (subdomainProduct) {
+  if (subdomainProduct && needsPrefix) {
     baseUrl = `${baseUrl}/${subdomainProduct}`;
   }
 

--- a/src/utils/get-site-url.js
+++ b/src/utils/get-site-url.js
@@ -12,7 +12,7 @@ const getSiteUrl = (project) => {
       break;
     default:
   }
-  return isDotCom() ? dotcomifyUrl(url, true) : url;
+  return isDotCom() ? dotcomifyUrl(url, { needsPrefix: false }) : url;
 };
 
 module.exports.getSiteUrl = getSiteUrl;

--- a/src/utils/get-site-url.js
+++ b/src/utils/get-site-url.js
@@ -1,7 +1,7 @@
 const { isDotCom, dotcomifyUrl } = require('./dotcom');
 
 // Given a project's `name`, return its base URL.
-const getSiteUrl = (project) => {
+const getSiteUrl = (project, needsPrefix = false) => {
   let url = 'https://docs.mongodb.com';
   switch (project) {
     case 'cloud-docs':
@@ -12,7 +12,7 @@ const getSiteUrl = (project) => {
       break;
     default:
   }
-  return isDotCom() ? dotcomifyUrl(url, { needsPrefix: false }) : url;
+  return isDotCom() ? dotcomifyUrl(url, { needsPrefix }) : url;
 };
 
 module.exports.getSiteUrl = getSiteUrl;

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -1,53 +1,59 @@
 import { dotcomifyUrl, isDotCom, baseUrl } from '../../../src/utils/dotcom';
 
 describe('dotcomifyUrl', () => {
-  it('by default does not return a url with protocols', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs-qa');
+  it('by default returns a url with protocols and prefix', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
   });
 
-  it('supports adding https:// protocol to url when given boolean flag', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com', true)).toBe('https://www.mongodb.com/docs-qa');
+  it('supports returning a url without the https:// protocol when options.needsProtocol is falsey', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com', { needsProtocol: false })).toBe('www.mongodb.com/docs-qa');
+  });
+
+  it('supports returning a url without a prefix when options.needsPrefix is falsey', () => {
+    expect(dotcomifyUrl('https://docs.mongodb.com', { needsPrefix: false })).toBe('https://www.mongodb.com');
   });
 
   it('supports both regular subdomain and product subdomain conversions', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs-qa');
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('www.mongodb.com/docs-qa/opsmanager');
-    expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('www.mongodb.com/docs-qa/atlas');
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/opsmanager');
+    expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/atlas');
   });
 
   it('supports conversions with pathname combinations, and handles `com` in pathname', () => {
     // single level subdomain
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('www.mongodb.com/docs-qa');
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
     expect(dotcomifyUrl('https://docs.mongodb.com/long-path/name/divided/by-many-paths')).toBe(
-      'www.mongodb.com/docs-qa/long-path/name/divided/by-many-paths'
+      'https://www.mongodb.com/docs-qa/long-path/name/divided/by-many-paths'
     );
-    expect(dotcomifyUrl('https://docs.mongodb.com/compound-indexes')).toBe('www.mongodb.com/docs-qa/compound-indexes');
+    expect(dotcomifyUrl('https://docs.mongodb.com/compound-indexes')).toBe(
+      'https://www.mongodb.com/docs-qa/compound-indexes'
+    );
 
     // product subdomains
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('www.mongodb.com/docs-qa/opsmanager');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/opsmanager');
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/this-is/a-long/pathname')).toBe(
-      'www.mongodb.com/docs-qa/opsmanager/this-is/a-long/pathname'
+      'https://www.mongodb.com/docs-qa/opsmanager/this-is/a-long/pathname'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/combine-results')).toBe(
-      'www.mongodb.com/docs-qa/opsmanager/combine-results'
+      'https://www.mongodb.com/docs-qa/opsmanager/combine-results'
     );
   });
 
   it('supports conversions with versions and aliases', () => {
     // single level subdomain
     expect(dotcomifyUrl('https://docs.mongodb.com/v1.2.3/compound-indexes')).toBe(
-      'www.mongodb.com/docs-qa/v1.2.3/compound-indexes'
+      'https://www.mongodb.com/docs-qa/v1.2.3/compound-indexes'
     );
     expect(dotcomifyUrl('https://docs.mongodb.com/upcoming/compound-indexes')).toBe(
-      'www.mongodb.com/docs-qa/upcoming/compound-indexes'
+      'https://www.mongodb.com/docs-qa/upcoming/compound-indexes'
     );
 
     // product subdomains
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/upcoming/compound-indexes')).toBe(
-      'www.mongodb.com/docs-qa/opsmanager/upcoming/compound-indexes'
+      'https://www.mongodb.com/docs-qa/opsmanager/upcoming/compound-indexes'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/v1.5/compound-indexes')).toBe(
-      'www.mongodb.com/docs-qa/opsmanager/v1.5/compound-indexes'
+      'https://www.mongodb.com/docs-qa/opsmanager/v1.5/compound-indexes'
     );
   });
 });

--- a/tests/unit/utils/get-site-url.test.js
+++ b/tests/unit/utils/get-site-url.test.js
@@ -1,0 +1,60 @@
+import { getSiteUrl } from '../../../src/utils/get-site-url';
+
+describe('getSiteUrl', () => {
+  it('returns docs.mongodb.com by default on docs. properties regardless of needsPrefix', () => {
+    process.env = {};
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'docs.mongodb.com',
+      },
+      writable: true,
+    });
+
+    expect(getSiteUrl('manual')).toBe('https://docs.mongodb.com');
+    expect(getSiteUrl('manual', false)).toBe('https://docs.mongodb.com');
+  });
+
+  it('returns subdomained projects for mms and cloud on docs. properties regardless of needsPrefix', () => {
+    process.env = {};
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'docs.mongodb.com',
+      },
+      writable: true,
+    });
+
+    expect(getSiteUrl('mms')).toBe('https://docs.opsmanager.mongodb.com');
+    expect(getSiteUrl('cloud-docs')).toBe('https://docs.atlas.mongodb.com');
+
+    expect(getSiteUrl('mms', false)).toBe('https://docs.opsmanager.mongodb.com');
+    expect(getSiteUrl('cloud-docs', false)).toBe('https://docs.atlas.mongodb.com');
+  });
+
+  it('returns only the base name for all www. properties by default', () => {
+    process.env = {};
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'www.mongodb.com',
+      },
+      writable: true,
+    });
+
+    expect(getSiteUrl('manual')).toBe('https://www.mongodb.com');
+    expect(getSiteUrl('mms')).toBe('https://www.mongodb.com');
+    expect(getSiteUrl('cloud-docs')).toBe('https://www.mongodb.com');
+  });
+
+  it('returns the prefix for all www. properties when needsPrefix is true, including project for mms and cloud', () => {
+    process.env = {};
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'www.mongodb.com',
+      },
+      writable: true,
+    });
+
+    expect(getSiteUrl('manual', true)).toBe('https://www.mongodb.com/docs-qa');
+    expect(getSiteUrl('mms', true)).toBe('https://www.mongodb.com/docs-qa/opsmanager');
+    expect(getSiteUrl('cloud-docs', true)).toBe('https://www.mongodb.com/docs-qa/atlas');
+  });
+});


### PR DESCRIPTION
### Stories/Links:

DOP-2819

### Staging Links:

_Put a link to your staging environment(s), if applicable_

**Nested Breadcrumbs (Cloud)**
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/cassidy.schaufele/DOP-2819/choose-database-deployment-type/

**Legacy Selector (Landing)**
https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2819/legacy/

**Nested Breadcrumbs (Manual, dotcom, built via autobuilder)**
https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/upcoming/reference/insert-methods/

### Notes:

#### The Context
In environments higher than staging, the autobuilder prepends `docs-qa` as a prefix - this is causing our html breadcrumbs to have a duplicate `/docs-qa` in urls past the base breadcrumb.

This is also causing a discrepancy between canonicals at build time vs. at Gatsby hydration time - Google uses the canonical at build time, not at hydration, so canonicals are also broken in the same pattern.

#### The Complications

Responsibility is currently a little tangled - we utilize our dotcomify util for both build time and runtime changes, and it contains logic for handling prefix + product. However, we also have logic at build time and runtime for handling prefix + product in 
some codepaths using `getSiteURL` , which is why we're observing this duplicate prefix behavior. 

I've taken extra care around the legacy version selector, which uses `getSiteURL` but *does not* attach logic for handling prefixes.

#### The Changes

1.  A refactor to our existing logic to support toggling a prefix. This also changes the function signature from multiple args with defaults to an `options` argument as an object. 
2. A refactor to getSiteURL, allowing us to passthrough an argument for toggling prefix append logic. **This allows us to disable prefix append behavior for only our dotcom instances, and selectively based on each getSiteURL invocation.**
3. Changed default behavior on the protocol toggle. All invocations were passing true for the toggle, so changing the default value to true seems to make the most sense here.
4. Split our DOTCOM_BASE_PREFIX from our DOTCOM_BASE_URL, for finer granularity options
5. Added an additional test suite for our getSiteURL logic. It's approaching complexity where having a test suite for asserting behavior and establishing context is rapidly necessary.