### PR TITLE
Fix modals' close button positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@leafygreen-ui/inline-definition": "^2.0.2",
         "@leafygreen-ui/leafygreen-provider": "^2.0.2",
         "@leafygreen-ui/logo": "^4.0.2",
-        "@leafygreen-ui/modal": "^6.0.2",
+        "@leafygreen-ui/modal": "^6.1.2",
         "@leafygreen-ui/palette": "^3.1.1",
         "@leafygreen-ui/select": "^3.0.1",
         "@leafygreen-ui/side-nav": "^7.2.1",
@@ -1509,9 +1509,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha1-ZvaFkWBeWdpHUjxjFBaxhQh3mUE=",
+      "version": "7.17.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha1-Plbkr/gb76Vaw6xqCWc0n9HFvKI=",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -4137,54 +4137,74 @@
       }
     },
     "node_modules/@leafygreen-ui/modal": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-6.0.2.tgz",
-      "integrity": "sha512-7BpiRVIoo3c2oKisDLA8GsFs05G/Q1Kb0/SwwNI5iyWvY7d98onGxs40I05GL/J16QGP/A5UOuGq5NS2iWyfyg==",
+      "version": "6.1.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/modal/-/modal-6.1.2.tgz",
+      "integrity": "sha1-uMw18WkO7/SEMPv7GTa7bzil/tU=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon": "^10.2.1",
-        "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1",
-        "@leafygreen-ui/portal": "^3.1.1",
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/icon": "^11.3.0",
+        "@leafygreen-ui/icon-button": "^9.1.6",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.2.2",
+        "@leafygreen-ui/portal": "^4.0.0",
         "focus-trap-react": "8.4.2",
         "react-transition-group": "^4.4.1"
       }
     },
-    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/emotion": {
-      "version": "3.0.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
-      "integrity": "sha1-s4C3lRJFnae5RUL22KaGCATLqxg=",
+    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/hooks": {
+      "version": "7.2.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.2.0.tgz",
+      "integrity": "sha1-wH529yAghkyqglOhFLz9/HPdCqs=",
       "license": "Apache-2.0",
       "dependencies": {
-        "create-emotion": "^10.0.7",
-        "create-emotion-server": "10.0.27",
-        "emotion": "^10.0.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/icon": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-      "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+      "version": "9.1.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+      "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/emotion": "^4.0.0",
         "facepaint": "^1.2.1",
-        "polished": "^2.3.0",
+        "polished": "^4.1.3",
         "prop-types": "^15.0.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/palette": {
+      "version": "3.3.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-3.3.1.tgz",
+      "integrity": "sha1-URkm+XdNIrAzyREzdeMDlRDZl3I=",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/portal": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-4.0.2.tgz",
+      "integrity": "sha1-MIQsDvTZQmFHXp9XiiWBmZlRRHQ=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^7.1.1",
+        "@leafygreen-ui/lib": "^9.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/modal/node_modules/polished": {
+      "version": "4.2.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.1.tgz",
+      "integrity": "sha1-44zfQkSzvqY/d7D4qyM14ipmvQg=",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@leafygreen-ui/palette": {
@@ -34429,9 +34449,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha1-ZvaFkWBeWdpHUjxjFBaxhQh3mUE=",
+      "version": "7.17.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha1-Plbkr/gb76Vaw6xqCWc0n9HFvKI=",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -36468,47 +36488,59 @@
       }
     },
     "@leafygreen-ui/modal": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-6.0.2.tgz",
-      "integrity": "sha512-7BpiRVIoo3c2oKisDLA8GsFs05G/Q1Kb0/SwwNI5iyWvY7d98onGxs40I05GL/J16QGP/A5UOuGq5NS2iWyfyg==",
+      "version": "6.1.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/modal/-/modal-6.1.2.tgz",
+      "integrity": "sha1-uMw18WkO7/SEMPv7GTa7bzil/tU=",
       "requires": {
-        "@leafygreen-ui/hooks": "^6.0.0",
-        "@leafygreen-ui/icon": "^10.2.1",
-        "@leafygreen-ui/icon-button": "^9.1.3",
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1",
-        "@leafygreen-ui/portal": "^3.1.1",
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/icon": "^11.3.0",
+        "@leafygreen-ui/icon-button": "^9.1.6",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.2.2",
+        "@leafygreen-ui/portal": "^4.0.0",
         "focus-trap-react": "8.4.2",
         "react-transition-group": "^4.4.1"
       },
       "dependencies": {
-        "@leafygreen-ui/emotion": {
-          "version": "3.0.1",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
-          "integrity": "sha1-s4C3lRJFnae5RUL22KaGCATLqxg=",
+        "@leafygreen-ui/hooks": {
+          "version": "7.2.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.2.0.tgz",
+          "integrity": "sha1-wH529yAghkyqglOhFLz9/HPdCqs=",
           "requires": {
-            "create-emotion": "^10.0.7",
-            "create-emotion-server": "10.0.27",
-            "emotion": "^10.0.7"
-          }
-        },
-        "@leafygreen-ui/icon": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-10.2.1.tgz",
-          "integrity": "sha512-8uw1U2DM9+c/SpewM3ZpXUsmtbsj2bUjFFKYQbiEAAP+GiK2TCFeIj53/ta28qprE8UnUDSoa4SmE3G+Z7hjUA==",
-          "requires": {
-            "@leafygreen-ui/lib": "^7.0.0"
+            "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
+          "version": "9.1.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+          "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
           "requires": {
-            "@leafygreen-ui/emotion": "^3.0.1",
+            "@leafygreen-ui/emotion": "^4.0.0",
             "facepaint": "^1.2.1",
-            "polished": "^2.3.0",
+            "polished": "^4.1.3",
             "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-3.3.1.tgz",
+          "integrity": "sha1-URkm+XdNIrAzyREzdeMDlRDZl3I="
+        },
+        "@leafygreen-ui/portal": {
+          "version": "4.0.2",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-4.0.2.tgz",
+          "integrity": "sha1-MIQsDvTZQmFHXp9XiiWBmZlRRHQ=",
+          "requires": {
+            "@leafygreen-ui/hooks": "^7.1.1",
+            "@leafygreen-ui/lib": "^9.0.0"
+          }
+        },
+        "polished": {
+          "version": "4.2.1",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.1.tgz",
+          "integrity": "sha1-44zfQkSzvqY/d7D4qyM14ipmvQg=",
+          "requires": {
+            "@babel/runtime": "^7.17.8"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@leafygreen-ui/inline-definition": "^2.0.2",
     "@leafygreen-ui/leafygreen-provider": "^2.0.2",
     "@leafygreen-ui/logo": "^4.0.2",
-    "@leafygreen-ui/modal": "^6.0.2",
+    "@leafygreen-ui/modal": "^6.1.2",
     "@leafygreen-ui/palette": "^3.1.1",
     "@leafygreen-ui/select": "^3.0.1",
     "@leafygreen-ui/side-nav": "^7.2.1",


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

Click to enlarge any figure to open a modal, or give feedback through the feedback widget when the screen size is medium size (say, 900px). The location of the close button will differ.

[Charts Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/charts/raymundrodriguez/master/) - master branch (7fda3590ae4788d7d008a1c901f576c5d3cc84d7) - the modal's close button can be found on the bottom left corner of the modal.

<img width="970" alt="fix-modal-close-example-1" src="https://user-images.githubusercontent.com/27821750/161636691-b23c63bc-9c80-4313-b382-d79f40499d8a.png">

[Charts Prod](https://www.mongodb.com/docs/charts/) - the modal's close button can be found on the upper right corner of the modal, where it should be.

### Staging Links:

[Charts Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/charts/raymundrodriguez/fix-modal-close/) - the modal's close button can be found on the upper right corner of the modal.

### Notes:
- This issue should not be present in production yet since we haven't made a release recently.
- The root of the issue seems to be that LG `IconButton`'s CSS was taking precedence over LG `Modal`'s styling for its close button.
- Upgrading our version of LeafyGreen's modal fixes the positioning of the close button. Version `6.1.2` was chosen as it's the latest in the same major version `6.*`.