### PR TITLE
Hotfix: Add mdx-js/react as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@loadable/component": "^5.14.1",
         "@mdb/consistent-nav": "^1.2.13",
         "@mdb/flora": "^0.20.1",
+        "@mdx-js/react": "^1.6.22",
         "clipboard": "^2.0.8",
         "dotenv": "^8.2.0",
         "gatsby": "^2.29.3",
@@ -4829,7 +4830,6 @@
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM=",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -37596,7 +37596,6 @@
       "version": "1.6.22",
       "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha1-rgm0dE/dx0cU7p+dbxembnfENXM=",
-      "peer": true,
       "requires": {}
     },
     "@mdx-js/util": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@loadable/component": "^5.14.1",
     "@mdb/consistent-nav": "^1.2.13",
     "@mdb/flora": "^0.20.1",
+    "@mdx-js/react": "^1.6.22",
     "clipboard": "^2.0.8",
     "dotenv": "^8.2.0",
     "gatsby": "^2.29.3",


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Drivers prod](https://www.mongodb.com/docs/drivers/)

### Staging Links:

[Drivers staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/drivers/raymundrodriguez/hotfix-add-dep/)

### Notes:
This hopefully fixes an issue with the frontend not being able to resolve a dependency for `@mdx-js/react` within `theme-ui`. 

For context, `@mdx-js/react` went from being a dependency to a [peer-dependency](https://github.com/system-ui/theme-ui/pull/1867/files#diff-ac3b342159924758a87a5f7b5a48087ee29bb461797aa51de76b33c87aab87a2R20) when v12 of `theme-ui` was released. `flora` and `consistent-nav` have followed suit to add `@mdx-js/react` as a peer dependency, but this wasn't an issue for snooty until we bumped these dependencies in #612.