### PR TITLE
DOP-3057: Add legacy-peer-deps flag to CI installation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install
-      run: npm ci
+      run: npm ci --legacy-peer-deps
     - name: Lint
       run: npm run lint && npm run format
     - name: Test


### PR DESCRIPTION
### Stories/Links:

DOP-3057

### Current Behavior:

N/A

### Staging Links:

N/A

### Notes:
* This should hopefully ensure that all dependencies are installed as they should be, regardless of the version of `npm` that the CI is using