### PR TITLE
DOP-2951: Add support for GATSBY_MARIAN_URL parameter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,4 +26,4 @@ export const REF_TARGETS = Object.fromEntries(
 );
 
 export const DOCS_URL = 'https://www.mongodb.com/docs/';
-export const MARIAN_URL = 'https://docs-search-transport.mongodb.com/';
+export const MARIAN_URL = process.env.GATSBY_MARIAN_URL || 'https://docs-search-transport.mongodb.com/';

--- a/src/hooks/use-marian-manifests.js
+++ b/src/hooks/use-marian-manifests.js
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { parseMarianManifests } from '../utils/parse-marian-manifests';
+import { MARIAN_URL } from '../constants';
 
 export const useMarianManifests = (organizeByManifest) => {
   const [filters, setFilters] = useState({});
 
   useEffect(() => {
     async function fetchManifests() {
-      const result = await fetch('https://docs-search-transport.mongodb.com/status');
+      const result = await fetch(MARIAN_URL + `status`);
       const jsonResult = await result.json();
       setFilters(parseMarianManifests(jsonResult.manifests, organizeByManifest));
     }


### PR DESCRIPTION
### Stories/Links:

DOP-2951

### Staging Links:

_Put a link to your staging environment(s), if applicable_
**No Environment Variable Specified**
https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2951/search/?q=test

**Environment Variable Specified (Staging)**
https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-2951-staging/search/?q=test

### Notes:
Currently encountering a CORS error when using staging search configuration. 