### PR TITLE
DOP-3086: removed unused font (Inconsolata) from html.js

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -17,7 +17,6 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
       <meta name="version" content="master" />
       <meta property="og:image" content={metaUrl} />
       <meta property="og:image:secure_url" content={metaSecureUrl} />
-      <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
       <link rel="shortcut icon" href={faviconUrl} />
       {headComponents}
     </head>


### PR DESCRIPTION
### Stories/Links:

[DOP-3086
](https://jira.mongodb.org/browse/DOP-3086)
### Current Behavior:

[Compass Docs](https://www.mongodb.com/docs/compass/current/) (current prod) 

Current docs have stylesheet link in head to Inconsolata font.

### Staging Links:

[Compass Docs](https://docs-mongodbcom-integration.corp.mongodb.com/master/compass/matt.meigs/DOP-3086/) (staging) 

### Notes:

Stylesheet link to unused Google font has simply been removed. I assume this is all that's necessary! 