### PR TITLE
DOP-3215: fix banners in PLP

### DIFF
--- a/src/components/Banner/styles/bannerItemStyle.js
+++ b/src/components/Banner/styles/bannerItemStyle.js
@@ -2,6 +2,8 @@ import { css } from '@emotion/react';
 import { theme } from '../../../theme/docsTheme';
 
 export const baseBannerStyle = css`
+  margin: ${theme.size.default} 0;
+
   /* Add margins below all child elements in the banner */
   & > div > div > * {
     margin: 0 0 12px;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -65,7 +65,6 @@ const Wrapper = styled('main')`
       grid-column: 2 / 4;
       grid-row: 1 / 1;
       align-items: center;
-      margin: ${theme.size.default} 0;
 
       @media ${theme.screenSize.upToLarge} {
         grid-column: 2/2;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -66,19 +66,16 @@ const Wrapper = styled('main')`
     }
 
     [role='alert'] {
-      grid-column: 2 / 4;
+      grid-column: 2 / 3;
       grid-row: banner;
       align-items: center;
-
-      @media ${theme.screenSize.upToLarge} {
-        grid-column: 2/2;
-      }
     }
 
     h1 {
       align-self: end;
       grid-column: 2;
       grid-row: header;
+
       ${({ isGuides }) =>
         isGuides &&
         `
@@ -97,13 +94,13 @@ const Wrapper = styled('main')`
 
       @media ${theme.screenSize.largeAndUp} {
         grid-column: 3;
-        grid-row: introduction;
+        grid-row: header/span 2;
       }
     }
 
     > .hero-img {
       grid-column: 1 / -1;
-      grid-row: 1 / 3;
+      grid-row: header / kicker;
       height: 310px;
       ${({ isGuides }) => !isGuides && `margin-bottom: ${theme.size.large};`}
       max-width: 100%;
@@ -154,22 +151,28 @@ const Wrapper = styled('main')`
 
 const ProductLanding = ({ children }) => {
   const { project } = useSiteMetadata();
+  const useHero = ['guides', 'realm'].includes(project);
+  const isGuides = project === 'guides';
 
   // shallow copy children, and search for existence of banner
-  const shallowChildren = children[0].props.nodeData.children.map((childNode) => {
-    const newNode = {};
-    for (let property in childNode) {
-      if (property !== 'children') {
-        newNode[property] = childNode[property];
+  const shallowChildren = children.reduce((res, child) => {
+    const copiedChildren = child.props.nodeData.children.map((childNode) => {
+      const newNode = {};
+      for (let property in childNode) {
+        if (property !== 'children') {
+          newNode[property] = childNode[property];
+        }
       }
-    }
-    return newNode;
-  });
+      return newNode;
+    });
+    res = res.concat(copiedChildren);
+    return res;
+  }, []);
+
   const bannerNode = findKeyValuePair([{ children: shallowChildren }], 'name', 'banner');
 
-  const isGuides = project === 'guides';
   return (
-    <Wrapper hasBanner={!!bannerNode} isGuides={isGuides}>
+    <Wrapper isGuides={isGuides} useHero={useHero} hasBanner={!!bannerNode}>
       {children}
     </Wrapper>
   );

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { palette } from '@leafygreen-ui/palette';
 import { useSiteMetadata } from '../hooks/use-site-metadata.js';
 import { theme } from '../theme/docsTheme.js';
+import { findKeyValuePair } from '../utils/find-key-value-pair.js';
 
 const CONTENT_MAX_WIDTH = 1200;
 
@@ -52,6 +53,9 @@ const Wrapper = styled('main')`
         ${theme.size.xlarge},
         1fr
       );
+    grid-template-rows: [header] auto [introduction] auto [kicker] auto;
+    ${({ hasBanner }) =>
+      hasBanner && `grid-template-rows: [banner] auto [header] auto [introduction] auto [kicker] auto;`}
 
     @media ${theme.screenSize.upToLarge} {
       grid-template-columns: 48px 1fr 48px;
@@ -63,7 +67,7 @@ const Wrapper = styled('main')`
 
     [role='alert'] {
       grid-column: 2 / 4;
-      grid-row: 1 / 1;
+      grid-row: banner;
       align-items: center;
 
       @media ${theme.screenSize.upToLarge} {
@@ -74,7 +78,7 @@ const Wrapper = styled('main')`
     h1 {
       align-self: end;
       grid-column: 2;
-      grid-row: 1;
+      grid-row: header;
       ${({ isGuides }) =>
         isGuides &&
         `
@@ -93,7 +97,7 @@ const Wrapper = styled('main')`
 
       @media ${theme.screenSize.largeAndUp} {
         grid-column: 3;
-        grid-row: 1 / span 2;
+        grid-row: introduction;
       }
     }
 
@@ -119,7 +123,7 @@ const Wrapper = styled('main')`
 
     > .introduction {
       grid-column: 2;
-      grid-row: 2;
+      grid-row: introduction;
       p {
         ${({ isGuides }) =>
           isGuides &&
@@ -150,8 +154,25 @@ const Wrapper = styled('main')`
 
 const ProductLanding = ({ children }) => {
   const { project } = useSiteMetadata();
+
+  // shallow copy children, and search for existence of banner
+  const shallowChildren = children[0].props.nodeData.children.map((childNode) => {
+    const newNode = {};
+    for (let property in childNode) {
+      if (property !== 'children') {
+        newNode[property] = childNode[property];
+      }
+    }
+    return newNode;
+  });
+  const bannerNode = findKeyValuePair([{ children: shallowChildren }], 'name', 'banner');
+
   const isGuides = project === 'guides';
-  return <Wrapper isGuides={isGuides}>{children}</Wrapper>;
+  return (
+    <Wrapper hasBanner={!!bannerNode} isGuides={isGuides}>
+      {children}
+    </Wrapper>
+  );
 };
 
 ProductLanding.propTypes = {

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -61,6 +61,17 @@ const Wrapper = styled('main')`
       grid-template-columns: ${theme.size.medium} 1fr ${theme.size.medium};
     }
 
+    [role='alert'] {
+      grid-column: 2 / 4;
+      grid-row: 1 / 1;
+      align-items: center;
+      margin: ${theme.size.default} 0;
+
+      @media ${theme.screenSize.upToLarge} {
+        grid-column: 2/2;
+      }
+    }
+
     h1 {
       align-self: end;
       grid-column: 2;

--- a/tests/unit/__snapshots__/Banner.test.js.snap
+++ b/tests/unit/__snapshots__/Banner.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders a Banner correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  margin: 16px 0;
   font-size: 13px;
 }
 

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  margin: 16px 0;
   font-size: 13px;
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
@@ -243,6 +244,7 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  margin: 16px 0;
   font-size: 13px;
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
@@ -476,6 +478,7 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  margin: 16px 0;
   font-size: 13px;
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;
@@ -707,6 +710,7 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
     href="https://university.mongodb.com/"
   />
   .emotion-0 {
+  margin: 16px 0;
   font-size: 13px;
   background-color: #E1F2F6;
   border: 1px solid #C5E4F2;


### PR DESCRIPTION
### Stories/Links:

[DOP-3215](https://jira.mongodb.org/browse/DOP-3215)

### Current Behavior:

[@jeff-allen-mongo 's staged version](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/v5.3-legacy-banner/)
[PLP without banner](https://www.mongodb.com/docs/manual/)
[existing banner in non PLP](https://www.mongodb.com/docs/atlas/reference/api/database-users/)

### Staging Links:

[staged changes from same forked repo](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/v5.3-legacy-banner/docs/seung.park/DOP-3215/)
[manual docs PLP without banner (regression test)](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/master/docs/seung.park/master/)
[existing banner (regression test)](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3215/reference/api/database-users/)

verified one-off PLP pages with test banner:
[guides PLP](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/DOP-3215-sample/guides/seung.park/DOP-3215/)
[guides PLP regression test](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/master/guides/seung.park/DOP-3215/)
[realm PLP](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/DOP-3215-sample/realm/seung.park/DOP-3215/)
[realm PLP regression test](https://docs-mongodbcom-integration.corp.mongodb.com/775894b310e16770681b8ca63b9f74ad5f3a734c/master/realm/seung.park/DOP-3215/)


### Notes:
- forked repo is [here](https://github.com/jeff-allen-mongo/docs-mongodb-internal/tree/v5.3-legacy-banner)