### PR TITLE
DOP-2813: added stripQueryString to gatsby-config to clean canonical url

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,6 +13,7 @@ module.exports = {
       resolve: 'gatsby-plugin-canonical-urls',
       options: {
         siteUrl: `${siteMetadata.siteUrl}${pathPrefix}`,
+        stripQueryString: true,
       },
     },
     {


### PR DESCRIPTION
### Stories/Links:

[DOP-2813](https://jira.mongodb.org/browse/DOP-2813)

### Current Behavior:

There should be no visual changes (other than in console or source code view).

[Compass w/ query string](https://www.mongodb.com/docs/compass/current/?skunkworks=skunktrek)
[Realm w/ query string](https://www.mongodb.com/docs/realm/?summer=hot)
[Landing w/ query string](https://www.mongodb.com/docs/?foo=bar)

(all with query strings)

### Staging Links:

In Elements tab of Chrome Dev Tools, search for “canonical” link to see that the query parameters have been excised.

[Compass Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/compass/matt.meigs/DOP-2813/?skunkworks=skunktrek)
[Realm Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/matt.meigs/DOP-2813/?summer=hot)
[Landing Staging](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/matt.meigs/DOP-2813/?foo=bar)

(all with query strings)

### Notes:

Gatsby-config flag does all the work. Seems dependable. 
Looking into... maybe... a Cypress pipeline integration for skunkworks. But no promises.
