### PR TITLE
DOP-2986: Load project name and branch from manifest

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,8 +23,8 @@ let db;
 exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => {
   const { createNode } = actions;
 
-  // setup env variables
-  const envResults = validateEnvVariables(siteMetadata.manifestPath, manifestMetadata);
+  // setup and validate env variables
+  const envResults = validateEnvVariables(manifestMetadata);
   if (envResults.error) {
     throw Error(envResults.message);
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const { saveAssetFiles, saveStaticFiles } = require('./src/utils/setup/save-asse
 const { validateEnvVariables } = require('./src/utils/setup/validate-env-variables');
 const { getNestedValue } = require('./src/utils/get-nested-value');
 const { getPageSlug } = require('./src/utils/get-page-slug');
-const { siteMetadata } = require('./src/utils/site-metadata');
+const { manifestMetadata, siteMetadata } = require('./src/utils/site-metadata');
 const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
 const { ManifestDocumentDatabase, StitchDocumentDatabase } = require('./src/init/DocumentDatabase.js');
@@ -24,8 +24,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
   const { createNode } = actions;
 
   // setup env variables
-  const envResults = validateEnvVariables();
-
+  const envResults = validateEnvVariables(siteMetadata.manifestPath, manifestMetadata);
   if (envResults.error) {
     throw Error(envResults.message);
   }
@@ -34,10 +33,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
 
   if (siteMetadata.manifestPath) {
     console.log('Loading documents from manifest');
-    db = new ManifestDocumentDatabase(siteMetadata.manifestPath);
+    db = ManifestDocumentDatabase;
   } else {
     console.log('Loading documents from stitch');
-    db = new StitchDocumentDatabase();
+    db = StitchDocumentDatabase;
   }
 
   await db.connect();

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ const { getPageSlug } = require('./src/utils/get-page-slug');
 const { manifestMetadata, siteMetadata } = require('./src/utils/site-metadata');
 const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
-const { ManifestDocumentDatabase, StitchDocumentDatabase } = require('./src/init/DocumentDatabase.js');
+const { manifestDocumentDatabase, stitchDocumentDatabase } = require('./src/init/DocumentDatabase.js');
 
 // different types of references
 const PAGES = [];
@@ -33,10 +33,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
 
   if (siteMetadata.manifestPath) {
     console.log('Loading documents from manifest');
-    db = ManifestDocumentDatabase;
+    db = manifestDocumentDatabase;
   } else {
     console.log('Loading documents from stitch');
-    db = StitchDocumentDatabase;
+    db = stitchDocumentDatabase;
   }
 
   await db.connect();

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -6,7 +6,7 @@ const {
   ASSETS_COLLECTION,
   BRANCHES_COLLECTION,
 } = require('../build-constants');
-const { siteMetadata } = require('../utils/site-metadata');
+const { manifestMetadata, siteMetadata } = require('../utils/site-metadata');
 const { constructBuildFilter } = require('../utils/setup/construct-build-filter');
 const AdmZip = require('adm-zip');
 const BSON = require('bson');
@@ -67,13 +67,7 @@ class ManifestDocumentDatabase {
   }
 
   async getMetadata() {
-    const zipEntries = this.zip.getEntries();
-    for (const entry of zipEntries) {
-      if (entry.entryName === 'site.bson') {
-        const doc = BSON.deserialize(entry.getData());
-        return doc;
-      }
-    }
+    return manifestMetadata;
   }
 
   async getAsset(checksum) {
@@ -121,5 +115,5 @@ class StitchDocumentDatabase {
   }
 }
 
-exports.ManifestDocumentDatabase = ManifestDocumentDatabase;
-exports.StitchDocumentDatabase = StitchDocumentDatabase;
+exports.ManifestDocumentDatabase = new ManifestDocumentDatabase(process.env.GATSBY_MANIFEST_PATH);
+exports.StitchDocumentDatabase = new StitchDocumentDatabase();

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -115,5 +115,5 @@ class StitchDocumentDatabase {
   }
 }
 
-exports.ManifestDocumentDatabase = new ManifestDocumentDatabase(process.env.GATSBY_MANIFEST_PATH);
-exports.StitchDocumentDatabase = new StitchDocumentDatabase();
+exports.manifestDocumentDatabase = new ManifestDocumentDatabase(process.env.GATSBY_MANIFEST_PATH);
+exports.stitchDocumentDatabase = new StitchDocumentDatabase();

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -1,0 +1,19 @@
+const AdmZip = require('adm-zip');
+const BSON = require('bson');
+
+// Returns the metadata from the manifest file if provided
+const fetchManifestMetadata = () => {
+  let metadata = {};
+  if (process.env.GATSBY_MANIFEST_PATH) {
+    const zip = new AdmZip(process.env.GATSBY_MANIFEST_PATH);
+    const zipEntries = zip.getEntries();
+    for (const entry of zipEntries) {
+      if (entry.entryName === 'site.bson') {
+        metadata = BSON.deserialize(entry.getData());
+      }
+    }
+  }
+  return metadata;
+};
+
+module.exports = { fetchManifestMetadata };

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -2,18 +2,18 @@ const fs = require('fs');
 
 // env variables for building site along with use in front-end
 // https://www.gatsbyjs.org/docs/environment-variables/#defining-environment-variables
-const validateEnvVariables = (manifestPath, manifestMetadata) => {
+const validateEnvVariables = (manifestMetadata) => {
   // only require env vars when no manifest path is specified
   if (
-    !manifestPath &&
+    !process.env.GATSBY_MANIFEST_PATH &&
     (!process.env.GATSBY_SITE || !process.env.GATSBY_PARSER_USER || !process.env.GATSBY_PARSER_BRANCH)
   ) {
     return {
       error: true,
       message: `${process.env.NODE_ENV} requires the variables GATSBY_SITE, GATSBY_PARSER_USER, and GATSBY_PARSER_BRANCH, found: ${process.env.GATSBY_SITE}, ${process.env.GATSBY_PARSER_USER}, ${process.env.GATSBY_PARSER_BRANCH}`,
     };
-  } else if (manifestPath) {
-    validateEnvVarsForManifest(manifestMetadata);
+  } else if (process.env.GATSBY_MANIFEST_PATH) {
+    validateManifestEnvVars(manifestMetadata);
   }
   // create split prefix for use in stitch function
   return {
@@ -22,7 +22,7 @@ const validateEnvVariables = (manifestPath, manifestMetadata) => {
 };
 
 // set env vars accordingly if none are provided
-const validateEnvVarsForManifest = (manifestMetadata) => {
+const validateManifestEnvVars = (manifestMetadata) => {
   let envVars = '';
   const site = `\nGATSBY_SITE=${manifestMetadata['project']}`;
   const branch = `\nGATSBY_PARSER_BRANCH=${manifestMetadata['branch']}`;

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -38,7 +38,10 @@ const validateManifestEnvVars = (manifestMetadata) => {
   try {
     ['.env.production', '.env.development'].forEach((file) => {
       fs.appendFile(file, envVars, function (err) {
-        if (err) throw err;
+        if (err) {
+          console.error(err);
+          throw err;
+        }
       });
     });
   } catch (err) {

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -1,17 +1,97 @@
+const fs = require('fs');
+
 // env variables for building site along with use in front-end
 // https://www.gatsbyjs.org/docs/environment-variables/#defining-environment-variables
-const validateEnvVariables = () => {
-  // make sure necessary env vars exist
-  if (!process.env.GATSBY_SITE || !process.env.GATSBY_PARSER_USER || !process.env.GATSBY_PARSER_BRANCH) {
+const validateEnvVariables = (manifestPath, manifestMetadata) => {
+  // only require env vars when no manifest path is specified
+  if (
+    !manifestPath &&
+    (!process.env.GATSBY_SITE || !process.env.GATSBY_PARSER_USER || !process.env.GATSBY_PARSER_BRANCH)
+  ) {
     return {
       error: true,
       message: `${process.env.NODE_ENV} requires the variables GATSBY_SITE, GATSBY_PARSER_USER, and GATSBY_PARSER_BRANCH, found: ${process.env.GATSBY_SITE}, ${process.env.GATSBY_PARSER_USER}, ${process.env.GATSBY_PARSER_BRANCH}`,
     };
+  } else if (manifestPath) {
+    validateEnvVarsForManifest(manifestMetadata);
   }
   // create split prefix for use in stitch function
   return {
     error: false,
   };
+};
+
+// set env vars accordingly if none are provided
+const validateEnvVarsForManifest = (manifestMetadata) => {
+  let envVars = '';
+  const site = `\nGATSBY_SITE=${manifestMetadata['project']}`;
+  const branch = `\nGATSBY_PARSER_BRANCH=${manifestMetadata['branch']}`;
+
+  if (!process.env.GATSBY_SITE) {
+    envVars += site;
+  }
+  if (!process.env.GATSBY_PARSER_BRANCH) {
+    envVars += branch;
+  }
+
+  // write to .env files with updated env vars
+  try {
+    ['.env.production', '.env.development'].forEach((file) => {
+      fs.appendFile(file, envVars, function (err) {
+        if (err) throw err;
+      });
+    });
+  } catch (err) {
+    console.error(err);
+  }
+
+  // if env variables are present, check that they are set to the correct values. Otherwise, override them.
+  let incorrectEnvVars = [];
+  let correctEnvVars = '';
+  if (process.env.GATSBY_SITE && process.env.GATSBY_SITE !== manifestMetadata['project']) {
+    incorrectEnvVars.push('GATSBY_SITE');
+    correctEnvVars += site;
+  }
+  if (process.env.GATSBY_PARSER_BRANCH && process.env.GATSBY_PARSER_BRANCH !== manifestMetadata['branch']) {
+    incorrectEnvVars.push('GATSBY_PARSER_BRANCH');
+    correctEnvVars += branch;
+  }
+  if (incorrectEnvVars.length > 0) {
+    replaceIncorrectEnvVars(incorrectEnvVars, correctEnvVars);
+  }
+};
+
+const replaceIncorrectEnvVars = (incorrectEnvVars, envVars) => {
+  try {
+    ['.env.production', '.env.development'].forEach((file) => {
+      fs.readFile(file, 'utf8', (err, data) => {
+        if (err) {
+          console.error(err);
+        }
+
+        const dataArray = data.split('\n');
+
+        // remove incorrect variables from .env files
+        for (const dataEntry in dataArray) {
+          for (const incorrectVar in incorrectEnvVars) {
+            if (dataArray[dataEntry].includes(incorrectEnvVars[incorrectVar])) {
+              dataArray.splice(dataEntry, 1);
+            }
+          }
+        }
+
+        // write to .env files with updated env vars
+        fs.writeFile(file, dataArray.join('\n').concat(envVars), (err) => {
+          if (err) {
+            console.error(err);
+          }
+        });
+      });
+    });
+  } catch (err) {
+    console.error(err);
+  }
+  return;
 };
 
 module.exports.validateEnvVariables = validateEnvVariables;

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -43,6 +43,7 @@ const validateManifestEnvVars = (manifestMetadata) => {
     });
   } catch (err) {
     console.error(err);
+    throw err;
   }
 
   // if env variables are present, check that they are set to the correct values. Otherwise, override them.
@@ -67,6 +68,7 @@ const replaceIncorrectEnvVars = (incorrectEnvVars, envVars) => {
       fs.readFile(file, 'utf8', (err, data) => {
         if (err) {
           console.error(err);
+          throw err;
         }
 
         const dataArray = data.split('\n');
@@ -84,12 +86,14 @@ const replaceIncorrectEnvVars = (incorrectEnvVars, envVars) => {
         fs.writeFile(file, dataArray.join('\n').concat(envVars), (err) => {
           if (err) {
             console.error(err);
+            throw err;
           }
         });
       });
     });
   } catch (err) {
     console.error(err);
+    throw err;
   }
 };
 

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -91,7 +91,6 @@ const replaceIncorrectEnvVars = (incorrectEnvVars, envVars) => {
   } catch (err) {
     console.error(err);
   }
-  return;
 };
 
 module.exports.validateEnvVariables = validateEnvVariables;

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -1,12 +1,16 @@
 const { execSync } = require('child_process');
 const userInfo = require('os').userInfo;
 const { DOTCOM_BASE_URL } = require('./base-url');
+const { fetchManifestMetadata } = require('../utils/setup/fetch-manifest-metadata');
 
+// loads vars from the .env file into process.env object
 const runningEnv = process.env.NODE_ENV || 'production';
 
 require('dotenv').config({
   path: `.env.${runningEnv}`,
 });
+
+const manifestMetadata = fetchManifestMetadata();
 
 const getDatabase = (env) => {
   switch (env) {
@@ -59,11 +63,11 @@ const siteMetadata = {
   commitHash: process.env.COMMIT_HASH || '',
   database: getDatabase(process.env.SNOOTY_ENV),
   reposDatabase: getReposDatabase(process.env.SNOOTY_ENV),
-  parserBranch: process.env.GATSBY_PARSER_BRANCH,
-  parserUser: process.env.GATSBY_PARSER_USER,
+  parserBranch: manifestMetadata['branch'] || process.env.GATSBY_PARSER_BRANCH,
+  parserUser: userInfo().username,
   patchId: process.env.PATCH_ID || '',
   pathPrefix: getPathPrefix(process.env.PATH_PREFIX),
-  project: process.env.GATSBY_SITE,
+  project: manifestMetadata['project'] || process.env.GATSBY_SITE,
   siteUrl: DOTCOM_BASE_URL,
   snootyBranch: gitBranch,
   snootyEnv: process.env.SNOOTY_ENV || 'development',
@@ -72,3 +76,4 @@ const siteMetadata = {
 };
 
 module.exports.siteMetadata = siteMetadata;
+module.exports.manifestMetadata = manifestMetadata;

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -64,7 +64,7 @@ const siteMetadata = {
   database: getDatabase(process.env.SNOOTY_ENV),
   reposDatabase: getReposDatabase(process.env.SNOOTY_ENV),
   parserBranch: manifestMetadata['branch'] || process.env.GATSBY_PARSER_BRANCH,
-  parserUser: userInfo().username,
+  parserUser: process.env.GATSBY_PARSER_USER || userInfo().username,
   patchId: process.env.PATCH_ID || '',
   pathPrefix: getPathPrefix(process.env.PATH_PREFIX),
   project: manifestMetadata['project'] || process.env.GATSBY_SITE,


### PR DESCRIPTION
### Stories/Links:

[DOP-2986](https://jira.mongodb.org/browse/DOP-2986)

### Current Behavior:
There should be no visual changes as a result of the PR. 

[Realm Prod](https://www.mongodb.com/docs/realm/)
[Compass Prod](https://www.mongodb.com/docs/compass/current/)
[Atlas Prod](https://www.mongodb.com/docs/atlas/)

### Staging Links:
[Realm Staging](https://docs-mongodbcom-integration.corp.mongodb.com/test/realm/grace.chong/DOP-2986/
)
[Compass Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/compass/grace.chong/DOP-2986/)
[Atlas Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/grace.chong/DOP-2986/)

### Notes:
If a manifest file is specified, this code pulls information related to environment variables directly from the file instead of using the environment variables. This avoids having to include `GATSBY_SITE`, `GATSBY_PARSER_BRANCH` and `GATSBY_USER` before building, developing, or staging a docs property if a manifest file is provided.

Just a few comments about some decisions that were made: 

- A new utils function `fetchManifestMetadata` was created to directly pull metadata from the manifest to avoid circular dependencies between the `ManifestDocumentDatabase` exported in `DocumentDatabase.js` and `site-metadata.js`. 
- Branch and project information is currently being pulled from the manifest file, since `user` and `parserUser` should be the same.
- Since the `Makefile` uses the `process.env.` vars to generate a staging link, I included logic to write to the `.env` files in the case that a manifest file is present (if the env vars are not already specified), or change what's in the `.env` files to properly represent the correct data. 