### PR TITLE
DOP-2847: Ensure TOC item open state matches active state

### DIFF
--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -40,7 +40,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
   // Disable linter to handle conditional dependency that allows drawers to close when a new page is loaded
   useEffect(() => {
     setIsOpen(isActive);
-  }, [isActive, isDrawer ? activeSection : null]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isActive, isDrawer || hasChildren ? activeSection : null]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const NodeLink = () => {
     // If title is a plaintext string, render as-is. Otherwise, iterate over the text nodes to properly format titles.


### PR DESCRIPTION
### Stories/Links:

[DOP-2847](https://jira.mongodb.org/browse/DOP-2847)

### Current Behavior:

[Prod link](https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/)

Steps to reproduce:

- click the "Connection Guide" TOC element to toggle it closed
- click one of the links on the page. for example, "Connect to MongoDB"
- note how the "Connection Guide" TOC element does not automatically expand to show you the selected TOC item. The current view makes it seem the page does not correspond to anything in the TOC 😢 

### Staging Links:

[Staging link](https://docs-mongodbcom-integration.corp.mongodb.com/master/java/drew.beckmen/dop-2847-toc-behavior/fundamentals/connection/)

Repeat the same steps as above. Now, the "Connection Guide" TOC element expands, allowing you to see the selected item.
_Put a link to your staging environment(s), if applicable_

### Notes:

The code (namely the `useEffect` hook) is designed to keep the `isOpen` state in sync with the value of `isActive`. However, this did not occur in the example above since the `useEffect` hook only depended on `isDrawer`, not `hasChildren`. 

Even though the "Connection Guide" TOC element behaves like a drawer, the current definition of drawer is a nav item that contains children but does not point to a content page (so it just acts as a toggle). We need to account for nav items that correspond to a page of content **and** have children.
