### PR TITLE
DOP-3044: Set site url to dotcom base url

### DIFF
--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -1,6 +1,6 @@
 const { execSync } = require('child_process');
 const userInfo = require('os').userInfo;
-const { getSiteUrl } = require('./get-site-url');
+const { DOTCOM_BASE_URL } = require('./base-url');
 
 const runningEnv = process.env.NODE_ENV || 'production';
 
@@ -64,7 +64,7 @@ const siteMetadata = {
   patchId: process.env.PATCH_ID || '',
   pathPrefix: getPathPrefix(process.env.PATH_PREFIX),
   project: process.env.GATSBY_SITE,
-  siteUrl: getSiteUrl(process.env.GATSBY_SITE),
+  siteUrl: DOTCOM_BASE_URL,
   snootyBranch: gitBranch,
   snootyEnv: process.env.SNOOTY_ENV || 'development',
   user: userInfo().username,


### PR DESCRIPTION
### Stories/Links:

DOP-3044

### Current Behavior:

[Landing Prod](https://mongodb.com/docs/)
[Atlas App Services Prod](https://www.mongodb.com/docs/atlas/app-services/)

### Staging Links:

[Landing Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/raymundrodriguez/DOP-3044/)
[Atlas App Services Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-app-services/raymundrodriguez/DOP-3044/)

### Notes:
* This fixes the problems with having "https://mongodb.com/docs/docs/" in the canonical URL and the breadcrumb schema.
* View page source in staging link and see that the canonical link and the breadcrumb schema do not contain the malformed url. They currently do not contain "/docs/" in the url since this should be appended as part of the prefix (passed down from the autobuilder)