### PR TITLE
DOP-2807: Map opsmanager to ops-manager in paths

### DIFF
--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -5,6 +5,14 @@ const isBrowser = typeof window !== 'undefined';
 const DOTCOM_BASE_URL = 'www.mongodb.com';
 const DOTCOM_BASE_PREFIX = `docs`;
 
+// Used for any product mappings that won't match prefix pathing 1:1
+const productToPrefixMapping = (product) => {
+  const mapping = {
+    opsmanager: 'ops-manager',
+  };
+  return mapping[product] ? mapping[product] : product;
+};
+
 // Used to convert a 'docs.mongodb.com' or 'docs.<product>.mongodb.com' url to the new dotcom format
 // this *should* be removed post consolidation, or alternatively, made to use `new URL(url)` and polyfilled for safari
 // with relevant string split-slice-join logic turned into URL.pathname, and etc.
@@ -17,7 +25,7 @@ const dotcomifyUrl = (url, options = {}) => {
 
   if (needsProtocol) baseUrl = `https://${baseUrl}`;
   if (subdomainProduct && needsPrefix) {
-    baseUrl = `${baseUrl}/${subdomainProduct}`;
+    baseUrl = `${baseUrl}/${productToPrefixMapping(subdomainProduct)}`;
   }
 
   pathname = pathname.split('/').slice(1).join('/');

--- a/src/utils/dotcom.js
+++ b/src/utils/dotcom.js
@@ -9,6 +9,7 @@ const DOTCOM_BASE_PREFIX = `docs`;
 const productToPrefixMapping = (product) => {
   const mapping = {
     opsmanager: 'ops-manager',
+    cloudmanager: 'cloud-manager',
   };
   return mapping[product] ? mapping[product] : product;
 };

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -15,8 +15,12 @@ describe('dotcomifyUrl', () => {
 
   it('supports both regular subdomain and product subdomain conversions', () => {
     expect(dotcomifyUrl('https://docs.mongodb.com')).toBe('https://www.mongodb.com/docs');
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/opsmanager');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/ops-manager');
     expect(dotcomifyUrl('https://docs.atlas.mongodb.com')).toBe('https://www.mongodb.com/docs/atlas');
+  });
+
+  it('supports mapping products to prefixes in special cases, ala opsmanager -> ops-manager ', () => {
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/ops-manager');
   });
 
   it('supports conversions with pathname combinations, and handles `com` in pathname', () => {
@@ -30,12 +34,12 @@ describe('dotcomifyUrl', () => {
     );
 
     // product subdomains
-    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/opsmanager');
+    expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/ops-manager');
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/this-is/a-long/pathname')).toBe(
-      'https://www.mongodb.com/docs/opsmanager/this-is/a-long/pathname'
+      'https://www.mongodb.com/docs/ops-manager/this-is/a-long/pathname'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/combine-results')).toBe(
-      'https://www.mongodb.com/docs/opsmanager/combine-results'
+      'https://www.mongodb.com/docs/ops-manager/combine-results'
     );
   });
 
@@ -50,10 +54,10 @@ describe('dotcomifyUrl', () => {
 
     // product subdomains
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/upcoming/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs/opsmanager/upcoming/compound-indexes'
+      'https://www.mongodb.com/docs/ops-manager/upcoming/compound-indexes'
     );
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com/v1.5/compound-indexes')).toBe(
-      'https://www.mongodb.com/docs/opsmanager/v1.5/compound-indexes'
+      'https://www.mongodb.com/docs/ops-manager/v1.5/compound-indexes'
     );
   });
 });

--- a/tests/unit/utils/dotcom.test.js
+++ b/tests/unit/utils/dotcom.test.js
@@ -21,6 +21,7 @@ describe('dotcomifyUrl', () => {
 
   it('supports mapping products to prefixes in special cases, ala opsmanager -> ops-manager ', () => {
     expect(dotcomifyUrl('https://docs.opsmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/ops-manager');
+    expect(dotcomifyUrl('https://docs.cloudmanager.mongodb.com')).toBe('https://www.mongodb.com/docs/cloud-manager');
   });
 
   it('supports conversions with pathname combinations, and handles `com` in pathname', () => {

--- a/tests/unit/utils/get-site-url.test.js
+++ b/tests/unit/utils/get-site-url.test.js
@@ -54,7 +54,7 @@ describe('getSiteUrl', () => {
     });
 
     expect(getSiteUrl('manual', true)).toBe('https://www.mongodb.com/docs');
-    expect(getSiteUrl('mms', true)).toBe('https://www.mongodb.com/docs/opsmanager');
+    expect(getSiteUrl('mms', true)).toBe('https://www.mongodb.com/docs/ops-manager');
     expect(getSiteUrl('cloud-docs', true)).toBe('https://www.mongodb.com/docs/atlas');
   });
 });


### PR DESCRIPTION
### Stories/Links:

Fix to resolve behavior flagged in: https://github.com/mongodb/snooty/pull/583

### Staging Links:

Non desk-testable right now, sadly - dotcom domain is not applicable in staging links.
Behavior is relatively assured via unit tests, however.

### Notes:
see https://github.com/mongodb/snooty/pull/583 for context