### PR TITLE
DOP-N/A: useSnootyMetadata in drivers-index, make parentPaths null safe

### DIFF
--- a/src/templates/drivers-index.js
+++ b/src/templates/drivers-index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { theme } from '../theme/docsTheme';
+import useSnootyMetadata from '../utils/use-snooty-metadata';
 import Breadcrumbs from '../components/Breadcrumbs';
 import MainColumn from '../components/MainColumn';
 
@@ -16,22 +17,19 @@ const StyledMainColumn = styled(MainColumn)`
   padding-top: 40px;
 `;
 
-const DriversIndex = ({
-  children,
-  pageContext: {
-    metadata: { title, parentPaths },
-    slug,
-  },
-}) => (
-  <DocumentContainer>
-    <StyledMainColumn>
-      <div className="body">
-        <Breadcrumbs parentPaths={parentPaths.slug} siteTitle={title} slug={slug} />
-        {children}
-      </div>
-    </StyledMainColumn>
-  </DocumentContainer>
-);
+const DriversIndex = ({ children, pageContext: { slug } }) => {
+  const { title, parentPaths } = useSnootyMetadata();
+  return (
+    <DocumentContainer>
+      <StyledMainColumn>
+        <div className="body">
+          <Breadcrumbs parentPaths={parentPaths?.slug} siteTitle={title} slug={slug} />
+          {children}
+        </div>
+      </StyledMainColumn>
+    </DocumentContainer>
+  );
+};
 
 DriversIndex.propTypes = {
   pageContext: PropTypes.shape({


### PR DESCRIPTION
### Stories/Links:

DOP-NNNN

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_
https://www.mongodb.com/docs/drivers/

### Staging Links:

_Put a link to your staging environment(s), if applicable_
https://docs-mongodbcom-integration.corp.mongodb.com/master/drivers/cassidy.schaufele/hotfix-drivers-landing.1/
### Notes:
Resolved observed issue from metadata page-data changes with drivers-index template