### PR TITLE
DOP-2736: Re-add main-column class name

### DIFF
--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { theme } from '../theme/docsTheme';
+import { MUT_CANDIDATES } from '../constants';
+import { joinClassNames } from '../utils/join-class-names';
 
 const MainColumn = ({ children, className }) => (
   <main
-    className={className}
+    className={joinClassNames(MUT_CANDIDATES.mainColumn, className)}
     css={css`
       margin: ${theme.size.default} ${theme.size.xlarge} ${theme.size.xlarge};
       max-width: 800px;

--- a/src/constants.js
+++ b/src/constants.js
@@ -27,3 +27,9 @@ export const REF_TARGETS = Object.fromEntries(
 
 export const DOCS_URL = 'https://www.mongodb.com/docs/';
 export const MARIAN_URL = 'https://docs-search-transport.mongodb.com/';
+
+// Class names to be used by mut for search indexing
+// https://github.com/mongodb/mut/blob/master/mut/index/Document.py#L68
+export const MUT_CANDIDATES = {
+  mainColumn: 'main-column',
+};

--- a/src/utils/join-class-names.js
+++ b/src/utils/join-class-names.js
@@ -1,0 +1,3 @@
+// Returns a string of joined class names. Only defined class names are included in the string
+// We return undefined if there are no classes to avoid returning an empty string
+export const joinClassNames = (...args) => args.filter((className) => !!className).join(' ') || undefined;

--- a/tests/unit/utils/join-class-names.test.js
+++ b/tests/unit/utils/join-class-names.test.js
@@ -1,0 +1,18 @@
+const { joinClassNames } = require('../../../src/utils/join-class-names');
+
+describe('joinClassNames', () => {
+  it('returns a string of all class names joined together', () => {
+    const className = joinClassNames('class1', 'class2', 'class3');
+    expect(className).toEqual('class1 class2 class3');
+  });
+
+  it('returns a string even when a class is undefined', () => {
+    const className = joinClassNames(undefined, undefined, 'class3');
+    expect(className).toEqual('class3');
+  });
+
+  it('returns undefined when no classes are defined', () => {
+    const className = joinClassNames(undefined, null);
+    expect(className).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
### Stories/Links:

DOP-2736

### Current Behavior:

[Drivers prod](https://www.mongodb.com/docs/drivers/community-supported-drivers/)

### Staging Links:

[Drivers staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/drivers/raymundrodriguez/DOP-2736/community-supported-drivers/)

### Notes:
* The only difference between the staging and prod links should be that the staging link has a `main-column` class applied to a div.
* I ran `mut-index` locally and a document was successfully created for `community-supported-drivers/index.html`. We should check to make sure that the autobuilder creates a search document for this page when we deploy or test deploy `docs-ecosystem`.