### PR TITLE
DOP-3210: add version context 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -134,6 +134,10 @@ exports.createPages = async ({ actions }) => {
     await Promise.all(
       siteMetadata.associatedProducts.map(async (product) => {
         associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
+        // filter all branches of associated repo by associated versions only
+        associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
+          return product.versions.includes(branch.gitBranchName);
+        });
       })
     );
     let errMsg;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -131,15 +131,17 @@ exports.createPages = async ({ actions }) => {
   try {
     const repoInfo = await db.stitchInterface.fetchRepoBranches();
 
-    await Promise.all(
-      siteMetadata.associatedProducts.map(async (product) => {
-        associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
-        // filter all branches of associated repo by associated versions only
-        associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
-          return product.versions.includes(branch.gitBranchName);
-        });
-      })
-    );
+    if (process.env.GATSBY_TEST_EMBED_VERSIONS) {
+      await Promise.all(
+        siteMetadata.associatedProducts.map(async (product) => {
+          associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
+          // filter all branches of associated repo by associated versions only
+          associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
+            return product.versions?.includes(branch.gitBranchName);
+          });
+        })
+      );
+    }
     let errMsg;
 
     if (!repoInfo) {
@@ -231,5 +233,15 @@ exports.createSchemaCustomization = ({ actions }) => {
     type SnootyMetadata implements Node @dontInfer {
         metadata: JSON!
     }
+
+    type AssociatedProduct {
+      name: String,
+      versions: [String]
+    }
+
+    type SiteSiteMetadata implements Node {
+      associatedProducts: [AssociatedProduct],
+    }
+
   `);
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -127,8 +127,15 @@ exports.createPages = async ({ actions }) => {
   const { createPage } = actions;
 
   let repoBranches = null;
+  const associatedReposInfo = {};
   try {
     const repoInfo = await db.stitchInterface.fetchRepoBranches();
+
+    await Promise.all(
+      siteMetadata.associatedProducts.map(async (product) => {
+        associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
+      })
+    );
     let errMsg;
 
     if (!repoInfo) {
@@ -180,7 +187,8 @@ exports.createPages = async ({ actions }) => {
           component: path.resolve(__dirname, './src/components/DocumentBody.js'),
           context: {
             slug,
-            repoBranches: repoBranches,
+            repoBranches,
+            associatedReposInfo,
             template: pageNodes?.options?.template,
             page: pageNodes,
           },

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,5 +27,12 @@ module.exports = {
         '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
       },
     },
+    {
+      displayName: 'context',
+      testMatch: ['<rootDir>/tests/context/*.test.js'],
+      transform: {
+        '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
+      },
+    },
   ],
 };

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -7,15 +7,15 @@ import { ContentsProvider } from './Contents/contents-context';
 import { NavigationProvider } from '../context/navigation-context';
 import { VersionContextProvider } from '../context/version-context';
 
-const RootProvider = ({ children, headingNodes, selectors, repoBranches }) => (
+const RootProvider = ({ children, headingNodes, selectors, repoBranches, associatedReposInfo }) => (
   <TabProvider selectors={selectors}>
     <ContentsProvider headingNodes={headingNodes}>
       <HeaderContextProvider>
-        <NavigationProvider>
-          <VersionContextProvider repoBranches={repoBranches}>
+        <VersionContextProvider repoBranches={repoBranches} associatedReposInfo={associatedReposInfo}>
+          <NavigationProvider>
             <SidenavContextProvider>{children}</SidenavContextProvider>
-          </VersionContextProvider>
-        </NavigationProvider>
+          </NavigationProvider>
+        </VersionContextProvider>
       </HeaderContextProvider>
     </ContentsProvider>
   </TabProvider>

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -5,16 +5,16 @@ import { SidenavContextProvider } from './Sidenav';
 import { TabProvider } from './Tabs/tab-context';
 import { ContentsProvider } from './Contents/contents-context';
 import { NavigationProvider } from '../context/navigation-context';
-import { VersionProvider } from '../context/version-context';
+import { VersionContextProvider } from '../context/version-context';
 
 const RootProvider = ({ children, headingNodes, selectors, repoBranches }) => (
   <TabProvider selectors={selectors}>
     <ContentsProvider headingNodes={headingNodes}>
       <HeaderContextProvider>
         <NavigationProvider>
-          <VersionProvider repoBranches={repoBranches}>
+          <VersionContextProvider repoBranches={repoBranches}>
             <SidenavContextProvider>{children}</SidenavContextProvider>
-          </VersionProvider>
+          </VersionContextProvider>
         </NavigationProvider>
       </HeaderContextProvider>
     </ContentsProvider>

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -5,13 +5,16 @@ import { SidenavContextProvider } from './Sidenav';
 import { TabProvider } from './Tabs/tab-context';
 import { ContentsProvider } from './Contents/contents-context';
 import { NavigationProvider } from '../context/navigation-context';
+import { VersionProvider } from '../context/version-context';
 
-const RootProvider = ({ children, headingNodes, selectors }) => (
+const RootProvider = ({ children, headingNodes, selectors, repoBranches }) => (
   <TabProvider selectors={selectors}>
     <ContentsProvider headingNodes={headingNodes}>
       <HeaderContextProvider>
         <NavigationProvider>
-          <SidenavContextProvider>{children}</SidenavContextProvider>
+          <VersionProvider repoBranches={repoBranches}>
+            <SidenavContextProvider>{children}</SidenavContextProvider>
+          </VersionProvider>
         </NavigationProvider>
       </HeaderContextProvider>
     </ContentsProvider>

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -190,6 +190,8 @@ const VersionDropdown = ({ repoBranches: { branches, groups, siteBasePrefix }, s
 };
 
 VersionDropdown.propTypes = {
+  // TODO: add active version dropdown prop
+  // consume from version context
   repoBranches: PropTypes.shape({
     branches: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -2,6 +2,37 @@ import React, { createContext, useReducer, useEffect, useMemo } from 'react';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 
+// begin helper functions
+const STORAGE_KEY = 'activeVersions';
+
+function getInitBranchName(branches) {
+  const activeBranch = branches.find((b) => b.active);
+  if (activeBranch) {
+    return activeBranch.name || activeBranch.gitBranchName;
+  }
+  return branches[0]?.name || null;
+}
+
+const versionStateReducer = (state, { project, versionName }) => {
+  return {
+    ...state,
+    [project]: versionName,
+  };
+};
+
+// return initial active versions of documents if not found in local storage
+function getInitVersions(metadata, repoBranches, associatedReposInfo) {
+  const initState = {};
+  // set version state of current project
+  initState[`${metadata.project}`] = getInitBranchName(repoBranches.branches);
+  // for each associated product, set version state
+  for (const productName in associatedReposInfo) {
+    initState[productName] = getInitBranchName(associatedReposInfo[productName]?.branches || []);
+  }
+  return initState;
+}
+// end helper functions
+
 const VersionContext = createContext({
   activeVersions: {},
   // active version for each product is marked is {[product name]: active version} pair
@@ -9,62 +40,36 @@ const VersionContext = createContext({
   availableVersions: {},
 });
 
-const STORAGE_KEY = 'activeVersions';
-
-const getBranchName = (branch) => {
-  return branch['name'];
-};
-
-function getInitBranch(repoBranches) {
-  if (repoBranches?.branches?.length === 1) {
-    return getBranchName(repoBranches.branches[0]);
-  }
-  return getBranchName(repoBranches?.branches?.find((b) => b.active));
-}
-
-const reducer = (state, { project, version }) => {
-  return {
-    ...state,
-    [project]: version,
-  };
-};
-
-// return initial active versions of documents if not found in local storage
-function getInitVersions(metadata, repoBranches) {
-  const initState = {};
-  // set version state of current project
-  initState[`${metadata.project}`] = getInitBranch(repoBranches);
-  // for each associated product, set version state
-  metadata.associatedProducts.forEach((product) => {
-    initState[product.name] = product.versions.sort((a, b) => b - a)[0];
-  });
-  return initState;
-}
-
-const VersionContextProvider = ({ repoBranches, children }) => {
+const VersionContextProvider = ({ repoBranches, associatedReposInfo, children }) => {
   const metadata = useSiteMetadata();
+  // expose the available versions for current and associated products
+  const availableVersions = useMemo(async () => {
+    try {
+      // TODO: call client side fn to realm app services to get repo branches
+      throw new Error('test err');
+    } catch (e) {
+      console.error(e);
+      const versions = {};
+      versions[metadata.project] = repoBranches?.branches || [];
+      for (const productName in associatedReposInfo) {
+        versions[productName] = associatedReposInfo[productName]?.repoInfo?.branches || [];
+      }
+      return versions;
+    }
+    // does not need to refetch after initial fetch
+    // also falls back to server side fetch for branches
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // this context logic tracks active versions across MongoDB docs
+  // tracks active versions across app
   const [activeVersions, setActiveVersions] = useReducer(
-    reducer,
-    getLocalValue(STORAGE_KEY) || getInitVersions(metadata, repoBranches)
+    versionStateReducer,
+    getLocalValue(STORAGE_KEY) || getInitVersions(metadata, repoBranches, associatedReposInfo)
   );
   // update local storage when active versions change
   useEffect(() => {
     setLocalValue(STORAGE_KEY, activeVersions);
   }, [activeVersions]);
-
-  // expose the available versions for current and associated products
-  const availableVersions = useMemo(() => {
-    const versions = {};
-    versions[metadata.project] = repoBranches?.branches.map((b) => b.name);
-    metadata.associatedProducts.forEach((product) => {
-      versions[product.name] = product.versions;
-    });
-    return versions;
-    // currently does not need to recompute after loading from manifest files
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <VersionContext.Provider value={{ activeVersions, setActiveVersions, availableVersions }}>

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -1,0 +1,77 @@
+import React, { createContext, useReducer, useEffect, useMemo } from 'react';
+import { getLocalValue, setLocalValue } from '../utils/browser-storage';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+
+const VersionContext = createContext({
+  activeVersions: {},
+  // active version for each product is marked is key value pair
+  //
+  setActiveVersions: () => {},
+  availableVersions: {},
+});
+
+const STORAGE_KEY = 'activeVersions';
+
+const getBranchName = (branch) => {
+  return branch['name'];
+};
+
+function getInitBranch(repoBranches) {
+  if (repoBranches?.branches?.length === 1) {
+    return getBranchName(repoBranches.branches[0]);
+  }
+  return getBranchName(repoBranches?.branches?.find((b) => b.active));
+}
+
+const reducer = (state, { project, version }) => {
+  return {
+    ...state,
+    [project]: version,
+  };
+};
+
+// return initial active versions of documents if not found in local storage
+function getInitVersions(metadata, repoBranches) {
+  const initState = {};
+  // set version state of current project
+  initState[`${metadata.project}`] = getInitBranch(repoBranches);
+  // for each associated product, set version state
+  metadata.associatedProducts.forEach((product) => {
+    initState[product.name] = product.versions.sort((a, b) => b - a)[0];
+  });
+  return initState;
+}
+
+export const VersionProvider = ({ repoBranches, children }) => {
+  const metadata = useSiteMetadata();
+
+  // this context logic tracks active versions across MongoDB docs
+  const [activeVersions, setActiveVersions] = useReducer(
+    reducer,
+    getLocalValue(STORAGE_KEY) || getInitVersions(metadata, repoBranches)
+  );
+  // update local storage when active versions change
+  useEffect(() => {
+    setLocalValue(STORAGE_KEY, activeVersions);
+  }, [activeVersions]);
+
+  // expose the available versions for current and associated products
+  const availableVersions = useMemo(() => {
+    const versions = {};
+    versions[metadata.project] = repoBranches?.branches.map((b) => b.name);
+    metadata.associatedProducts.forEach((product) => {
+      versions[product.name] = product.versions;
+    });
+    return versions;
+    // currently does not need to recompute after loading from manifest files
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <VersionContext.Provider value={{ activeVersions, setActiveVersions, availableVersions }}>
+      {children}
+    </VersionContext.Provider>
+  );
+};
+
+export default VersionContext;

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -4,8 +4,7 @@ import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 const VersionContext = createContext({
   activeVersions: {},
-  // active version for each product is marked is key value pair
-  //
+  // active version for each product is marked is {[product name]: active version} pair
   setActiveVersions: () => {},
   availableVersions: {},
 });
@@ -42,7 +41,7 @@ function getInitVersions(metadata, repoBranches) {
   return initState;
 }
 
-export const VersionProvider = ({ repoBranches, children }) => {
+const VersionContextProvider = ({ repoBranches, children }) => {
   const metadata = useSiteMetadata();
 
   // this context logic tracks active versions across MongoDB docs
@@ -74,4 +73,4 @@ export const VersionProvider = ({ repoBranches, children }) => {
   );
 };
 
-export default VersionContext;
+export { VersionContext, VersionContextProvider };

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -7,21 +7,21 @@ import { BRANCHES_COLLECTION } from '../build-constants';
 // begin helper functions
 const STORAGE_KEY = 'activeVersions';
 
-function getInitBranchName(branches) {
+const getInitBranchName = (branches) => {
   const activeBranch = branches.find((b) => b.isStableBranch);
   if (activeBranch) {
     return activeBranch.name || activeBranch.gitBranchName;
   }
   return branches[0]?.name || null;
-}
+};
 
-function getInitVersions(branchListByProduct) {
+const getInitVersions = (branchListByProduct) => {
   const initState = {};
   for (const productName in branchListByProduct) {
     initState[productName] = getInitBranchName(branchListByProduct[productName]);
   }
   return initState;
-}
+};
 
 // version state reducer helper fn
 // overwrite current state with any new state attributes

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -18,6 +18,8 @@ function getInitVersions(branchListByProduct) {
   for (const productName in branchListByProduct) {
     initState[productName] = getInitBranchName(branchListByProduct[productName]);
   }
+  console.log('check initState');
+  console.log(initState);
   return initState;
 }
 
@@ -42,7 +44,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, children })
   const metadata = useSiteMetadata();
   // expose the available versions for current and associated products
   // TODO: usememo not correct here. useEffect for async call
-  const [availableVersions, setAvailableVersions] = useState();
+  const [availableVersions, setAvailableVersions] = useState({});
   // on init, fetch versions from realm app services
   useEffect(() => {
     const getVersions = async () => {
@@ -53,13 +55,12 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, children })
 
     getVersions().catch((e) => {
       // on error of realm function, fall back to build time fetches
-      console.error(e);
       const versions = {};
       versions[metadata.project] = repoBranches?.branches || [];
       for (const productName in associatedReposInfo) {
         versions[productName] = associatedReposInfo[productName].branches || [];
       }
-      if (!activeVersions) {
+      if (!activeVersions || !activeVersions.length) {
         setActiveVersions(getInitVersions(versions));
       }
       setAvailableVersions(versions);
@@ -70,7 +71,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, children })
   }, []);
 
   // tracks active versions across app
-  const [activeVersions, setActiveVersions] = useReducer(versionStateReducer, getLocalValue(STORAGE_KEY));
+  const [activeVersions, setActiveVersions] = useReducer(versionStateReducer, getLocalValue(STORAGE_KEY) || []);
   // update local storage when active versions change
   useEffect(() => {
     setLocalValue(STORAGE_KEY, activeVersions);

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -17,10 +17,6 @@ export const useSiteMetadata = () => {
             snootyBranch
             snootyEnv
             user
-            associatedProducts {
-              name
-              versions
-            }
           }
         }
       }

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -17,6 +17,10 @@ export const useSiteMetadata = () => {
             snootyBranch
             snootyEnv
             user
+            associatedProducts {
+              name
+              versions
+            }
           }
         }
       }

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -13,10 +13,15 @@ export const useSiteMetadata = () => {
             patchId
             pathPrefix
             project
+            reposDatabase
             siteUrl
             snootyBranch
             snootyEnv
             user
+            associatedProducts {
+              name
+              versions
+            }
           }
         }
       }

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -27,11 +27,11 @@ class StitchInterface {
     return this.stitchClient.callFunction('fetchAllProducts', [siteMetadata.database]);
   }
 
-  fetchRepoBranches() {
+  fetchRepoBranches(project = siteMetadata.project) {
     return this.stitchClient.callFunction('fetchDocument', [
       siteMetadata.reposDatabase,
       BRANCHES_COLLECTION,
-      constructReposFilter(siteMetadata.project),
+      constructReposFilter(project, project === siteMetadata.project),
     ]);
   }
 

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -85,7 +85,11 @@ const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, temp
     <>
       <Global styles={globalCSS} />
       <SiteMetadata siteTitle={title} />
-      <RootProvider headingNodes={page?.options?.headings} selectors={page?.options?.selectors}>
+      <RootProvider
+        repoBranches={repoBranches}
+        headingNodes={page?.options?.headings}
+        selectors={page?.options?.selectors}
+      >
         <GlobalGrid>
           <Header sidenav={sidenav} eol={eol} />
           {sidenav && (

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -74,7 +74,7 @@ const GlobalGrid = styled('div')`
   grid-template-rows: auto 1fr;
 `;
 
-const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, template } }) => {
+const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, template, associatedReposInfo } }) => {
   const { sidenav } = getTemplate(template);
   const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol } = useSnootyMetadata();
 
@@ -87,6 +87,7 @@ const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, temp
       <SiteMetadata siteTitle={title} />
       <RootProvider
         repoBranches={repoBranches}
+        associatedReposInfo={associatedReposInfo}
         headingNodes={page?.options?.headings}
         selectors={page?.options?.selectors}
       >

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -38,3 +38,11 @@ export const fetchSearchPropertyMapping = async (snootyEnv) => {
 export const fetchOASFile = async (apiName, database) => {
   return await fetchData('fetchOASFile', apiName, database);
 };
+
+export const fetchDocument = async (database, collectionName, query) => {
+  return await fetchData('fetchDocument', database, collectionName, query);
+};
+
+export const fetchDocuments = async (database, collectionName, query) => {
+  return await fetchData('fetchDocuments', database, collectionName, query);
+};

--- a/src/utils/setup/construct-repos-filter.js
+++ b/src/utils/setup/construct-repos-filter.js
@@ -1,10 +1,10 @@
 // Returns the filter to use when querying for a site's versions/branches.
-const constructReposFilter = (project) => {
+const constructReposFilter = (project, useRepoName) => {
   const filter = { project };
 
   // Handles case where public and internal docs share the same project name.
   // REPO_NAME should be passed in by the autobuilder as an env variable
-  if (process.env.REPO_NAME) {
+  if (process.env.REPO_NAME && useRepoName) {
     filter['repoName'] = process.env.REPO_NAME;
   }
 

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -10,6 +10,15 @@ const fetchManifestMetadata = () => {
     for (const entry of zipEntries) {
       if (entry.entryName === 'site.bson') {
         metadata = BSON.deserialize(entry.getData());
+
+        // TODO DOP-3210: remove test code. will be provided in metadata
+        // if (metadata['project'] === 'cloud-docs') {
+        metadata['associated_products'] = [
+          {
+            name: 'docs-atlas-cli',
+            versions: ['1.1', '1.0'],
+          },
+        ];
       }
     }
   }

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -11,13 +11,14 @@ const fetchManifestMetadata = () => {
       if (entry.entryName === 'site.bson') {
         metadata = BSON.deserialize(entry.getData());
 
-        // TODO DOP-3210: remove test code. will be provided in metadata
-        metadata['associated_products'] = [
-          {
-            name: 'atlas-cli',
-            versions: ['v1.1', 'v1.0'],
-          },
-        ];
+        if (process.env.TEST_EMBED_VERSIONS && metadata['project'] === 'cloud-docs') {
+          metadata['associated_products'] = [
+            {
+              name: 'atlas-cli',
+              versions: ['v1.1', 'v1.0'],
+            },
+          ];
+        }
       }
     }
   }

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -15,7 +15,7 @@ const fetchManifestMetadata = () => {
         // if (metadata['project'] === 'cloud-docs') {
         metadata['associated_products'] = [
           {
-            name: 'docs-atlas-cli',
+            name: 'atlas-cli',
             versions: ['1.1', '1.0'],
           },
         ];

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -12,11 +12,10 @@ const fetchManifestMetadata = () => {
         metadata = BSON.deserialize(entry.getData());
 
         // TODO DOP-3210: remove test code. will be provided in metadata
-        // if (metadata['project'] === 'cloud-docs') {
         metadata['associated_products'] = [
           {
             name: 'atlas-cli',
-            versions: ['1.1', '1.0'],
+            versions: ['v1.1', 'v1.0'],
           },
         ];
       }

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -11,7 +11,7 @@ const fetchManifestMetadata = () => {
       if (entry.entryName === 'site.bson') {
         metadata = BSON.deserialize(entry.getData());
 
-        if (process.env.TEST_EMBED_VERSIONS && metadata['project'] === 'cloud-docs') {
+        if (process.env.GATSBY_TEST_EMBED_VERSIONS && metadata['project'] === 'cloud-docs') {
           metadata['associated_products'] = [
             {
               name: 'atlas-cli',

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -60,6 +60,7 @@ const getPathPrefix = (pathPrefix) => {
  * Get site metadata used to identify this build and query correct documents
  */
 const siteMetadata = {
+  associatedProducts: manifestMetadata['associated_products'] || [],
   commitHash: process.env.COMMIT_HASH || '',
   database: getDatabase(process.env.SNOOTY_ENV),
   reposDatabase: getReposDatabase(process.env.SNOOTY_ENV),

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -21,7 +21,7 @@ const TestConsumer = () => {
   const handleClick = (project, version) => {
     console.log(project);
     console.log(version);
-    setActiveVersions(project, version);
+    setActiveVersions({ project, version });
   };
   return (
     <>

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -1,0 +1,75 @@
+import React, { useContext } from 'react';
+import * as Gatsby from 'gatsby';
+import { render } from '@testing-library/react';
+
+import { VersionContextProvider, VersionContext } from '../../src/context/version-context';
+
+const useStaticQuery = jest.spyOn(Gatsby, 'useStaticQuery');
+const setProjectAndAssociatedProducts = (project) => {
+  useStaticQuery.mockImplementation(() => ({
+    site: {
+      siteMetadata: {
+        project,
+      },
+    },
+  }));
+};
+
+const TestConsumer = () => {
+  const { activeVersions, setActiveVersions, availableVersions } = useContext(VersionContext);
+
+  const handleClick = (project, version) => {
+    console.log(project);
+    console.log(version);
+    setActiveVersions(project, version);
+  };
+  return (
+    <>
+      <h1>active versions:</h1>
+      <div id="active-versions">
+        {activeVersions.map((versionName, projectName) => `${projectName} : ${versionName}`)}
+      </div>
+      <h1>availableVersions:</h1>
+      <div id="available-versions">
+        {availableVersions.map((versionName, projectName) => (
+          <div
+            onClick={() => {
+              handleClick(projectName, versionName);
+            }}
+            key={projectName + versionName}
+            id={projectName + versionName}
+          >
+            {projectName} : {versionName}:
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+const mountConsumer = () => {
+  setProjectAndAssociatedProducts();
+  return render(
+    <VersionContextProvider>
+      <TestConsumer />
+    </VersionContextProvider>
+  );
+};
+
+describe('Version Context', () => {
+  let wrapper;
+  beforeEach(() => {
+    // CHECK LOCAL STORAGE
+    wrapper = mountConsumer();
+  });
+
+  it('it has initial value if local storage is empty', () => {
+    wrapper.debug();
+  });
+
+  it('initializes with values from local storage', () => {});
+
+  it('updates context values and local storage if called from consumers', () => {});
+
+  it('does not change availableVersions after init', () => {});
+});

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -1,75 +1,181 @@
 import React, { useContext } from 'react';
 import * as Gatsby from 'gatsby';
 import { render } from '@testing-library/react';
-
-import { VersionContextProvider, VersionContext } from '../../src/context/version-context';
+import { act } from 'react-dom/test-utils';
+import { VersionContextProvider, VersionContext, STORAGE_KEY } from '../../src/context/version-context';
+import * as browserStorage from '../../src/utils/browser-storage';
+import userEvent from '@testing-library/user-event';
 
 const useStaticQuery = jest.spyOn(Gatsby, 'useStaticQuery');
-const setProjectAndAssociatedProducts = (project) => {
+const project = 'cloud-docs';
+const setProjectAndAssociatedProducts = () => {
   useStaticQuery.mockImplementation(() => ({
     site: {
       siteMetadata: {
-        project,
+        project: project,
+        associatedProducts: [
+          {
+            name: 'atlas-cli',
+            versions: ['v1.1', 'v1.0'],
+          },
+        ],
       },
     },
   }));
 };
 
+const getKey = (project, branchName) => `${project}-${branchName}`;
+
 const TestConsumer = () => {
   const { activeVersions, setActiveVersions, availableVersions } = useContext(VersionContext);
 
   const handleClick = (project, version) => {
-    console.log(project);
-    console.log(version);
-    setActiveVersions({ project, version });
+    const value = {};
+    value[project] = version;
+    setActiveVersions(value);
   };
+
+  const versionElms = [];
+  for (let project in availableVersions) {
+    for (let branch of availableVersions[project]) {
+      versionElms.push(
+        <div
+          onClick={() => {
+            handleClick(project, branch.gitBranchName);
+          }}
+          key={getKey(project, branch.gitBranchName)}
+          id={getKey(project, branch.gitBranchName)}
+        >
+          {getKey(project, branch.gitBranchName)}
+        </div>
+      );
+    }
+  }
   return (
     <>
       <h1>active versions:</h1>
-      <div id="active-versions">
-        {activeVersions.map((versionName, projectName) => `${projectName} : ${versionName}`)}
-      </div>
+      <div id="active-versions">{JSON.stringify(activeVersions)}</div>
       <h1>availableVersions:</h1>
-      <div id="available-versions">
-        {availableVersions.map((versionName, projectName) => (
-          <div
-            onClick={() => {
-              handleClick(projectName, versionName);
-            }}
-            key={projectName + versionName}
-            id={projectName + versionName}
-          >
-            {projectName} : {versionName}:
-          </div>
-        ))}
-      </div>
+      <div id="available-versions">{versionElms}</div>
     </>
   );
+};
+
+const cloudDocsRepoBranches = {
+  branches: [
+    {
+      name: 'master',
+      publishOriginalBranchName: false,
+      active: true,
+      aliases: null,
+      gitBranchName: 'master',
+      urlSlug: null,
+      urlAliases: null,
+      isStableBranch: true,
+      id: { $oid: '62e29389da7afd105b30c360' },
+    },
+  ],
+};
+const mockedAssociatedRepoInfo = {
+  'atlas-cli': {
+    branches: [
+      {
+        gitBranchName: 'master',
+        publishOriginalBranchName: true,
+        active: true,
+        isStableBranch: false,
+        urlAliases: ['upcoming'],
+        urlSlug: 'upcoming',
+        versionSelectorLabel: 'Beta',
+        buildsWithSnooty: true,
+        id: { $oid: '62e2938ada7afd105b30c3d0' },
+      },
+      {
+        publishOriginalBranchName: true,
+        active: true,
+        aliases: ['stable'],
+        gitBranchName: 'v1.0',
+        isStableBranch: true,
+        urlAliases: ['stable'],
+        urlSlug: 'stable',
+        versionSelectorLabel: 'Stable',
+        buildsWithSnooty: true,
+        id: { $oid: '62e2938ada7afd105b30c3d1' },
+      },
+    ],
+  },
 };
 
 const mountConsumer = () => {
   setProjectAndAssociatedProducts();
   return render(
-    <VersionContextProvider>
+    <VersionContextProvider repoBranches={cloudDocsRepoBranches} associatedReposInfo={mockedAssociatedRepoInfo}>
+      test consumer below
       <TestConsumer />
     </VersionContextProvider>
   );
 };
 
 describe('Version Context', () => {
-  let wrapper;
+  let wrapper, mockedBrowserStorageSetter, mockedBrowserStorageGetter, mockedLocalStorage;
+
   beforeEach(() => {
-    // CHECK LOCAL STORAGE
-    wrapper = mountConsumer();
+    mockedLocalStorage = {};
+    mockedBrowserStorageSetter = jest
+      .spyOn(browserStorage, 'setLocalValue')
+      .mockImplementation((localStorageKey, value) => {
+        mockedLocalStorage[localStorageKey] = value;
+      });
+
+    mockedBrowserStorageGetter = jest.spyOn(browserStorage, 'getLocalValue').mockImplementation((key) => {
+      return mockedLocalStorage[key];
+    });
   });
 
-  it('it has initial value if local storage is empty', () => {
-    wrapper.debug();
+  afterAll(() => {
+    mockedBrowserStorageSetter.mockClear();
+    mockedBrowserStorageGetter.mockClear();
   });
 
-  it('initializes with values from local storage', () => {});
+  it('it has initial available and active version values if local storage is empty', async () => {
+    // available checks
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    cloudDocsRepoBranches.branches.forEach((branch) => {
+      expect(wrapper.getByText(getKey(project, branch.gitBranchName))).toBeTruthy();
+    });
+    for (let projectName in mockedAssociatedRepoInfo) {
+      for (let branch of mockedAssociatedRepoInfo[projectName].branches) {
+        expect(wrapper.getByText(getKey(projectName, branch.gitBranchName))).toBeTruthy();
+      }
+    }
 
-  it('updates context values and local storage if called from consumers', () => {});
+    // active checks
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'v1.0' };
+    expect(wrapper.getByText(JSON.stringify(expectedActive))).toBeTruthy();
+  });
 
-  it('does not change availableVersions after init', () => {});
+  it('initializes with values from local storage', async () => {
+    mockedLocalStorage[STORAGE_KEY] = { 'atlas-cli': 'master' };
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    const expectedActive = { 'atlas-cli': 'master' };
+    expect(wrapper.getAllByText(JSON.stringify(expectedActive))).toBeTruthy();
+  });
+
+  it('updates context values and local storage if called from consumers', async () => {
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    const option = wrapper.getByText('atlas-cli-master');
+    userEvent.click(option);
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'master' };
+    expect(wrapper.getByText(JSON.stringify(expectedActive))).toBeTruthy();
+  });
+
+  it('calls client stitch fn to fetch documents on load', () => {
+    // TODO. mock stitch
+  });
 });


### PR DESCRIPTION
### Stories/Links:

[DOP-3210](https://jira.mongodb.org/browse/DOP-3210)
This PR adds a version context that should be consumable by points of navigation (ie. sidenav, right column) for a consolidated ToC tree and content with embedded documentations

### Current Behavior:

[Atlas Docs](https://www.mongodb.com/docs/atlas/)
[landing](https://www.mongodb.com/docs/)

### Staging Links:

[staged Atlas Docs](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3210/)
[staged landing](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/seung.park/DOP-3210/)

### Notes:
There are no visible behavior changes in front end.
However, you should be able to observe network requests when first loading the page, and [debugging server side code](https://www.gatsbyjs.com/docs/debugging-the-build-process/#vs-code-debugger-auto-config) should also allow you to observe server side requests for realm app services.
