### PR TITLE
DOP-2934: Bump consistent-nav version to 1.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "@leafygreen-ui/tooltip": "^6.1.7",
         "@leafygreen-ui/typography": "^7.5.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^1.2.10-rc.0",
-        "@mdb/flora": "^0.11.0",
+        "@mdb/consistent-nav": "^1.2.13",
+        "@mdb/flora": "^0.20.1",
         "clipboard": "^2.0.8",
         "dotenv": "^8.2.0",
         "gatsby": "^2.29.3",
@@ -48,6 +48,7 @@
         "gatsby-plugin-layout": "^1.7.0",
         "gatsby-plugin-react-helmet": "^3.7.0",
         "gatsby-plugin-sitemap": "^2.11.0",
+        "hex-rgb": "^5.0.0",
         "highlight.js": "~10.6.0",
         "html-screen-capture-js": "^1.0.50",
         "mobx": "^6.1.5",
@@ -67,7 +68,7 @@
         "redoc": "^2.0.0-rc.48",
         "sanitize-html": "^2.2.0",
         "styled-components": "^5.2.1",
-        "theme-ui": "^0.10.0"
+        "theme-ui": "^0.13.1"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -1802,9 +1803,9 @@
       "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
-      "integrity": "sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==",
+      "version": "0.8.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha1-2yixxDaKJZtgqXMR1qlS1P0BrBo=",
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "0.7.4"
@@ -4804,14 +4805,14 @@
       }
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.2.10-rc.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.10-rc.0.tgz",
-      "integrity": "sha1-8b/JF17kfxpqtebv/+GBxRKzCzQ=",
+      "version": "1.2.13",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.13.tgz",
+      "integrity": "sha1-WsXxibxf0MPdHBMp9STNfVCK5Nw=",
       "license": "ISC",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
-        "@mdb/flora": ">= 0.17.5",
+        "@mdb/flora": ">= 0.20.1",
         "@mdx-js/react": "^1.6.22",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
@@ -4819,9 +4820,9 @@
       }
     },
     "node_modules/@mdb/flora": {
-      "version": "0.11.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.11.1.tgz",
-      "integrity": "sha1-QAs/9c8n4HrCSpEkS/NXBYz1Isw=",
+      "version": "0.20.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.20.1.tgz",
+      "integrity": "sha1-9R7fiXBMcITRRSWifybXxCc667o=",
       "license": "ISC",
       "dependencies": {
         "@imgix/js-core": "^3.2.1",
@@ -4830,9 +4831,12 @@
         "lazysizes": "^5.3.2"
       },
       "peerDependencies": {
+        "@emotion/react": ">= 11.6.0",
+        "@emotion/styled": ">= 11.6.0",
+        "@mdx-js/react": ">= 1.6.22",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
-        "theme-ui": ">= 0.9"
+        "theme-ui": ">= 0.13.1"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -4840,6 +4844,7 @@
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM=",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -6017,112 +6022,114 @@
       }
     },
     "node_modules/@theme-ui/color-modes": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/color-modes/-/color-modes-0.10.0.tgz",
-      "integrity": "sha1-hQcfFtfURY89q1p6+LnqRZ2k3NA=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/color-modes/-/color-modes-0.13.1.tgz",
+      "integrity": "sha1-xEW/7vpsaJUCJgkjocPE8eGtd5M=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@theme-ui/components": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/components/-/components-0.10.0.tgz",
-      "integrity": "sha1-waqcreceWmz3wZ+eCt6QASLvI/k=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/components/-/components-0.13.1.tgz",
+      "integrity": "sha1-/io9/YueNndCJda7X2jL9JhK18c=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@emotion/styled": "^11.0.0",
         "@styled-system/color": "^5.1.2",
         "@styled-system/should-forward-prop": "^5.1.2",
         "@styled-system/space": "^5.1.2",
-        "@theme-ui/css": "0.10.0",
-        "@types/styled-system": "^5.1.10"
+        "@theme-ui/css": "0.13.1",
+        "@types/styled-system": "^5.1.13"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "@emotion/styled": "^11",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@theme-ui/core": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/core/-/core-0.10.0.tgz",
-      "integrity": "sha1-I3PVM2jaX6VhkVQUreBwqd4Olng=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/core/-/core-0.13.1.tgz",
+      "integrity": "sha1-Hj3biZobhiyoDwD2gkNSTcAHaCA=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/parse-props": "0.10.0",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/parse-props": "0.13.1",
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@theme-ui/css": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/css/-/css-0.10.0.tgz",
-      "integrity": "sha1-hx9jM0+xOEkUBsMvg0fVOxmEaps=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/css/-/css-0.13.1.tgz",
+      "integrity": "sha1-hy6AoDr4nIveIb4p2/0C9TsLb4M=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "csstype": "^3.0.5"
+        "csstype": "^3.0.10"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11"
       }
     },
     "node_modules/@theme-ui/css/node_modules/csstype": {
-      "version": "3.0.8",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
+      "version": "3.0.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha1-1mcAxerPrBlA3rTj7lZCeS2FzTM=",
       "license": "MIT"
     },
     "node_modules/@theme-ui/mdx": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/mdx/-/mdx-0.10.0.tgz",
-      "integrity": "sha1-FBJMsZTfgCP3JTORkA2NF6YBGpI=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/mdx/-/mdx-0.13.1.tgz",
+      "integrity": "sha1-I/5uQjUgOLtRbMovwlORdxJ6YKM=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@emotion/styled": "^11.0.0",
-        "@mdx-js/react": "^1.6.22",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0"
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "@emotion/styled": "^11",
+        "@mdx-js/react": "^1 || ^2",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@theme-ui/parse-props": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/parse-props/-/parse-props-0.10.0.tgz",
-      "integrity": "sha1-jS9POz7a/ZJcOHLd1VnitiAG9D8=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/parse-props/-/parse-props-0.13.1.tgz",
+      "integrity": "sha1-wRcf8CNW6mMAlPpEzthoLvifJlM=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/css": "0.10.0"
+        "@theme-ui/css": "0.13.1"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@theme-ui/theme-provider": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/theme-provider/-/theme-provider-0.10.0.tgz",
-      "integrity": "sha1-Flhq9Xm++ATx5Jl6ExE00kZb/V0=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/theme-provider/-/theme-provider-0.13.1.tgz",
+      "integrity": "sha1-oAWV91ec2e5EczL2tkCFPMcEHyI=",
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/color-modes": "0.10.0",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/mdx": "0.10.0"
+        "@theme-ui/color-modes": "0.13.1",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/mdx": "0.13.1"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "@emotion/react": "^11",
+        "react": "^16 || ^17"
       }
     },
     "node_modules/@turist/fetch": {
@@ -6638,18 +6645,18 @@
       "license": "MIT"
     },
     "node_modules/@types/styled-system": {
-      "version": "5.1.12",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/styled-system/-/styled-system-5.1.12.tgz",
-      "integrity": "sha1-Tzyo2j3/48WmzDsql/UbQUZMEEo=",
+      "version": "5.1.15",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/styled-system/-/styled-system-5.1.15.tgz",
+      "integrity": "sha1-B1+WnMAoqJXbqRbAdwji/oKNcHc=",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/styled-system/node_modules/csstype": {
-      "version": "3.0.8",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A=",
+      "version": "3.0.11",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha1-1mcAxerPrBlA3rTj7lZCeS2FzTM=",
       "license": "MIT"
     },
     "node_modules/@types/tern": {
@@ -16545,6 +16552,18 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "license": "MIT"
+    },
+    "node_modules/hex-rgb": {
+      "version": "5.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hex-rgb/-/hex-rgb-5.0.0.tgz",
+      "integrity": "sha1-4snrajdJjWbFo1CiIe1MLH0aktY=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/hicat": {
       "version": "0.7.0",
@@ -30054,15 +30073,6 @@
         "react-is": ">= 16.8.0"
       }
     },
-    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
     "node_modules/styled-system": {
       "version": "5.1.5",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/styled-system/-/styled-system-5.1.5.tgz",
@@ -30669,20 +30679,21 @@
       "license": "MIT"
     },
     "node_modules/theme-ui": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/theme-ui/-/theme-ui-0.10.0.tgz",
-      "integrity": "sha1-T86PvnrQCOwHs4Pq9fRosDF/z6E=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/theme-ui/-/theme-ui-0.13.1.tgz",
+      "integrity": "sha1-M4RbUquXgiYXoz3lnD4yZ9wAOYo=",
       "license": "MIT",
       "dependencies": {
-        "@theme-ui/color-modes": "0.10.0",
-        "@theme-ui/components": "0.10.0",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/mdx": "0.10.0",
-        "@theme-ui/theme-provider": "0.10.0"
+        "@theme-ui/color-modes": "0.13.1",
+        "@theme-ui/components": "0.13.1",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/mdx": "0.13.1",
+        "@theme-ui/theme-provider": "0.13.1"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "react": "^16 || ^17",
+        "react-dom": "^16 || ^17"
       }
     },
     "node_modules/throat": {
@@ -35227,7 +35238,8 @@
     "@emotion/eslint-plugin": {
       "version": "11.7.0",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/eslint-plugin/-/eslint-plugin-11.7.0.tgz",
-      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM="
+      "integrity": "sha1-JTyKzibzkhaVp6qF7L9vrHXnSzM=",
+      "requires": {}
     },
     "@emotion/hash": {
       "version": "0.8.0",
@@ -35235,9 +35247,9 @@
       "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM="
     },
     "@emotion/is-prop-valid": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
-      "integrity": "sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==",
+      "version": "0.8.8",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha1-2yixxDaKJZtgqXMR1qlS1P0BrBo=",
       "requires": {
         "@emotion/memoize": "0.7.4"
       }
@@ -35757,7 +35769,8 @@
         "ws": {
           "version": "7.4.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+          "requires": {}
         }
       }
     },
@@ -37583,14 +37596,15 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "1.2.10-rc.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.10-rc.0.tgz",
-      "integrity": "sha1-8b/JF17kfxpqtebv/+GBxRKzCzQ="
+      "version": "1.2.13",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.13.tgz",
+      "integrity": "sha1-WsXxibxf0MPdHBMp9STNfVCK5Nw=",
+      "requires": {}
     },
     "@mdb/flora": {
-      "version": "0.11.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.11.1.tgz",
-      "integrity": "sha1-QAs/9c8n4HrCSpEkS/NXBYz1Isw=",
+      "version": "0.20.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-0.20.1.tgz",
+      "integrity": "sha1-9R7fiXBMcITRRSWifybXxCc667o=",
       "requires": {
         "@imgix/js-core": "^3.2.1",
         "codemirror": "^5.62.2",
@@ -37601,7 +37615,9 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM="
+      "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM=",
+      "peer": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "2.0.0-next.8",
@@ -37898,7 +37914,8 @@
           "version": "8.5.0",
           "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ws/-/ws-8.5.0.tgz",
           "integrity": "sha1-v7S+lmAHV/5Tgt4SxnDauYSh7U8=",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -37980,7 +37997,8 @@
     "@redocly/react-dropdown-aria": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@redocly/react-dropdown-aria/-/react-dropdown-aria-2.0.11.tgz",
-      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A=="
+      "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==",
+      "requires": {}
     },
     "@sideway/address": {
       "version": "4.1.0",
@@ -38407,88 +38425,78 @@
       }
     },
     "@theme-ui/color-modes": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/color-modes/-/color-modes-0.10.0.tgz",
-      "integrity": "sha1-hQcfFtfURY89q1p6+LnqRZ2k3NA=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/color-modes/-/color-modes-0.13.1.tgz",
+      "integrity": "sha1-xEW/7vpsaJUCJgkjocPE8eGtd5M=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
         "deepmerge": "^4.2.2"
       }
     },
     "@theme-ui/components": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/components/-/components-0.10.0.tgz",
-      "integrity": "sha1-waqcreceWmz3wZ+eCt6QASLvI/k=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/components/-/components-0.13.1.tgz",
+      "integrity": "sha1-/io9/YueNndCJda7X2jL9JhK18c=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@emotion/styled": "^11.0.0",
         "@styled-system/color": "^5.1.2",
         "@styled-system/should-forward-prop": "^5.1.2",
         "@styled-system/space": "^5.1.2",
-        "@theme-ui/css": "0.10.0",
-        "@types/styled-system": "^5.1.10"
+        "@theme-ui/css": "0.13.1",
+        "@types/styled-system": "^5.1.13"
       }
     },
     "@theme-ui/core": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/core/-/core-0.10.0.tgz",
-      "integrity": "sha1-I3PVM2jaX6VhkVQUreBwqd4Olng=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/core/-/core-0.13.1.tgz",
+      "integrity": "sha1-Hj3biZobhiyoDwD2gkNSTcAHaCA=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/parse-props": "0.10.0",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/parse-props": "0.13.1",
         "deepmerge": "^4.2.2"
       }
     },
     "@theme-ui/css": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/css/-/css-0.10.0.tgz",
-      "integrity": "sha1-hx9jM0+xOEkUBsMvg0fVOxmEaps=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/css/-/css-0.13.1.tgz",
+      "integrity": "sha1-hy6AoDr4nIveIb4p2/0C9TsLb4M=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "csstype": "^3.0.5"
+        "csstype": "^3.0.10"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.8",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A="
+          "version": "3.0.11",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.11.tgz",
+          "integrity": "sha1-1mcAxerPrBlA3rTj7lZCeS2FzTM="
         }
       }
     },
     "@theme-ui/mdx": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/mdx/-/mdx-0.10.0.tgz",
-      "integrity": "sha1-FBJMsZTfgCP3JTORkA2NF6YBGpI=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/mdx/-/mdx-0.13.1.tgz",
+      "integrity": "sha1-I/5uQjUgOLtRbMovwlORdxJ6YKM=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@emotion/styled": "^11.0.0",
-        "@mdx-js/react": "^1.6.22",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0"
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1"
       }
     },
     "@theme-ui/parse-props": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/parse-props/-/parse-props-0.10.0.tgz",
-      "integrity": "sha1-jS9POz7a/ZJcOHLd1VnitiAG9D8=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/parse-props/-/parse-props-0.13.1.tgz",
+      "integrity": "sha1-wRcf8CNW6mMAlPpEzthoLvifJlM=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/css": "0.10.0"
+        "@theme-ui/css": "0.13.1"
       }
     },
     "@theme-ui/theme-provider": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/theme-provider/-/theme-provider-0.10.0.tgz",
-      "integrity": "sha1-Flhq9Xm++ATx5Jl6ExE00kZb/V0=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@theme-ui/theme-provider/-/theme-provider-0.13.1.tgz",
+      "integrity": "sha1-oAWV91ec2e5EczL2tkCFPMcEHyI=",
       "requires": {
-        "@emotion/react": "^11.1.1",
-        "@theme-ui/color-modes": "0.10.0",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/mdx": "0.10.0"
+        "@theme-ui/color-modes": "0.13.1",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/mdx": "0.13.1"
       }
     },
     "@turist/fetch": {
@@ -38905,17 +38913,17 @@
       "dev": true
     },
     "@types/styled-system": {
-      "version": "5.1.12",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/styled-system/-/styled-system-5.1.12.tgz",
-      "integrity": "sha1-Tzyo2j3/48WmzDsql/UbQUZMEEo=",
+      "version": "5.1.15",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/styled-system/-/styled-system-5.1.15.tgz",
+      "integrity": "sha1-B1+WnMAoqJXbqRbAdwji/oKNcHc=",
       "requires": {
         "csstype": "^3.0.2"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.8",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha1-0iZqeScp+yJ80hb7Vy9Dco4a00A="
+          "version": "3.0.11",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/csstype/-/csstype-3.0.11.tgz",
+          "integrity": "sha1-1mcAxerPrBlA3rTj7lZCeS2FzTM="
         }
       }
     },
@@ -39360,7 +39368,8 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -39401,12 +39410,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -39856,7 +39867,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -40222,7 +40234,8 @@
     "babel-plugin-remove-graphql-queries": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.13.0.tgz",
-      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ=="
+      "integrity": "sha512-6sL3JVKDa3OjXtmBYrr467BnQeUjNI7p2dy+aBwbB8WqChHLJOFh5+lxfzC0z/7hBehqmWpBV7xHfZdIP1lAzQ==",
+      "requires": {}
     },
     "babel-plugin-styled-components": {
       "version": "1.12.0",
@@ -43588,7 +43601,8 @@
     "eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
+      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -45747,7 +45761,8 @@
         "graphql-type-json": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
+          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
+          "requires": {}
         }
       }
     },
@@ -45804,7 +45819,8 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+      "requires": {}
     },
     "graphql-upload": {
       "version": "11.0.0",
@@ -45845,7 +45861,8 @@
     "graphql-ws": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-3.1.0.tgz",
-      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg=="
+      "integrity": "sha512-zbex3FSiFz0iRgfkzDNWpOY/sYWoX+iZ5XUhakaDwOh99HSuk8rPt5suuxdXUVzEg5TGQ9rwzNaz/+mTPtS0yg==",
+      "requires": {}
     },
     "growly": {
       "version": "1.3.0",
@@ -46102,6 +46119,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "hex-rgb": {
+      "version": "5.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hex-rgb/-/hex-rgb-5.0.0.tgz",
+      "integrity": "sha1-4snrajdJjWbFo1CiIe1MLH0aktY="
     },
     "hicat": {
       "version": "0.7.0",
@@ -47396,7 +47418,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -48518,7 +48541,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -50821,7 +50845,8 @@
     "mobx-react-lite": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz",
-      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g=="
+      "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==",
+      "requires": {}
     },
     "moment": {
       "version": "2.29.1",
@@ -53493,7 +53518,8 @@
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
-      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==",
+      "requires": {}
     },
     "react-tabs": {
       "version": "3.1.2",
@@ -55893,16 +55919,6 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
-      },
-      "dependencies": {
-        "@emotion/is-prop-valid": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-          "requires": {
-            "@emotion/memoize": "0.7.4"
-          }
-        }
       }
     },
     "styled-system": {
@@ -56331,16 +56347,16 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.10.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/theme-ui/-/theme-ui-0.10.0.tgz",
-      "integrity": "sha1-T86PvnrQCOwHs4Pq9fRosDF/z6E=",
+      "version": "0.13.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/theme-ui/-/theme-ui-0.13.1.tgz",
+      "integrity": "sha1-M4RbUquXgiYXoz3lnD4yZ9wAOYo=",
       "requires": {
-        "@theme-ui/color-modes": "0.10.0",
-        "@theme-ui/components": "0.10.0",
-        "@theme-ui/core": "0.10.0",
-        "@theme-ui/css": "0.10.0",
-        "@theme-ui/mdx": "0.10.0",
-        "@theme-ui/theme-provider": "0.10.0"
+        "@theme-ui/color-modes": "0.13.1",
+        "@theme-ui/components": "0.13.1",
+        "@theme-ui/core": "0.13.1",
+        "@theme-ui/css": "0.13.1",
+        "@theme-ui/mdx": "0.13.1",
+        "@theme-ui/theme-provider": "0.13.1"
       }
     },
     "throat": {
@@ -57048,7 +57064,8 @@
     "use-ssr": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.23.tgz",
-      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA=="
+      "integrity": "sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",
@@ -58517,7 +58534,8 @@
     "ws": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "@leafygreen-ui/tooltip": "^6.1.7",
     "@leafygreen-ui/typography": "^7.5.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^1.2.10-rc.0",
-    "@mdb/flora": "^0.11.0",
+    "@mdb/consistent-nav": "^1.2.13",
+    "@mdb/flora": "^0.20.1",
     "clipboard": "^2.0.8",
     "dotenv": "^8.2.0",
     "gatsby": "^2.29.3",
@@ -88,6 +88,7 @@
     "gatsby-plugin-layout": "^1.7.0",
     "gatsby-plugin-react-helmet": "^3.7.0",
     "gatsby-plugin-sitemap": "^2.11.0",
+    "hex-rgb": "^5.0.0",
     "highlight.js": "~10.6.0",
     "html-screen-capture-js": "^1.0.50",
     "mobx": "^6.1.5",
@@ -107,6 +108,6 @@
     "redoc": "^2.0.0-rc.48",
     "sanitize-html": "^2.2.0",
     "styled-components": "^5.2.1",
-    "theme-ui": "^0.10.0"
+    "theme-ui": "^0.13.1"
   }
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,6 @@ import { UnifiedNav } from '@mdb/consistent-nav';
 import { SidenavMobileMenuDropdown } from './Sidenav';
 import SiteBanner from './Banner/SiteBanner';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { isDotCom, DOTCOM_BASE_URL, DOTCOM_BASE_PREFIX } from '../utils/dotcom';
 
 const StyledHeaderContainer = styled.header`
   grid-area: header;
@@ -26,13 +25,11 @@ const Header = ({ sidenav, eol }) => {
   const shouldSearchRealm = project === 'realm' || searchProperty === 'realm-master';
   const unifiedNavProperty = shouldSearchRealm ? 'REALM' : 'DOCS';
 
-  const docsBaseUrl = isDotCom() ? `https://${DOTCOM_BASE_URL}/${DOTCOM_BASE_PREFIX}` : null;
-
   return (
     <StyledHeaderContainer>
       <SiteBanner />
       <>
-        {!eol && <UnifiedNav position="relative" property={{ name: unifiedNavProperty }} docsBaseUrl={docsBaseUrl} />}
+        {!eol && <UnifiedNav position="relative" property={{ name: unifiedNavProperty }} />}
         {sidenav && <SidenavMobileMenuDropdown />}
       </>
     </StyledHeaderContainer>


### PR DESCRIPTION
### Stories/Links:

DOP-2934

### Current Behavior:

[Landing prod](https://www.mongodb.com/docs/)
[Realm docs prod](https://www.mongodb.com/docs/realm/)

### Staging Links:

[Landing staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-2934/)
[Realm docs staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/raymundrodriguez/DOP-2934/)

### Notes:
* Updates our version of `consistent-nav` and its peer dependencies.
* The main difference between staging links and current behavior is that hovering over the top nav links doesn't immediately open the menu dropdowns. They also close faster!
* Removed use of the `docsBaseUrl` prop from the `UnifiedNav` component since the docs-related URLs on the top nav seem to be in the "mongodb.com/docs" format already.