### PR TITLE
DOP-2578: update cards to use new typography

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -76,6 +76,12 @@ const CompactTextWrapper = styled('div')`
   }
 `;
 
+const StyledBody = styled(Body)`
+  a {
+    line-height: unset;
+  }
+`;
+
 const onCardClick = (url) => {
   isRelativeUrl(url) ? navigate(url) : (window.location.href = url);
 };
@@ -115,9 +121,9 @@ const Card = ({
           <ComponentFactory nodeData={child} key={i} cardRef={true} />
         ))}
         {cta && (
-          <Body>
+          <StyledBody>
             <Link to={url}>{cta}</Link>
-          </Body>
+          </StyledBody>
         )}
       </ConditionalWrapper>
     </Card>

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -33,10 +33,6 @@ const H4 = styled(Body)`
     compact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
 `;
 
-const CTA = styled('p')`
-  margin-top: 8px;
-`;
-
 const FlexTag = styled(Tag)`
   margin-right: auto;
 `;
@@ -73,6 +69,10 @@ const CompactTextWrapper = styled('div')`
   margin-left: ${theme.size.medium};
   @media ${theme.screenSize.upToSmall} {
     margin-left: ${theme.size.default};
+  }
+
+  p {
+    line-height: ${theme.size.medium};
   }
 `;
 
@@ -115,9 +115,9 @@ const Card = ({
           <ComponentFactory nodeData={child} key={i} cardRef={true} />
         ))}
         {cta && (
-          <CTA>
+          <Body>
             <Link to={url}>{cta}</Link>
-          </CTA>
+          </Body>
         )}
       </ConditionalWrapper>
     </Card>

--- a/src/components/Chapters/Chapter.js
+++ b/src/components/Chapters/Chapter.js
@@ -14,7 +14,6 @@ const IMAGE_SIZE = 200;
 
 const Container = styled(Card)`
   background-color: ${uiColors.white};
-  border-radius: ${theme.size.tiny};
   border: 1px solid ${uiColors.gray.light3};
   padding: ${theme.size.large} ${theme.size.medium};
 
@@ -145,6 +144,8 @@ const Chapter = ({ metadata, nodeData: { argument, options } }) => {
   const guides = useMemo(() => getGuidesData(metadata, currentChapter), [metadata, currentChapter]);
 
   return (
+    // TODO: have to return specific typography here. card is explicit size 13 font
+
     <Container id={currentChapter?.id}>
       {image ? (
         <ChapterImage

--- a/src/components/Chapters/Chapter.js
+++ b/src/components/Chapters/Chapter.js
@@ -4,6 +4,7 @@ import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import Card from '@leafygreen-ui/card';
 import { uiColors } from '@leafygreen-ui/palette';
+import { Body } from '@leafygreen-ui/typography';
 import ChapterNumberLabel from './ChapterNumberLabel';
 import Link from '../Link';
 import { theme } from '../../theme/docsTheme';
@@ -78,7 +79,7 @@ const ChapterTitle = styled('div')`
   margin-top: ${theme.size.small};
 `;
 
-const ChapterDescription = styled('div')`
+const ChapterDescription = styled(Body)`
   margin-top: ${theme.size.small};
 `;
 
@@ -101,11 +102,16 @@ const GuideLink = styled(Link)`
   flex-direction: column;
   padding: ${theme.size.small};
   position: relative;
+  font-size: ${theme.size.default};
+  line-height: ${theme.size.medium};
 
   :hover {
     background-color: ${uiColors.gray.light2};
     color: unset;
-    text-decoration: none;
+
+    ::after {
+      content: none;
+    }
   }
 
   @media ${theme.screenSize.mediumAndUp} {

--- a/src/components/Chapters/ChapterNumberLabel.js
+++ b/src/components/Chapters/ChapterNumberLabel.js
@@ -10,6 +10,7 @@ const Label = styled('div')`
   color: ${uiColors.green.base};
   font-size: ${theme.fontSize.small};
   font-weight: bold;
+  line-height: ${theme.size.medium};
   height: ${theme.size.medium};
   text-align: center;
   width: 83px;

--- a/src/components/Chapters/RightColumn.js
+++ b/src/components/Chapters/RightColumn.js
@@ -18,7 +18,6 @@ const learningCardStyle = ({ isVisible }) => css`
   display: flex;
   flex-direction: column;
   padding: ${theme.size.large};
-  border-radius: ${theme.size.tiny};
   margin-bottom: ${theme.size.default};
 
   > p {

--- a/src/components/DriversIndexTiles.js
+++ b/src/components/DriversIndexTiles.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Link as GatsbyLink } from 'gatsby';
 import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import LeafyGreenCard from '@leafygreen-ui/card';
-import Link from './Link';
 import { theme } from '../theme/docsTheme';
 import { baseUrl } from '../utils/base-url';
+import Link from './Link';
 
 import IconC from './icons/C';
 import IconCpp from './icons/Cpp';
@@ -89,6 +90,11 @@ const StyledGrid = styled('div')`
   display: grid;
   grid-gap: ${theme.size.default};
   grid-template-columns: repeat(3, 1fr);
+  margin-bottom: ${theme.size.medium};
+
+  a {
+    text-decoration: none;
+  }
 
   @media ${theme.screenSize.upToMedium} {
     grid-gap: 12px;
@@ -102,15 +108,16 @@ const StyledGrid = styled('div')`
 `;
 
 const StyledCard = styled(LeafyGreenCard)`
-  border: 1px solid ${uiColors.gray.light2};
-  box-shadow: none;
   display: flex;
   flex-direction: row;
   padding: ${theme.size.default};
+  align-items: center;
+  border: 1px solid ${uiColors.gray.light2};
+  box-shadow: none;
 
   &:hover {
     box-shadow: 0 3px 6px -2px ${uiColors.gray.light1};
-    color: unset;
+    // color: unset;
     text-decoration: none;
   }
 `;
@@ -130,10 +137,12 @@ const DriversIndexTiles = () => {
   return (
     <StyledGrid>
       {tiles.map((t) => (
-        <StyledCard as={Link} contentStyle="clickable" key={t.title} to={t.slug}>
-          <StyledIcon>{t.icon}</StyledIcon>
-          {t.title}
-        </StyledCard>
+        <GatsbyLink key={t.title} to={t.slug}>
+          <StyledCard className="styled-card-from-driver-index-tiles">
+            <StyledIcon>{t.icon}</StyledIcon>
+            <Link to={t.slug}>{t.title}</Link>
+          </StyledCard>
+        </GatsbyLink>
       ))}
     </StyledGrid>
   );

--- a/src/components/DriversIndexTiles.js
+++ b/src/components/DriversIndexTiles.js
@@ -5,7 +5,6 @@ import { uiColors } from '@leafygreen-ui/palette';
 import LeafyGreenCard from '@leafygreen-ui/card';
 import { theme } from '../theme/docsTheme';
 import { baseUrl } from '../utils/base-url';
-import Link from './Link';
 
 import IconC from './icons/C';
 import IconCpp from './icons/Cpp';
@@ -117,7 +116,6 @@ const StyledCard = styled(LeafyGreenCard)`
 
   &:hover {
     box-shadow: 0 3px 6px -2px ${uiColors.gray.light1};
-    // color: unset;
     text-decoration: none;
   }
 `;
@@ -140,7 +138,7 @@ const DriversIndexTiles = () => {
         <GatsbyLink key={t.title} to={t.slug}>
           <StyledCard className="styled-card-from-driver-index-tiles">
             <StyledIcon>{t.icon}</StyledIcon>
-            <Link to={t.slug}>{t.title}</Link>
+            {t.title}
           </StyledCard>
         </GatsbyLink>
       ))}

--- a/src/components/DriversIndexTiles.js
+++ b/src/components/DriversIndexTiles.js
@@ -113,6 +113,7 @@ const StyledCard = styled(LeafyGreenCard)`
   align-items: center;
   border: 1px solid ${uiColors.gray.light2};
   box-shadow: none;
+  font-size: ${theme.fontSize.default};
 
   &:hover {
     box-shadow: 0 3px 6px -2px ${uiColors.gray.light1};

--- a/src/components/Operation.js
+++ b/src/components/Operation.js
@@ -55,6 +55,12 @@ const iconAdjust = css`
   top: -5px;
 `;
 
+const StyledCardContainer = styled(Card)`
+  padding: 0;
+  margin-bottom: ${theme.size.default};
+  overflow: hidden;
+`;
+
 const OperationHeader = styled('div')`
   align-items: baseline;
   background-color: ${uiColors.gray.light3};
@@ -137,12 +143,7 @@ const Operation = ({
   }, [hash, setShowDetails, showDetails]);
 
   return (
-    <Card
-      id={hash}
-      css={css`
-        margin-bottom: ${theme.size.default};
-      `}
-    >
+    <StyledCardContainer id={hash}>
       <OperationHeader>
         <Badge variant={methodBadgeMap[method]}>{method}</Badge>
         <div>
@@ -180,7 +181,7 @@ const Operation = ({
           ))}
         </Details>
       )}
-    </Card>
+    </StyledCardContainer>
   );
 };
 

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useFeedbackState } from './context';
 import { displayNone } from '../../../utils/display-none';
+import { theme } from '../../../theme/docsTheme';
 
 export default function FeedbackTab(props) {
   const { feedback, initializeFeedback } = useFeedbackState();
@@ -15,12 +16,15 @@ export default function FeedbackTab(props) {
   );
 }
 
+// TODO: resolve conflict with DOP-2400.
 const Container = styled(LeafygreenCard)`
-  bottom: -6px;
-  cursor: pointer;
-  padding: 12px;
   position: fixed;
+  bottom: -24px;
   right: 42px;
-  user-select: none;
+  padding: 12px;
   z-index: 9;
+  border-radius: 7px;
+  cursor: pointer;
+  user-select: none;
+  font-size: ${theme.fontSize.default};
 `;

--- a/src/components/Widgets/QuizWidget/QuizChoice.js
+++ b/src/components/Widgets/QuizWidget/QuizChoice.js
@@ -42,6 +42,8 @@ const getCardStyling = ({ isSelected, isSubmitted, isCorrect }) => css`
   box-shadow: none !important;
   margin: auto auto ${theme.size.default} auto;
   padding: ${theme.size.default};
+  min-height: unset;
+  border-radius: 7px;
   ${isSelected && `border-color: ${uiColors.black} !important;`};
   ${isSubmitted ? submittedStyle({ isCorrect }) : `:hover{ border-color: ${uiColors.black} !important; }`}
 `;


### PR DESCRIPTION
### Stories/Links:

[DOP-2578](https://jira.mongodb.org/browse/DOP-2578)

### Current Behavior:

[Guides](https://www.mongodb.com/docs/guides/)
[Landing](https://www.mongodb.com/docs/)
[Drivers](https://www.mongodb.com/docs/drivers/)

### Staging Links:
[Guides](https://docs-mongodbcom-integration.corp.mongodb.com/098a51155afa851ada950d2f32e93107a46bcd59/master/guides/seung.park/DOP-2578-post-typography/)
[Landing](https://docs-mongodbcom-integration.corp.mongodb.com/ca1cc8487251860566cc18198a0059a91c4d4fd7/master/landing/seung.park/DOP-2578-post-typography/)
[Drivers](https://docs-mongodbcom-integration.corp.mongodb.com/098a51155afa851ada950d2f32e93107a46bcd59/master/drivers/seung.park/DOP-2578-post-typography/)


### Notes:
- used updated typography to fill in the card content, applying when necessary. Cards, Driver Index Tiles, Chapters, and FeedbackTab were the only ones I found in use
- operation and quiz components were not updated due to lack of content from docs repos? cmiiw but these seem unused.
- seeing a momentary flash of clashing CSS styles on landing and drivers pages. investigation in progress