### PR TITLE
DOP-3150: Defer Optimizely script

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -8,7 +8,7 @@ import { theme } from './src/theme/docsTheme';
 export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([
     // Optimizely
-    <script src="https://cdn.optimizely.com/js/20988630008.js" />,
+    <script defer src="https://cdn.optimizely.com/js/20988630008.js" />,
     // Delighted
     <script
       type="text/javascript"


### PR DESCRIPTION
### Stories/Links:

DOP-3150

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_
www.mongodb.com/docs

### Staging Links:

_Put a link to your staging environment(s), if applicable_
https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/cassidy.schaufele/DOP-3150/

### Notes:
Adds `defer` to our optimizely script include to make it non-render blocking. This will potentially cause screen flicker should experiments be run, but we don't expect anybody to be running experiments on docs.

Why not `async`? Because we want to make sure it fetches + spends cpu *after* html parse is complete within the browser 👍 