### PR TITLE
Fix: Add trailing slash to docs homepage url

### DIFF
--- a/src/components/Sidenav/SidenavDocsLogo.js
+++ b/src/components/Sidenav/SidenavDocsLogo.js
@@ -14,7 +14,7 @@ const PaddedDocsLogo = styled(DocsLogo)`
 const SidenavDocsLogo = ({ border, ...props }) => {
   return (
     <>
-      <Link to={`${DOCS_URL}/`}>
+      <Link to={DOCS_URL}>
         <PaddedDocsLogo height={20} width={184} {...props} />
       </Link>
       {border}

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,5 +25,5 @@ export const REF_TARGETS = Object.fromEntries(
   })
 );
 
-export const DOCS_URL = 'https://mongodb.com/docs/';
+export const DOCS_URL = 'https://www.mongodb.com/docs/';
 export const MARIAN_URL = 'https://docs-search-transport.mongodb.com/';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-import { baseUrl, dotcomifyUrl, isDotCom } from './utils/dotcom';
+import { dotcomifyUrl, isDotCom } from './utils/dotcom';
 
 // hardcoded for now because this target lookup will be complex
 // as it relies on other sites (e.g. manual) cc. Andrew
@@ -25,5 +25,5 @@ export const REF_TARGETS = Object.fromEntries(
   })
 );
 
-export const DOCS_URL = baseUrl(true);
-export const MARIAN_URL = 'https://docs-search-transport.mongodb.com';
+export const DOCS_URL = 'https://mongodb.com/docs/';
+export const MARIAN_URL = 'https://docs-search-transport.mongodb.com/';

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -1,8 +1,9 @@
 import { DOCS_URL, MARIAN_URL } from '../constants';
+import { assertTrailingSlash } from './assert-trailing-slash';
 
 // Search helper function to generate marian URL from params and filters
 export const searchParamsToURL = (searchQuery, searchFilters, isMarian = true) => {
   const queryParams = `?q=${searchQuery}${searchFilters ? `&searchProperty=${searchFilters}` : ''}`;
   const url = isMarian ? MARIAN_URL : DOCS_URL;
-  return `${url}/search${queryParams}`;
+  return `${assertTrailingSlash(url)}search${queryParams}`;
 };

--- a/tests/unit/utils/mock-marian-fetch.js
+++ b/tests/unit/utils/mock-marian-fetch.js
@@ -17,7 +17,7 @@ export const UNFILTERED_RESULT = {
 export const mockMarianFetch = (url) => {
   let endpoint = url;
   if (endpoint.includes(MARIAN_URL)) {
-    endpoint = endpoint.split(`${MARIAN_URL}/`)[1];
+    endpoint = endpoint.split(`${MARIAN_URL}`)[1];
   }
   switch (endpoint) {
     case 'status':


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Landing Prod](https://www.mongodb.com/docs/)
[Landing QA Site](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

### Staging Links:

[Landing Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymundrodriguez/fix-docs-homepage-style/index.html)

### Notes:
* Adds trailing slash to docs homepage url to prevent different link styling from applying through our `Link` component.
* `DOCS_URL` isn't used in too many places currently so I just updated it to `https://www.mongodb.com/docs/`. Let me know if we don't want to commit to this url yet and if we should stick to using `baseUrl()`!