### PR TITLE
DOP-2372: Allow images to be enlarged on initial page load

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -15,6 +15,14 @@ export default class Image extends Component {
     };
   }
 
+  // For statically generated site, manually trigger the onLoad event for initial page load
+  componentDidMount() {
+    const img = this.imgRef.current;
+    if (img && img.complete) {
+      this.handleLoad(img);
+    }
+  }
+
   handleLoad = ({ target: img }) => {
     const { handleImageLoaded, nodeData } = this.props;
     handleImageLoaded(this.imgRef.current);

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -12,7 +12,7 @@ const Image = ({ nodeData, handleImageLoaded, className }) => {
 
   useEffect(() => {
     if (imgRef.current && imgRef.current.complete) {
-      handleLoad(imgRef.current);
+      handleLoad();
     }
   });
 
@@ -39,9 +39,8 @@ const Image = ({ nodeData, handleImageLoaded, className }) => {
 
   const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
   const altText = getNestedValue(['options', 'alt'], nodeData) || imgSrc;
-  const customAlign = getNestedValue(['options', 'align'], nodeData)
-    ? `align-${getNestedValue(['options', 'align'], nodeData)}`
-    : '';
+  const imgAlignment = getNestedValue(['options', 'align'], nodeData);
+  const customAlign = imgAlignment ? `align-${imgAlignment}` : '';
 
   const hasBorder = getNestedValue(['options', 'border'], nodeData);
   const borderStyling = css`

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,91 +1,79 @@
-import React, { Component } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 import { css } from '@emotion/react';
 import { getNestedValue } from '../utils/get-nested-value';
 import { uiColors } from '@leafygreen-ui/palette';
 
-export default class Image extends Component {
-  constructor(props) {
-    super(props);
-    this.imgRef = React.createRef();
-    this.state = {
-      height: null,
-      width: null,
-    };
-  }
+const Image = ({ nodeData, handleImageLoaded, className }) => {
+  const [height, setHeight] = useState(null);
+  const [width, setWidth] = useState(null);
+  const imgRef = useRef();
 
-  // For statically generated site, manually trigger the onLoad event for initial page load
-  componentDidMount() {
-    const img = this.imgRef.current;
-    if (img && img.complete) {
-      this.handleLoad(img);
+  useEffect(() => {
+    if (imgRef.current && imgRef.current.complete) {
+      handleLoad(imgRef.current);
     }
-  }
+  });
 
-  handleLoad = ({ target: img }) => {
-    const { handleImageLoaded, nodeData } = this.props;
-    handleImageLoaded(this.imgRef.current);
+  const handleLoad = () => {
+    const img = imgRef.current;
+    handleImageLoaded(img);
 
     const scale = getNestedValue(['options', 'scale'], nodeData);
     if (scale) {
-      this.scaleSize(img.naturalWidth, img.naturalHeight, scale);
+      scaleSize(img.naturalWidth, img.naturalHeight, scale);
     } else {
       const height = getNestedValue(['options', 'height'], nodeData);
       const width = getNestedValue(['options', 'width'], nodeData);
-      if (height) this.setState({ height });
-      if (width) this.setState({ width });
+      if (height) setHeight(height);
+      if (width) setWidth(height);
     }
   };
 
-  scaleSize = (width, height, scale) => {
+  const scaleSize = (width, height, scale) => {
     const scaleValue = parseInt(scale, 10) / 100.0;
-    this.setState({
-      height: height * scaleValue,
-      width: width * scaleValue,
-    });
+    setHeight(height * scaleValue);
+    setWidth(width * scaleValue);
   };
 
-  render() {
-    const { className, nodeData } = this.props;
-    const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
-    const altText = getNestedValue(['options', 'alt'], nodeData) || imgSrc;
-    const customAlign = getNestedValue(['options', 'align'], nodeData)
-      ? `align-${getNestedValue(['options', 'align'], nodeData)}`
-      : '';
+  const imgSrc = getNestedValue(['argument', 0, 'value'], nodeData);
+  const altText = getNestedValue(['options', 'alt'], nodeData) || imgSrc;
+  const customAlign = getNestedValue(['options', 'align'], nodeData)
+    ? `align-${getNestedValue(['options', 'align'], nodeData)}`
+    : '';
 
-    const hasBorder = getNestedValue(['options', 'border'], nodeData);
-    const borderStyling = css`
-      border: 0.5px solid ${uiColors.gray.light1};
-      width: 100%;
-      border-radius: 4px;
-    `;
+  const hasBorder = getNestedValue(['options', 'border'], nodeData);
+  const borderStyling = css`
+    border: 0.5px solid ${uiColors.gray.light1};
+    width: 100%;
+    border-radius: 4px;
+  `;
 
-    const buildStyles = () => {
-      const { height, width } = this.state;
-      return {
-        ...(height && { height }),
-        ...(width && { width }),
-      };
+  const buildStyles = () => {
+    return {
+      ...(height && { height }),
+      ...(width && { width }),
     };
+  };
 
-    const { options: { class: directiveClass } = {} } = nodeData;
-    return (
-      <img
-        src={withPrefix(imgSrc)}
-        alt={altText}
-        className={[directiveClass, customAlign, className].join(' ')}
-        style={nodeData.options ? buildStyles() : {}}
-        onLoad={this.handleLoad}
-        ref={this.imgRef}
-        css={css`
-          ${hasBorder ? borderStyling : ''}
-          max-width: 100%;
-        `}
-      />
-    );
-  }
-}
+  const { options: { class: directiveClass } = {} } = nodeData;
+
+  return (
+    <img
+      src={withPrefix(imgSrc)}
+      alt={altText}
+      className={[directiveClass, customAlign, className].join(' ')}
+      style={nodeData.options ? buildStyles() : {}}
+      onLoad={handleLoad}
+      ref={imgRef}
+      css={css`
+        ${hasBorder ? borderStyling : ''}
+        max-width: 100%;
+      `}
+    />
+  );
+};
 
 Image.propTypes = {
   className: PropTypes.string,
@@ -111,3 +99,5 @@ Image.defaultProps = {
   className: '',
   handleImageLoaded: () => {},
 };
+
+export default Image;


### PR DESCRIPTION
### Stories/Links:

[DOP-2372](https://jira.mongodb.org/browse/DOP-2372)

### Current Behavior:

[Prod site example](https://www.mongodb.com/docs/atlas/production-notes/#single-region-and-multi-region-clusters): On initial page load, the image cannot be clicked. However, if you navigate to a separate page via the TOC and then return to the initial page, the image becomes clickable. We expect the click behavior on initial page load as well.

### Staging Links:

[Staging site](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/drew.beckmen/dop-2372-image-enlargement/production-notes/#single-region-and-multi-region-clusters): On initial page load, the "click to enlarge" message is present, and users can click on the image to open a modal.

### Notes:

- The behavior is **not** reproducible locally when running `npm run develop`. The fact that the code behaves as expected locally but not in prod proved to be a key insight in the debugging process.
- Since we have a statically generated site, the images can be loaded before the Javascript, so we may never hit the `onLoad` callback on initial page load. That callback is responsible for enabling the click to enlarge behavior.
- To resolve the issue, I transformed `Image` to a functional component and leveraged the `useEffect` hook to check if the image has already been loaded. As a result, on initial page load, even if the image has been loaded, we will hit the `useEffect` hook post-render, which will invoke the `onLoad` callback function.
- Note: this issue could have been solved using class component lifecycle methods such as `componentDidMount()`. However, `useEffect` provides a cleaner interface since we don't have to think about `componentDidMount()`, `componentDidUpdate()`, etc. separately. Functional components are also somewhat of a standard now, so I felt this PR was a good opportunity to refactor the `Image` component.