### PR TITLE
DOP-3106: Prevent Images from repeatedly re-rendering

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 import { css } from '@emotion/react';
@@ -10,13 +10,7 @@ const Image = ({ nodeData, handleImageLoaded, className }) => {
   const [width, setWidth] = useState(null);
   const imgRef = useRef();
 
-  useEffect(() => {
-    if (imgRef.current && imgRef.current.complete) {
-      handleLoad();
-    }
-  });
-
-  const handleLoad = () => {
+  const handleLoad = useCallback(() => {
     const img = imgRef.current;
     handleImageLoaded(img);
 
@@ -29,7 +23,13 @@ const Image = ({ nodeData, handleImageLoaded, className }) => {
       if (height) setHeight(height);
       if (width) setWidth(height);
     }
-  };
+  }, [handleImageLoaded, nodeData]);
+
+  useEffect(() => {
+    if (imgRef.current && imgRef.current.complete) {
+      handleLoad();
+    }
+  }, [handleLoad]);
 
   const scaleSize = (width, height, scale) => {
     const scaleValue = parseInt(scale, 10) / 100.0;


### PR DESCRIPTION
### Stories/Links:

DOP-3106

### Current Behavior:

[Atlas App Services](https://www.mongodb.com/docs/atlas/app-services/authentication/custom-jwt/) (prod)

### Staging Links:

[Atlas App Services](https://docs-mongodbcom-integration.corp.mongodb.com/test-figure-rendering/atlas-app-services/raymundrodriguez/DOP-3106/authentication/custom-jwt/index.html) (staging) - pay attention to the images on the page under the "App Services UI" tab.

### Notes:
* This bug only affects images that are not rendering with a lightbox (i.e. they cannot be clicked to expanded). The `useEffect` hook in the `Image` component was being triggered and ran repeatedly.
* For testing/validating, you can use the React Dev Tools extension, toggle the setting that highlights components that are re-rendering. Going to the prod page should show the problem images re-rendering. Going to the page on the staging link should not show any re-rendering for those same images. Alternatively, you can console log some statements for the before and after states locally.