### PR TITLE
DOP-2807: Get rid of -qa

### DIFF
--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -3,7 +3,7 @@
 const isBrowser = typeof window !== 'undefined';
 
 const DOTCOM_BASE_URL = 'www.mongodb.com';
-const DOTCOM_BASE_PREFIX = `docs-qa`;
+const DOTCOM_BASE_PREFIX = `docs`;
 
 // Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
 // this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -2,11 +2,11 @@ import { dotcomifyUrl, isDotCom, baseUrl } from '../../../src/utils/dotcom';
 
 describe('dotcomifyUrl', () => {
   it('by default returns a url with protocols and prefix', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs');
   });
 
   it('supports returning a url without the https:// protocol when options.needsProtocol is falsey', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com', { needsProtocol: false })).toBe('www.mongodb.com/docs-qa');
+    expect(dotcomifyUrl('https://docs.mongodb.com', { needsProtocol: false })).toBe('www.mongodb.com/docs');
   });
 
   it('supports returning a url without a prefix when options.needsPrefix is falsey', () => {
@@ -14,46 +14,46 @@ describe('dotcomifyUrl', () => {
   });
 
   it('supports both regular subdomain and product subdomain conversions', () => {
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/opsmanager');
-    expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/atlas');
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/opsmanager');
+    expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('https://www.mongodb.com/docs/atlas');
   });
 
   it('supports conversions with pathname combinations, and handles `com` in pathname', () => {
     // single level subdomain
-    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs-qa');
+    expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs');
     expect(dotcomifyUrl('https://docs.mongodb.com/long-path/name/divided/by-many-paths')).toBe(
-      'https://www.mongodb.com/docs-qa/long-path/name/divided/by-many-paths'
+      'https://www.mongodb.com/docs/long-path/name/divided/by-many-paths'
     );
     expect(dotcomifyUrl('https://docs.mongodb.com/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs-qa/compound-indexes'
+      'https://www.mongodb.com/docs/compound-indexes'
     );
 
     // product subdomains
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs-qa/opsmanager');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/opsmanager');
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/this-is/a-long/pathname')).toBe(
-      'https://www.mongodb.com/docs-qa/opsmanager/this-is/a-long/pathname'
+      'https://www.mongodb.com/docs/opsmanager/this-is/a-long/pathname'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/combine-results')).toBe(
-      'https://www.mongodb.com/docs-qa/opsmanager/combine-results'
+      'https://www.mongodb.com/docs/opsmanager/combine-results'
     );
   });
 
   it('supports conversions with versions and aliases', () => {
     // single level subdomain
     expect(dotcomifyUrl('https://docs.mongodb.com/v1.2.3/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs-qa/v1.2.3/compound-indexes'
+      'https://www.mongodb.com/docs/v1.2.3/compound-indexes'
     );
     expect(dotcomifyUrl('https://docs.mongodb.com/upcoming/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs-qa/upcoming/compound-indexes'
+      'https://www.mongodb.com/docs/upcoming/compound-indexes'
     );
 
     // product subdomains
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/upcoming/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs-qa/opsmanager/upcoming/compound-indexes'
+      'https://www.mongodb.com/docs/opsmanager/upcoming/compound-indexes'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/v1.5/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs-qa/opsmanager/v1.5/compound-indexes'
+      'https://www.mongodb.com/docs/opsmanager/v1.5/compound-indexes'
     );
   });
 });
@@ -103,7 +103,7 @@ describe('baseUrl', () => {
         writeable: true,
       });
 
-      expect(baseUrl()).toBe('www.mongodb.com/docs-qa');
+      expect(baseUrl()).toBe('www.mongodb.com/docs');
 
       Object.defineProperty(window, 'location', {
         value: {

--- a/tests/unit/utils/get-site-url.test.js
+++ b/tests/unit/utils/get-site-url.test.js
@@ -53,8 +53,8 @@ describe('getSiteUrl', () => {
       writable: true,
     });
 
-    expect(getSiteUrl('manual', true)).toBe('https://www.mongodb.com/docs-qa');
-    expect(getSiteUrl('mms', true)).toBe('https://www.mongodb.com/docs-qa/opsmanager');
-    expect(getSiteUrl('cloud-docs', true)).toBe('https://www.mongodb.com/docs-qa/atlas');
+    expect(getSiteUrl('manual', true)).toBe('https://www.mongodb.com/docs');
+    expect(getSiteUrl('mms', true)).toBe('https://www.mongodb.com/docs/opsmanager');
+    expect(getSiteUrl('cloud-docs', true)).toBe('https://www.mongodb.com/docs/atlas');
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-2807

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_
*In Progress*


### Staging Links:

_Put a link to your staging environment(s), if applicable_
*In Progress*

### Notes:
Switches our prefix to `docs` from `docs-qa`.
This doesn't apply to path prefixes provided via `.env`.