### PR TITLE
Remove metadata static query from openapi sub component

### DIFF
--- a/src/components/OpenAPI.js
+++ b/src/components/OpenAPI.js
@@ -9,7 +9,6 @@ import ComponentFactory from './ComponentFactory';
 import { SidenavBackButton } from './Sidenav';
 import Spinner from './Spinner';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import useSnootyMetadata from '../utils/use-snooty-metadata';
 import useStickyTopValues from '../hooks/useStickyTopValues';
 import { isBrowser } from '../utils/is-browser';
 import { theme } from '../theme/docsTheme';
@@ -244,12 +243,11 @@ const LoadingWidget = ({ className }) => (
 
 const MenuTitleContainer = ({ siteTitle, pageTitle }) => {
   const docsTitle = siteTitle ? `${siteTitle} Docs` : 'Docs';
-  const { eol } = useSnootyMetadata();
   return (
     <>
       {/* Disable LG left arrow glyph due to bug where additional copies of the LG icon would be rendered 
           at the bottom of the page. */}
-      <SidenavBackButton border={<Border />} enableGlyph={false} target="/" titleOverride={docsTitle} eol={eol} />
+      <SidenavBackButton border={<Border />} enableGlyph={false} target="/" titleOverride={docsTitle} />
       <MenuTitle>{pageTitle}</MenuTitle>
     </>
   );

--- a/src/components/Sidenav/SidenavBackButton.js
+++ b/src/components/Sidenav/SidenavBackButton.js
@@ -114,7 +114,7 @@ SidenavBackButton.propTypes = {
   project: PropTypes.string,
   target: PropTypes.string,
   titleOverride: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.string]),
-  eol: PropTypes.bool.isRequired,
+  eol: PropTypes.bool,
 };
 
 export default SidenavBackButton;


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Landing Prod](https://www.mongodb.com/docs/openapi/preview/?src=https%3A%2F%2Fraw.githubusercontent.com%2FOAI%2FOpenAPI-Specification%2Fmain%2Fexamples%2Fv3.0%2Fpetstore-expanded.yaml)
[Landing](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-1998/openapi/preview/?src=https%3A%2F%2Fraw.githubusercontent.com%2FOAI%2FOpenAPI-Specification%2Fmain%2Fexamples%2Fv3.0%2Fpetstore-expanded.yaml) - on a staging link with changes from Snotoy master branch

### Staging Links:

[Landing Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/fix-eol-openapi/openapi/preview/?src=https%3A%2F%2Fraw.githubusercontent.com%2FOAI%2FOpenAPI-Specification%2Fmain%2Fexamples%2Fv3.0%2Fpetstore-expanded.yaml)

### Notes:
* Fixes a small bug where a static query was preventing our `OpenAPI` component from loading.