### PR TITLE
DOP-2573: Upgrade LG Button to v13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@leafygreen-ui/badge": "^4.0.3",
         "@leafygreen-ui/banner": "^3.0.6",
         "@leafygreen-ui/box": "^3.0.6",
-        "@leafygreen-ui/button": "^12.0.2",
+        "@leafygreen-ui/button": "^13.0.0",
         "@leafygreen-ui/callout": "^3.0.6",
         "@leafygreen-ui/card": "^5.1.1",
         "@leafygreen-ui/checkbox": "^6.0.3",
@@ -3585,26 +3585,26 @@
       }
     },
     "node_modules/@leafygreen-ui/button": {
-      "version": "12.0.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.5.tgz",
-      "integrity": "sha1-DOCwdr3s7KPNArG5sObRNCNrUSA=",
+      "version": "13.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-13.0.0.tgz",
+      "integrity": "sha1-vbRgVbWroAMX1AeLT4NDcKj9sP8=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/box": "^3.0.6",
         "@leafygreen-ui/emotion": "^4.0.0",
         "@leafygreen-ui/lib": "^9.0.0",
-        "@leafygreen-ui/palette": "^3.2.2",
+        "@leafygreen-ui/palette": "^3.3.1",
         "@leafygreen-ui/ripple": "^1.1.1",
-        "@leafygreen-ui/tokens": "^0.5.3"
+        "@leafygreen-ui/tokens": "^1.0.0"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^2.1.3"
       }
     },
     "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/lib": {
-      "version": "9.1.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
-      "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
+      "version": "9.2.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+      "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.0",
@@ -3622,13 +3622,22 @@
       "integrity": "sha1-URkm+XdNIrAzyREzdeMDlRDZl3I=",
       "license": "Apache-2.0"
     },
+    "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/tokens": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.2.0.tgz",
+      "integrity": "sha1-uzsW5vYMOaYKsALWRB+rGvCfNQQ=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^9.2.1"
+      }
+    },
     "node_modules/@leafygreen-ui/button/node_modules/polished": {
-      "version": "4.1.4",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.1.4.tgz",
-      "integrity": "sha1-ZAKTuoNBCWFJYacA/ay7ZZn7EtA=",
+      "version": "4.2.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha1-JSm7fDGYlFNzxS40YYyP57GqhNE=",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.16.7"
+        "@babel/runtime": "^7.17.8"
       },
       "engines": {
         "node": ">=10"
@@ -4363,6 +4372,23 @@
         "@types/react-is": "^17.0.0",
         "polished": "^4.1.3",
         "react-is": "^17.0.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.1.3"
+      }
+    },
+    "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/button": {
+      "version": "12.0.5",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.5.tgz",
+      "integrity": "sha1-DOCwdr3s7KPNArG5sObRNCNrUSA=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/box": "^3.0.6",
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.2.2",
+        "@leafygreen-ui/ripple": "^1.1.1",
+        "@leafygreen-ui/tokens": "^0.5.3"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^2.1.3"
@@ -35227,7 +35253,8 @@
     "@emotion/eslint-plugin": {
       "version": "11.7.0",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/eslint-plugin/-/eslint-plugin-11.7.0.tgz",
-      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM="
+      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM=",
+      "requires": {}
     },
     "@emotion/hash": {
       "version": "0.8.0",
@@ -35757,7 +35784,8 @@
         "ws": {
           "version": "7.4.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+          "requires": {}
         }
       }
     },
@@ -36578,22 +36606,22 @@
       }
     },
     "@leafygreen-ui/button": {
-      "version": "12.0.5",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.5.tgz",
-      "integrity": "sha1-DOCwdr3s7KPNArG5sObRNCNrUSA=",
+      "version": "13.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-13.0.0.tgz",
+      "integrity": "sha1-vbRgVbWroAMX1AeLT4NDcKj9sP8=",
       "requires": {
         "@leafygreen-ui/box": "^3.0.6",
         "@leafygreen-ui/emotion": "^4.0.0",
         "@leafygreen-ui/lib": "^9.0.0",
-        "@leafygreen-ui/palette": "^3.2.2",
+        "@leafygreen-ui/palette": "^3.3.1",
         "@leafygreen-ui/ripple": "^1.1.1",
-        "@leafygreen-ui/tokens": "^0.5.3"
+        "@leafygreen-ui/tokens": "^1.0.0"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "9.1.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
-          "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
+          "version": "9.2.1",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+          "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.0",
             "facepaint": "^1.2.1",
@@ -36606,12 +36634,20 @@
           "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-3.3.1.tgz",
           "integrity": "sha1-URkm+XdNIrAzyREzdeMDlRDZl3I="
         },
-        "polished": {
-          "version": "4.1.4",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.1.4.tgz",
-          "integrity": "sha1-ZAKTuoNBCWFJYacA/ay7ZZn7EtA=",
+        "@leafygreen-ui/tokens": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.2.0.tgz",
+          "integrity": "sha1-uzsW5vYMOaYKsALWRB+rGvCfNQQ=",
           "requires": {
-            "@babel/runtime": "^7.16.7"
+            "@leafygreen-ui/lib": "^9.2.1"
+          }
+        },
+        "polished": {
+          "version": "4.2.2",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.2.tgz",
+          "integrity": "sha1-JSm7fDGYlFNzxS40YYyP57GqhNE=",
+          "requires": {
+            "@babel/runtime": "^7.17.8"
           }
         }
       }
@@ -37229,6 +37265,19 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
+        "@leafygreen-ui/button": {
+          "version": "12.0.5",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-12.0.5.tgz",
+          "integrity": "sha1-DOCwdr3s7KPNArG5sObRNCNrUSA=",
+          "requires": {
+            "@leafygreen-ui/box": "^3.0.6",
+            "@leafygreen-ui/emotion": "^4.0.0",
+            "@leafygreen-ui/lib": "^9.0.0",
+            "@leafygreen-ui/palette": "^3.2.2",
+            "@leafygreen-ui/ripple": "^1.1.1",
+            "@leafygreen-ui/tokens": "^0.5.3"
+          }
+        },
         "@leafygreen-ui/hooks": {
           "version": "7.2.0",
           "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.2.0.tgz",
@@ -37585,7 +37634,8 @@
     "@mdb/consistent-nav": {
       "version": "1.2.10-rc.0",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.10-rc.0.tgz",
-      "integrity": "sha1-8b/JF17kfxpqtebv/+GBxRKzCzQ="
+      "integrity": "sha1-8b/JF17kfxpqtebv/+GBxRKzCzQ=",
+      "requires": {}
     },
     "@mdb/flora": {
       "version": "0.11.1",
@@ -37601,7 +37651,8 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM="
+      "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM=",
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "2.0.0-next.8",
@@ -37898,7 +37949,8 @@
           "version": "8.5.0",
           "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ws/-/ws-8.5.0.tgz",
           "integrity": "sha1-v7S+lmAHV/5Tgt4SxnDauYSh7U8=",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -37980,7 +38032,8 @@
     "@redocly/react-dropdown-aria": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@redocly/react-dropdown-aria/-/react-dropdown-aria-2.0.11.tgz",
-      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A=="
+      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==",
+      "requires": {}
     },
     "@sideway/address": {
       "version": "4.1.0",
@@ -39360,7 +39413,8 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -39401,12 +39455,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -39856,7 +39912,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -40222,7 +40279,8 @@
     "babel-plugin-remove-graphql-queries": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.13.0.tgz",
-      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ=="
+      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ==",
+      "requires": {}
     },
     "babel-plugin-styled-components": {
       "version": "1.12.0",
@@ -43588,7 +43646,8 @@
     "eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
+      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -45747,7 +45806,8 @@
         "graphql-type-json": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
+          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
+          "requires": {}
         }
       }
     },
@@ -45804,7 +45864,8 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+      "requires": {}
     },
     "graphql-upload": {
       "version": "11.0.0",
@@ -45845,7 +45906,8 @@
     "graphql-ws": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-3.1.0.tgz",
-      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg=="
+      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg==",
+      "requires": {}
     },
     "growly": {
       "version": "1.3.0",
@@ -47396,7 +47458,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -48518,7 +48581,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -50821,7 +50885,8 @@
     "mobx-react-lite": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz",
-      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g=="
+      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==",
+      "requires": {}
     },
     "moment": {
       "version": "2.29.1",
@@ -53493,7 +53558,8 @@
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
-      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==",
+      "requires": {}
     },
     "react-tabs": {
       "version": "3.1.2",
@@ -57048,7 +57114,8 @@
     "use-ssr": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.23.tgz",
-      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA=="
+      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",
@@ -58517,7 +58584,8 @@
     "ws": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@leafygreen-ui/badge": "^4.0.3",
     "@leafygreen-ui/banner": "^3.0.6",
     "@leafygreen-ui/box": "^3.0.6",
-    "@leafygreen-ui/button": "^12.0.2",
+    "@leafygreen-ui/button": "^13.0.0",
     "@leafygreen-ui/callout": "^3.0.6",
     "@leafygreen-ui/card": "^5.1.1",
     "@leafygreen-ui/checkbox": "^6.0.3",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,7 +12,7 @@ const Button = ({
   ...rest
 }) => {
   return (
-    <LeafyButton baseFontSize={16} className="button" as={Link} hideExternalIcon={true} variant="primary" to={uri}>
+    <LeafyButton className="button" as={Link} hideExternalIcon={true} variant="primary" to={uri}>
       {argument.map((child, i) => (
         <ComponentFactory {...rest} nodeData={child} key={i} />
       ))}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,7 +12,7 @@ const Button = ({
   ...rest
 }) => {
   return (
-    <LeafyButton baseFontSize={16} className="button" as={Link} variant="primary" to={uri}>
+    <LeafyButton baseFontSize={16} className="button" as={Link} hideExternalIcon={true} variant="primary" to={uri}>
       {argument.map((child, i) => (
         <ComponentFactory {...rest} nodeData={child} key={i} />
       ))}

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -11,13 +11,25 @@ export const baseCodeStyle = css`
 
   // Inner div of LG component has a width set to 700px. Unset this as part of our
   // override for docs when the language switcher is being used.
+  // TODO: (DOP-2576) See if we can remove all of this when we upgrade LG Code component.
   > div > div {
     width: unset;
 
-    // TODO: (DOP-2576) Remove this when we upgrade LG Code component.
-    // Keep this within the context of the language switcher
-    button > div {
-      grid-template-columns: 16px 1fr 16px;
+    & > div[data-testid='leafygreen-code-panel'] {
+      padding-left: 0;
+
+      & > div > div {
+        width: unset;
+        min-width: 144px;
+      }
+    }
+
+    button[aria-labelledby='Language Picker'] {
+      margin-left: 0;
+
+      & > div {
+        grid-template-columns: 16px 1fr 16px;
+      }
     }
   }
 

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -13,6 +13,12 @@ export const baseCodeStyle = css`
   // override for docs when the language switcher is being used.
   > div > div {
     width: unset;
+
+    // TODO: (DOP-2576) Remove this when we upgrade LG Code component.
+    // Keep this within the context of the language switcher
+    button > div {
+      grid-template-columns: 16px 1fr 16px;
+    }
   }
 
   // Override default LG Code language switcher font size

--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -118,7 +118,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
         onChange={updateVersion}
         value={version}
       />
-      <Button variant="primary" title="View Documentation" size="large" href={generateUrl()} disabled={buttonDisabled}>
+      <Button variant="primary" title="View Documentation" href={generateUrl()} disabled={buttonDisabled}>
         View Documentation
       </Button>
     </>

--- a/src/components/GuideNext/Content.js
+++ b/src/components/GuideNext/Content.js
@@ -69,7 +69,7 @@ const Content = ({ argument, children, guideData }) => {
       </ConditionalWrapper>
       {/* We only want to show the button if argument/children are empty */}
       {!hasCustomContent && buttonUrl && (
-        <Button as={Link} baseFontSize={16} to={buttonUrl} variant="primary">
+        <Button as={Link} baseFontSize={16} to={buttonUrl} hideExternalIcon={true} variant="primary">
           {buttonText}
         </Button>
       )}

--- a/src/components/GuideNext/Content.js
+++ b/src/components/GuideNext/Content.js
@@ -69,7 +69,7 @@ const Content = ({ argument, children, guideData }) => {
       </ConditionalWrapper>
       {/* We only want to show the button if argument/children are empty */}
       {!hasCustomContent && buttonUrl && (
-        <Button as={Link} baseFontSize={16} to={buttonUrl} hideExternalIcon={true} variant="primary">
+        <Button as={Link} to={buttonUrl} hideExternalIcon={true} variant="primary">
           {buttonText}
         </Button>
       )}

--- a/src/components/Introduction.js
+++ b/src/components/Introduction.js
@@ -6,7 +6,6 @@ import ComponentFactory from './ComponentFactory';
 
 const StyledIntroduction = styled('div')`
   .button {
-    font-size: ${theme.fontSize.default};
     margin: ${theme.size.medium} ${theme.size.default} ${theme.size.default} 0;
     min-height: ${theme.size.large};
   }

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -55,6 +55,9 @@ const ListTableRow = ({ row = [], stubColumnCount, ...rest }) => (
 
             * {
               font-size: ${theme.fontSize.small} !important;
+            }
+
+            & > div {
               align-items: start;
             }
 

--- a/src/components/Video/VideoPlayButton.js
+++ b/src/components/Video/VideoPlayButton.js
@@ -16,6 +16,7 @@ const StyledButton = styled(LeafyButton)`
   &:active {
     border: none !important;
     box-shadow: none !important;
+    color: ${uiColors.gray.dark2};
   }
 `;
 

--- a/tests/unit/__snapshots__/Button.test.js.snap
+++ b/tests/unit/__snapshots__/Button.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19,7 +19,6 @@ exports[`renders correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -27,14 +26,17 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
-  background-color: #09804C;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #00684A;
+  border-color: #00684A;
   color: #FFFFFF;
   font-size: 16px;
   -webkit-transform: translateY(1px);
   -moz-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+  font-weight: 500;
   height: 36px;
 }
 
@@ -53,37 +55,37 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
 }
 
-.emotion-0:focus {
-  color: #FFFFFF;
-}
-
 .emotion-0:hover,
 .emotion-0:active {
   color: #FFFFFF;
-  background-color: #116149;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
+  background-color: #00593f;
+  border-color: #00593f;
+  box-shadow: 0 0 0 3px #C0FAE6;
 }
 
 .emotion-0:focus {
-  background-color: #116149;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  color: #FFFFFF;
+  background-color: #00593f;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-1 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -93,18 +95,14 @@ exports[`renders correctly 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 <a
     aria-disabled="false"
     class="emotion-0 button"
+    data-leafygreen-ui="button"
     href="/install/"
   >
     <div

--- a/tests/unit/__snapshots__/Button.test.js.snap
+++ b/tests/unit/__snapshots__/Button.test.js.snap
@@ -31,11 +31,7 @@ exports[`renders correctly 1`] = `
   background-color: #00684A;
   border-color: #00684A;
   color: #FFFFFF;
-  font-size: 16px;
-  -webkit-transform: translateY(1px);
-  -moz-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
+  font-size: 13px;
   font-weight: 500;
   height: 36px;
 }

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -14,20 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+.emotion-0>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 
@@ -244,20 +244,20 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+.emotion-0>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -14,7 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div button>div {
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 
@@ -231,7 +244,20 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div button>div {
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -14,6 +14,10 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
+.emotion-0>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
+}
+
 .emotion-0 button>div>div {
   font-size: 16px;
 }
@@ -225,6 +229,10 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 
 .emotion-0>div>div {
   width: unset;
+}
+
+.emotion-0>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
 }
 
 .emotion-0 button>div>div {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -14,20 +14,20 @@ exports[`CodeIO renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+.emotion-0>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 
@@ -60,20 +60,20 @@ exports[`CodeIO renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-1>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-1>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-1>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-1>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-1>div>div button[aria-labelledby="Language Picker"] {
+.emotion-1>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-1>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-1>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -220,7 +220,7 @@ exports[`CodeIO renders correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -229,7 +229,6 @@ exports[`CodeIO renders correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -237,11 +236,13 @@ exports[`CodeIO renders correctly 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
   background-color: #F9FBFA;
-  border: 1px solid #89979B;
-  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
-  color: #3D4F58;
-  font-size: 14px;
+  border-color: #889397;
+  color: #1C2D38;
+  font-size: 13px;
+  font-weight: 500;
   height: 36px;
   padding: 0px;
   font-size: 12px;
@@ -265,39 +266,34 @@ exports[`CodeIO renders correctly 1`] = `
   text-decoration: none;
 }
 
-.emotion-16:focus {
-  color: #3D4F58;
-}
-
 .emotion-16:hover,
 .emotion-16:active {
-  color: #3D4F58;
   background-color: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+  box-shadow: 0 0 0 3px #E8EDEB;
 }
 
 .emotion-16:focus {
-  background: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-17 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -307,21 +303,16 @@ exports[`CodeIO renders correctly 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-19 {
   color: #FF0000;
-  color: #5D6C74;
+  color: #889397;
   height: 16px;
   width: 16px;
-  margin-right: 6px;
+  justify-self: right;
 }
 
 .emotion-20 {
@@ -485,6 +476,7 @@ exports[`CodeIO renders correctly 1`] = `
       <button
         aria-disabled="false"
         class="emotion-16"
+        data-leafygreen-ui="button"
         role="button"
         type="button"
       >

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -14,7 +14,20 @@ exports[`CodeIO renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div button>div {
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 
@@ -47,7 +60,20 @@ exports[`CodeIO renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-1>div>div button>div {
+.emotion-1>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-1>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-1>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-1>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -14,6 +14,10 @@ exports[`CodeIO renders correctly 1`] = `
   width: unset;
 }
 
+.emotion-0>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
+}
+
 .emotion-0 button>div>div {
   font-size: 16px;
 }
@@ -41,6 +45,10 @@ exports[`CodeIO renders correctly 1`] = `
 
 .emotion-1>div>div {
   width: unset;
+}
+
+.emotion-1>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
 }
 
 .emotion-1 button>div>div {

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -78,11 +78,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   background-color: #00684A;
   border-color: #00684A;
   color: #FFFFFF;
-  font-size: 16px;
-  -webkit-transform: translateY(1px);
-  -moz-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
+  font-size: 13px;
   font-weight: 500;
   height: 36px;
 }
@@ -515,11 +511,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   background-color: #00684A;
   border-color: #00684A;
   color: #FFFFFF;
-  font-size: 16px;
-  -webkit-transform: translateY(1px);
-  -moz-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
+  font-size: 13px;
   font-weight: 500;
   height: 36px;
 }
@@ -885,11 +877,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   background-color: #00684A;
   border-color: #00684A;
   color: #FFFFFF;
-  font-size: 16px;
-  -webkit-transform: translateY(1px);
-  -moz-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
+  font-size: 13px;
   font-weight: 500;
   height: 36px;
 }

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -57,7 +57,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -66,7 +66,6 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -74,14 +73,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
-  background-color: #09804C;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #00684A;
+  border-color: #00684A;
   color: #FFFFFF;
   font-size: 16px;
   -webkit-transform: translateY(1px);
   -moz-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+  font-weight: 500;
   height: 36px;
 }
 
@@ -100,20 +102,18 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   text-decoration: none;
 }
 
-.emotion-8:focus {
-  color: #FFFFFF;
-}
-
 .emotion-8:hover,
 .emotion-8:active {
   color: #FFFFFF;
-  background-color: #116149;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
+  background-color: #00593f;
+  border-color: #00593f;
+  box-shadow: 0 0 0 3px #C0FAE6;
 }
 
 .emotion-8:focus {
-  background-color: #116149;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  color: #FFFFFF;
+  background-color: #00593f;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-9 {
@@ -171,19 +171,21 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 
 .emotion-11 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -193,38 +195,23 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-13 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  position: relative;
-  bottom: 4px;
-  left: -1px;
-  height: 12px;
-}
-
-.emotion-14 {
   margin-top: 40px;
   padding: 40px 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-14 {
+  .emotion-13 {
     padding: 48px;
   }
 }
 
 @media not all and (max-width: 1023px) {
-  .emotion-14 {
+  .emotion-13 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -238,7 +225,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-14 {
   position: relative;
   border-radius: 7px;
   -webkit-transition: border 300ms ease-in-out,box-shadow 300ms ease-in-out;
@@ -249,12 +236,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   color: #21313C;
 }
 
-.emotion-16 {
+.emotion-15 {
   margin-bottom: 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-16 {
+  .emotion-15 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -264,7 +251,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-19 {
+.emotion-18 {
   background-color: #E4F4E4;
   border-radius: 4px;
   color: #13AA52;
@@ -276,17 +263,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-21 {
+.emotion-20 {
   color: #061621;
   font-weight: bold;
 }
 
-.emotion-23 {
+.emotion-22 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-25 {
+.emotion-24 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -300,11 +287,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   position: relative;
 }
 
-.emotion-25:not(:last-child) {
+.emotion-24:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-25:not(:last-child):before {
+.emotion-24:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -313,7 +300,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   border-left: solid 1px #13AA52;
 }
 
-.emotion-27 {
+.emotion-26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -333,18 +320,18 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   min-height: 20px;
 }
 
-.emotion-29 {
+.emotion-28 {
   color: #13AA52;
 }
 
-.emotion-30 {
+.emotion-29 {
   color: #061621;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-30:hover,
-.emotion-30:active {
+.emotion-29:hover,
+.emotion-29:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -372,7 +359,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
       <a
         aria-disabled="false"
         class="emotion-8 emotion-9"
-        data-leafygreen-ui="anchor-container"
+        data-leafygreen-ui="button"
         href="https://university.mongodb.com/certification/developer/about"
         rel="noopener noreferrer"
         target="_blank"
@@ -389,57 +376,39 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             Learn More
           </div>
         </span>
-        <svg
-          alt=""
-          aria-hidden="true"
-          class="emotion-13"
-          height="16"
-          role="presentation"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <path
-            d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
-            fill="currentColor"
-          />
-          <path
-            d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
-            fill="currentColor"
-          />
-        </svg>
       </a>
     </div>
     <div
-      class="emotion-14 emotion-15"
+      class="emotion-13 emotion-14"
     >
       <div
-        class="emotion-16 emotion-17"
+        class="emotion-15 emotion-16"
       >
         <div
-          class="emotion-18 emotion-19 emotion-20"
+          class="emotion-17 emotion-18 emotion-19"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-20 emotion-21"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-23 emotion-24"
+        class="emotion-22 emotion-23"
       >
         <li
-          class="emotion-25 emotion-26"
+          class="emotion-24 emotion-25"
           color="#13AA52"
         >
           <div
-            class="emotion-27 emotion-28"
+            class="emotion-26 emotion-27"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-29"
+              class="emotion-28"
               fill="none"
               height="16"
               role="img"
@@ -456,7 +425,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-30 emotion-31"
+            class="emotion-29 emotion-30"
             href="/server/read/"
           >
             Read Data in MongoDB
@@ -525,7 +494,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -534,7 +503,6 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -542,14 +510,17 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
-  background-color: #09804C;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #00684A;
+  border-color: #00684A;
   color: #FFFFFF;
   font-size: 16px;
   -webkit-transform: translateY(1px);
   -moz-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+  font-weight: 500;
   height: 36px;
 }
 
@@ -568,37 +539,37 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   text-decoration: none;
 }
 
-.emotion-8:focus {
-  color: #FFFFFF;
-}
-
 .emotion-8:hover,
 .emotion-8:active {
   color: #FFFFFF;
-  background-color: #116149;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
+  background-color: #00593f;
+  border-color: #00593f;
+  box-shadow: 0 0 0 3px #C0FAE6;
 }
 
 .emotion-8:focus {
-  background-color: #116149;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  color: #FFFFFF;
+  background-color: #00593f;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-9 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -608,13 +579,8 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-11 {
@@ -774,6 +740,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
       <a
         aria-disabled="false"
         class="emotion-8"
+        data-leafygreen-ui="button"
         href="/server/read/"
       >
         <div
@@ -897,7 +864,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -906,7 +873,6 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -914,14 +880,17 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
-  background-color: #09804C;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4);
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #00684A;
+  border-color: #00684A;
   color: #FFFFFF;
   font-size: 16px;
   -webkit-transform: translateY(1px);
   -moz-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+  font-weight: 500;
   height: 36px;
 }
 
@@ -940,37 +909,37 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   text-decoration: none;
 }
 
-.emotion-8:focus {
-  color: #FFFFFF;
-}
-
 .emotion-8:hover,
 .emotion-8:active {
   color: #FFFFFF;
-  background-color: #116149;
-  box-shadow: 0px 2px 3px rgba(19, 170, 82, 0.4),0px 0px 0px 3px #c3e7ca;
+  background-color: #00593f;
+  border-color: #00593f;
+  box-shadow: 0 0 0 3px #C0FAE6;
 }
 
 .emotion-8:focus {
-  background-color: #116149;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  color: #FFFFFF;
+  background-color: #00593f;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-9 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -980,13 +949,8 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-11 {
@@ -1201,6 +1165,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
       <a
         aria-disabled="false"
         class="emotion-8"
+        data-leafygreen-ui="button"
         href="/cloud/connectionstring/"
       >
         <div

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -216,6 +216,9 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 
 .emotion-32 * {
   font-size: 14px!important;
+}
+
+.emotion-32>div {
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -634,6 +637,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 
 .emotion-31 * {
   font-size: 14px!important;
+}
+
+.emotion-31>div {
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -690,6 +696,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 
 .emotion-34 * {
   font-size: 14px!important;
+}
+
+.emotion-34>div {
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -14,7 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div button>div {
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -14,6 +14,10 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
+.emotion-0>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
+}
+
 .emotion-0 button>div>div {
   font-size: 16px;
 }

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -14,20 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+.emotion-0>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/QuizWidget.test.js.snap
+++ b/tests/unit/__snapshots__/QuizWidget.test.js.snap
@@ -105,7 +105,7 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -114,7 +114,6 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -122,11 +121,13 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
   background-color: #F9FBFA;
-  border: 1px solid #89979B;
-  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
-  color: #3D4F58;
-  font-size: 14px;
+  border-color: #889397;
+  color: #1C2D38;
+  font-size: 13px;
+  font-weight: 500;
   height: 36px;
 }
 
@@ -145,22 +146,15 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   text-decoration: none;
 }
 
-.emotion-24:focus {
-  color: #3D4F58;
-}
-
 .emotion-24:hover,
 .emotion-24:active {
-  color: #3D4F58;
   background-color: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+  box-shadow: 0 0 0 3px #E8EDEB;
 }
 
 .emotion-24:focus {
-  background: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-25 {
@@ -169,19 +163,21 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
 
 .emotion-27 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -191,13 +187,8 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 <div
@@ -266,6 +257,7 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
     <button
       aria-disabled="false"
       class="emotion-24 emotion-25 emotion-26"
+      data-leafygreen-ui="button"
       type="button"
     >
       <div

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -14,7 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div button>div {
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+  padding-left: 0;
+}
+
+.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+  width: unset;
+  min-width: 144px;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+  margin-left: 0;
+}
+
+.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -14,6 +14,10 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
+.emotion-0>div>div button>div {
+  grid-template-columns: 16px 1fr 16px;
+}
+
 .emotion-0 button>div>div {
   font-size: 16px;
 }

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -14,20 +14,20 @@ exports[`renders correctly 1`] = `
   width: unset;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"] {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
   padding-left: 0;
 }
 
-.emotion-0>div>div>div[data-testid="leafygreen-code-panel"]>div>div {
+.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
   width: unset;
   min-width: 144px;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"] {
+.emotion-0>div>div button[aria-labelledby='Language Picker'] {
   margin-left: 0;
 }
 
-.emotion-0>div>div button[aria-labelledby="Language Picker"]>div {
+.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
   grid-template-columns: 16px 1fr 16px;
 }
 

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -255,7 +255,7 @@ exports[`Search Results Page renders loading images before returning no results 
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -264,7 +264,6 @@ exports[`Search Results Page renders loading images before returning no results 
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -272,11 +271,13 @@ exports[`Search Results Page renders loading images before returning no results 
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
   background-color: #F9FBFA;
-  border: 1px solid #89979B;
-  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
-  color: #3D4F58;
-  font-size: 14px;
+  border-color: #889397;
+  color: #1C2D38;
+  font-size: 13px;
+  font-weight: 500;
   height: 36px;
 }
 
@@ -295,39 +296,34 @@ exports[`Search Results Page renders loading images before returning no results 
   text-decoration: none;
 }
 
-.emotion-8:focus {
-  color: #3D4F58;
-}
-
 .emotion-8:hover,
 .emotion-8:active {
-  color: #3D4F58;
   background-color: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+  box-shadow: 0 0 0 3px #E8EDEB;
 }
 
 .emotion-8:focus {
-  background: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-9 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -337,20 +333,15 @@ exports[`Search Results Page renders loading images before returning no results 
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-11 {
-  color: #5D6C74;
+  color: #889397;
   height: 16px;
   width: 16px;
-  margin-right: 6px;
+  justify-self: right;
 }
 
 .emotion-12 {
@@ -468,6 +459,7 @@ exports[`Search Results Page renders loading images before returning no results 
         <button
           aria-disabled="false"
           class="emotion-8"
+          data-leafygreen-ui="button"
           type="button"
         >
           <div
@@ -1047,7 +1039,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
   padding: 0;
   margin: 0;
   background-color: transparent;
-  border: 0px solid transparent;
+  border: 1px solid transparent;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1056,7 +1048,6 @@ exports[`Search Results Page renders loading images before returning nonempty re
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  border-radius: 4px;
   -webkit-transition: all 150ms ease-in-out;
   transition: all 150ms ease-in-out;
   position: relative;
@@ -1064,11 +1055,13 @@ exports[`Search Results Page renders loading images before returning nonempty re
   text-decoration: none;
   cursor: pointer;
   z-index: 0;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
   background-color: #F9FBFA;
-  border: 1px solid #89979B;
-  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
-  color: #3D4F58;
-  font-size: 14px;
+  border-color: #889397;
+  color: #1C2D38;
+  font-size: 13px;
+  font-weight: 500;
   height: 36px;
 }
 
@@ -1087,39 +1080,34 @@ exports[`Search Results Page renders loading images before returning nonempty re
   text-decoration: none;
 }
 
-.emotion-8:focus {
-  color: #3D4F58;
-}
-
 .emotion-8:hover,
 .emotion-8:active {
-  color: #3D4F58;
   background-color: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+  box-shadow: 0 0 0 3px #E8EDEB;
 }
 
 .emotion-8:focus {
-  background: #FFFFFF;
-  border: 1px solid #5D6C74;
-  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
 .emotion-9 {
   overflow: hidden;
-  border-radius: 3px;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  border-radius: 6px;
 }
 
 .emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1129,20 +1117,15 @@ exports[`Search Results Page renders loading images before returning nonempty re
   pointer-events: none;
   position: relative;
   z-index: 0;
-  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 0 12px;
+  gap: 6px;
 }
 
 .emotion-11 {
-  color: #5D6C74;
+  color: #889397;
   height: 16px;
   width: 16px;
-  margin-right: 6px;
+  justify-self: right;
 }
 
 .emotion-12 {
@@ -1260,6 +1243,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
         <button
           aria-disabled="false"
           class="emotion-8"
+          data-leafygreen-ui="button"
           type="button"
         >
           <div


### PR DESCRIPTION
### Stories/Links:

DOP-2573

### Current Behavior:

[Server docs prod](https://www.mongodb.com/docs/manual/)
[Landing prod - search page](https://www.mongodb.com/docs/search/?q=test)
[Landing prod - legacy page](https://www.mongodb.com/docs/legacy/)
[Realm docs prod](https://www.mongodb.com/docs/realm/tutorial/ios-swift/#part-1--set-up-the-mobile-app) (see video button)
[Guides old staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/test-guides/guides/raymundrodriguez/master/server/import/index.html#summary) (built on master branch of Snooty)

### Staging Links:

[Server docs staging](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-2573/docs/raymundrodriguez/DOP-2573/index.html)
[Landing staging - search page](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-2573/search/?q=test)
[Landing staging - legacy page](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-2573/legacy/index.html)
[Realm docs staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2573/tutorial/ios-swift/#part-1--set-up-the-mobile-app) (see video button - should look the same as on prod)
[Guides staging](https://docs-mongodbcom-integration.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2573/server/import/index.html#summary)

### Notes:
* The current version of LG's `Button` component is `v14.0.0`. However, `v13.0.1` and up introduce a breaking change that prevents us from rendering their Button as a Gatsby Link. Let's upgrade this to `v13.0.0` for now to get the new branding updates until LeafyGreen releases the fix (I have already reached out to their team and have a ticket filed).