### PR TITLE
DOP-2583: address typography in cards. TODO: update links styling

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -28,13 +28,14 @@ const CardIcon = styled('img')`
 `;
 
 const H4 = styled(Body)`
+  font-weight: 600;
   letter-spacing: 0.5px;
   margin: ${({ compact, theme }) =>
-    compact ? `0 0 ${theme.size.small}` : `${theme.size.medium} 0 ${theme.size.small} 0`};
+    compact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
 `;
 
 const CTA = styled('p')`
-  margin-top: 16px;
+  margin-top: 8px;
 `;
 
 const FlexTag = styled(Tag)`
@@ -92,8 +93,9 @@ const Card = ({
 }) => {
   const Card = isCompact || isExtraCompact ? CompactCard : StyledCard;
   const Icon = isCompact ? CompactIcon : CardIcon;
+  console.log('isCompact', isCompact);
   return (
-    <Card onClick={url ? () => onCardClick(url) : undefined}>
+    <Card className={isCompact ? 'compact-card' : 'styled-card'} onClick={url ? () => onCardClick(url) : undefined}>
       {icon && (
         <ConditionalWrapper
           condition={isCompact}
@@ -107,9 +109,11 @@ const Card = ({
         wrapper={(children) => <CompactTextWrapper>{children}</CompactTextWrapper>}
       >
         {tag && <FlexTag>{tag}</FlexTag>}
-        <H4 compact={isCompact || isExtraCompact} weight="medium">
-          {headline}
-        </H4>
+        {headline && (
+          <H4 className="check-h4" compact={isCompact || isExtraCompact} weight="medium">
+            {headline}
+          </H4>
+        )}
         {children.map((child, i) => (
           // The cardRef prop's purpose to distinguish wich RefRoles are coming from the Card component (a workaround while we figure out card-ref support in the parser/)
           <ComponentFactory nodeData={child} key={i} cardRef={true} />

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -93,7 +93,6 @@ const Card = ({
 }) => {
   const Card = isCompact || isExtraCompact ? CompactCard : StyledCard;
   const Icon = isCompact ? CompactIcon : CardIcon;
-  console.log('isCompact', isCompact);
   return (
     <Card className={isCompact ? 'compact-card' : 'styled-card'} onClick={url ? () => onCardClick(url) : undefined}>
       {icon && (

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { withPrefix, navigate } from 'gatsby';
 import styled from '@emotion/styled';
 import LeafyGreenCard from '@leafygreen-ui/card';
-import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
 import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
@@ -57,8 +56,6 @@ const CompactIcon = styled('img')`
 `;
 
 const CompactIconCircle = styled('div')`
-  background: ${palette.green.light3};
-  border-radius: 50%;
   display: flex;
   flex-shrink: 0 !important;
   height: 48px;
@@ -94,7 +91,7 @@ const Card = ({
   const Card = isCompact || isExtraCompact ? CompactCard : StyledCard;
   const Icon = isCompact ? CompactIcon : CardIcon;
   return (
-    <Card className={isCompact ? 'compact-card' : 'styled-card'} onClick={url ? () => onCardClick(url) : undefined}>
+    <Card onClick={url ? () => onCardClick(url) : undefined}>
       {icon && (
         <ConditionalWrapper
           condition={isCompact}

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -10,13 +10,14 @@ import { TabContext } from './Tabs/tab-context';
 import ConditionalWrapper from './ConditionalWrapper';
 import Contents from './Contents';
 import Permalink from './Permalink';
-import { H2, H3, Subtitle, Body } from '@leafygreen-ui/typography';
+import { H3, Subtitle, Body } from '@leafygreen-ui/typography';
 
 const FeedbackHeading = Loadable(() => import('./Widgets/FeedbackWidget/FeedbackHeading'));
 
-const StyledH2 = styled(H2)`
+const StyledH3 = styled(H3)`
   margin-top: 16px;
   margin-bottom: 24px;
+  font-weight: 500;
 `;
 
 const headingStyles = css`
@@ -26,7 +27,7 @@ const headingStyles = css`
 
 const determineHeading = (sectionDepth) => {
   if (sectionDepth === 1) {
-    return StyledH2;
+    return StyledH3;
   } else if (sectionDepth === 2) {
     return H3;
   } else if (sectionDepth === 3) {

--- a/src/components/Introduction.js
+++ b/src/components/Introduction.js
@@ -6,7 +6,7 @@ import ComponentFactory from './ComponentFactory';
 
 const StyledIntroduction = styled('div')`
   .button {
-    margin: ${theme.size.medium} ${theme.size.default} ${theme.size.default} 0;
+    margin: ${theme.size.small} ${theme.size.default} ${theme.size.default} 0;
     min-height: ${theme.size.large};
   }
   .button + p {

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -18,12 +18,12 @@ const Wrapper = styled('main')`
   h4,
   h5,
   h6 {
-    font-weight: 600;
+    font-weight: 500;
   }
 
   h1 {
-    font-size: ${theme.fontSize.h2};
-    margin-bottom: ${theme.size.default};
+    margin-top: ${theme.size.medium};
+    margin-bottom: ${theme.size.small};
   }
 
   h2,


### PR DESCRIPTION
### Stories/Links:

DOP-2583
DOP-2578

### Current Behavior:

this is a merge to DOP-2583-typography so check these staging links for cards:

https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/allison/branding/
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/allison/branding/atlas-search/
https://docs-mongodbcom-integration.corp.mongodb.com/foo/drivers/allison/branding/

### Staging Links:

https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-2583-2578/
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-2583-2578/atlas-search/
https://docs-mongodbcom-integration.corp.mongodb.com/master/drivers/seung.park/DOP-2583-2578/


### Notes:
- links still need to be addressed. see cloud-docs staging link for atlas search
- links are also wrapping card context to next lines cc @schmalliso 