### PR TITLE
DOP-2952: Include full literalinclude support for io-code-block directives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@leafygreen-ui/callout": "^3.0.6",
         "@leafygreen-ui/card": "^5.1.1",
         "@leafygreen-ui/checkbox": "^6.0.3",
-        "@leafygreen-ui/code": "^9.3.0",
+        "@leafygreen-ui/code": "^11.0.0",
         "@leafygreen-ui/emotion": "^4.0.0",
         "@leafygreen-ui/hooks": "^6.0.1",
         "@leafygreen-ui/icon": "^11.6.1",
@@ -3779,24 +3779,43 @@
       }
     },
     "node_modules/@leafygreen-ui/code": {
-      "version": "9.5.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-9.5.0.tgz",
-      "integrity": "sha1-VqzklIOBgSDwoLtZuTqAhgfyS+8=",
+      "version": "11.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-11.0.0.tgz",
+      "integrity": "sha1-Gp/1c27juN0tXeHZXBK01xzWQBE=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/a11y": "^1.2.2",
         "@leafygreen-ui/hooks": "^7.1.1",
-        "@leafygreen-ui/icon": "^11.6.0",
-        "@leafygreen-ui/icon-button": "^9.1.6",
-        "@leafygreen-ui/leafygreen-provider": "^2.1.3",
+        "@leafygreen-ui/icon": "^11.9.0",
+        "@leafygreen-ui/icon-button": "^11.0.0",
         "@leafygreen-ui/lib": "^9.0.1",
         "@leafygreen-ui/palette": "^3.2.2",
-        "@leafygreen-ui/select": "^3.1.0",
-        "@leafygreen-ui/tokens": "^0.5.3",
+        "@leafygreen-ui/select": "^5.0.0",
+        "@leafygreen-ui/tokens": "^1.3.0",
         "clipboard": "^2.0.6",
         "highlight.js": "^11.0.0",
         "highlightjs-graphql": "^1.0.1",
         "highlightjs-line-numbers.js": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/button": {
+      "version": "15.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-15.0.0.tgz",
+      "integrity": "sha1-eJP5pF/hkWYjesojSXeDrHFPALU=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/box": "^3.0.6",
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/lib": "^9.2.1",
+        "@leafygreen-ui/palette": "^3.3.1",
+        "@leafygreen-ui/ripple": "^1.1.1",
+        "@leafygreen-ui/tokens": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
       }
     },
     "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/hooks": {
@@ -3808,10 +3827,40 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/icon-button": {
+      "version": "11.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-11.0.0.tgz",
+      "integrity": "sha1-BfD4o659qR1c4jpkfqGLXq7CeFE=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/a11y": "^1.2.2",
+        "@leafygreen-ui/box": "^3.0.6",
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/lib": "^9.2.0",
+        "@leafygreen-ui/palette": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/interaction-ring": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/interaction-ring/-/interaction-ring-3.0.0.tgz",
+      "integrity": "sha1-wNX87K1fpC3NfGjKMS0cltjdlIo=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/lib": "^9.0.0",
+        "@leafygreen-ui/palette": "^3.3.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+      }
+    },
     "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/lib": {
-      "version": "9.1.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
-      "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
+      "version": "9.2.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+      "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.0",
@@ -3821,6 +3870,85 @@
       },
       "peerDependencies": {
         "react": "^17.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/popover": {
+      "version": "8.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-8.0.0.tgz",
+      "integrity": "sha1-OI/TK/Zx679d1bT/FhXwE4uT2OA=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^7.0.0",
+        "@leafygreen-ui/lib": "^9.2.1",
+        "@leafygreen-ui/portal": "^4.0.0",
+        "lodash": "^4.17.21",
+        "react-transition-group": "^4.4.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/portal": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-4.0.2.tgz",
+      "integrity": "sha1-MIQsDvTZQmFHXp9XiiWBmZlRRHQ=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^7.1.1",
+        "@leafygreen-ui/lib": "^9.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/select": {
+      "version": "5.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-5.0.0.tgz",
+      "integrity": "sha1-aE26cvs4d3prAIc/iZIxTessiJQ=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/button": "^15.0.0",
+        "@leafygreen-ui/emotion": "^4.0.0",
+        "@leafygreen-ui/hooks": "^7.1.1",
+        "@leafygreen-ui/icon": "^11.9.0",
+        "@leafygreen-ui/interaction-ring": "^3.0.0",
+        "@leafygreen-ui/lib": "^9.2.1",
+        "@leafygreen-ui/palette": "^3.3.1",
+        "@leafygreen-ui/popover": "^8.0.0",
+        "@leafygreen-ui/tokens": "1.3.0",
+        "@leafygreen-ui/typography": "^11.0.0",
+        "@types/react-is": "^17.0.0",
+        "polished": "^4.1.3",
+        "react-is": "^17.0.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/tokens": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.3.0.tgz",
+      "integrity": "sha1-7XMdmBvGaeq1IztUeD21JCZ3l1Y=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^9.2.1",
+        "@leafygreen-ui/palette": "^3.3.2"
+      }
+    },
+    "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/typography": {
+      "version": "11.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-11.0.0.tgz",
+      "integrity": "sha1-dliAha/z3VlHF0l0Ty1KGzkD0kw=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@leafygreen-ui/box": "^3.0.6",
+        "@leafygreen-ui/icon": "^11.9.0",
+        "@leafygreen-ui/lib": "^9.2.1",
+        "@leafygreen-ui/palette": "^3.3.1",
+        "@leafygreen-ui/tokens": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
       }
     },
     "node_modules/@leafygreen-ui/code/node_modules/highlight.js": {
@@ -3844,6 +3972,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@leafygreen-ui/code/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
+      "license": "MIT"
+    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.0",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
@@ -3865,12 +3999,12 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "11.6.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.6.1.tgz",
-      "integrity": "sha1-NKCggh/4S7S9f6hT0UskJ0wpFVE=",
+      "version": "11.9.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.9.0.tgz",
+      "integrity": "sha1-s8cveZi9r1oHxA3gNtGulqpJpwI=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^9.0.1"
+        "@leafygreen-ui/lib": "^9.2.0"
       }
     },
     "node_modules/@leafygreen-ui/icon-button": {
@@ -3914,9 +4048,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon/node_modules/@leafygreen-ui/lib": {
-      "version": "9.0.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.0.1.tgz",
-      "integrity": "sha1-QV/G9wLlhdGIFE3rNrP3wIO8gNM=",
+      "version": "9.2.1",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+      "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.0",
@@ -3929,12 +4063,12 @@
       }
     },
     "node_modules/@leafygreen-ui/icon/node_modules/polished": {
-      "version": "4.1.3",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.1.3.tgz",
-      "integrity": "sha1-ejq/KXI2Tn2XdwuCfuyanmQALPw=",
+      "version": "4.2.2",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha1-JSm7fDGYlFNzxS40YYyP57GqhNE=",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.14.0"
+        "@babel/runtime": "^7.17.8"
       },
       "engines": {
         "node": ">=10"
@@ -4003,9 +4137,9 @@
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "2.1.3",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.3.tgz",
-      "integrity": "sha1-VQawYYyBZTn8S5pF3YfwQwZEmBM=",
+      "version": "2.2.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.2.0.tgz",
+      "integrity": "sha1-gb1Bh8X4yw2Qak2jZqcJ6PODYO0=",
       "license": "Apache-2.0",
       "dependencies": {
         "@leafygreen-ui/hooks": "^7.0.0",
@@ -36742,25 +36876,37 @@
       }
     },
     "@leafygreen-ui/code": {
-      "version": "9.5.0",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-9.5.0.tgz",
-      "integrity": "sha1-VqzklIOBgSDwoLtZuTqAhgfyS+8=",
+      "version": "11.0.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-11.0.0.tgz",
+      "integrity": "sha1-Gp/1c27juN0tXeHZXBK01xzWQBE=",
       "requires": {
         "@leafygreen-ui/a11y": "^1.2.2",
         "@leafygreen-ui/hooks": "^7.1.1",
-        "@leafygreen-ui/icon": "^11.6.0",
-        "@leafygreen-ui/icon-button": "^9.1.6",
-        "@leafygreen-ui/leafygreen-provider": "^2.1.3",
+        "@leafygreen-ui/icon": "^11.9.0",
+        "@leafygreen-ui/icon-button": "^11.0.0",
         "@leafygreen-ui/lib": "^9.0.1",
         "@leafygreen-ui/palette": "^3.2.2",
-        "@leafygreen-ui/select": "^3.1.0",
-        "@leafygreen-ui/tokens": "^0.5.3",
+        "@leafygreen-ui/select": "^5.0.0",
+        "@leafygreen-ui/tokens": "^1.3.0",
         "clipboard": "^2.0.6",
         "highlight.js": "^11.0.0",
         "highlightjs-graphql": "^1.0.1",
         "highlightjs-line-numbers.js": "^2.7.0"
       },
       "dependencies": {
+        "@leafygreen-ui/button": {
+          "version": "15.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-15.0.0.tgz",
+          "integrity": "sha1-eJP5pF/hkWYjesojSXeDrHFPALU=",
+          "requires": {
+            "@leafygreen-ui/box": "^3.0.6",
+            "@leafygreen-ui/emotion": "^4.0.0",
+            "@leafygreen-ui/lib": "^9.2.1",
+            "@leafygreen-ui/palette": "^3.3.1",
+            "@leafygreen-ui/ripple": "^1.1.1",
+            "@leafygreen-ui/tokens": "^1.3.0"
+          }
+        },
         "@leafygreen-ui/hooks": {
           "version": "7.2.0",
           "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.2.0.tgz",
@@ -36769,15 +36915,99 @@
             "lodash": "^4.17.21"
           }
         },
+        "@leafygreen-ui/icon-button": {
+          "version": "11.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-11.0.0.tgz",
+          "integrity": "sha1-BfD4o659qR1c4jpkfqGLXq7CeFE=",
+          "requires": {
+            "@leafygreen-ui/a11y": "^1.2.2",
+            "@leafygreen-ui/box": "^3.0.6",
+            "@leafygreen-ui/emotion": "^4.0.0",
+            "@leafygreen-ui/lib": "^9.2.0",
+            "@leafygreen-ui/palette": "^3.3.2"
+          }
+        },
+        "@leafygreen-ui/interaction-ring": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/interaction-ring/-/interaction-ring-3.0.0.tgz",
+          "integrity": "sha1-wNX87K1fpC3NfGjKMS0cltjdlIo=",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.0",
+            "@leafygreen-ui/lib": "^9.0.0",
+            "@leafygreen-ui/palette": "^3.3.1"
+          }
+        },
         "@leafygreen-ui/lib": {
-          "version": "9.1.0",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
-          "integrity": "sha1-HMBAKpdGLEaF2iVCx5EOMPv1nfA=",
+          "version": "9.2.1",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+          "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.0",
             "facepaint": "^1.2.1",
             "polished": "^4.1.3",
             "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/popover": {
+          "version": "8.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-8.0.0.tgz",
+          "integrity": "sha1-OI/TK/Zx679d1bT/FhXwE4uT2OA=",
+          "requires": {
+            "@leafygreen-ui/hooks": "^7.0.0",
+            "@leafygreen-ui/lib": "^9.2.1",
+            "@leafygreen-ui/portal": "^4.0.0",
+            "lodash": "^4.17.21",
+            "react-transition-group": "^4.4.1"
+          }
+        },
+        "@leafygreen-ui/portal": {
+          "version": "4.0.2",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-4.0.2.tgz",
+          "integrity": "sha1-MIQsDvTZQmFHXp9XiiWBmZlRRHQ=",
+          "requires": {
+            "@leafygreen-ui/hooks": "^7.1.1",
+            "@leafygreen-ui/lib": "^9.0.0"
+          }
+        },
+        "@leafygreen-ui/select": {
+          "version": "5.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-5.0.0.tgz",
+          "integrity": "sha1-aE26cvs4d3prAIc/iZIxTessiJQ=",
+          "requires": {
+            "@leafygreen-ui/button": "^15.0.0",
+            "@leafygreen-ui/emotion": "^4.0.0",
+            "@leafygreen-ui/hooks": "^7.1.1",
+            "@leafygreen-ui/icon": "^11.9.0",
+            "@leafygreen-ui/interaction-ring": "^3.0.0",
+            "@leafygreen-ui/lib": "^9.2.1",
+            "@leafygreen-ui/palette": "^3.3.1",
+            "@leafygreen-ui/popover": "^8.0.0",
+            "@leafygreen-ui/tokens": "1.3.0",
+            "@leafygreen-ui/typography": "^11.0.0",
+            "@types/react-is": "^17.0.0",
+            "polished": "^4.1.3",
+            "react-is": "^17.0.1"
+          }
+        },
+        "@leafygreen-ui/tokens": {
+          "version": "1.3.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.3.0.tgz",
+          "integrity": "sha1-7XMdmBvGaeq1IztUeD21JCZ3l1Y=",
+          "requires": {
+            "@leafygreen-ui/lib": "^9.2.1",
+            "@leafygreen-ui/palette": "^3.3.2"
+          }
+        },
+        "@leafygreen-ui/typography": {
+          "version": "11.0.0",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-11.0.0.tgz",
+          "integrity": "sha1-dliAha/z3VlHF0l0Ty1KGzkD0kw=",
+          "requires": {
+            "@leafygreen-ui/box": "^3.0.6",
+            "@leafygreen-ui/icon": "^11.9.0",
+            "@leafygreen-ui/lib": "^9.2.1",
+            "@leafygreen-ui/palette": "^3.3.1",
+            "@leafygreen-ui/tokens": "^1.3.0"
           }
         },
         "highlight.js": {
@@ -36792,6 +37022,11 @@
           "requires": {
             "@babel/runtime": "^7.16.7"
           }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA="
         }
       }
     },
@@ -36814,17 +37049,17 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "11.6.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.6.1.tgz",
-      "integrity": "sha1-NKCggh/4S7S9f6hT0UskJ0wpFVE=",
+      "version": "11.9.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.9.0.tgz",
+      "integrity": "sha1-s8cveZi9r1oHxA3gNtGulqpJpwI=",
       "requires": {
-        "@leafygreen-ui/lib": "^9.0.1"
+        "@leafygreen-ui/lib": "^9.2.0"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "9.0.1",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.0.1.tgz",
-          "integrity": "sha1-QV/G9wLlhdGIFE3rNrP3wIO8gNM=",
+          "version": "9.2.1",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-9.2.1.tgz",
+          "integrity": "sha1-qsIo4CrLTwBV5OPeyvO+vwB2SB4=",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.0",
             "facepaint": "^1.2.1",
@@ -36833,11 +37068,11 @@
           }
         },
         "polished": {
-          "version": "4.1.3",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.1.3.tgz",
-          "integrity": "sha1-ejq/KXI2Tn2XdwuCfuyanmQALPw=",
+          "version": "4.2.2",
+          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/polished/-/polished-4.2.2.tgz",
+          "integrity": "sha1-JSm7fDGYlFNzxS40YYyP57GqhNE=",
           "requires": {
-            "@babel/runtime": "^7.14.0"
+            "@babel/runtime": "^7.17.8"
           }
         }
       }
@@ -36934,9 +37169,9 @@
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
-      "version": "2.1.3",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.3.tgz",
-      "integrity": "sha1-VQawYYyBZTn8S5pF3YfwQwZEmBM=",
+      "version": "2.2.0",
+      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.2.0.tgz",
+      "integrity": "sha1-gb1Bh8X4yw2Qak2jZqcJ6PODYO0=",
       "requires": {
         "@leafygreen-ui/hooks": "^7.0.0",
         "@leafygreen-ui/lib": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@leafygreen-ui/callout": "^3.0.6",
     "@leafygreen-ui/card": "^5.1.1",
     "@leafygreen-ui/checkbox": "^6.0.3",
-    "@leafygreen-ui/code": "^9.3.0",
+    "@leafygreen-ui/code": "^11.0.0",
     "@leafygreen-ui/emotion": "^4.0.0",
     "@leafygreen-ui/hooks": "^6.0.1",
     "@leafygreen-ui/icon": "^11.6.1",

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -39,7 +39,9 @@ const getLanguage = (lang) => {
   return 'none';
 };
 
-const Code = ({ nodeData: { caption, copyable, emphasize_lines: emphasizeLines, lang, linenos, value, source } }) => {
+const Code = ({
+  nodeData: { caption, copyable, emphasize_lines: emphasizeLines, lang, linenos, value, source, lineno_start },
+}) => {
   const { setActiveTab } = useContext(TabContext);
   const { languageOptions, codeBlockLanguage } = useContext(CodeContext);
   const code = value;
@@ -109,6 +111,7 @@ const Code = ({ nodeData: { caption, copyable, emphasize_lines: emphasizeLines, 
         showLineNumbers={linenos}
         showCustomActionButtons={sourceSpecified}
         customActionButtons={customActionButtonList}
+        lineNumberStart={lineno_start}
       >
         {code}
       </CodeBlock>
@@ -132,6 +135,7 @@ Code.propTypes = {
     linenos: PropTypes.bool,
     value: PropTypes.string.isRequired,
     source: PropTypes.string,
+    lineno_start: PropTypes.number,
   }).isRequired,
 };
 

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -85,9 +85,16 @@ const Code = ({
       css={css`
         ${baseCodeStyle}
 
+        // Remove whitespace when copyable false
+        > div > div {
+          display: ${!copyable && languageOptions?.length === 0 ? 'inline' : 'grid'};
+          grid-template-columns: ${!copyable && language === 'none' ? 'auto' : 'code panel'};
+        }
+
         > div {
           border-top-left-radius: ${captionBorderRadius};
           border-top-right-radius: ${captionBorderRadius};
+          display: grid;
         }
       `}
     >

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -52,7 +52,7 @@ const Code = ({
   }
   const captionSpecified = !!caption;
   const sourceSpecified = !!source;
-  const captionBorderRadius = captionSpecified ? '0px' : '4px';
+  const captionBorderRadius = captionSpecified ? '0px' : '12px';
 
   let customActionButtonList = [];
   if (sourceSpecified) {
@@ -122,8 +122,8 @@ const Code = ({
 const CaptionContainer = styled.div`
   ${borderCodeStyle}
   border-bottom: none;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-top-right-radius: 12px;
+  border-top-left-radius: 12px;
 `;
 
 Code.propTypes = {

--- a/src/components/Code/CodeIO.js
+++ b/src/components/Code/CodeIO.js
@@ -55,8 +55,6 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
         }
         // Controls output code block and toggle view bar style
         > div {
-          border-top-right-radius: 0px;
-          border-top-left-radius: 0px;
           border-bottom-right-radius: ${outputBorderRadius};
           border-bottom-left-radius: ${outputBorderRadius};
           margin: 0px;
@@ -78,7 +76,21 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
               {buttonText}
             </Button>
           </IOToggle>
-          {showOutput && <Output nodeData={children[1]} />}
+          {showOutput && (
+            <div
+              css={css`
+                .leafygreen-ui-1g8q0tn,
+                .leafygreen-ui-1ryj72u,
+                .leafygreen-ui-1th51br,
+                .leafygreen-ui-1fyye0e,
+                .leafygreen-ui-olcyvn {
+                  display: inline;
+                }
+              `}
+            >
+              <Output className="OutputClass" nodeData={children[1]} />
+            </div>
+          )}
         </>
       )}
       {onlyInputSpecified && <Input nodeData={children[0]} />}

--- a/src/components/Code/CodeIO.js
+++ b/src/components/Code/CodeIO.js
@@ -29,8 +29,8 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
   const [showOutput, setShowOutput] = useState(initialOutputVisibility);
   const buttonText = showOutput ? 'HIDE OUTPUT' : 'VIEW OUTPUT';
   const arrow = showOutput ? 'ChevronUp' : 'ChevronDown';
-  const outputBorderRadius = !showOutput ? theme.size.tiny : '0px';
-  const singleInputBorderRadius = onlyInputSpecified ? theme.size.tiny : '0px';
+  const outputBorderRadius = !showOutput ? '12px' : '0px';
+  const singleInputBorderRadius = onlyInputSpecified ? '12px' : '0px';
 
   const handleClick = (e) => {
     if (showOutput) {
@@ -43,6 +43,7 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
   if (children.length === 0) {
     return null;
   }
+
   return (
     <div
       css={css`
@@ -53,6 +54,7 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
           border-bottom-right-radius: ${singleInputBorderRadius};
           border-bottom-left-radius: ${singleInputBorderRadius};
         }
+
         // Controls output code block and toggle view bar style
         > div {
           border-bottom-right-radius: ${outputBorderRadius};

--- a/src/components/Code/CodeIO.js
+++ b/src/components/Code/CodeIO.js
@@ -78,21 +78,7 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
               {buttonText}
             </Button>
           </IOToggle>
-          {showOutput && (
-            <div
-              css={css`
-                .leafygreen-ui-1g8q0tn,
-                .leafygreen-ui-1ryj72u,
-                .leafygreen-ui-1th51br,
-                .leafygreen-ui-1fyye0e,
-                .leafygreen-ui-olcyvn {
-                  display: inline;
-                }
-              `}
-            >
-              <Output className="OutputClass" nodeData={children[1]} />
-            </div>
-          )}
+          {showOutput && <Output nodeData={children[1]} />}
         </>
       )}
       {onlyInputSpecified && <Input nodeData={children[0]} />}

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -26,7 +26,6 @@ const Output = ({ nodeData: { children }, ...rest }) => {
         showLineNumbers={linenos}
         darkMode={true}
         copyable={false}
-        linenos={linenos}
         lineNumberStart={lineno_start}
       >
         {value}

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { default as CodeBlock } from '@leafygreen-ui/code';
 import { cx, css } from '@leafygreen-ui/emotion';
-import { theme } from '../../theme/docsTheme';
 
 const outputCodeStyle = css`
-  border-bottom-right-radius: ${theme.size.tiny};
-  border-bottom-left-radius: ${theme.size.tiny};
+  border-bottom-right-radius: 12px;
+  border-bottom-left-radius: 12px;
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;
 `;

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -10,7 +10,7 @@ const outputCodeStyle = css`
 `;
 
 const Output = ({ nodeData: { children }, ...rest }) => {
-  const { emphasize_lines, value, linenos, lang } = children[0];
+  const { emphasize_lines, value, linenos, lang, lineno_start } = children[0];
   const language = lang || 'none';
   return (
     <CodeBlock
@@ -21,6 +21,7 @@ const Output = ({ nodeData: { children }, ...rest }) => {
       darkMode={true}
       copyable={false}
       linenos={linenos}
+      lineNumberStart={lineno_start}
     >
       {value}
     </CodeBlock>

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -1,31 +1,37 @@
 import React from 'react';
+import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { default as CodeBlock } from '@leafygreen-ui/code';
-import { cx, css } from '@leafygreen-ui/emotion';
-
-const outputCodeStyle = css`
-  border-bottom-right-radius: 12px;
-  border-bottom-left-radius: 12px;
-  border-top-right-radius: 0px;
-  border-top-left-radius: 0px;
-`;
 
 const Output = ({ nodeData: { children }, ...rest }) => {
   const { emphasize_lines, value, linenos, lang, lineno_start } = children[0];
   const language = lang || 'none';
   return (
-    <CodeBlock
-      className={cx(outputCodeStyle)}
-      highlightLines={emphasize_lines}
-      language={language}
-      showLineNumbers={linenos}
-      darkMode={true}
-      copyable={false}
-      linenos={linenos}
-      lineNumberStart={lineno_start}
+    <div
+      css={css`
+        > div > * {
+          display: inline !important;
+        }
+        * {
+          border-top-right-radius: 0px;
+          border-top-left-radius: 0px;
+          border-bottom-right-radius: 12px;
+          border-bottom-left-radius: 12px;
+        }
+      `}
     >
-      {value}
-    </CodeBlock>
+      <CodeBlock
+        highlightLines={emphasize_lines}
+        language={language}
+        showLineNumbers={linenos}
+        darkMode={true}
+        copyable={false}
+        linenos={linenos}
+        lineNumberStart={lineno_start}
+      >
+        {value}
+      </CodeBlock>
+    </div>
   );
 };
 

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -7,6 +7,8 @@ import { theme } from '../../theme/docsTheme';
 const outputCodeStyle = css`
   border-bottom-right-radius: ${theme.size.tiny};
   border-bottom-left-radius: ${theme.size.tiny};
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
 `;
 
 const Output = ({ nodeData: { children }, ...rest }) => {

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -11,7 +11,11 @@ export const baseCodeStyle = css`
 
   // Override default LG Code language switcher font size
   button > div > div {
-    font-size: ${theme.fontSize.default};
+    font-size: ${theme.fontSize.small};
+    margin-top: 2px;
+  }
+  button > div > svg {
+    margin-top: 1px;
   }
 `;
 

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -9,28 +9,9 @@ export const baseCodeStyle = css`
   table-layout: fixed;
   width: 100%;
 
-  // Inner div of LG component has a width set to 700px. Unset this as part of our
-  // override for docs when the language switcher is being used.
-  // TODO: (DOP-2576) See if we can remove all of this when we upgrade LG Code component.
+  // Remove whitespace when copyable false
   > div > div {
-    width: unset;
-
-    & > div[data-testid='leafygreen-code-panel'] {
-      padding-left: 0;
-
-      & > div > div {
-        width: unset;
-        min-width: 144px;
-      }
-    }
-
-    button[aria-labelledby='Language Picker'] {
-      margin-left: 0;
-
-      & > div {
-        grid-template-columns: 16px 1fr 16px;
-      }
-    }
+    grid-template-columns: auto !important;
   }
 
   // Override default LG Code language switcher font size

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -9,11 +9,6 @@ export const baseCodeStyle = css`
   table-layout: fixed;
   width: 100%;
 
-  // Remove whitespace when copyable false
-  > div > :after {
-    box-shadow: none !important;
-  }
-
   // Override default LG Code language switcher font size
   button > div > div {
     font-size: ${theme.fontSize.default};

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -12,10 +12,6 @@ export const baseCodeStyle = css`
   // Override default LG Code language switcher font size
   button > div > div {
     font-size: ${theme.fontSize.small};
-    margin-top: 2px;
-  }
-  button > div > svg {
-    margin-top: 1px;
   }
 `;
 

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -10,8 +10,8 @@ export const baseCodeStyle = css`
   width: 100%;
 
   // Remove whitespace when copyable false
-  > div > div {
-    grid-template-columns: auto !important;
+  > div > :after {
+    box-shadow: none !important;
   }
 
   // Override default LG Code language switcher font size

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -12,11 +12,6 @@ exports[`renders correctly 1`] = `
 
 .emotion-0 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-0 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-0>div>div {
@@ -290,11 +285,6 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 
 .emotion-0 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-0 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-0>div>div {

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -56,35 +56,85 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-4 {
-  border: 1px solid #E7EEEC;
-  border-radius: 4px;
+  border: 1px solid #E8EDEB;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .emotion-5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-areas: 'code panel';
+  grid-template-columns: auto 38px;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.emotion-5:before,
+.emotion-5:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-5:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-5:after {
+  grid-column: 2;
+}
+
+.emotion-5:before,
+.emotion-5:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-5:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-5:after {
+  grid-column: 2;
 }
 
 .emotion-6 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
-  border-color: #E7EEEC;
+  border-color: #E8EDEB;
   background-color: #F9FBFA;
-  color: #061621;
+  color: #001E2B;
 }
 
 @media only screen and (max-device-width: 812px) and (-webkit-min-device-pixel-ratio: 2) {
@@ -99,11 +149,20 @@ exports[`renders correctly 1`] = `
   }
 }
 
+.emotion-6:focus,
+.emotion-6:active,
+.emotion-6:focus-visible,
+.emotion-6:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
+}
+
 .emotion-7 {
   color: inherit;
   font-size: 13px;
   font-family: 'Source Code Pro',Menlo,monospace;
   line-height: 24px;
+  font-size: 13px;
 }
 
 .emotion-8 {
@@ -118,28 +177,27 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-12 {
-  width: 38px;
-  border-left: solid 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  padding-top: 6px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   gap: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  border-color: #E7EEEC;
-  background-color: white;
+  padding: 6px;
+  border-left: solid 1px;
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+  z-index: 2;
+  grid-area: panel;
 }
 
 .emotion-12 svg {
@@ -172,7 +230,7 @@ exports[`renders correctly 1`] = `
           tabindex="-1"
         >
           <code
-            class="lg-highlight-hljs-light emotion-7 javascript"
+            class="lg-highlight-hljs-light javascript emotion-7"
           >
             <table
               class="emotion-8"
@@ -271,35 +329,85 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 }
 
 .emotion-1 {
-  border: 1px solid #E7EEEC;
-  border-radius: 4px;
+  border: 1px solid #E8EDEB;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-areas: 'code panel';
+  grid-template-columns: auto 38px;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
 }
 
 .emotion-3 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
-  border-color: #E7EEEC;
+  border-color: #E8EDEB;
   background-color: #F9FBFA;
-  color: #061621;
+  color: #001E2B;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -324,11 +432,20 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   }
 }
 
+.emotion-3:focus,
+.emotion-3:active,
+.emotion-3:focus-visible,
+.emotion-3:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
+}
+
 .emotion-4 {
   color: inherit;
   font-size: 13px;
   font-family: 'Source Code Pro',Menlo,monospace;
   line-height: 24px;
+  font-size: 13px;
 }
 
 .emotion-5 {
@@ -343,30 +460,27 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 }
 
 .emotion-7 {
-  width: 38px;
-  border-left: solid 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  padding-top: 6px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   gap: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  border-color: #E7EEEC;
-  background-color: white;
+  padding: 6px;
+  border-left: solid 1px;
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+  z-index: 2;
+  grid-area: panel;
 }
 
 .emotion-7 svg {
@@ -388,7 +502,7 @@ exports[`renders correctly when none is passed in as a language 1`] = `
           tabindex="-1"
         >
           <code
-            class="lg-highlight-hljs-light emotion-4 none"
+            class="lg-highlight-hljs-light none emotion-4"
           >
             <table
               class="emotion-5"

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -11,7 +11,12 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-0 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-0>div>div {
@@ -284,7 +289,12 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 }
 
 .emotion-0 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-0 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-0>div>div {

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -11,24 +11,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0>div>div {
-  width: unset;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-0 button>div>div {
@@ -299,24 +282,7 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 }
 
 .emotion-0>div>div {
-  width: unset;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-0 button>div>div {

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -10,8 +10,8 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>div {
-  grid-template-columns: auto!important;
+.emotion-0>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-0 button>div>div {
@@ -26,8 +26,8 @@ exports[`renders correctly 1`] = `
 .emotion-1 {
   border: 1px solid #E7EEEC;
   border-bottom: none;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-top-right-radius: 12px;
+  border-top-left-radius: 12px;
 }
 
 .emotion-3 {
@@ -281,8 +281,8 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>div {
-  grid-template-columns: auto!important;
+.emotion-0>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-0 button>div>div {
@@ -290,8 +290,8 @@ exports[`renders correctly when none is passed in as a language 1`] = `
 }
 
 .emotion-0>div {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -10,17 +10,19 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-0 button>div>div {
   font-size: 16px;
+}
+
+.emotion-0>div>div {
+  display: grid;
+  grid-template-columns: code panel;
 }
 
 .emotion-0>div {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
+  display: grid;
 }
 
 .emotion-1 {
@@ -281,17 +283,19 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-0 button>div>div {
   font-size: 16px;
+}
+
+.emotion-0>div>div {
+  display: grid;
+  grid-template-columns: code panel;
 }
 
 .emotion-0>div {
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
+  display: grid;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -10,10 +10,6 @@ exports[`CodeIO renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-0 button>div>div {
   font-size: 16px;
 }
@@ -37,17 +33,19 @@ exports[`CodeIO renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-1>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-1 button>div>div {
   font-size: 16px;
+}
+
+.emotion-1>div>div {
+  display: grid;
+  grid-template-columns: code panel;
 }
 
 .emotion-1>div {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
+  display: grid;
 }
 
 .emotion-2 {
@@ -369,12 +367,15 @@ exports[`CodeIO renders correctly 1`] = `
   justify-self: right;
 }
 
-.emotion-20 .emotion-21,
-.emotion-20 .leafygreen-ui-1ryj72u,
-.emotion-20 .emotion-6,
-.emotion-20 .leafygreen-ui-1fyye0e,
-.emotion-20 .leafygreen-ui-olcyvn {
-  display: inline;
+.emotion-20>div>* {
+  display: inline!important;
+}
+
+.emotion-20 * {
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
+  border-bottom-right-radius: 12px;
+  border-bottom-left-radius: 12px;
 }
 
 .emotion-21 {
@@ -410,10 +411,6 @@ exports[`CodeIO renders correctly 1`] = `
   align-items: center;
   padding-top: 6px;
   padding-bottom: 6px;
-  border-bottom-right-radius: 12px;
-  border-bottom-left-radius: 12px;
-  border-top-right-radius: 0px;
-  border-top-left-radius: 0px;
 }
 
 @media only screen and (max-device-width: 812px) and (-webkit-min-device-pixel-ratio: 2) {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -12,11 +12,6 @@ exports[`CodeIO renders correctly 1`] = `
 
 .emotion-0 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-0 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-0>div>div {
@@ -40,11 +35,6 @@ exports[`CodeIO renders correctly 1`] = `
 
 .emotion-1 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-1 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-1>div>div {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -11,7 +11,12 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-0 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-0 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-0>div>div {
@@ -34,7 +39,12 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-1 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-1 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-1>div>div {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -11,24 +11,7 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-0>div>div {
-  width: unset;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-0 button>div>div {
@@ -41,8 +24,6 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-0>div {
-  border-top-right-radius: 0px;
-  border-top-left-radius: 0px;
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
   margin: 0px;
@@ -57,24 +38,7 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-1>div>div {
-  width: unset;
-}
-
-.emotion-1>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-1>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-1>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-1>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-1 button>div>div {
@@ -405,13 +369,21 @@ exports[`CodeIO renders correctly 1`] = `
   justify-self: right;
 }
 
-.emotion-20 {
+.emotion-20 .emotion-21,
+.emotion-20 .leafygreen-ui-1ryj72u,
+.emotion-20 .emotion-6,
+.emotion-20 .leafygreen-ui-1fyye0e,
+.emotion-20 .leafygreen-ui-olcyvn {
+  display: inline;
+}
+
+.emotion-21 {
   border: 0;
   border-radius: 6px;
   overflow: hidden;
 }
 
-.emotion-22 {
+.emotion-23 {
   grid-area: code;
   overflow-x: auto;
   border-radius: inherit;
@@ -440,51 +412,53 @@ exports[`CodeIO renders correctly 1`] = `
   padding-bottom: 6px;
   border-bottom-right-radius: 4px;
   border-bottom-left-radius: 4px;
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
 }
 
 @media only screen and (max-device-width: 812px) and (-webkit-min-device-pixel-ratio: 2) {
-  .emotion-22 {
+  .emotion-23 {
     white-space: pre-wrap;
   }
 }
 
 @media only screen and (min-device-width: 813px) and (-webkit-min-device-pixel-ratio: 2) {
-  .emotion-22 {
+  .emotion-23 {
     white-space: pre;
   }
 }
 
-.emotion-22:focus,
-.emotion-22:active,
-.emotion-22:focus-visible,
-.emotion-22:focus-within {
+.emotion-23:focus,
+.emotion-23:active,
+.emotion-23:focus-visible,
+.emotion-23:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px #0498EC inset;
 }
 
-.emotion-25 {
+.emotion-26 {
   background-color: transparent;
   background-image: linear-gradient(90deg, #21313C, rgba(33,49,60,0));
   background-attachment: fixed;
 }
 
-.emotion-25>td {
+.emotion-26>td {
   border-top: 1px solid #21313C;
 }
 
-.emotion-25+tr>td {
+.emotion-26+tr>td {
   border-top: 1px solid #21313C;
 }
 
-.emotion-25+.emotion-25>td {
+.emotion-26+.emotion-26>td {
   border-top: 0;
 }
 
-.emotion-25:last-child>td {
+.emotion-26:last-child>td {
   border-bottom: 1px solid #21313C;
 }
 
-.emotion-26 {
+.emotion-27 {
   border-spacing: 0;
   vertical-align: top;
   padding: 0 16px;
@@ -610,37 +584,41 @@ exports[`CodeIO renders correctly 1`] = `
       class="emotion-20"
     >
       <div
-        class="emotion-6"
+        class="emotion-21"
       >
-        <pre
-          class="emotion-22"
-          tabindex="-1"
+        <div
+          class="emotion-6"
         >
-          <code
-            class="lg-highlight-hljs-dark python emotion-8"
+          <pre
+            class="emotion-23"
+            tabindex="-1"
           >
-            <table
-              class="emotion-9"
+            <code
+              class="lg-highlight-hljs-dark python emotion-8"
             >
-              <tbody>
-                <tr
-                  class="emotion-25"
-                >
-                  <td
+              <table
+                class="emotion-9"
+              >
+                <tbody>
+                  <tr
                     class="emotion-26"
                   >
-                    1
-                  </td>
-                  <td
-                    class="emotion-12"
-                  >
-                    hello world
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </code>
-        </pre>
+                    <td
+                      class="emotion-27"
+                    >
+                      1
+                    </td>
+                    <td
+                      class="emotion-12"
+                    >
+                      hello world
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </code>
+          </pre>
+        </div>
       </div>
     </div>
   </div>

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -102,35 +102,85 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-5 {
-  border: 1px solid #E7EEEC;
-  border-radius: 4px;
+  border: 1px solid #E8EDEB;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-areas: 'code panel';
+  grid-template-columns: auto 38px;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.emotion-6:before,
+.emotion-6:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-6:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-6:after {
+  grid-column: 2;
+}
+
+.emotion-6:before,
+.emotion-6:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-6:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-6:after {
+  grid-column: 2;
 }
 
 .emotion-7 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
-  border-color: #E7EEEC;
+  border-color: #E8EDEB;
   background-color: #F9FBFA;
-  color: #061621;
+  color: #001E2B;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,11 +205,20 @@ exports[`CodeIO renders correctly 1`] = `
   }
 }
 
+.emotion-7:focus,
+.emotion-7:active,
+.emotion-7:focus-visible,
+.emotion-7:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
+}
+
 .emotion-8 {
   color: inherit;
   font-size: 13px;
   font-family: 'Source Code Pro',Menlo,monospace;
   line-height: 24px;
+  font-size: 13px;
 }
 
 .emotion-9 {
@@ -200,7 +259,7 @@ exports[`CodeIO renders correctly 1`] = `
   text-align: right;
   padding-left: 8px;
   padding-right: 0;
-  color: #86681D;
+  color: #944F01;
 }
 
 .emotion-12 {
@@ -210,30 +269,27 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-13 {
-  width: 38px;
-  border-left: solid 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  padding-top: 6px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   gap: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  border-color: #E7EEEC;
-  background-color: white;
+  padding: 6px;
+  border-left: solid 1px;
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+  z-index: 2;
+  grid-area: panel;
 }
 
 .emotion-13 svg {
@@ -351,29 +407,27 @@ exports[`CodeIO renders correctly 1`] = `
 
 .emotion-20 {
   border: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   overflow: hidden;
 }
 
 .emotion-22 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
   border: 0;
   background-color: #061621;
   color: #F9FBFA;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -384,6 +438,8 @@ exports[`CodeIO renders correctly 1`] = `
   align-items: center;
   padding-top: 6px;
   padding-bottom: 6px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
 @media only screen and (max-device-width: 812px) and (-webkit-min-device-pixel-ratio: 2) {
@@ -396,6 +452,14 @@ exports[`CodeIO renders correctly 1`] = `
   .emotion-22 {
     white-space: pre;
   }
+}
+
+.emotion-22:focus,
+.emotion-22:active,
+.emotion-22:focus-visible,
+.emotion-22:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
 }
 
 .emotion-25 {
@@ -462,7 +526,7 @@ exports[`CodeIO renders correctly 1`] = `
             tabindex="-1"
           >
             <code
-              class="lg-highlight-hljs-light emotion-8 python"
+              class="lg-highlight-hljs-light python emotion-8"
             >
               <table
                 class="emotion-9"
@@ -553,7 +617,7 @@ exports[`CodeIO renders correctly 1`] = `
           tabindex="-1"
         >
           <code
-            class="lg-highlight-hljs-dark emotion-8 python"
+            class="lg-highlight-hljs-dark python emotion-8"
           >
             <table
               class="emotion-9"

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -10,8 +10,8 @@ exports[`CodeIO renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>div {
-  grid-template-columns: auto!important;
+.emotion-0>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-0 button>div>div {
@@ -37,8 +37,8 @@ exports[`CodeIO renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-1>div>div {
-  grid-template-columns: auto!important;
+.emotion-1>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-1 button>div>div {
@@ -53,8 +53,8 @@ exports[`CodeIO renders correctly 1`] = `
 .emotion-2 {
   border: 1px solid #E7EEEC;
   border-bottom: none;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-top-right-radius: 12px;
+  border-top-left-radius: 12px;
 }
 
 .emotion-4 {
@@ -410,8 +410,8 @@ exports[`CodeIO renders correctly 1`] = `
   align-items: center;
   padding-top: 6px;
   padding-bottom: 6px;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 12px;
+  border-bottom-left-radius: 12px;
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;
 }

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -10,8 +10,8 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>div {
-  grid-template-columns: auto!important;
+.emotion-0>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-0 button>div>div {
@@ -19,8 +19,8 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0>div {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -41,35 +41,85 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-1 {
-  border: 1px solid #E7EEEC;
-  border-radius: 4px;
+  border: 1px solid #E8EDEB;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-areas: 'code panel';
+  grid-template-columns: auto 38px;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
 }
 
 .emotion-3 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
-  border-color: #E7EEEC;
+  border-color: #E8EDEB;
   background-color: #F9FBFA;
-  color: #061621;
+  color: #001E2B;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,11 +144,20 @@ exports[`renders correctly 1`] = `
   }
 }
 
+.emotion-3:focus,
+.emotion-3:active,
+.emotion-3:focus-visible,
+.emotion-3:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
+}
+
 .emotion-4 {
   color: inherit;
   font-size: 13px;
   font-family: 'Source Code Pro',Menlo,monospace;
   line-height: 24px;
+  font-size: 13px;
 }
 
 .emotion-5 {
@@ -139,7 +198,7 @@ exports[`renders correctly 1`] = `
   text-align: right;
   padding-left: 8px;
   padding-right: 0;
-  color: #86681D;
+  color: #944F01;
 }
 
 .emotion-8 {
@@ -149,30 +208,27 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-9 {
-  width: 38px;
-  border-left: solid 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  padding-top: 6px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   gap: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  border-color: #E7EEEC;
-  background-color: white;
+  padding: 6px;
+  border-left: solid 1px;
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+  z-index: 2;
+  grid-area: panel;
 }
 
 .emotion-9 svg {
@@ -194,7 +250,7 @@ exports[`renders correctly 1`] = `
           tabindex="-1"
         >
           <code
-            class="lg-highlight-hljs-light emotion-4 java"
+            class="lg-highlight-hljs-light java emotion-4"
           >
             <table
               class="emotion-5"

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -11,24 +11,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0>div>div {
-  width: unset;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-0 button>div>div {

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -11,7 +11,12 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-0 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-0>div>div {

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -10,17 +10,19 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-0 button>div>div {
   font-size: 16px;
+}
+
+.emotion-0>div>div {
+  display: grid;
+  grid-template-columns: code panel;
 }
 
 .emotion-0>div {
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
+  display: grid;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -12,11 +12,6 @@ exports[`renders correctly 1`] = `
 
 .emotion-0 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-0 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-0>div>div {

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -10,8 +10,8 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>div {
-  grid-template-columns: auto!important;
+.emotion-0>div>:after {
+  box-shadow: none!important;
 }
 
 .emotion-0 button>div>div {
@@ -19,8 +19,8 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0>div {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -11,24 +11,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0>div>div {
-  width: unset;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel'] {
-  padding-left: 0;
-}
-
-.emotion-0>div>div>div[data-testid='leafygreen-code-panel']>div>div {
-  width: unset;
-  min-width: 144px;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker'] {
-  margin-left: 0;
-}
-
-.emotion-0>div>div button[aria-labelledby='Language Picker']>div {
-  grid-template-columns: 16px 1fr 16px;
+  grid-template-columns: auto!important;
 }
 
 .emotion-0 button>div>div {

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -11,7 +11,12 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0 button>div>div {
-  font-size: 16px;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.emotion-0 button>div>svg {
+  margin-top: 1px;
 }
 
 .emotion-0>div>div {

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -41,35 +41,85 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-1 {
-  border: 1px solid #E7EEEC;
-  border-radius: 4px;
+  border: 1px solid #E8EDEB;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-areas: 'code panel';
+  grid-template-columns: auto 38px;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
+}
+
+.emotion-2:before,
+.emotion-2:after {
+  content: '';
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  height: 100%;
+  width: 8px;
+  border-radius: 100%;
+  box-shadow: unset;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
+}
+
+.emotion-2:before {
+  grid-column: 1;
+  left: -8px;
+}
+
+.emotion-2:after {
+  grid-column: 2;
 }
 
 .emotion-3 {
-  border: 2px solid;
+  grid-area: code;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: inherit;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border: 0;
   padding-top: 8px;
   padding-bottom: 8px;
   margin: 0;
   position: relative;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+  -webkit-transition: box-shadow 100ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
   white-space: pre;
-  border-color: #E7EEEC;
+  border-color: #E8EDEB;
   background-color: #F9FBFA;
-  color: #061621;
+  color: #001E2B;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,11 +144,20 @@ exports[`renders correctly 1`] = `
   }
 }
 
+.emotion-3:focus,
+.emotion-3:active,
+.emotion-3:focus-visible,
+.emotion-3:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #0498EC inset;
+}
+
 .emotion-4 {
   color: inherit;
   font-size: 13px;
   font-family: 'Source Code Pro',Menlo,monospace;
   line-height: 24px;
+  font-size: 13px;
 }
 
 .emotion-5 {
@@ -113,30 +172,27 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-7 {
-  width: 38px;
-  border-left: solid 1px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  padding-top: 6px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   gap: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  min-height: 36px;
-  padding-top: 4px;
-  border-color: #E7EEEC;
-  background-color: white;
+  padding: 6px;
+  border-left: solid 1px;
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+  z-index: 2;
+  grid-area: panel;
 }
 
 .emotion-7 svg {
@@ -158,7 +214,7 @@ exports[`renders correctly 1`] = `
           tabindex="-1"
         >
           <code
-            class="lg-highlight-hljs-light emotion-4 none"
+            class="lg-highlight-hljs-light none emotion-4"
           >
             <table
               class="emotion-5"

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -10,17 +10,19 @@ exports[`renders correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>div>:after {
-  box-shadow: none!important;
-}
-
 .emotion-0 button>div>div {
   font-size: 16px;
+}
+
+.emotion-0>div>div {
+  display: grid;
+  grid-template-columns: code panel;
 }
 
 .emotion-0>div {
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
+  display: grid;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -12,11 +12,6 @@ exports[`renders correctly 1`] = `
 
 .emotion-0 button>div>div {
   font-size: 14px;
-  margin-top: 2px;
-}
-
-.emotion-0 button>div>svg {
-  margin-top: 1px;
 }
 
 .emotion-0>div>div {


### PR DESCRIPTION
### Stories/Links:

[DOP-2952](https://jira.mongodb.org/browse/DOP-2952)

### Current Behavior:

[Atlas Prod Ex. 1](https://www.mongodb.com/docs/atlas/driver-connection/#driver-examples)
[Atlas Prod Ex. 2](https://www.mongodb.com/docs/atlas/tutorial/connect-to-your-cluster/#test-your-pymongo-installation)
[Realm Prod](https://www.mongodb.com/docs/realm/sdk/flutter/quick-start/#create-data-model)

### Staging Links:

[Atlas Staging Ex. 1](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2952/driver-connection/#driver-examples)
[Atlas Staging Ex. 2](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2952/tutorial/connect-to-your-cluster/#download-and-install-utility)
[Realm Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/grace.chong/DOP-2952/sdk/flutter/quick-start/#create-data-model)

### Notes:

- Dart syntax highlighting seems to already be present in production 