### PR TITLE
DOP-2577: update LG/tabs to v8 (post typography update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@leafygreen-ui/select": "^6.0.0",
     "@leafygreen-ui/side-nav": "^10.0.0",
     "@leafygreen-ui/table": "^2.0.2",
-    "@leafygreen-ui/tabs": "^5.1.1",
+    "@leafygreen-ui/tabs": "^8.0.0",
     "@leafygreen-ui/text-input": "^6.0.1",
     "@leafygreen-ui/tooltip": "^6.1.7",
     "@leafygreen-ui/typography": "^13.0.0",

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -21,6 +21,21 @@ const getPosition = (element) => {
   return { x, y };
 };
 
+const defaultTabsStyling = css`
+  button {
+    font-size: ${theme.size.default};
+    align-items: center;
+  }
+
+  @media ${theme.screenSize.upToXLarge} {
+    button {
+      overflow: initial;
+      max-width: initial;
+      text-overflow: initial;
+    }
+  }
+`;
+
 const hiddenTabsStyling = css`
   & > div:first-of-type {
     display: none;
@@ -30,11 +45,17 @@ const hiddenTabsStyling = css`
 const landingTabsStyling = css`
   & > div:first-of-type {
     margin-top: ${theme.size.medium};
-    margin-bottom: ${theme.size.medium};
+    margin-bottom: ${theme.size.large};
+
+    button[role='tab'] {
+      display: block;
+      flex-grow: 1;
+    }
   }
 `;
 
 const getTabsStyling = ({ isHidden, isProductLanding }) => css`
+  ${defaultTabsStyling};
   ${isHidden && hiddenTabsStyling};
   ${isProductLanding && landingTabsStyling};
 `;


### PR DESCRIPTION
### Stories/Links:

[DOP-2577](https://jira.mongodb.org/browse/DOP-2577)

### Current Behavior:

PLP tabs:
https://www.mongodb.com/docs/atlas/

non PLP tabs:
https://www.mongodb.com/docs/atlas/access-tracking/#procedure

also hidden tabs:
https://www.mongodb.com/docs/atlas/alert-resolutions/#view-alerts

### Staging Links:

PLP tabs:
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-2577-post-typography/

non PLP tabs:
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-2577-post-typography/access-tracking/#procedure

also hidden tabs:
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-2577-post-typography/alert-resolutions/#view-alerts

### Notes:

- [LG updates](https://github.com/mongodb/leafygreen-ui/blob/main/packages/tabs/src/TabTitle.tsx#L42) pushed a change that makes active tab take a font-weight of 700, reducing legibility. we can reduce this to only update color 
- [also included in update](https://github.com/mongodb/leafygreen-ui/blob/main/packages/tabs/src/TabTitle.tsx#L114 ) was to use 13px font, stuck with 16px for consistency with rest of typography update