### PR TITLE
DOP-2581

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.0.0",
-        "@leafygreen-ui/badge": "^4.0.3",
+        "@leafygreen-ui/badge": "^5.0.1",
         "@leafygreen-ui/banner": "^4.0.0",
         "@leafygreen-ui/box": "^3.0.6",
         "@leafygreen-ui/button": "^13.0.0",
@@ -3873,39 +3873,13 @@
       }
     },
     "node_modules/@leafygreen-ui/badge": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-4.0.3.tgz",
-      "integrity": "sha512-CAEavAfcM8G6TaFW6LLQ+YGXa8ODxxjtu06uCxg61MjSZJQ7FvGVlvVfd2T6Mz9A6Jm6ZDmW8JpqHrjau/DDkQ==",
+      "version": "5.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-5.0.1.tgz",
+      "integrity": "sha512-KbDyTGOvpbO0LswEDUfPaTVBnCygYl/jjG1ITchg5gVtrT7FDI79hYJai+LffPWJEjr96Zg0QID72+TX6nrvxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1"
-      }
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/emotion": {
-      "version": "3.0.1",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
-      "integrity": "sha1-s4C3lRJFnae5RUL22KaGCATLqxg=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "create-emotion": "^10.0.7",
-        "create-emotion-server": "10.0.27",
-        "emotion": "^10.0.7"
-      }
-    },
-    "node_modules/@leafygreen-ui/badge/node_modules/@leafygreen-ui/lib": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-      "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^3.0.1",
-        "facepaint": "^1.2.1",
-        "polished": "^2.3.0",
-        "prop-types": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
+        "@leafygreen-ui/lib": "^9.3.0",
+        "@leafygreen-ui/palette": "^3.4.0"
       }
     },
     "node_modules/@leafygreen-ui/banner": {
@@ -39231,35 +39205,12 @@
       }
     },
     "@leafygreen-ui/badge": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/badge/-/badge-4.0.3.tgz",
-      "integrity": "sha512-CAEavAfcM8G6TaFW6LLQ+YGXa8ODxxjtu06uCxg61MjSZJQ7FvGVlvVfd2T6Mz9A6Jm6ZDmW8JpqHrjau/DDkQ==",
+      "version": "5.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-5.0.1.tgz",
+      "integrity": "sha512-KbDyTGOvpbO0LswEDUfPaTVBnCygYl/jjG1ITchg5gVtrT7FDI79hYJai+LffPWJEjr96Zg0QID72+TX6nrvxA==",
       "requires": {
-        "@leafygreen-ui/lib": "^7.0.0",
-        "@leafygreen-ui/palette": "^3.2.1"
-      },
-      "dependencies": {
-        "@leafygreen-ui/emotion": {
-          "version": "3.0.1",
-          "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
-          "integrity": "sha1-s4C3lRJFnae5RUL22KaGCATLqxg=",
-          "requires": {
-            "create-emotion": "^10.0.7",
-            "create-emotion-server": "10.0.27",
-            "emotion": "^10.0.7"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-7.0.0.tgz",
-          "integrity": "sha512-ZIqfa+XLD77KEDSPZPtuLxk2VuktFfLFghUViZEBissQ790gq2V9BXAzRgU5MCtaP6HlJ+kQ2BA5iv6iD5KgIQ==",
-          "requires": {
-            "@leafygreen-ui/emotion": "^3.0.1",
-            "facepaint": "^1.2.1",
-            "polished": "^2.3.0",
-            "prop-types": "^15.0.0"
-          }
-        }
+        "@leafygreen-ui/lib": "^9.3.0",
+        "@leafygreen-ui/palette": "^3.4.0"
       }
     },
     "@leafygreen-ui/banner": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@emotion/eslint-plugin": "^11.7.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.0.0",
-    "@leafygreen-ui/badge": "^4.0.3",
+    "@leafygreen-ui/badge": "^5.0.1",
     "@leafygreen-ui/banner": "^4.0.0",
     "@leafygreen-ui/box": "^3.0.6",
     "@leafygreen-ui/button": "^13.0.0",


### PR DESCRIPTION
### Stories/Links:

[DOP-2581](https://jira.mongodb.org/browse/DOP-2581)

### Current Behavior:

Snooty Badges are not currently used in any doc repos, @casthewiz has assisted in creating sample RST to convert to local AST for testing

### Staging Links:

https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/seung.park/DOP-2581/sandbox/
- badges are used in the GET/POST/etc operation indicators, as well as the `app services` icon at the bottom

### Notes:
- no direct directive for use of badges, used in Operations and Icon, which is not used but tested in staging link
