### PR TITLE
DOP-2602: Add option for external links to open in a new tab/window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34650,7 +34650,8 @@
     "@emotion/eslint-plugin": {
       "version": "11.7.0",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/eslint-plugin/-/eslint-plugin-11.7.0.tgz",
-      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM="
+      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM=",
+      "requires": {}
     },
     "@emotion/hash": {
       "version": "0.8.0",
@@ -35180,7 +35181,8 @@
         "ws": {
           "version": "7.4.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+          "requires": {}
         }
       }
     },
@@ -37104,7 +37106,8 @@
     "@redocly/react-dropdown-aria": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@redocly/react-dropdown-aria/-/react-dropdown-aria-2.0.11.tgz",
-      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A=="
+      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==",
+      "requires": {}
     },
     "@sideway/address": {
       "version": "4.1.0",
@@ -38474,7 +38477,8 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -38515,12 +38519,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -38970,7 +38976,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -39336,7 +39343,8 @@
     "babel-plugin-remove-graphql-queries": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.13.0.tgz",
-      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ=="
+      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ==",
+      "requires": {}
     },
     "babel-plugin-styled-components": {
       "version": "1.12.0",
@@ -42696,7 +42704,8 @@
     "eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
+      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -44824,7 +44833,8 @@
         "graphql-type-json": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
+          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
+          "requires": {}
         }
       }
     },
@@ -44881,7 +44891,8 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+      "requires": {}
     },
     "graphql-upload": {
       "version": "11.0.0",
@@ -44922,7 +44933,8 @@
     "graphql-ws": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-3.1.0.tgz",
-      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg=="
+      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg==",
+      "requires": {}
     },
     "growly": {
       "version": "1.3.0",
@@ -46464,7 +46476,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -47586,7 +47599,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -49889,7 +49903,8 @@
     "mobx-react-lite": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz",
-      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g=="
+      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==",
+      "requires": {}
     },
     "moment": {
       "version": "2.29.1",
@@ -52546,7 +52561,8 @@
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
-      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==",
+      "requires": {}
     },
     "react-tabs": {
       "version": "3.1.2",
@@ -57565,7 +57581,8 @@
     "ws": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -2,11 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link as GatsbyLink } from 'gatsby';
 import { Link as LGLink } from '@leafygreen-ui/typography';
+import { cx, css } from '@leafygreen-ui/emotion';
 
 /*
  * Note: This component is not suitable for internal page navigation:
  * https://www.gatsbyjs.org/docs/gatsby-link/#recommendations-for-programmatic-in-app-navigation
  */
+
+const LGlinkStyling = css`
+  text-decoration: none !important;
+`;
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,
 // destructure the prop here and pass it only to GatsbyLink.
@@ -28,8 +33,15 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
         {children}
       </GatsbyLink>
     );
-  } else if (!anchor && !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/))) {
-    return <LGLink href={to}>{children}</LGLink>;
+  } else if (
+    !anchor &&
+    !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/) || to.match(/localhost/))
+  ) {
+    return (
+      <LGLink className={cx(LGlinkStyling)} href={to}>
+        {children}
+      </LGLink>
+    );
   }
   return (
     <a href={to} {...other}>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link as GatsbyLink } from 'gatsby';
+import { Link as LGLink } from '@leafygreen-ui/typography';
 
 /*
  * Note: This component is not suitable for internal page navigation:
@@ -27,6 +28,8 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
         {children}
       </GatsbyLink>
     );
+  } else if (!anchor && !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/))) {
+    return <LGLink href={to}>{children}</LGLink>;
   }
   return (
     <a href={to} {...other}>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -33,10 +33,7 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
         {children}
       </GatsbyLink>
     );
-  } else if (
-    !anchor &&
-    !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/) || to.match(/localhost/))
-  ) {
+  } else if (!anchor && !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/))) {
     return (
       <LGLink className={cx(LGlinkStyling)} href={to}>
         {children}

--- a/tests/unit/Link.test.js
+++ b/tests/unit/Link.test.js
@@ -13,25 +13,25 @@ describe('Link component renders a variety of strings correctly', () => {
   it('external URL', () => {
     const tree = setup({ to: 'http://mongodb.com', text: 'MongoDB Company' });
     expect(tree.asFragment()).toMatchSnapshot();
-    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
+    expect(tree.getByRole('link')).toHaveAttribute('data-leafygreen-ui', 'anchor-container');
   });
 
   it('external MDB docs URL', () => {
     const tree = setup({ to: 'https://www.mongodb.com/docs/atlas/', text: 'MongoDB Atlas Docs' });
     expect(tree.asFragment()).toMatchSnapshot();
-    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(0);
+    expect(tree.getByRole('link')).not.toHaveAttribute('data-leafygreen-ui', 'anchor-container');
   });
 
   it('external MDB non-docs URL', () => {
     const tree = setup({ to: 'https://account.mongodb.com/account/', text: 'MongoDB Atlas Registration Page' });
     expect(tree.asFragment()).toMatchSnapshot();
-    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
+    expect(tree.getByRole('link')).toHaveAttribute('data-leafygreen-ui', 'anchor-container');
   });
 
   it('external non-MDB docs URL', () => {
     const tree = setup({ to: 'https://safety.google/authentication/', text: 'Google 2-Step Verification' });
     expect(tree.asFragment()).toMatchSnapshot();
-    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
+    expect(tree.getByRole('link')).toHaveAttribute('data-leafygreen-ui', 'anchor-container');
   });
 
   it('internal link', () => {

--- a/tests/unit/Link.test.js
+++ b/tests/unit/Link.test.js
@@ -13,6 +13,25 @@ describe('Link component renders a variety of strings correctly', () => {
   it('external URL', () => {
     const tree = setup({ to: 'http://mongodb.com', text: 'MongoDB Company' });
     expect(tree.asFragment()).toMatchSnapshot();
+    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
+  });
+
+  it('external MDB docs URL', () => {
+    const tree = setup({ to: 'https://www.mongodb.com/docs/atlas/', text: 'MongoDB Atlas Docs' });
+    expect(tree.asFragment()).toMatchSnapshot();
+    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(0);
+  });
+
+  it('external MDB non-docs URL', () => {
+    const tree = setup({ to: 'https://account.mongodb.com/account/', text: 'MongoDB Atlas Registration Page' });
+    expect(tree.asFragment()).toMatchSnapshot();
+    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
+  });
+
+  it('external non-MDB docs URL', () => {
+    const tree = setup({ to: 'https://safety.google/authentication/', text: 'Google 2-Step Verification' });
+    expect(tree.asFragment()).toMatchSnapshot();
+    expect(tree.container.getElementsByClassName('leafygreen-ui-16bw3aj').length).toBe(1);
   });
 
   it('internal link', () => {

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -2,7 +2,56 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  <blockquote>
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<blockquote>
     <p>
       There are several ways to connect to your MongoDB instance.
     </p>
@@ -14,12 +63,34 @@ exports[`renders correctly 1`] = `
          interactive shell
       </li>
       <li>
-        <a
-          class="reference external"
-          href=""
+        <span
+          class="emotion-2"
+          data-leafygreen-ui="anchor-container"
         >
-          programmatic access
-        </a>
+          <span
+            class="emotion-0"
+          >
+            programmatic access
+          </span>
+          <svg
+            alt=""
+            aria-hidden="true"
+            class="emotion-1"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+              fill="currentColor"
+            />
+            <path
+              d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
         
 through a number of programming APIs.
       </li>

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -3,6 +3,11 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23,39 +28,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-1 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-2 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -78,18 +83,18 @@ exports[`renders correctly 1`] = `
       </li>
       <li>
         <span
-          class="emotion-0"
+          class="emotion-0 emotion-1"
           data-leafygreen-ui="anchor-container"
         >
           <span
-            class="emotion-1"
+            class="emotion-2"
           >
             programmatic access
           </span>
           <svg
             alt=""
             aria-hidden="true"
-            class="emotion-2"
+            class="emotion-3"
             height="16"
             role="presentation"
             viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -3,20 +3,6 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -37,11 +23,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -64,18 +78,18 @@ exports[`renders correctly 1`] = `
       </li>
       <li>
         <span
-          class="emotion-2"
+          class="emotion-0"
           data-leafygreen-ui="anchor-container"
         >
           <span
-            class="emotion-0"
+            class="emotion-1"
           >
             programmatic access
           </span>
           <svg
             alt=""
             aria-hidden="true"
-            class="emotion-1"
+            class="emotion-2"
             height="16"
             role="presentation"
             viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -3,6 +3,45 @@
 exports[`renders correctly with pageTitle 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-6 {
   font-size: 14px;
   margin-bottom: 24px;
 }
@@ -16,18 +55,18 @@ exports[`renders correctly with pageTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2:last-of-type {
+.emotion-4:last-of-type {
   color: #21313C;
 }
 
-.emotion-2:hover,
-.emotion-2:focus {
+.emotion-4:hover,
+.emotion-4:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:hover:not(:last-of-type),
-.emotion-2:focus:not(:last-of-type) {
+.emotion-4:hover:not(:last-of-type),
+.emotion-4:focus:not(:last-of-type) {
   color: #21313C;
 }
 
@@ -44,10 +83,16 @@ exports[`renders correctly with pageTitle 1`] = `
   >
     <p>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-1"
+        data-leafygreen-ui="anchor-container"
         href="https://localhost/"
+        target="_self"
       >
-        Docs Home
+        <span
+          class="emotion-0"
+        >
+          Docs Home
+        </span>
       </a>
       <span
         class="emotion-4 emotion-5"
@@ -55,7 +100,7 @@ exports[`renders correctly with pageTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-4 emotion-5"
         href="/view-analyze/"
       >
         View & Analyze Data
@@ -68,6 +113,45 @@ exports[`renders correctly with pageTitle 1`] = `
 exports[`renders correctly with siteTitle 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-6 {
   font-size: 14px;
   margin-bottom: 24px;
 }
@@ -81,18 +165,18 @@ exports[`renders correctly with siteTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2:last-of-type {
+.emotion-4:last-of-type {
   color: #21313C;
 }
 
-.emotion-2:hover,
-.emotion-2:focus {
+.emotion-4:hover,
+.emotion-4:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:hover:not(:last-of-type),
-.emotion-2:focus:not(:last-of-type) {
+.emotion-4:hover:not(:last-of-type),
+.emotion-4:focus:not(:last-of-type) {
   color: #21313C;
 }
 
@@ -109,10 +193,16 @@ exports[`renders correctly with siteTitle 1`] = `
   >
     <p>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-1"
+        data-leafygreen-ui="anchor-container"
         href="https://localhost/"
+        target="_self"
       >
-        Docs Home
+        <span
+          class="emotion-0"
+        >
+          Docs Home
+        </span>
       </a>
       <span
         class="emotion-4 emotion-5"
@@ -120,7 +210,7 @@ exports[`renders correctly with siteTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-4 emotion-5"
         href="/"
       >
         MongoDB Compass

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -3,20 +3,20 @@
 exports[`renders correctly with pageTitle 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
+  font-size: 14px;
+  margin-bottom: 24px;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+.emotion-0 * {
+  color: #5D6C74;
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+.emotion-0>p {
+  margin-top: 0;
+  min-height: 24px;
 }
 
-.emotion-1 {
+.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -37,37 +37,36 @@ exports[`renders correctly with pageTitle 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-1:focus {
+.emotion-2:focus {
   outline: none;
 }
 
-.emotion-6 {
-  font-size: 14px;
-  margin-bottom: 24px;
+.emotion-3 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-0 * {
-  color: #5D6C74;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-0>p {
-  margin-top: 0;
-  min-height: 24px;
+[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-4:last-of-type {
-  color: #21313C;
+.emotion-3 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-4:hover,
-.emotion-4:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-4:hover:not(:last-of-type),
-.emotion-4:focus:not(:last-of-type) {
-  color: #21313C;
+[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-4 {
@@ -78,18 +77,33 @@ exports[`renders correctly with pageTitle 1`] = `
   color: #21313C;
 }
 
+.emotion-6:last-of-type {
+  color: #21313C;
+}
+
+.emotion-6:hover,
+.emotion-6:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-6:hover:not(:last-of-type),
+.emotion-6:focus:not(:last-of-type) {
+  color: #21313C;
+}
+
 <nav
     class="emotion-0 emotion-1"
   >
     <p>
       <a
-        class="emotion-1"
+        class="emotion-2"
         data-leafygreen-ui="anchor-container"
         href="https://localhost/"
         target="_self"
       >
         <span
-          class="emotion-0"
+          class="emotion-3"
         >
           Docs Home
         </span>
@@ -100,7 +114,7 @@ exports[`renders correctly with pageTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         href="/view-analyze/"
       >
         View & Analyze Data
@@ -113,20 +127,20 @@ exports[`renders correctly with pageTitle 1`] = `
 exports[`renders correctly with siteTitle 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
+  font-size: 14px;
+  margin-bottom: 24px;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+.emotion-0 * {
+  color: #5D6C74;
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+.emotion-0>p {
+  margin-top: 0;
+  min-height: 24px;
 }
 
-.emotion-1 {
+.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -147,37 +161,36 @@ exports[`renders correctly with siteTitle 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-1:focus {
+.emotion-2:focus {
   outline: none;
 }
 
-.emotion-6 {
-  font-size: 14px;
-  margin-bottom: 24px;
+.emotion-3 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-0 * {
-  color: #5D6C74;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-0>p {
-  margin-top: 0;
-  min-height: 24px;
+[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-4:last-of-type {
-  color: #21313C;
+.emotion-3 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-4:hover,
-.emotion-4:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-4:hover:not(:last-of-type),
-.emotion-4:focus:not(:last-of-type) {
-  color: #21313C;
+[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-4 {
@@ -188,18 +201,33 @@ exports[`renders correctly with siteTitle 1`] = `
   color: #21313C;
 }
 
+.emotion-6:last-of-type {
+  color: #21313C;
+}
+
+.emotion-6:hover,
+.emotion-6:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-6:hover:not(:last-of-type),
+.emotion-6:focus:not(:last-of-type) {
+  color: #21313C;
+}
+
 <nav
     class="emotion-0 emotion-1"
   >
     <p>
       <a
-        class="emotion-1"
+        class="emotion-2"
         data-leafygreen-ui="anchor-container"
         href="https://localhost/"
         target="_self"
       >
         <span
-          class="emotion-0"
+          class="emotion-3"
         >
           Docs Home
         </span>
@@ -210,7 +238,7 @@ exports[`renders correctly with siteTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-4 emotion-5"
+        class="emotion-6 emotion-7"
         href="/"
       >
         MongoDB Compass

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -16,57 +16,19 @@ exports[`renders correctly with pageTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.emotion-2:last-of-type {
+  color: #21313C;
+}
+
+.emotion-2:hover,
+.emotion-2:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
 }
 
-.emotion-2:focus {
-  outline: none;
-}
-
-.emotion-3 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-3 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+.emotion-2:hover:not(:last-of-type),
+.emotion-2:focus:not(:last-of-type) {
+  color: #21313C;
 }
 
 .emotion-4 {
@@ -77,36 +39,15 @@ exports[`renders correctly with pageTitle 1`] = `
   color: #21313C;
 }
 
-.emotion-6:last-of-type {
-  color: #21313C;
-}
-
-.emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-6:hover:not(:last-of-type),
-.emotion-6:focus:not(:last-of-type) {
-  color: #21313C;
-}
-
 <nav
     class="emotion-0 emotion-1"
   >
     <p>
       <a
-        class="emotion-2"
-        data-leafygreen-ui="anchor-container"
+        class="emotion-2 emotion-3"
         href="https://localhost/"
-        target="_self"
       >
-        <span
-          class="emotion-3"
-        >
-          Docs Home
-        </span>
+        Docs Home
       </a>
       <span
         class="emotion-4 emotion-5"
@@ -114,7 +55,7 @@ exports[`renders correctly with pageTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-6 emotion-7"
+        class="emotion-2 emotion-3"
         href="/view-analyze/"
       >
         View & Analyze Data
@@ -140,57 +81,19 @@ exports[`renders correctly with siteTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.emotion-2:last-of-type {
+  color: #21313C;
+}
+
+.emotion-2:hover,
+.emotion-2:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
 }
 
-.emotion-2:focus {
-  outline: none;
-}
-
-.emotion-3 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-3 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-3 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-3 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+.emotion-2:hover:not(:last-of-type),
+.emotion-2:focus:not(:last-of-type) {
+  color: #21313C;
 }
 
 .emotion-4 {
@@ -201,36 +104,15 @@ exports[`renders correctly with siteTitle 1`] = `
   color: #21313C;
 }
 
-.emotion-6:last-of-type {
-  color: #21313C;
-}
-
-.emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-6:hover:not(:last-of-type),
-.emotion-6:focus:not(:last-of-type) {
-  color: #21313C;
-}
-
 <nav
     class="emotion-0 emotion-1"
   >
     <p>
       <a
-        class="emotion-2"
-        data-leafygreen-ui="anchor-container"
+        class="emotion-2 emotion-3"
         href="https://localhost/"
-        target="_self"
       >
-        <span
-          class="emotion-3"
-        >
-          Docs Home
-        </span>
+        Docs Home
       </a>
       <span
         class="emotion-4 emotion-5"
@@ -238,7 +120,7 @@ exports[`renders correctly with siteTitle 1`] = `
          → 
       </span>
       <a
-        class="emotion-6 emotion-7"
+        class="emotion-2 emotion-3"
         href="/"
       >
         MongoDB Compass

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -16,26 +16,84 @@ exports[`renders correctly with pageTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2:last-of-type {
+.emotion-2 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-3:focus {
+  outline: none;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-5 {
+  cursor: default;
+}
+
+.emotion-5:last-of-type {
   color: #21313C;
 }
 
-.emotion-2:hover,
-.emotion-2:focus {
+.emotion-7:last-of-type {
+  color: #21313C;
+}
+
+.emotion-7:hover,
+.emotion-7:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:hover:not(:last-of-type),
-.emotion-2:focus:not(:last-of-type) {
-  color: #21313C;
-}
-
-.emotion-4 {
-  cursor: default;
-}
-
-.emotion-4:last-of-type {
+.emotion-7:hover:not(:last-of-type),
+.emotion-7:focus:not(:last-of-type) {
   color: #21313C;
 }
 
@@ -45,17 +103,23 @@ exports[`renders correctly with pageTitle 1`] = `
     <p>
       <a
         class="emotion-2 emotion-3"
+        data-leafygreen-ui="anchor-container"
         href="https://localhost/"
+        target="_self"
       >
-        Docs Home
+        <span
+          class="emotion-4"
+        >
+          Docs Home
+        </span>
       </a>
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-5 emotion-6"
       >
          → 
       </span>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-7 emotion-8"
         href="/view-analyze/"
       >
         View & Analyze Data
@@ -81,26 +145,84 @@ exports[`renders correctly with siteTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2:last-of-type {
+.emotion-2 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-3:focus {
+  outline: none;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-5 {
+  cursor: default;
+}
+
+.emotion-5:last-of-type {
   color: #21313C;
 }
 
-.emotion-2:hover,
-.emotion-2:focus {
+.emotion-7:last-of-type {
+  color: #21313C;
+}
+
+.emotion-7:hover,
+.emotion-7:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:hover:not(:last-of-type),
-.emotion-2:focus:not(:last-of-type) {
-  color: #21313C;
-}
-
-.emotion-4 {
-  cursor: default;
-}
-
-.emotion-4:last-of-type {
+.emotion-7:hover:not(:last-of-type),
+.emotion-7:focus:not(:last-of-type) {
   color: #21313C;
 }
 
@@ -110,17 +232,23 @@ exports[`renders correctly with siteTitle 1`] = `
     <p>
       <a
         class="emotion-2 emotion-3"
+        data-leafygreen-ui="anchor-container"
         href="https://localhost/"
+        target="_self"
       >
-        Docs Home
+        <span
+          class="emotion-4"
+        >
+          Docs Home
+        </span>
       </a>
       <span
-        class="emotion-4 emotion-5"
+        class="emotion-5 emotion-6"
       >
          → 
       </span>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-7 emotion-8"
         href="/"
       >
         MongoDB Compass

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -12,6 +12,68 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-6:focus {
+  outline: none;
+}
+
+.emotion-5 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-2 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
+.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -26,19 +88,19 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-0>div>div>* {
+.emotion-7 > div > div > * {
   margin: 0 0 12px;
 }
 
-.emotion-0>div>div>*:last-child {
+.emotion-7 > div > div > *:last-child {
   margin: 0;
 }
 
-.emotion-0 p {
+.emotion-7 p {
   margin: 0;
 }
 
-.emotion-0>p {
+.emotion-7 > p {
   margin-left: 35px;
 }
 
@@ -78,7 +140,7 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
 }
 
 <div
-    class="emotion-0"
+    class="emotion-7"
   >
     <a
       class="emotion-1"
@@ -112,10 +174,35 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="reference external"
+        class="emotion-6"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        MongoDB University
+        <span
+          class="emotion-4"
+        >
+          MongoDB University
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-5"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </div>
@@ -134,6 +221,68 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-6:focus {
+  outline: none;
+}
+
+.emotion-5 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-2 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
+.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -148,19 +297,19 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-0>div>div>* {
+.emotion-7 > div > div > * {
   margin: 0 0 12px;
 }
 
-.emotion-0>div>div>*:last-child {
+.emotion-7 > div > div > *:last-child {
   margin: 0;
 }
 
-.emotion-0 p {
+.emotion-7 p {
   margin: 0;
 }
 
-.emotion-0>p {
+.emotion-7 > p {
   margin-left: 35px;
 }
 
@@ -200,7 +349,7 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
 }
 
 <div
-    class="emotion-0"
+    class="emotion-7"
   >
     <a
       class="emotion-1"
@@ -236,10 +385,35 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="reference external"
+        class="emotion-6"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        MongoDB University
+        <span
+          class="emotion-4"
+        >
+          MongoDB University
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-5"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </div>
@@ -258,6 +432,68 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-6:focus {
+  outline: none;
+}
+
+.emotion-5 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-2 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
+.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -272,19 +508,19 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-0>div>div>* {
+.emotion-7 > div > div > * {
   margin: 0 0 12px;
 }
 
-.emotion-0>div>div>*:last-child {
+.emotion-7 > div > div > *:last-child {
   margin: 0;
 }
 
-.emotion-0 p {
+.emotion-7 p {
   margin: 0;
 }
 
-.emotion-0>p {
+.emotion-7 > p {
   margin-left: 35px;
 }
 
@@ -324,7 +560,7 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
 }
 
 <div
-    class="emotion-0"
+    class="emotion-7"
   >
     <a
       class="emotion-1"
@@ -358,10 +594,35 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="reference external"
+        class="emotion-6"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        MongoDB University
+        <span
+          class="emotion-4"
+        >
+          MongoDB University
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-5"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </div>
@@ -380,6 +641,68 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-4 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-0 {
+  color: #007CAD;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-6:focus {
+  outline: none;
+}
+
+.emotion-5 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-2 {
+  -webkit-text-decoration: none !important;
+  text-decoration: none !important;
+}
+
+.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -394,19 +717,19 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   margin: 24px 0px;
 }
 
-.emotion-0>div>div>* {
+.emotion-7 > div > div > * {
   margin: 0 0 12px;
 }
 
-.emotion-0>div>div>*:last-child {
+.emotion-7 > div > div > *:last-child {
   margin: 0;
 }
 
-.emotion-0 p {
+.emotion-7 p {
   margin: 0;
 }
 
-.emotion-0>p {
+.emotion-7 > p {
   margin-left: 35px;
 }
 
@@ -446,7 +769,7 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
 }
 
 <div
-    class="emotion-0"
+    class="emotion-7"
   >
     <a
       class="emotion-1"
@@ -480,10 +803,35 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="reference external"
+        class="emotion-6"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        MongoDB University
+        <span
+          class="emotion-4"
+        >
+          MongoDB University
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-5"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </div>

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -12,68 +12,6 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-6:focus {
-  outline: none;
-}
-
-.emotion-5 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-2 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
-}
-
-.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -88,19 +26,19 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-7 > div > div > * {
+.emotion-0>div>div>* {
   margin: 0 0 12px;
 }
 
-.emotion-7 > div > div > *:last-child {
+.emotion-0>div>div>*:last-child {
   margin: 0;
 }
 
-.emotion-7 p {
+.emotion-0 p {
   margin: 0;
 }
 
-.emotion-7 > p {
+.emotion-0>p {
   margin-left: 35px;
 }
 
@@ -139,8 +77,71 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   color: #007CAD;
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-5:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="emotion-7"
+    class="emotion-0"
   >
     <a
       class="emotion-1"
@@ -174,21 +175,21 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-6"
+        class="emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-4"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-5"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -221,68 +222,6 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-6:focus {
-  outline: none;
-}
-
-.emotion-5 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-2 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
-}
-
-.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -297,19 +236,19 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-7 > div > div > * {
+.emotion-0>div>div>* {
   margin: 0 0 12px;
 }
 
-.emotion-7 > div > div > *:last-child {
+.emotion-0>div>div>*:last-child {
   margin: 0;
 }
 
-.emotion-7 p {
+.emotion-0 p {
   margin: 0;
 }
 
-.emotion-7 > p {
+.emotion-0>p {
   margin-left: 35px;
 }
 
@@ -348,8 +287,71 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   color: #007CAD;
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-5:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="emotion-7"
+    class="emotion-0"
   >
     <a
       class="emotion-1"
@@ -385,21 +387,21 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-6"
+        class="emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-4"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-5"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -432,68 +434,6 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-6:focus {
-  outline: none;
-}
-
-.emotion-5 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-2 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
-}
-
-.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -508,19 +448,19 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   margin: 24px 0px;
 }
 
-.emotion-7 > div > div > * {
+.emotion-0>div>div>* {
   margin: 0 0 12px;
 }
 
-.emotion-7 > div > div > *:last-child {
+.emotion-0>div>div>*:last-child {
   margin: 0;
 }
 
-.emotion-7 p {
+.emotion-0 p {
   margin: 0;
 }
 
-.emotion-7 > p {
+.emotion-0>p {
   margin-left: 35px;
 }
 
@@ -559,8 +499,71 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   color: #007CAD;
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-5:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="emotion-7"
+    class="emotion-0"
   >
     <a
       class="emotion-1"
@@ -594,21 +597,21 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-6"
+        class="emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-4"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-5"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -641,68 +644,6 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-0 {
-  color: #007CAD;
-}
-
-.emotion-6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-6:focus {
-  outline: none;
-}
-
-.emotion-5 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-2 {
-  -webkit-text-decoration: none !important;
-  text-decoration: none !important;
-}
-
-.emotion-7 {
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
   border-radius: 6px;
@@ -717,19 +658,19 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   margin: 24px 0px;
 }
 
-.emotion-7 > div > div > * {
+.emotion-0>div>div>* {
   margin: 0 0 12px;
 }
 
-.emotion-7 > div > div > *:last-child {
+.emotion-0>div>div>*:last-child {
   margin: 0;
 }
 
-.emotion-7 p {
+.emotion-0 p {
   margin: 0;
 }
 
-.emotion-7 > p {
+.emotion-0>p {
   margin-left: 35px;
 }
 
@@ -768,8 +709,71 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   color: #007CAD;
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-5:focus {
+  outline: none;
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="emotion-7"
+    class="emotion-0"
   >
     <a
       class="emotion-1"
@@ -803,21 +807,21 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-6"
+        class="emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-4"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-5"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -78,6 +78,11 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
 }
 
 .emotion-5 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -98,39 +103,39 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   outline: none;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-7 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-8 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -175,21 +180,21 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5"
+        class="emotion-5 emotion-6"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-7"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-8"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -288,6 +293,11 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
 }
 
 .emotion-5 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -308,39 +318,39 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   outline: none;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-7 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-8 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -387,21 +397,21 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5"
+        class="emotion-5 emotion-6"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-7"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-8"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -500,6 +510,11 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
 }
 
 .emotion-5 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -520,39 +535,39 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   outline: none;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-7 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-8 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -597,21 +612,21 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5"
+        class="emotion-5 emotion-6"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-7"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-8"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -710,6 +725,11 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
 }
 
 .emotion-5 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -730,39 +750,39 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   letter-spacing: 0px;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   outline: none;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-7 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-8 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -807,21 +827,21 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5"
+        class="emotion-5 emotion-6"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-7"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-8"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -72,6 +72,11 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-11 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -92,39 +97,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-11:focus {
+.emotion-12:focus {
   outline: none;
 }
 
-.emotion-12 {
+.emotion-13 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-12 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-13 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-12 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-12 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-12 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-12 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-13 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-13 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-13 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-13 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -159,21 +164,21 @@ exports[`renders correctly 1`] = `
       class="emotion-9 emotion-10"
     >
       <a
-        class="emotion-11"
+        class="emotion-11 emotion-12"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/courses/M001/about"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-12"
+          class="emotion-13"
         >
           Test card CTA
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-13"
+          class="emotion-14"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -2,23 +2,21 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
-  padding: 32px;
+  .emotion-6 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-0 p:last-of-type {
-  margin-bottom: 0;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-2 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-13 {
   position: relative;
   border-radius: 7px;
   -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
@@ -30,21 +28,72 @@ exports[`renders correctly 1`] = `
   cursor: pointer;
 }
 
-.emotion-2:focus {
+.emotion-13:focus {
   outline: none;
   box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
 }
 
-.emotion-2:hover {
+.emotion-13:hover {
   border: 1px solid #E7EEEC;
   box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
 }
 
-.emotion-2:hover:focus {
+.emotion-13:hover:focus {
   box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
 }
 
-.emotion-3 {
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-8:focus {
+  outline: none;
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 32px;
+}
+
+.emotion-11 p:last-of-type {
+  margin-bottom: 0;
+}
+
+.emotion-0 {
   width: 24px;
 }
 
@@ -67,12 +116,12 @@ exports[`renders correctly 1`] = `
   margin-top: auto;
 }
 
-.emotion-9>a:hover {
+.emotion-9 > a:hover {
   color: #1A567E;
 }
 
 <div
-    class="emotion-0 emotion-1 emotion-2"
+    class="emotion-11 emotion-12 emotion-13"
   >
     <img
       alt="MongoDB University icon"
@@ -96,9 +145,35 @@ exports[`renders correctly 1`] = `
       class="emotion-9 emotion-10"
     >
       <a
+        class="emotion-8"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/courses/M001/about"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        Test card CTA
+        <span
+          class="emotion-6"
+        >
+          Test card CTA
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-7"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </div>

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -2,82 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  .emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-13 {
-  position: relative;
-  border-radius: 7px;
-  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-  background-color: white;
-  color: #21313C;
-  cursor: pointer;
-}
-
-.emotion-13:focus {
-  outline: none;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
-}
-
-.emotion-13:hover {
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
-}
-
-.emotion-13:hover:focus {
-  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
-}
-
-.emotion-8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-8:focus {
-  outline: none;
-}
-
-.emotion-7 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-11 {
+  .emotion-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,11 +14,37 @@ exports[`renders correctly 1`] = `
   padding: 32px;
 }
 
-.emotion-11 p:last-of-type {
+.emotion-0 p:last-of-type {
   margin-bottom: 0;
 }
 
-.emotion-0 {
+.emotion-2 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
+  cursor: pointer;
+}
+
+.emotion-2:focus {
+  outline: none;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
+}
+
+.emotion-2:hover {
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
+}
+
+.emotion-2:hover:focus {
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
+}
+
+.emotion-3 {
   width: 24px;
 }
 
@@ -116,12 +67,75 @@ exports[`renders correctly 1`] = `
   margin-top: auto;
 }
 
-.emotion-9 > a:hover {
+.emotion-9>a:hover {
   color: #1A567E;
 }
 
+.emotion-11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-11:focus {
+  outline: none;
+}
+
+.emotion-12 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-12 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-12 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-12 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-12 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-12 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="emotion-11 emotion-12 emotion-13"
+    class="emotion-0 emotion-1 emotion-2"
   >
     <img
       alt="MongoDB University icon"
@@ -145,21 +159,21 @@ exports[`renders correctly 1`] = `
       class="emotion-9 emotion-10"
     >
       <a
-        class="emotion-8"
+        class="emotion-11"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/courses/M001/about"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-12"
         >
           Test card CTA
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-13"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -2,82 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  .emotion-19 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-19 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-19 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-12 {
-  position: relative;
-  border-radius: 7px;
-  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-  background-color: white;
-  color: #21313C;
-  cursor: pointer;
-}
-
-.emotion-12:focus {
-  outline: none;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
-}
-
-.emotion-12:hover {
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
-}
-
-.emotion-12:hover:focus {
-  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
-}
-
-.emotion-21 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #007CAD;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
-}
-
-.emotion-21:focus {
-  outline: none;
-}
-
-.emotion-20 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-42 {
+  .emotion-0 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -90,14 +15,14 @@ exports[`renders correctly 1`] = `
   margin: 32px 0;
 }
 
-@media only screen and (max-width:1200px) {
-  .emotion-42 {
-    grid-template-columns: repeat(2,1fr);
+@media only screen and (max-width: 1200px) {
+  .emotion-0 {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media only screen and (max-width:767px) {
-  .emotion-42 {
+@media only screen and (max-width: 767px) {
+  .emotion-0 {
     grid-gap: calc(24px * 0.75);
     grid-template-columns: calc(24px / 2) repeat(3, calc(75% - calc(2 * 24px))) calc(24px / 2);
     grid-template-rows: minmax(150px, 1fr);
@@ -107,8 +32,8 @@ exports[`renders correctly 1`] = `
     scroll-snap-type: x proximity;
   }
 
-  .emotion-42:before,
-  .emotion-42:after {
+  .emotion-0:before,
+  .emotion-0:after {
     content: '';
   }
 }
@@ -227,8 +152,71 @@ exports[`renders correctly 1`] = `
   color: #1A567E;
 }
 
+.emotion-28 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-28:focus {
+  outline: none;
+}
+
+.emotion-29 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-29 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-29 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-29 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-29 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-29 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-30 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
 <div
-    class="card-group  emotion-42 emotion-43"
+    class="card-group  emotion-0 emotion-1"
   >
     <div
       class="emotion-2 emotion-3 emotion-4"
@@ -287,21 +275,21 @@ exports[`renders correctly 1`] = `
           class="emotion-13 emotion-14"
         >
           <a
-            class="emotion-21"
+            class="emotion-28"
             data-leafygreen-ui="anchor-container"
             href="https://university.mongodb.com/courses/M001/about"
             rel="noopener noreferrer"
             target="_blank"
           >
             <span
-              class="emotion-19"
+              class="emotion-29"
             >
               Learn MongoDB Basics
             </span>
             <svg
               alt=""
               aria-hidden="true"
-              class="emotion-20"
+              class="emotion-30"
               height="16"
               role="presentation"
               viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -2,7 +2,82 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  .emotion-0 {
+  .emotion-19 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-19 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-19 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-12 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
+  cursor: pointer;
+}
+
+.emotion-12:focus {
+  outline: none;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3),0 0 0 3px #9DD0E7;
+}
+
+.emotion-12:hover {
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6);
+}
+
+.emotion-12:hover:focus {
+  box-shadow: 0 2px 6px -2px rgba(6,22,33,0.6),0 0 0 3px #9DD0E7;
+}
+
+.emotion-21 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-21:focus {
+  outline: none;
+}
+
+.emotion-20 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-42 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -15,14 +90,14 @@ exports[`renders correctly 1`] = `
   margin: 32px 0;
 }
 
-@media only screen and (max-width: 1200px) {
-  .emotion-0 {
-    grid-template-columns: repeat(2, 1fr);
+@media only screen and (max-width:1200px) {
+  .emotion-42 {
+    grid-template-columns: repeat(2,1fr);
   }
 }
 
-@media only screen and (max-width: 767px) {
-  .emotion-0 {
+@media only screen and (max-width:767px) {
+  .emotion-42 {
     grid-gap: calc(24px * 0.75);
     grid-template-columns: calc(24px / 2) repeat(3, calc(75% - calc(2 * 24px))) calc(24px / 2);
     grid-template-rows: minmax(150px, 1fr);
@@ -32,8 +107,8 @@ exports[`renders correctly 1`] = `
     scroll-snap-type: x proximity;
   }
 
-  .emotion-0:before,
-  .emotion-0:after {
+  .emotion-42:before,
+  .emotion-42:after {
     content: '';
   }
 }
@@ -153,7 +228,7 @@ exports[`renders correctly 1`] = `
 }
 
 <div
-    class="card-group  emotion-0 emotion-1"
+    class="card-group  emotion-42 emotion-43"
   >
     <div
       class="emotion-2 emotion-3 emotion-4"
@@ -212,9 +287,35 @@ exports[`renders correctly 1`] = `
           class="emotion-13 emotion-14"
         >
           <a
+            class="emotion-21"
+            data-leafygreen-ui="anchor-container"
             href="https://university.mongodb.com/courses/M001/about"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            Learn MongoDB Basics
+            <span
+              class="emotion-19"
+            >
+              Learn MongoDB Basics
+            </span>
+            <svg
+              alt=""
+              aria-hidden="true"
+              class="emotion-20"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+                fill="currentColor"
+              />
+              <path
+                d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+                fill="currentColor"
+              />
+            </svg>
           </a>
         </p>
       </div>

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -153,6 +153,11 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-28 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-29 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -173,39 +178,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-28:focus {
+.emotion-29:focus {
   outline: none;
 }
 
-.emotion-29 {
+.emotion-30 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-29 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-30 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-29 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-29 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-29 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-29 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-30 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-30 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-30 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-30 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-31 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -275,21 +280,21 @@ exports[`renders correctly 1`] = `
           class="emotion-13 emotion-14"
         >
           <a
-            class="emotion-28"
+            class="emotion-28 emotion-29"
             data-leafygreen-ui="anchor-container"
             href="https://university.mongodb.com/courses/M001/about"
             rel="noopener noreferrer"
             target="_blank"
           >
             <span
-              class="emotion-29"
+              class="emotion-30"
             >
               Learn MongoDB Basics
             </span>
             <svg
               alt=""
               aria-hidden="true"
-              class="emotion-30"
+              class="emotion-31"
               height="16"
               role="presentation"
               viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -50,6 +50,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-8 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -70,39 +75,39 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-8:focus {
+.emotion-9:focus {
   outline: none;
 }
 
-.emotion-9 {
+.emotion-10 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-9 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-10 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-9 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-9 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-9 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-9 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-10 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-10 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-10 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-10 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-11 {
   overflow: hidden;
   border-radius: 3px;
   position: absolute;
@@ -112,7 +117,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   bottom: 0;
 }
 
-.emotion-11 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,7 +140,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   padding-right: 12px;
 }
 
-.emotion-12 {
+.emotion-13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -145,19 +150,19 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   height: 12px;
 }
 
-.emotion-13 {
+.emotion-14 {
   margin-top: 40px;
   padding: 40px 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-13 {
+  .emotion-14 {
     padding: 48px;
   }
 }
 
 @media not all and (max-width: 1023px) {
-  .emotion-13 {
+  .emotion-14 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -171,7 +176,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-14 {
+.emotion-15 {
   position: relative;
   border-radius: 7px;
   -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
@@ -182,12 +187,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   color: #21313C;
 }
 
-.emotion-15 {
+.emotion-16 {
   margin-bottom: 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-15 {
+  .emotion-16 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -197,7 +202,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-18 {
+.emotion-19 {
   background-color: #E4F4E4;
   border-radius: 4px;
   color: #13AA52;
@@ -209,17 +214,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-20 {
+.emotion-21 {
   color: #061621;
   font-weight: bold;
 }
 
-.emotion-22 {
+.emotion-23 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-24 {
+.emotion-25 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -233,11 +238,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   position: relative;
 }
 
-.emotion-24:not(:last-child) {
+.emotion-25:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-24:not(:last-child):before {
+.emotion-25:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -246,7 +251,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   border-left: solid 1px #13AA52;
 }
 
-.emotion-26 {
+.emotion-27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -266,18 +271,18 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   min-height: 20px;
 }
 
-.emotion-28 {
+.emotion-29 {
   color: #13AA52;
 }
 
-.emotion-29 {
+.emotion-30 {
   color: #061621;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-29:hover,
-.emotion-29:active {
+.emotion-30:hover,
+.emotion-30:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -303,20 +308,20 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         Congrats. You’ve completed all the guides. Want to take the next step? Register for the developer exam.
       </p>
       <a
-        class="emotion-8"
+        class="emotion-8 emotion-9"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/certification/developer/about"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-9"
+          class="emotion-10"
         >
           <div
-            class="emotion-10"
+            class="emotion-11"
           />
           <div
-            class="emotion-11"
+            class="emotion-12"
           >
             Learn More
           </div>
@@ -324,7 +329,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-12"
+          class="emotion-13"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -342,36 +347,36 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
       </a>
     </div>
     <div
-      class="emotion-13 emotion-14"
+      class="emotion-14 emotion-15"
     >
       <div
-        class="emotion-15 emotion-16"
+        class="emotion-16 emotion-17"
       >
         <div
-          class="emotion-17 emotion-18 emotion-19"
+          class="emotion-18 emotion-19 emotion-20"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-20 emotion-21"
+          class="emotion-21 emotion-22"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-22 emotion-23"
+        class="emotion-23 emotion-24"
       >
         <li
-          class="emotion-24 emotion-25"
+          class="emotion-25 emotion-26"
           color="#13AA52"
         >
           <div
-            class="emotion-26 emotion-27"
+            class="emotion-27 emotion-28"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-28"
+              class="emotion-29"
               fill="none"
               height="16"
               role="img"
@@ -388,7 +393,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-29 emotion-30"
+            class="emotion-30 emotion-31"
             href="/server/read/"
           >
             Read Data in MongoDB

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -2,40 +2,8 @@
 
 exports[`GuideNext renders the default copy on the final guide 1`] = `
 <DocumentFragment>
-  .emotion-0 {
-  border-top: 1px solid #E7EEEC;
-  margin-bottom: 24px;
-  padding-top: 56px;
-}
-
-@media not all and (max-width: 1023px) {
-  .emotion-0 {
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    gap: 0 34px;
-  }
-}
-
-.emotion-2 p {
-  margin-top: 8px;
-}
-
-@media not all and (max-width: 1023px) {
-  .emotion-2 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-  }
+  .emotion-18 {
+  color: #13AA52;
 }
 
 .emotion-4 {
@@ -45,85 +13,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-6 {
-  font-size: 24px;
-  font-weight: bold;
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
 }
 
-.emotion-8 {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  -ms-appearance: none;
-  appearance: none;
-  padding: 0;
-  margin: 0;
-  background-color: transparent;
-  border: 0px solid transparent;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-radius: 4px;
-  -webkit-transition: all 150ms ease-in-out;
-  transition: all 150ms ease-in-out;
-  position: relative;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  cursor: pointer;
-  z-index: 0;
-  background-color: #09804C;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
-  color: #FFFFFF;
-  font-size: 16px;
-  -webkit-transform: translateY(1px);
-  -moz-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
-  height: 36px;
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-.emotion-8:focus {
-  outline: none;
-}
-
-.emotion-8:disabled {
-  pointer-events: none;
-}
-
-.emotion-8:active,
-.emotion-8:focus,
-.emotion-8:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-8:focus {
-  color: #FFFFFF;
-}
-
-.emotion-8:hover,
-.emotion-8:active {
-  color: #FFFFFF;
-  background-color: #116149;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
-}
-
-.emotion-8:focus {
-  background-color: #116149;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
-}
-
-.emotion-9 {
-  overflow: hidden;
-  border-radius: 3px;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-10 {
@@ -149,19 +49,27 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   padding-right: 12px;
 }
 
-.emotion-11 {
+.emotion-27 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
   margin-top: 40px;
   padding: 40px 24px;
 }
 
-@media not all and (max-width: 767px) {
-  .emotion-11 {
+@media not all and (max-width:767px) {
+  .emotion-27 {
     padding: 48px;
   }
 }
 
-@media not all and (max-width: 1023px) {
-  .emotion-11 {
+@media not all and (max-width:1023px) {
+  .emotion-27 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -175,23 +83,94 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-12 {
-  position: relative;
-  border-radius: 7px;
-  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-  background-color: white;
-  color: #21313C;
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
 }
 
-.emotion-13 {
+.emotion-8:focus {
+  outline: none;
+}
+
+.emotion-7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+.emotion-28 {
+  border-top: 1px solid #E7EEEC;
+  margin-bottom: 24px;
+  padding-top: 56px;
+}
+
+@media not all and (max-width:1023px) {
+  .emotion-28 {
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    gap: 0 34px;
+  }
+}
+
+.emotion-9 p {
+  margin-top: 8px;
+}
+
+@media not all and (max-width:1023px) {
+  .emotion-9 {
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+.emotion-0 {
+  color: #5D6C74;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+
+.emotion-2 {
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.emotion-16 {
   margin-bottom: 24px;
 }
 
-@media not all and (max-width: 767px) {
-  .emotion-13 {
+@media not all and (max-width:767px) {
+  .emotion-16 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -201,7 +180,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   background-color: #E4F4E4;
   border-radius: 4px;
   color: #13AA52;
@@ -213,44 +192,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-18 {
+.emotion-14 {
   color: #061621;
   font-weight: bold;
 }
 
-.emotion-20 {
+.emotion-25 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-22 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 40px;
-  padding-top: 0!important;
-  position: relative;
-}
-
-.emotion-22:not(:last-child) {
-  padding-bottom: 16px;
-}
-
-.emotion-22:not(:last-child):before {
-  content: '';
-  position: absolute;
-  left: 10px;
-  top: 20px;
-  height: calc(100% - 20px);
-  border-left: solid 1px #13AA52;
-}
-
-.emotion-24 {
+.emotion-19 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -270,28 +222,51 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   min-height: 20px;
 }
 
-.emotion-26 {
-  color: #13AA52;
-}
-
-.emotion-27 {
+.emotion-21 {
   color: #061621;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-27:hover,
-.emotion-27:active {
+.emotion-21:hover,
+.emotion-21:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
+.emotion-23 {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 40px;
+  padding-top: 0 !important;
+  position: relative;
+}
+
+.emotion-23:not(:last-child) {
+  padding-bottom: 16px;
+}
+
+.emotion-23:not(:last-child):before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 20px;
+  height: calc(100% - 20px);
+  border-left: solid 1px #13AA52;
+}
+
 <div
-    class="emotion-0 emotion-1"
+    class="emotion-28 emotion-29"
   >
     <div
-      class="emotion-2 emotion-3"
+      class="emotion-9 emotion-10"
     >
       <div
         class="emotion-4 emotion-5"
@@ -307,51 +282,75 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         Congrats. You’ve completed all the guides. Want to take the next step? Register for the developer exam.
       </p>
       <a
-        aria-disabled="false"
         class="emotion-8"
+        data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/certification/developer/about"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        <div
-          class="emotion-9"
-        />
-        <div
-          class="emotion-10"
+        <span
+          class="emotion-6"
         >
-          Learn More
-        </div>
+          <div
+            class="emotion-4"
+          />
+          <div
+            class="emotion-5"
+          >
+            Learn More
+          </div>
+        </span>
+        <svg
+          alt=""
+          aria-hidden="true"
+          class="emotion-7"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+            fill="currentColor"
+          />
+          <path
+            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </div>
     <div
-      class="emotion-11 emotion-12"
+      class="emotion-27"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-16 emotion-17"
       >
         <div
-          class="emotion-15 emotion-16 emotion-17"
+          class="emotion-11 emotion-12 emotion-13"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-18 emotion-19"
+          class="emotion-14 emotion-15"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-20 emotion-21"
+        class="emotion-25 emotion-26"
       >
         <li
-          class="emotion-22 emotion-23"
+          class="emotion-23 emotion-24"
           color="#13AA52"
         >
           <div
-            class="emotion-24 emotion-25"
+            class="emotion-19 emotion-20"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-26"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -368,7 +367,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-27 emotion-28"
+            class="emotion-21 emotion-22"
             href="/server/read/"
           >
             Read Data in MongoDB

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -2,8 +2,40 @@
 
 exports[`GuideNext renders the default copy on the final guide 1`] = `
 <DocumentFragment>
-  .emotion-18 {
-  color: #13AA52;
+  .emotion-0 {
+  border-top: 1px solid #E7EEEC;
+  margin-bottom: 24px;
+  padding-top: 56px;
+}
+
+@media not all and (max-width: 1023px) {
+  .emotion-0 {
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    gap: 0 34px;
+  }
+}
+
+.emotion-2 p {
+  margin-top: 8px;
+}
+
+@media not all and (max-width: 1023px) {
+  .emotion-2 {
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
 }
 
 .emotion-4 {
@@ -13,74 +45,8 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-6 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-  width: 100%;
-  pointer-events: none;
-  position: relative;
-  z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.emotion-27 {
-  position: relative;
-  border-radius: 7px;
-  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
-  border: 1px solid #E7EEEC;
-  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
-  background-color: white;
-  color: #21313C;
-  margin-top: 40px;
-  padding: 40px 24px;
-}
-
-@media not all and (max-width:767px) {
-  .emotion-27 {
-    padding: 48px;
-  }
-}
-
-@media not all and (max-width:1023px) {
-  .emotion-27 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    min-width: 300px;
-    margin-top: 0;
-    max-width: 510px;
-  }
+  font-size: 24px;
+  font-weight: bold;
 }
 
 .emotion-8 {
@@ -108,7 +74,68 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   outline: none;
 }
 
-.emotion-7 {
+.emotion-9 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-9 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-9 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-9 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-9 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-9 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-10 {
+  overflow: hidden;
+  border-radius: 3px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+  position: relative;
+  z-index: 0;
+  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.emotion-12 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -118,32 +145,19 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   height: 12px;
 }
 
-.emotion-28 {
-  border-top: 1px solid #E7EEEC;
-  margin-bottom: 24px;
-  padding-top: 56px;
+.emotion-13 {
+  margin-top: 40px;
+  padding: 40px 24px;
 }
 
-@media not all and (max-width:1023px) {
-  .emotion-28 {
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    gap: 0 34px;
+@media not all and (max-width: 767px) {
+  .emotion-13 {
+    padding: 48px;
   }
 }
 
-.emotion-9 p {
-  margin-top: 8px;
-}
-
-@media not all and (max-width:1023px) {
-  .emotion-9 {
+@media not all and (max-width: 1023px) {
+  .emotion-13 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -151,26 +165,29 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
+    min-width: 300px;
+    margin-top: 0;
+    max-width: 510px;
   }
 }
 
-.emotion-0 {
-  color: #5D6C74;
-  font-size: 16px;
-  margin-bottom: 16px;
+.emotion-14 {
+  position: relative;
+  border-radius: 7px;
+  -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
+  border: 1px solid #E7EEEC;
+  box-shadow: 0 4px 10px -4px rgba(6,22,33,0.3);
+  background-color: white;
+  color: #21313C;
 }
 
-.emotion-2 {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.emotion-16 {
+.emotion-15 {
   margin-bottom: 24px;
 }
 
-@media not all and (max-width:767px) {
-  .emotion-16 {
+@media not all and (max-width: 767px) {
+  .emotion-15 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -180,7 +197,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-12 {
+.emotion-18 {
   background-color: #E4F4E4;
   border-radius: 4px;
   color: #13AA52;
@@ -192,17 +209,44 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-14 {
+.emotion-20 {
   color: #061621;
   font-weight: bold;
 }
 
-.emotion-25 {
+.emotion-22 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-19 {
+.emotion-24 {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 40px;
+  padding-top: 0!important;
+  position: relative;
+}
+
+.emotion-24:not(:last-child) {
+  padding-bottom: 16px;
+}
+
+.emotion-24:not(:last-child):before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 20px;
+  height: calc(100% - 20px);
+  border-left: solid 1px #13AA52;
+}
+
+.emotion-26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -222,51 +266,28 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   min-height: 20px;
 }
 
-.emotion-21 {
+.emotion-28 {
+  color: #13AA52;
+}
+
+.emotion-29 {
   color: #061621;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-21:hover,
-.emotion-21:active {
+.emotion-29:hover,
+.emotion-29:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-23 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 40px;
-  padding-top: 0 !important;
-  position: relative;
-}
-
-.emotion-23:not(:last-child) {
-  padding-bottom: 16px;
-}
-
-.emotion-23:not(:last-child):before {
-  content: '';
-  position: absolute;
-  left: 10px;
-  top: 20px;
-  height: calc(100% - 20px);
-  border-left: solid 1px #13AA52;
-}
-
 <div
-    class="emotion-28 emotion-29"
+    class="emotion-0 emotion-1"
   >
     <div
-      class="emotion-9 emotion-10"
+      class="emotion-2 emotion-3"
     >
       <div
         class="emotion-4 emotion-5"
@@ -289,13 +310,13 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         target="_blank"
       >
         <span
-          class="emotion-6"
+          class="emotion-9"
         >
           <div
-            class="emotion-4"
+            class="emotion-10"
           />
           <div
-            class="emotion-5"
+            class="emotion-11"
           >
             Learn More
           </div>
@@ -303,7 +324,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-7"
+          class="emotion-12"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -321,36 +342,36 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
       </a>
     </div>
     <div
-      class="emotion-27"
+      class="emotion-13 emotion-14"
     >
       <div
-        class="emotion-16 emotion-17"
+        class="emotion-15 emotion-16"
       >
         <div
-          class="emotion-11 emotion-12 emotion-13"
+          class="emotion-17 emotion-18 emotion-19"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-14 emotion-15"
+          class="emotion-20 emotion-21"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-25 emotion-26"
+        class="emotion-22 emotion-23"
       >
         <li
-          class="emotion-23 emotion-24"
+          class="emotion-24 emotion-25"
           color="#13AA52"
         >
           <div
-            class="emotion-19 emotion-20"
+            class="emotion-26 emotion-27"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-18"
+              class="emotion-28"
               fill="none"
               height="16"
               role="img"
@@ -367,7 +388,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-21 emotion-22"
+            class="emotion-29 emotion-30"
             href="/server/read/"
           >
             Read Data in MongoDB

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -3,20 +3,6 @@
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -37,11 +23,25 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -52,18 +52,18 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 }
 
 <span
-    class="emotion-2"
+    class="emotion-0"
     data-leafygreen-ui="anchor-container"
   >
     <span
-      class="emotion-0"
+      class="emotion-1"
     >
       Empty string
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -95,20 +95,6 @@ exports[`Link component renders a variety of strings correctly external MDB docs
 exports[`Link component renders a variety of strings correctly external MDB non-docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -129,11 +115,25 @@ exports[`Link component renders a variety of strings correctly external MDB non-
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -144,21 +144,21 @@ exports[`Link component renders a variety of strings correctly external MDB non-
 }
 
 <a
-    class="emotion-2"
+    class="emotion-0"
     data-leafygreen-ui="anchor-container"
     href="https://account.mongodb.com/account/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-0"
+      class="emotion-1"
     >
       MongoDB Atlas Registration Page
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -180,20 +180,6 @@ exports[`Link component renders a variety of strings correctly external MDB non-
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -214,11 +200,25 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -229,21 +229,21 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 }
 
 <a
-    class="emotion-2"
+    class="emotion-0"
     data-leafygreen-ui="anchor-container"
     href="http://mongodb.com"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-0"
+      class="emotion-1"
     >
       MongoDB Company
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -265,20 +265,6 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 exports[`Link component renders a variety of strings correctly external non-MDB docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -299,11 +285,25 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -314,21 +314,21 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
 }
 
 <a
-    class="emotion-2"
+    class="emotion-0"
     data-leafygreen-ui="anchor-container"
     href="https://safety.google/authentication/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-0"
+      class="emotion-1"
     >
       Google 2-Step Verification
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -82,6 +82,101 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 </DocumentFragment>
 `;
 
+exports[`Link component renders a variety of strings correctly external MDB docs URL 1`] = `
+<DocumentFragment>
+  <a
+    href="https://www.mongodb.com/docs/atlas/"
+  >
+    MongoDB Atlas Docs
+  </a>
+</DocumentFragment>
+`;
+
+exports[`Link component renders a variety of strings correctly external MDB non-docs URL 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<a
+    class="emotion-2"
+    data-leafygreen-ui="anchor-container"
+    href="https://account.mongodb.com/account/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      class="emotion-0"
+    >
+      MongoDB Atlas Registration Page
+    </span>
+    <svg
+      alt=""
+      aria-hidden="true"
+      class="emotion-1"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+        fill="currentColor"
+      />
+      <path
+        d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+        fill="currentColor"
+      />
+    </svg>
+  </a>
+</DocumentFragment>
+`;
+
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
@@ -144,6 +239,91 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
       class="emotion-0"
     >
       MongoDB Company
+    </span>
+    <svg
+      alt=""
+      aria-hidden="true"
+      class="emotion-1"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+        fill="currentColor"
+      />
+      <path
+        d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+        fill="currentColor"
+      />
+    </svg>
+  </a>
+</DocumentFragment>
+`;
+
+exports[`Link component renders a variety of strings correctly external non-MDB docs URL 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<a
+    class="emotion-2"
+    data-leafygreen-ui="anchor-container"
+    href="https://safety.google/authentication/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      class="emotion-0"
+    >
+      Google 2-Step Verification
     </span>
     <svg
       alt=""

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -2,20 +2,167 @@
 
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <DocumentFragment>
-  <a
-    href=""
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<span
+    class="emotion-2"
+    data-leafygreen-ui="anchor-container"
   >
-    Empty string
-  </a>
+    <span
+      class="emotion-0"
+    >
+      Empty string
+    </span>
+    <svg
+      alt=""
+      aria-hidden="true"
+      class="emotion-1"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+        fill="currentColor"
+      />
+      <path
+        d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
 </DocumentFragment>
 `;
 
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <DocumentFragment>
-  <a
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<a
+    class="emotion-2"
+    data-leafygreen-ui="anchor-container"
     href="http://mongodb.com"
+    rel="noopener noreferrer"
+    target="_blank"
   >
-    MongoDB Company
+    <span
+      class="emotion-0"
+    >
+      MongoDB Company
+    </span>
+    <svg
+      alt=""
+      aria-hidden="true"
+      class="emotion-1"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+        fill="currentColor"
+      />
+      <path
+        d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+        fill="currentColor"
+      />
+    </svg>
   </a>
 </DocumentFragment>
 `;

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -3,6 +3,11 @@
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23,25 +28,25 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -52,18 +57,18 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 }
 
 <span
-    class="emotion-0"
+    class="emotion-0 emotion-1"
     data-leafygreen-ui="anchor-container"
   >
     <span
-      class="emotion-1"
+      class="emotion-2"
     >
       Empty string
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-2"
+      class="emotion-3"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -95,6 +100,11 @@ exports[`Link component renders a variety of strings correctly external MDB docs
 exports[`Link component renders a variety of strings correctly external MDB non-docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -115,25 +125,25 @@ exports[`Link component renders a variety of strings correctly external MDB non-
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -144,21 +154,21 @@ exports[`Link component renders a variety of strings correctly external MDB non-
 }
 
 <a
-    class="emotion-0"
+    class="emotion-0 emotion-1"
     data-leafygreen-ui="anchor-container"
     href="https://account.mongodb.com/account/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-1"
+      class="emotion-2"
     >
       MongoDB Atlas Registration Page
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-2"
+      class="emotion-3"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -180,6 +190,11 @@ exports[`Link component renders a variety of strings correctly external MDB non-
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -200,25 +215,25 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -229,21 +244,21 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 }
 
 <a
-    class="emotion-0"
+    class="emotion-0 emotion-1"
     data-leafygreen-ui="anchor-container"
     href="http://mongodb.com"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-1"
+      class="emotion-2"
     >
       MongoDB Company
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-2"
+      class="emotion-3"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -265,6 +280,11 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 exports[`Link component renders a variety of strings correctly external non-MDB docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -285,25 +305,25 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -314,21 +334,21 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
 }
 
 <a
-    class="emotion-0"
+    class="emotion-0 emotion-1"
     data-leafygreen-ui="anchor-container"
     href="https://safety.google/authentication/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-1"
+      class="emotion-2"
     >
       Google 2-Step Verification
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-2"
+      class="emotion-3"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -2,11 +2,85 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
-  <a
-    class="reference external"
+  .emotion-0 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-1 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<a
+    class="emotion-2"
+    data-leafygreen-ui="anchor-container"
     href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
+    rel="noopener noreferrer"
+    target="_blank"
   >
-    mLab documentation
+    <span
+      class="emotion-0"
+    >
+      mLab documentation
+    </span>
+    <svg
+      alt=""
+      aria-hidden="true"
+      class="emotion-1"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+        fill="currentColor"
+      />
+      <path
+        d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+        fill="currentColor"
+      />
+    </svg>
   </a>
 </DocumentFragment>
 `;

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -3,6 +3,11 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23,39 +28,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-1 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-2 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -66,21 +71,21 @@ exports[`renders correctly 1`] = `
 }
 
 <a
-    class="emotion-0"
+    class="emotion-0 emotion-1"
     data-leafygreen-ui="anchor-container"
     href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-1"
+      class="emotion-2"
     >
       mLab documentation
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-2"
+      class="emotion-3"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -3,20 +3,6 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-0 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-0 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -37,11 +23,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-2:focus {
+.emotion-0:focus {
   outline: none;
 }
 
 .emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-1 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -52,21 +66,21 @@ exports[`renders correctly 1`] = `
 }
 
 <a
-    class="emotion-2"
+    class="emotion-0"
     data-leafygreen-ui="anchor-container"
     href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-0"
+      class="emotion-1"
     >
       mLab documentation
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"


### PR DESCRIPTION
### Stories/Links:

[DOP-2602](https://jira.mongodb.org/browse/DOP-2602)

### Current Behavior:

[Atlas Production Example 1](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/#google-accounts)
[Atlas Production Example 2](https://www.mongodb.com/docs/atlas/reference/unsupported-commands/#unsupported-commands-in-m0-m2-m5-clusters)

### Staging Links:

[Atlas Staging Example 1](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2602/tutorial/create-atlas-account/#google-accounts)
[Atlas Staging Example 2](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2602/reference/unsupported-commands/#unsupported-commands-in-m0-m2-m5-clusters) 

### Notes:

In summary, any link that isn't to `www.mongodb.com/docs/*` should opens in a new tab and should be styled according to LG's new link component found [here](https://www.mongodb.design/component/typography/example/), even if the link is a MDB link to a non-documentation site. Links that are internal MDB docs links should be styled with blue text and no link icon, and should not open in a new tab. 

Right now, since all of the URLs may not have been changed yet after the subdomain consolidation project, the old docs URL format has been included in the logic (this can be removed once all links have been changed to reflect the updated URL pattern by content folks). 