### PR TITLE
DOP-2912: Pass classnames through to external links

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -35,7 +35,7 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
     );
   } else if (!anchor && !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/))) {
     return (
-      <LGLink className={cx(LGlinkStyling)} href={to}>
+      <LGLink className={cx(LGlinkStyling)} href={to} {...other}>
         {children}
       </LGLink>
     );

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -3,11 +3,6 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -28,39 +23,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-1:focus {
+.emotion-0:focus {
   outline: none;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-1 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-3 {
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -83,18 +78,18 @@ exports[`renders correctly 1`] = `
       </li>
       <li>
         <span
-          class="emotion-0 emotion-1"
+          class="reference external emotion-0"
           data-leafygreen-ui="anchor-container"
         >
           <span
-            class="emotion-2"
+            class="emotion-1"
           >
             programmatic access
           </span>
           <svg
             alt=""
             aria-hidden="true"
-            class="emotion-3"
+            class="emotion-2"
             height="16"
             role="presentation"
             viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -16,12 +16,22 @@ exports[`renders correctly with pageTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
+.emotion-2:last-of-type {
+  color: #21313C;
 }
 
-.emotion-3 {
+.emotion-2:hover,
+.emotion-2:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover:not(:last-of-type),
+.emotion-2:focus:not(:last-of-type) {
+  color: #21313C;
+}
+
+.emotion-4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -42,58 +52,43 @@ exports[`renders correctly with pageTitle 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-3:focus {
+.emotion-4:focus {
   outline: none;
 }
 
-.emotion-4 {
+.emotion-5 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-5 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-5 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-5 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-5 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-5 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
   cursor: default;
 }
 
-.emotion-5:last-of-type {
-  color: #21313C;
-}
-
-.emotion-7:last-of-type {
-  color: #21313C;
-}
-
-.emotion-7:hover,
-.emotion-7:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-7:hover:not(:last-of-type),
-.emotion-7:focus:not(:last-of-type) {
+.emotion-6:last-of-type {
   color: #21313C;
 }
 
@@ -102,24 +97,24 @@ exports[`renders correctly with pageTitle 1`] = `
   >
     <p>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-2 emotion-3 emotion-4"
         data-leafygreen-ui="anchor-container"
         href="https://localhost/"
         target="_self"
       >
         <span
-          class="emotion-4"
+          class="emotion-5"
         >
           Docs Home
         </span>
       </a>
       <span
-        class="emotion-5 emotion-6"
+        class="emotion-6 emotion-7"
       >
          → 
       </span>
       <a
-        class="emotion-7 emotion-8"
+        class="emotion-2 emotion-3"
         href="/view-analyze/"
       >
         View & Analyze Data
@@ -145,12 +140,22 @@ exports[`renders correctly with siteTitle 1`] = `
   min-height: 24px;
 }
 
-.emotion-2 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
+.emotion-2:last-of-type {
+  color: #21313C;
 }
 
-.emotion-3 {
+.emotion-2:hover,
+.emotion-2:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover:not(:last-of-type),
+.emotion-2:focus:not(:last-of-type) {
+  color: #21313C;
+}
+
+.emotion-4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -171,58 +176,43 @@ exports[`renders correctly with siteTitle 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-3:focus {
+.emotion-4:focus {
   outline: none;
 }
 
-.emotion-4 {
+.emotion-5 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-5 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-4 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
-}
-
-[data-leafygreen-ui="anchor-container"]:hover .emotion-4 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-4 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-5 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
 .emotion-5 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-5 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-5 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-6 {
   cursor: default;
 }
 
-.emotion-5:last-of-type {
-  color: #21313C;
-}
-
-.emotion-7:last-of-type {
-  color: #21313C;
-}
-
-.emotion-7:hover,
-.emotion-7:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-7:hover:not(:last-of-type),
-.emotion-7:focus:not(:last-of-type) {
+.emotion-6:last-of-type {
   color: #21313C;
 }
 
@@ -231,24 +221,24 @@ exports[`renders correctly with siteTitle 1`] = `
   >
     <p>
       <a
-        class="emotion-2 emotion-3"
+        class="emotion-2 emotion-3 emotion-4"
         data-leafygreen-ui="anchor-container"
         href="https://localhost/"
         target="_self"
       >
         <span
-          class="emotion-4"
+          class="emotion-5"
         >
           Docs Home
         </span>
       </a>
       <span
-        class="emotion-5 emotion-6"
+        class="emotion-6 emotion-7"
       >
          → 
       </span>
       <a
-        class="emotion-7 emotion-8"
+        class="emotion-2 emotion-3"
         href="/"
       >
         MongoDB Compass

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -78,11 +78,6 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
 }
 
 .emotion-5 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -103,39 +98,39 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   outline: none;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -180,21 +175,21 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5 emotion-6"
+        class="reference external emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-7"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-8"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -293,11 +288,6 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
 }
 
 .emotion-5 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -318,39 +308,39 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   outline: none;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -397,21 +387,21 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5 emotion-6"
+        class="reference external emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-7"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-8"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -510,11 +500,6 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
 }
 
 .emotion-5 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -535,39 +520,39 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   outline: none;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -612,21 +597,21 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5 emotion-6"
+        class="reference external emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-7"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-8"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"
@@ -725,11 +710,6 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
 }
 
 .emotion-5 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -750,39 +730,39 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   letter-spacing: 0px;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   outline: none;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-7 {
+.emotion-6 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-6 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-7 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-6 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -827,21 +807,21 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
         If you prefer learning through videos, try this lesson on 
       </a>
       <a
-        class="emotion-5 emotion-6"
+        class="reference external emotion-5"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span
-          class="emotion-7"
+          class="emotion-6"
         >
           MongoDB University
         </span>
         <svg
           alt=""
           aria-hidden="true"
-          class="emotion-8"
+          class="emotion-7"
           height="16"
           role="presentation"
           viewBox="0 0 16 16"

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -50,8 +50,70 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-8 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 0px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 4px;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  background-color: #09804C;
+  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
+  color: #FFFFFF;
+  font-size: 16px;
+  -webkit-transform: translateY(1px);
+  -moz-transform: translateY(1px);
+  -ms-transform: translateY(1px);
+  transform: translateY(1px);
+  height: 36px;
+}
+
+.emotion-8:focus {
+  outline: none;
+}
+
+.emotion-8:disabled {
+  pointer-events: none;
+}
+
+.emotion-8:active,
+.emotion-8:focus,
+.emotion-8:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8:focus {
+  color: #FFFFFF;
+}
+
+.emotion-8:hover,
+.emotion-8:active {
+  color: #FFFFFF;
+  background-color: #116149;
+  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
+}
+
+.emotion-8:focus {
+  background-color: #116149;
+  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
 }
 
 .emotion-9 {
@@ -308,6 +370,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         Congrats. You’ve completed all the guides. Want to take the next step? Register for the developer exam.
       </p>
       <a
+        aria-disabled="false"
         class="emotion-8 emotion-9"
         data-leafygreen-ui="anchor-container"
         href="https://university.mongodb.com/certification/developer/about"

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -3,11 +3,6 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
-}
-
-.emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -28,39 +23,39 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0px;
 }
 
-.emotion-1:focus {
+.emotion-0:focus {
   outline: none;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-2 {
+.emotion-1 {
   background-repeat: repeat-x;
   background-size: 2px 2px;
   background-position: center bottom;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:hover .emotion-1 {
   background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+[data-leafygreen-ui="anchor-container"]:focus .emotion-1 {
   background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
 }
 
-.emotion-3 {
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -71,21 +66,21 @@ exports[`renders correctly 1`] = `
 }
 
 <a
-    class="emotion-0 emotion-1"
+    class="reference external emotion-0"
     data-leafygreen-ui="anchor-container"
     href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
     rel="noopener noreferrer"
     target="_blank"
   >
     <span
-      class="emotion-2"
+      class="emotion-1"
     >
       mLab documentation
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-3"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"


### PR DESCRIPTION
### Stories/Links:

DOP-NNNN

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_
https://www.mongodb.com/docs/realm/sdk/react-native/

### Staging Links:

_Put a link to your staging environment(s), if applicable_
https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/cassidy.schaufele/hotfix-sidenav-styling-external-links/

### Notes:
<img width="290" alt="Screen Shot 2022-04-15 at 4 42 29 PM" src="https://user-images.githubusercontent.com/3813528/163650183-23ea38de-4695-434d-82f9-6b687169e6bb.png">

This fixes some of the more obvious styling mismatches in the Realm sidenav by allowing passthrough of relevant css props. 
