### PR TITLE
hotfix-add-dotcom-repos-database-case

### DIFF
--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -29,6 +29,10 @@ const getReposDatabase = (env) => {
       return 'pool_test';
     case 'production':
       return 'pool';
+    case 'dotcomstg':
+      return 'pool_test';
+    case 'dotcomprd':
+      return 'pool';
     default:
       return 'pool_test';
   }


### PR DESCRIPTION
### Current Behavior:

[Mongo CLI, Data sourcing from pool_test](https://www.mongodb.com/docs/mongocli/v1.24/)


### Notes:

Adds cases to site-metdata to prevent our switch to defaulting to `pool_test` in `dotcomprd` environments