### PR TITLE
DOP-3167: fixed terrifying multiplication of punctuation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@leafygreen-ui/icon-button": "^9.1.6",
         "@leafygreen-ui/inline-definition": "^2.0.2",
         "@leafygreen-ui/leafygreen-provider": "^2.3.2",
-        "@leafygreen-ui/lib": "9.4.1",
+        "@leafygreen-ui/lib": "^9.4.1",
         "@leafygreen-ui/logo": "^4.0.2",
         "@leafygreen-ui/modal": "^6.1.2",
         "@leafygreen-ui/palette": "^3.4.0",

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 import { Body } from '@leafygreen-ui/typography';
 import styled from '@emotion/styled';
+import { appendTrailingPunctuation } from '../utils/append-trailing-punctuation';
 
 const SKIP_P_TAGS = new Set(['caption', 'footnote', 'field']);
 
@@ -11,13 +12,14 @@ const StyledParagraph = styled(Body)`
 `;
 
 const Paragraph = ({ nodeData, parentNode, skipPTag, ...rest }) => {
+  const children = appendTrailingPunctuation(nodeData.children);
   // For paragraph nodes that appear inside certain containers, skip <p> tags and just render their contents
   if (skipPTag || SKIP_P_TAGS.has(parentNode)) {
-    return nodeData.children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
+    return children.map((element, index) => <ComponentFactory {...rest} nodeData={element} key={index} />);
   }
   return (
     <StyledParagraph>
-      {nodeData.children.map((element, index) => (
+      {children.map((element, index) => (
         <ComponentFactory {...rest} nodeData={element} key={index} />
       ))}
     </StyledParagraph>

--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -20,20 +20,20 @@ export const appendTrailingPunctuation = (nodes) => {
 };
 
 // Make a copy of node with a deep copy of the new child node with added punctuation
-function deepCopyNodesChildren(node, additionalValue) {
-  if (!node.children || !node.children.length) return node;
-  const deepCopyChildren = [...node.children];
-  const lastChild = deepCopyChildren.pop();
+function deepCopyNodesChildren(refNode, additionalValue) {
+  if (!refNode.children || !refNode.children.length) return refNode;
+  const copyOfChildren = [...refNode.children];
+  const lastChild = copyOfChildren.pop();
 
   const deepCopyLastChild = {
     ...lastChild,
     value: lastChild.value + additionalValue,
   };
 
-  deepCopyChildren.push(deepCopyLastChild);
+  copyOfChildren.push(deepCopyLastChild);
   const copyOfNode = {
-    ...node,
-    children: deepCopyChildren,
+    ...refNode,
+    children: copyOfChildren,
   };
   return copyOfNode;
 }

--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -21,7 +21,7 @@ export const appendTrailingPunctuation = (nodes) => {
 
 // Make a copy of node with a deep copy of the new child node with added punctuation
 function deepCopyNodesChildren(refNode, additionalValue) {
-  if (!refNode.children || !refNode.children.length) return refNode;
+  if (!refNode.children || !refNode.children.length) return { ...refNode };
   const copyOfChildren = [...refNode.children];
   const lastChild = copyOfChildren.pop();
 

--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -1,0 +1,39 @@
+// Append dangling punctuation to preceding Link's text
+export const appendTrailingPunctuation = (nodes) => {
+  const truncatedNodes = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const currNode = nodes[i];
+    const nextNode = nodes[i + 1];
+    const isReference = currNode.type === 'reference';
+    const hasDanglingSibling = nextNode?.type === 'text' && nextNode.value?.length === 1;
+
+    if (isReference && hasDanglingSibling) {
+      const copyOfNodeWithDeepCopiedChildren = deepCopyNodesChildren(currNode, nextNode.value);
+      truncatedNodes.push(copyOfNodeWithDeepCopiedChildren);
+      i++;
+      continue;
+    }
+    truncatedNodes.push(currNode);
+  }
+  return truncatedNodes;
+};
+
+// Make a copy of node with a deep copy of the new child node with added punctuation
+function deepCopyNodesChildren(node, additionalValue) {
+  if (!node.children || !node.children.length) return node;
+  const deepCopyChildren = [...node.children];
+  const lastChild = deepCopyChildren.pop();
+
+  const deepCopyLastChild = {
+    ...lastChild,
+    value: lastChild.value + additionalValue,
+  };
+
+  deepCopyChildren.push(deepCopyLastChild);
+  const copyOfNode = {
+    ...node,
+    children: deepCopyChildren,
+  };
+  return copyOfNode;
+}

--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -5,8 +5,8 @@ export const appendTrailingPunctuation = (nodes) => {
   for (let i = 0; i < nodes.length; i++) {
     const currNode = nodes[i];
     const nextNode = nodes[i + 1];
-    const isReference = currNode.type === 'reference';
-    const hasDanglingSibling = nextNode?.type === 'text' && nextNode.value?.length === 1;
+    const isReference = currNode.type === 'reference' || currNode.type === 'ref_role';
+    const hasDanglingSibling = nextNode?.type === 'text' && nextNode.value?.length === 1 && nextNode.value !== '\n';
 
     if (isReference && hasDanglingSibling) {
       const copyOfNodeWithDeepCopiedChildren = deepCopyNodesChildren(currNode, nextNode.value);

--- a/tests/unit/Paragraph.test.js
+++ b/tests/unit/Paragraph.test.js
@@ -4,6 +4,7 @@ import Paragraph from '../../src/components/Paragraph';
 
 // data for this component
 import mockData from './data/Paragraph.test.json';
+import mockDataFormat from './data/Paragraph-Format.test.json';
 
 describe('Paragraph unit tests', () => {
   it('renders correctly', () => {

--- a/tests/unit/Paragraph.test.js
+++ b/tests/unit/Paragraph.test.js
@@ -5,7 +5,16 @@ import Paragraph from '../../src/components/Paragraph';
 // data for this component
 import mockData from './data/Paragraph.test.json';
 
-it('renders correctly', () => {
-  const tree = render(<Paragraph nodeData={mockData} />);
-  expect(tree.asFragment()).toMatchSnapshot();
+describe('Paragraph unit tests', () => {
+  it('renders correctly', () => {
+    const tree = render(<Paragraph nodeData={mockData} />);
+    expect(tree.asFragment()).toMatchSnapshot();
+  });
+
+  it('handles formatting dangling punctuation after Links and no extra multiplying on rerenders', () => {
+    const tree = render(<Paragraph nodeData={mockDataFormat} />);
+    expect(tree.asFragment()).toMatchSnapshot();
+    const treeRerender = render(<Paragraph nodeData={mockDataFormat} />);
+    expect(treeRerender.asFragment()).toMatchSnapshot();
+  });
 });

--- a/tests/unit/__snapshots__/Paragraph.test.js.snap
+++ b/tests/unit/__snapshots__/Paragraph.test.js.snap
@@ -91,7 +91,7 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
       <span
         class="emotion-4"
       >
-        Deploy a Free Tier Cluster
+        Deploy a Free Tier Cluster.
       </span>
       <svg
         alt=""
@@ -112,7 +112,6 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
         />
       </svg>
     </a>
-    .
   </p>
 </DocumentFragment>
 `;
@@ -208,7 +207,7 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
       <span
         class="emotion-4"
       >
-        Deploy a Free Tier Cluster
+        Deploy a Free Tier Cluster.
       </span>
       <svg
         alt=""
@@ -229,7 +228,6 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
         />
       </svg>
     </a>
-    .
   </p>
 </DocumentFragment>
 `;

--- a/tests/unit/__snapshots__/Paragraph.test.js.snap
+++ b/tests/unit/__snapshots__/Paragraph.test.js.snap
@@ -3,11 +3,28 @@
 exports[`Paragraph unit tests handles formatting dangling punctuation after Links and no extra multiplying on rerenders 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  -webkit-text-decoration: none!important;
-  text-decoration: none!important;
+  margin-bottom: 16px;
 }
 
-.emotion-1 {
+.emotion-2 {
+  margin: unset;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+}
+
+.emotion-2 strong,
+.emotion-2 b {
+  font-weight: 700;
+}
+
+.emotion-3 {
+  font-size: 13px;
+  line-height: 20px;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18,49 +35,41 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #007CAD;
   cursor: pointer;
-  font-size: 14px;
-  line-height: 20px;
-  -webkit-letter-spacing: 0px;
-  -moz-letter-spacing: 0px;
-  -ms-letter-spacing: 0px;
-  letter-spacing: 0px;
+  line-height: 13px;
+  color: #016BF8;
+  font-weight: 400;
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
 }
 
-.emotion-1:focus {
+.emotion-3:focus {
   outline: none;
 }
 
-.emotion-2 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
+.emotion-4 {
+  position: relative;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+.emotion-4::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
 }
 
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+.constant-classname:focus .emotion-4::after {
+  background-color: #0498EC;
 }
 
-.emotion-2 {
-  background-repeat: repeat-x;
-  background-size: 2px 2px;
-  background-position: center bottom;
+.constant-classname:hover .emotion-4::after {
+  background-color: #E8EDEB;
 }
 
-[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
-  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
-}
-
-[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
-  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
-}
-
-.emotion-3 {
+.emotion-5 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -70,23 +79,24 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
   height: 12px;
 }
 
-<p>
+<p
+    class="emotion-0 emotion-1 emotion-2"
+  >
     <a
-      class="emotion-0 emotion-1"
-      data-leafygreen-ui="anchor-container"
+      class="constant-classname emotion-3"
       href="https://cloud.mongodb.com?tck=docs_realm"
       rel="noopener noreferrer"
       target="_blank"
     >
       <span
-        class="emotion-2"
+        class="emotion-4"
       >
-        Deploy a Free Tier Cluster.
+        Deploy a Free Tier Cluster
       </span>
       <svg
         alt=""
         aria-hidden="true"
-        class="emotion-3"
+        class="emotion-5"
         height="16"
         role="presentation"
         viewBox="0 0 16 16"
@@ -102,11 +112,129 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
         />
       </svg>
     </a>
+    .
   </p>
 </DocumentFragment>
 `;
 
 exports[`Paragraph unit tests handles formatting dangling punctuation after Links and no extra multiplying on rerenders 2`] = `
+<DocumentFragment>
+  .emotion-0 {
+  margin-bottom: 16px;
+}
+
+.emotion-2 {
+  margin: unset;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+}
+
+.emotion-2 strong,
+.emotion-2 b {
+  font-weight: 700;
+}
+
+.emotion-3 {
+  font-size: 13px;
+  line-height: 20px;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  line-height: 13px;
+  color: #016BF8;
+  font-weight: 400;
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-3:focus {
+  outline: none;
+}
+
+.emotion-4 {
+  position: relative;
+}
+
+.emotion-4::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.constant-classname:focus .emotion-4::after {
+  background-color: #0498EC;
+}
+
+.constant-classname:hover .emotion-4::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-5 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<p
+    class="emotion-0 emotion-1 emotion-2"
+  >
+    <a
+      class="constant-classname emotion-3"
+      href="https://cloud.mongodb.com?tck=docs_realm"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <span
+        class="emotion-4"
+      >
+        Deploy a Free Tier Cluster
+      </span>
+      <svg
+        alt=""
+        aria-hidden="true"
+        class="emotion-5"
+        height="16"
+        role="presentation"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+          fill="currentColor"
+        />
+        <path
+          d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+    .
+  </p>
+</DocumentFragment>
+`;
+
+exports[`Paragraph unit tests renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-bottom: 16px;

--- a/tests/unit/__snapshots__/Paragraph.test.js.snap
+++ b/tests/unit/__snapshots__/Paragraph.test.js.snap
@@ -1,6 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`Paragraph unit tests handles formatting dangling punctuation after Links and no extra multiplying on rerenders 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  -webkit-text-decoration: none!important;
+  text-decoration: none!important;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007CAD;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+}
+
+.emotion-1:focus {
+  outline: none;
+}
+
+.emotion-2 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-2 {
+  background-repeat: repeat-x;
+  background-size: 2px 2px;
+  background-position: center bottom;
+}
+
+[data-leafygreen-ui="anchor-container"]:hover .emotion-2 {
+  background-image: linear-gradient( #E7EEEC 100%, #E7EEEC 0 );
+}
+
+[data-leafygreen-ui="anchor-container"]:focus .emotion-2 {
+  background-image: linear-gradient( to right, #9DD0E7 100%, #9DD0E7 0 );
+}
+
+.emotion-3 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+  bottom: 4px;
+  left: -1px;
+  height: 12px;
+}
+
+<p>
+    <a
+      class="emotion-0 emotion-1"
+      data-leafygreen-ui="anchor-container"
+      href="https://cloud.mongodb.com?tck=docs_realm"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <span
+        class="emotion-2"
+      >
+        Deploy a Free Tier Cluster.
+      </span>
+      <svg
+        alt=""
+        aria-hidden="true"
+        class="emotion-3"
+        height="16"
+        role="presentation"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M13.823 2.4491C13.8201 2.30008 13.6999 2.17994 13.5509 2.17704L9.5062 2.09836C9.25654 2.09351 9.12821 2.39519 9.30482 2.5718L10.3856 3.65257L7.93433 6.10383C7.87964 6.15852 7.83047 6.21665 7.78683 6.27752L5.99909 8.06525C5.46457 8.59977 5.46457 9.4664 5.99909 10.0009C6.53361 10.5354 7.40023 10.5354 7.93475 10.0009L9.72249 8.21317C9.78336 8.16953 9.84148 8.12037 9.89618 8.06567L12.3474 5.61441L13.4282 6.69518C13.6048 6.87179 13.9065 6.74347 13.9016 6.4938L13.823 2.4491Z"
+          fill="currentColor"
+        />
+        <path
+          d="M7.25 3.12893C7.66421 3.12893 8 3.46472 8 3.87893C8 4.29315 7.66421 4.62893 7.25 4.62893H4C3.72386 4.62893 3.5 4.85279 3.5 5.12893V11.9929C3.5 12.2691 3.72386 12.4929 4 12.4929H10.864C11.1401 12.4929 11.364 12.2691 11.364 11.9929V8.75C11.364 8.33579 11.6998 8 12.114 8C12.5282 8 12.864 8.33579 12.864 8.75V11.9929C12.864 13.0975 11.9686 13.9929 10.864 13.9929H4C2.89543 13.9929 2 13.0975 2 11.9929V5.12893C2 4.02436 2.89543 3.12893 4 3.12893H7.25Z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+  </p>
+</DocumentFragment>
+`;
+
+exports[`Paragraph unit tests handles formatting dangling punctuation after Links and no extra multiplying on rerenders 2`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-bottom: 16px;

--- a/tests/unit/data/Paragraph-Format.test.json
+++ b/tests/unit/data/Paragraph-Format.test.json
@@ -1,0 +1,37 @@
+{
+  "type": "paragraph",
+  "position": {
+    "start": {
+      "line": 0
+    }
+  },
+  "children": [
+    {
+      "type": "reference",
+      "children": [{
+        "position": {
+          "start": {
+          "line": 0
+          }
+        },
+        "type": "text",
+        "value": "Deploy a Free Tier Cluster"
+      }],
+      "position": {
+        "start": {
+          "line": 0
+        }
+      },
+      "refuri": "https://cloud.mongodb.com?tck=docs_realm"
+    },
+    {
+      "type": "text",
+      "position": {
+        "start": {
+          "line": 0
+        }
+      },
+      "value": "."
+    }
+  ]
+} 


### PR DESCRIPTION
### Stories/Links:

[DOP-3167](https://jira.mongodb.org/browse/DOP-3167)

### Current Behavior:

Reverted in production at the moment, but dangling punctuation multiplies on rerenders.
- when the user navigates back and forth between pages the punctuation is added on again and again. 
Attaching picture.

### Staging Links:

[Realm page with a Link and dangling period in first admonition on the page](https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/matt.meigs/DOP-3167/sdk/kotlin/install/android/)

### Notes:

First fix of DOP-3167 - (attaching dangling punctuation to preceding Links) - was plagued by unintended consequence of never-ending additions of the same punctuation. References to the same node causes this. 
Current fix creates a deep copy of the change so as not to influence further renders from the same data.