### PR TITLE
DOP-3023: Fix typos in search property mapping

### DIFF
--- a/src/utils/parse-marian-manifests.js
+++ b/src/utils/parse-marian-manifests.js
@@ -2,6 +2,8 @@ import { compareBranchesWithVersionNumbers } from './compare-branches-with-versi
 
 const PROPERTY_MAPPING = {
   atlas: 'Atlas',
+  'atlas-cli': 'Atlas CLI',
+  AtlasGov: 'Atlas for Government',
   'bi-connector': 'BI Connector',
   charts: 'Charts',
   compass: 'Compass',
@@ -11,15 +13,19 @@ const PROPERTY_MAPPING = {
   'docs-ruby': 'Ruby Driver',
   drivers: 'Drivers',
   ecosystem: 'Ecosystem',
+  golang: 'Go Driver',
   guides: 'Guides',
+  java: 'Java Driver',
   'kafka-connector': 'Kafka Connector',
   'kubernetes-operator': 'Kubernetes Operator',
   manual: 'MongoDB Manual',
   'mms-cloud': 'Cloud Manager',
   'mms-onprem': 'Ops Manager',
   mongocli: 'MongoDB CLI',
+  'mongodb-shell': 'MongoDB Shell',
   'mongodb-vscode': 'MongoDB for VSCode',
   mongoid: 'mongoid',
+  node: 'Node Driver',
   realm: 'Realm',
   'spark-connector': 'Spark Connector',
 };


### PR DESCRIPTION
### Stories/Links:

DOP-3023

### Current Behavior:

[Landing Prod](https://www.mongodb.com/docs/search/?q=test)

### Staging Links:

[Landing Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-3023/search/?q=test)

### Notes:
* Although the main issue was the typo for Atlas CLI, there are other malformed search property names for certain categories. I'm bundling this all up here to avoid more typo tickets during World.
* This hardcoded mapping should be temporary and may be removed once #624 is ready for release.