### PR TITLE
DOP-2183: Fix styling issue with padding differences between table header and cell

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -55,6 +55,7 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
 
             * {
               font-size: ${theme.fontSize.small} !important;
+              align-items: start;
             }
 
             & > div > span > * {

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -126,6 +126,10 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 
 .emotion-22 * {
   font-size: 14px !important;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
 }
 
 .emotion-22 > div > span > * {
@@ -611,6 +615,10 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 
 .emotion-21 * {
   font-size: 14px !important;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
 }
 
 .emotion-21 > div > span > * {
@@ -637,6 +645,10 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 
 .emotion-23 * {
   font-size: 14px !important;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
 }
 
 .emotion-23 > div > span > * {


### PR DESCRIPTION
### Stories/Links:

[DOP-2183](https://jira.mongodb.org/browse/DOP-2183)

### Current Behavior:

[Atlas Docs in Prod](https://www.mongodb.com/docs/atlas/reference/api/database-users-update-a-user/#request-body-parameters)

### Staging Links:

[Atlas Staging ](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2183/reference/api/database-users-update-a-user/#request-body-parameters)

### Notes:
