### PR TITLE
DOP-3225: add version context

### DIFF
--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -6,15 +6,18 @@ import { TabProvider } from './Tabs/tab-context';
 import { ContentsProvider } from './Contents/contents-context';
 import { NavigationProvider } from '../context/navigation-context';
 import { VersionContextProvider } from '../context/version-context';
+import { TocContextProvider } from '../context/toc-context';
 
 const RootProvider = ({ children, headingNodes, selectors, repoBranches, associatedReposInfo }) => (
   <TabProvider selectors={selectors}>
     <ContentsProvider headingNodes={headingNodes}>
       <HeaderContextProvider>
         <VersionContextProvider repoBranches={repoBranches} associatedReposInfo={associatedReposInfo}>
-          <NavigationProvider>
-            <SidenavContextProvider>{children}</SidenavContextProvider>
-          </NavigationProvider>
+          <TocContextProvider>
+            <NavigationProvider>
+              <SidenavContextProvider>{children}</SidenavContextProvider>
+            </NavigationProvider>
+          </TocContextProvider>
         </VersionContextProvider>
       </HeaderContextProvider>
     </ContentsProvider>

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -203,7 +203,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
       return (
         <>
           {Object.keys(activeToc).length > 0 && (
-            <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={toctree} />
+            <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={activeToc} />
           )}
         </>
       );

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -25,6 +25,7 @@ import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { theme } from '../../theme/docsTheme';
 import { formatText } from '../../utils/format-text';
 import { baseUrl } from '../../utils/base-url';
+import { TocContext } from '../../context/toc-context';
 
 const SIDENAV_WIDTH = 268;
 
@@ -178,6 +179,8 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
     setHideMobile(true);
   }, [setHideMobile]);
 
+  const { activeToc } = useContext(TocContext);
+
   // Renders side nav content based on the current project and template.
   // The guides docs typically have a different TOC compared to other docs.
   const navContent = useMemo(() => {
@@ -194,8 +197,19 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
         />
       );
     }
+
+    // TODO: update sidenav. use new context and show options for filtering versions via ToC
+    if (process.env.GATSBY_TEST_EMBED_VERSIONS) {
+      return (
+        <>
+          {Object.keys(activeToc).length > 0 && (
+            <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={toctree} />
+          )}
+        </>
+      );
+    }
     return <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={toctree} />;
-  }, [chapters, guides, hideMobileSidenav, isGuidesLanding, isGuidesTemplate, page, slug, toctree]);
+  }, [chapters, guides, hideMobileSidenav, isGuidesLanding, isGuidesTemplate, page, slug, toctree, activeToc]);
 
   const navTitle = isGuidesTemplate ? guides?.[slug]?.['chapter_name'] : siteTitle;
 

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -64,6 +64,8 @@ const getTocMetadata = async (db, project, parserUser, parserBranch, manifestTre
       page_id: `${project}/${parserUser}/${parserBranch}`,
     };
     if (process.env.GATSBY_TEST_EMBED_VERSIONS && project === 'cloud-docs') {
+      // TODO: remove testing code
+      db = 'snooty_dev';
       filter = {
         page_id: 'cloud-docs/spark/DOP-3225',
       };

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -88,12 +88,10 @@ const TocContextProvider = ({ children }) => {
   useEffect(() => {
     getTocMetadata(database, project, parserUser, parserBranch, toctree).then((toctreeResponse) => {
       const filtered = filterTocByVersion(toctreeResponse, activeVersions, availableVersions);
-      console.log('setting filtered');
-      console.log(JSON.stringify(filtered.children[filtered.children.length - 1]));
       setActiveToc(filtered);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [activeVersions, availableVersions]);
 
   return <TocContext.Provider value={{ activeToc }}>{children}</TocContext.Provider>;
 };

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { VersionContext } from './version-context';
+
+const TocContext = createContext({
+  activeToc: {}, // table of contents
+  // TODO: doc format of contents
+});
+
+const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availableVersions = {}) {
+  if (
+    Object.keys(tocTree).length === 0 ||
+    Object.keys(availableVersions).length === 0 ||
+    Object.keys(currentVersion).length === 0
+  ) {
+    return tocTree;
+  }
+  // Q: how to filter by options.version and current versions?
+  // ie. v1.1.0 with atlas cli
+  // vs v1.1.0 with atlas-cli
+  // need to verify consistency of gitBranchName in "versions"
+  // need project name in versions
+
+  // if i mutate toctree, will it still be reset to full tree, since using useSnootyMetadata?
+  tocTree.children = tocTree?.children?.filter((child) => {
+    // if it has "versions" in options, filter those versions by available versions
+    // don't include this child if available versions does not match
+    // also should filter this toctree.children[].children[] by current version
+    if (child.options?.versions) {
+      child.options.versions = child.options.versions.filter((version) =>
+        availableVersions[child.slug].map((branchObj) => branchObj['gitBranchName']).includes(version)
+      );
+      child.children = child.children?.filter(
+        (versionedChild) => currentVersion[child.slug] === versionedChild.options.version
+      );
+      return child.options.versions.length ? child : false;
+    }
+    return child;
+  });
+
+  return tocTree;
+};
+
+// ToC context that provides ToC content in form of *above*
+// filters all available ToC by currently selected version via VersionContext
+const TocContextProvider = ({ children }) => {
+  const { activeVersions, availableVersions } = useContext(VersionContext);
+  const { toctree } = useSnootyMetadata();
+  const [activeToc, setActiveToc] = useState({});
+
+  // TODO: client side call to get Toc Metadata from Atlas
+  // useEffect(() => {
+  //   getTocMetadata().then((toctree) => setBaseTocTree(toctree))
+  // }, []);
+
+  useEffect(() => {
+    const filtered = filterTocByVersion(toctree, activeVersions, availableVersions);
+    console.log('filtered');
+    console.log(filtered);
+    setActiveToc(filtered);
+  }, [activeVersions, toctree, availableVersions]);
+
+  return <TocContext.Provider value={{ activeToc }}>{children}</TocContext.Provider>;
+};
+
+export { TocContext, TocContextProvider };

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -14,15 +14,17 @@ const TocContext = createContext({
  * @param {object} tocTree toc tree head node
  * @param {object} currentVersion see version-context currentVersion{}
  * @param {object} availableVersions see version-context availableVersions{}
+ * @modifies [tocTree.children[], tocTree.children[].options.versions[], tocTree.children[].options.versions]
+ *
  * @returns tocTree toc tree head node, with nodes filtered by current and available versions
  */
 const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availableVersions = {}) {
-  const clonedToc = { ...tocTree };
+  const shallowCloneToc = { ...tocTree };
   if (Object.keys(tocTree).length === 0) {
-    return clonedToc;
+    return shallowCloneToc;
   }
-  clonedToc.children =
-    clonedToc.children?.filter((tocNode) => {
+  shallowCloneToc.children =
+    shallowCloneToc.children?.filter((tocNode) => {
       if (!tocNode?.options?.versions) {
         return true;
       }
@@ -47,7 +49,7 @@ const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availabl
       return tocNode;
     }) || [];
 
-  return clonedToc;
+  return shallowCloneToc;
 };
 
 const getTocMetadata = async (db, project, parserUser, parserBranch, manifestTree) => {

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -1,4 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { METADATA_COLLECTION } from '../build-constants';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { fetchDocument } from '../utils/realm';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
 import { VersionContext } from './version-context';
 
@@ -23,35 +26,54 @@ const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availabl
   ) {
     return clonedToc;
   }
-  clonedToc.children = clonedToc?.children?.filter((child) => {
-    // tocTree child.options.versions exists if it is specific to a version
-    // if no version, include the child
-    if (!child?.options?.versions) {
-      return true;
-    }
-    const childProject = child.options.project;
+  clonedToc.children =
+    clonedToc?.children?.filter((child) => {
+      // tocTree child.options.versions exists if it is specific to a version
+      // if no version, include the child
+      if (!child?.options?.versions) {
+        return true;
+      }
+      const childProject = child.options.project;
 
-    // filter ToC version options by version context
-    child.options.versions = child.options.versions.filter((version) =>
-      availableVersions[childProject]?.map((branchObj) => branchObj['gitBranchName']).includes(version)
-    );
+      // filter ToC version options by version context
+      child.options.versions = child.options.versions.filter((version) =>
+        availableVersions[childProject]?.map((branchObj) => branchObj['gitBranchName']).includes(version)
+      );
 
-    // if ToC and version context don't match, don't show versioned ToC children
-    if (!child.options.versions.length) {
-      return false;
-    }
+      // if ToC and version context don't match, don't show versioned ToC children
+      if (!child.options.versions.length) {
+        return false;
+      }
 
-    let targetVersion = currentVersion[childProject];
-    // if current version is not part of merged ToC, fallback to last
-    if (!targetVersion || !child.options.versions.includes(targetVersion)) {
-      targetVersion = child.options.versions[child.options.version.length - 1];
-      // NOTE. not updating version context since active versions should be most recent to their homepage
-    }
-    child.children = child.children?.filter((versionedChild) => versionedChild.options?.version === targetVersion);
-    return child;
-  });
+      let targetVersion = currentVersion[childProject];
+      // if current version is not part of merged ToC, fallback to last
+      if (!targetVersion || !child.options.versions.includes(targetVersion)) {
+        targetVersion = child.options.versions[child.options.version.length - 1];
+        // NOTE. not updating version context since active versions should be most recent to their homepage
+      }
+      child.children = child.children?.filter((versionedChild) => versionedChild.options?.version === targetVersion);
+      return child;
+    }) || [];
 
   return clonedToc;
+};
+
+const getTocMetadata = async (db, project, parserUser, parserBranch, manifestTree) => {
+  try {
+    let filter = {
+      page_id: `${project}/${parserUser}/${parserBranch}`,
+    };
+    if (process.env.GATSBY_TEST_EMBED_VERSIONS && project === 'cloud-docs') {
+      filter = {
+        page_id: 'cloud-docs/spark/DOP-3225',
+      };
+    }
+    const metadata = await fetchDocument(db, METADATA_COLLECTION, filter);
+    return metadata.toctree;
+  } catch (e) {
+    console.error(e);
+    return manifestTree;
+  }
 };
 
 // ToC context that provides ToC content in form of *above*
@@ -59,18 +81,19 @@ const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availabl
 const TocContextProvider = ({ children }) => {
   const { activeVersions, availableVersions } = useContext(VersionContext);
   const { toctree } = useSnootyMetadata();
+  const { database, project, parserUser, parserBranch } = useSiteMetadata();
   const [activeToc, setActiveToc] = useState({});
-  // TODO: useReducer for setActiveToc
-
-  // TODO: client side call to get Toc Metadata from Atlas
-  // useEffect(() => {
-  //   getTocMetadata().then((toctree) => setBaseTocTree(toctree))
-  // }, []);
+  // TODO: optimization: useMemo here to have memoized version of activeToc
 
   useEffect(() => {
-    const filtered = filterTocByVersion(toctree, activeVersions, availableVersions);
-    setActiveToc(filtered);
-  }, [activeVersions, toctree, availableVersions]);
+    getTocMetadata(database, project, parserUser, parserBranch, toctree).then((toctreeResponse) => {
+      const filtered = filterTocByVersion(toctreeResponse, activeVersions, availableVersions);
+      console.log('setting filtered');
+      console.log(JSON.stringify(filtered.children[filtered.children.length - 1]));
+      setActiveToc(filtered);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <TocContext.Provider value={{ activeToc }}>{children}</TocContext.Provider>;
 };

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -4,7 +4,6 @@ import { VersionContext } from './version-context';
 
 const TocContext = createContext({
   activeToc: {}, // table of contents
-  // TODO: doc format of contents
 });
 
 const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availableVersions = {}) {
@@ -15,23 +14,17 @@ const filterTocByVersion = function (tocTree = {}, currentVersion = {}, availabl
   ) {
     return tocTree;
   }
-  // Q: how to filter by options.version and current versions?
-  // ie. v1.1.0 with atlas cli
-  // vs v1.1.0 with atlas-cli
-  // need to verify consistency of gitBranchName in "versions"
-  // need project name in versions
 
-  // if i mutate toctree, will it still be reset to full tree, since using useSnootyMetadata?
   tocTree.children = tocTree?.children?.filter((child) => {
     // if it has "versions" in options, filter those versions by available versions
     // don't include this child if available versions does not match
     // also should filter this toctree.children[].children[] by current version
     if (child.options?.versions) {
       child.options.versions = child.options.versions.filter((version) =>
-        availableVersions[child.slug].map((branchObj) => branchObj['gitBranchName']).includes(version)
+        availableVersions[child.options?.project]?.map((branchObj) => branchObj['gitBranchName']).includes(version)
       );
       child.children = child.children?.filter(
-        (versionedChild) => currentVersion[child.slug] === versionedChild.options.version
+        (versionedChild) => currentVersion[child.options?.project] === versionedChild.options?.version
       );
       return child.options.versions.length ? child : false;
     }

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -10,9 +10,9 @@ const STORAGE_KEY = 'activeVersions';
 const getInitBranchName = (branches) => {
   const activeBranch = branches.find((b) => b.isStableBranch);
   if (activeBranch) {
-    return activeBranch.name || activeBranch.gitBranchName;
+    return activeBranch.gitBranchName;
   }
-  return branches[0]?.name || null;
+  return branches[0]?.gitBranchName || null;
 };
 
 const getInitVersions = (branchListByProduct) => {

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -4,7 +4,6 @@ const testTOCNode = require('./toc-test-data.json');
 
 // Returns the metadata from the manifest file if provided
 const fetchManifestMetadata = () => {
-  console.log('fetchmanifest');
   let metadata = {};
   if (process.env.GATSBY_MANIFEST_PATH) {
     const zip = new AdmZip(process.env.GATSBY_MANIFEST_PATH);

--- a/src/utils/setup/fetch-manifest-metadata.js
+++ b/src/utils/setup/fetch-manifest-metadata.js
@@ -1,8 +1,10 @@
 const AdmZip = require('adm-zip');
 const BSON = require('bson');
+const testTOCNode = require('./toc-test-data.json');
 
 // Returns the metadata from the manifest file if provided
 const fetchManifestMetadata = () => {
+  console.log('fetchmanifest');
   let metadata = {};
   if (process.env.GATSBY_MANIFEST_PATH) {
     const zip = new AdmZip(process.env.GATSBY_MANIFEST_PATH);
@@ -15,9 +17,10 @@ const fetchManifestMetadata = () => {
           metadata['associated_products'] = [
             {
               name: 'atlas-cli',
-              versions: ['v1.1', 'v1.0'],
+              versions: ['v1.1.7', 'v1.0'],
             },
           ];
+          metadata.toctree.children.push(testTOCNode);
         }
       }
     }

--- a/src/utils/setup/toc-test-data.json
+++ b/src/utils/setup/toc-test-data.json
@@ -1,379 +1,381 @@
 {
   "title": [{ "type": "text", "value": "Atlas CLI" }],
   "slug": "atlas-cli",
-  "options": { "versions": ["v1.0", "v1.1.7"] },
-  "children": [{
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "0"
+  "options": { "versions": ["v1.0", "v1.1.7"], "project": "atlas-cli" },
+  "children": [
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "0"
+              }
             }
+          },
+          "value": "Overview"
+        }
+      ],
+      "slug": "/",
+      "children": [],
+      "options": {
+        "version": "v1.0",
+        "drawer": true
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "4"
+              }
+            }
+          },
+          "value": "Install or Update the Atlas CLI v1.0"
+        }
+      ],
+      "slug": "install-atlas-cli",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Check Compatibility"
+            }
+          ],
+          "slug": "compatibility",
+          "children": [],
+          "options": {
+            "drawer": false
+          }
+        }
+      ],
+      "options": {
+        "drawer": false,
+        "version": "v1.0"
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "4"
+              }
+            }
+          },
+          "value": "Connect from the Atlas CLI v1.0"
+        }
+      ],
+      "slug": "connect-atlas-cli",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Save Connection Settings"
+            }
+          ],
+          "slug": "atlas-cli-save-connection-settings",
+          "children": [],
+          "options": {
+            "drawer": true
           }
         },
-        "value": "Overview"
-      }
-    ],
-    "slug": "/",
-    "children": [],
-    "options": {
-      "version": "v1.0",
-      "drawer": true
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "4"
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Atlas CLI Environment Variables"
             }
+          ],
+          "slug": "atlas-cli-env-variables",
+          "children": [],
+          "options": {
+            "drawer": false
           }
         },
-        "value": "Install or Update the Atlas CLI v1.0"
-      }
-    ],
-    "slug": "install-atlas-cli",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
                 }
-              }
-            },
-            "value": "Check Compatibility"
-          }
-        ],
-        "slug": "compatibility",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      }
-    ],
-    "options": {
-      "drawer": false,
-      "version": "v1.0"
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "4"
+              },
+              "value": "Migrate to the Atlas CLI"
             }
+          ],
+          "slug": "migrate-to-atlas-cli",
+          "children": [],
+          "options": {
+            "drawer": false
+          }
+        }
+      ],
+      "options": {
+        "version": "v1.0",
+        "drawer": false
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "3"
+              }
+            }
+          },
+          "value": "Configure Optional Settings"
+        }
+      ],
+      "slug": "configure-optional-settings",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Configure Telemetry v1.0"
+            }
+          ],
+          "slug": "telemetry",
+          "children": [],
+          "options": {
+            "drawer": false
+          }
+        }
+      ],
+      "options": {
+        "version": "v1.0",
+        "drawer": true
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "0"
+              }
+            }
+          },
+          "value": "Overview"
+        }
+      ],
+      "slug": "/",
+      "children": [],
+      "options": {
+        "version": "v1.1.7",
+        "drawer": true
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "4"
+              }
+            }
+          },
+          "value": "Install or Update the Atlas CLI v1.1.7"
+        }
+      ],
+      "slug": "install-atlas-cli",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Check Compatibility"
+            }
+          ],
+          "slug": "compatibility",
+          "children": [],
+          "options": {
+            "drawer": false
+          }
+        }
+      ],
+      "options": {
+        "drawer": false,
+        "version": "v1.1.7"
+      }
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "4"
+              }
+            }
+          },
+          "value": "Connect from the Atlas CLI v1.1.7"
+        }
+      ],
+      "slug": "connect-atlas-cli",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Save Connection Settings"
+            }
+          ],
+          "slug": "atlas-cli-save-connection-settings",
+          "children": [],
+          "options": {
+            "drawer": true
           }
         },
-        "value": "Connect from the Atlas CLI v1.0"
-      }
-    ],
-    "slug": "connect-atlas-cli",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
                 }
-              }
-            },
-            "value": "Save Connection Settings"
-          }
-        ],
-        "slug": "atlas-cli-save-connection-settings",
-        "children": [],
-        "options": {
-          "drawer": true
-        }
-      },
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Atlas CLI Environment Variables"
-          }
-        ],
-        "slug": "atlas-cli-env-variables",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      },
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Migrate to the Atlas CLI"
-          }
-        ],
-        "slug": "migrate-to-atlas-cli",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      }
-    ],
-    "options": {
-      "version": "v1.0",
-      "drawer": false
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "3"
+              },
+              "value": "Atlas CLI Environment Variables"
             }
+          ],
+          "slug": "atlas-cli-env-variables",
+          "children": [],
+          "options": {
+            "drawer": false
           }
         },
-        "value": "Configure Optional Settings"
-      }
-    ],
-    "slug": "configure-optional-settings",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
                 }
-              }
-            },
-            "value": "Configure Telemetry v1.0"
-          }
-        ],
-        "slug": "telemetry",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      }
-    ],
-    "options": {
-      "version": "v1.0",
-      "drawer": true
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "0"
+              },
+              "value": "Migrate to the Atlas CLI"
             }
+          ],
+          "slug": "migrate-to-atlas-cli",
+          "children": [],
+          "options": {
+            "drawer": false
           }
-        },
-        "value": "Overview"
+        }
+      ],
+      "options": {
+        "version": "v1.1.7",
+        "drawer": false
       }
-    ],
-    "slug": "/",
-    "children": [],
-    "options": {
-      "version": "v1.1.7",
-      "drawer": true
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "4"
+    },
+    {
+      "title": [
+        {
+          "type": "text",
+          "position": {
+            "start": {
+              "line": {
+                "$numberInt": "3"
+              }
             }
-          }
-        },
-        "value": "Install or Update the Atlas CLI v1.1.7"
-      }
-    ],
-    "slug": "install-atlas-cli",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Check Compatibility"
-          }
-        ],
-        "slug": "compatibility",
-        "children": [],
-        "options": {
-          "drawer": false
+          },
+          "value": "Configure Optional Settings"
         }
-      }
-    ],
-    "options": {
-      "drawer": false,
-      "version": "v1.1.7"
-    }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "4"
+      ],
+      "slug": "configure-optional-settings",
+      "children": [
+        {
+          "title": [
+            {
+              "type": "text",
+              "position": {
+                "start": {
+                  "line": {
+                    "$numberInt": "4"
+                  }
+                }
+              },
+              "value": "Configure Telemetry v1.1.7"
             }
+          ],
+          "slug": "telemetry",
+          "children": [],
+          "options": {
+            "drawer": false
           }
-        },
-        "value": "Connect from the Atlas CLI v1.1.7"
+        }
+      ],
+      "options": {
+        "version": "v1.1.7",
+        "drawer": true
       }
-    ],
-    "slug": "connect-atlas-cli",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Save Connection Settings"
-          }
-        ],
-        "slug": "atlas-cli-save-connection-settings",
-        "children": [],
-        "options": {
-          "drawer": true
-        }
-      },
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Atlas CLI Environment Variables"
-          }
-        ],
-        "slug": "atlas-cli-env-variables",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      },
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Migrate to the Atlas CLI"
-          }
-        ],
-        "slug": "migrate-to-atlas-cli",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      }
-    ],
-    "options": {
-      "version": "v1.1.7",
-      "drawer": false
     }
-  },
-  {
-    "title": [
-      {
-        "type": "text",
-        "position": {
-          "start": {
-            "line": {
-              "$numberInt": "3"
-            }
-          }
-        },
-        "value": "Configure Optional Settings"
-      }
-    ],
-    "slug": "configure-optional-settings",
-    "children": [
-      {
-        "title": [
-          {
-            "type": "text",
-            "position": {
-              "start": {
-                "line": {
-                  "$numberInt": "4"
-                }
-              }
-            },
-            "value": "Configure Telemetry v1.1.7"
-          }
-        ],
-        "slug": "telemetry",
-        "children": [],
-        "options": {
-          "drawer": false
-        }
-      }
-    ],
-    "options": {
-      "version": "v1.1.7",
-      "drawer": true
-    }
-  }]
+  ]
 }

--- a/src/utils/setup/toc-test-data.json
+++ b/src/utils/setup/toc-test-data.json
@@ -1,0 +1,379 @@
+{
+  "title": [{ "type": "text", "value": "Atlas CLI" }],
+  "slug": "atlas-cli",
+  "options": { "versions": ["v1.0", "v1.1.7"] },
+  "children": [{
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "0"
+            }
+          }
+        },
+        "value": "Overview"
+      }
+    ],
+    "slug": "/",
+    "children": [],
+    "options": {
+      "version": "v1.0",
+      "drawer": true
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "4"
+            }
+          }
+        },
+        "value": "Install or Update the Atlas CLI v1.0"
+      }
+    ],
+    "slug": "install-atlas-cli",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Check Compatibility"
+          }
+        ],
+        "slug": "compatibility",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "drawer": false,
+      "version": "v1.0"
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "4"
+            }
+          }
+        },
+        "value": "Connect from the Atlas CLI v1.0"
+      }
+    ],
+    "slug": "connect-atlas-cli",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Save Connection Settings"
+          }
+        ],
+        "slug": "atlas-cli-save-connection-settings",
+        "children": [],
+        "options": {
+          "drawer": true
+        }
+      },
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Atlas CLI Environment Variables"
+          }
+        ],
+        "slug": "atlas-cli-env-variables",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      },
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Migrate to the Atlas CLI"
+          }
+        ],
+        "slug": "migrate-to-atlas-cli",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "version": "v1.0",
+      "drawer": false
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "3"
+            }
+          }
+        },
+        "value": "Configure Optional Settings"
+      }
+    ],
+    "slug": "configure-optional-settings",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Configure Telemetry v1.0"
+          }
+        ],
+        "slug": "telemetry",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "version": "v1.0",
+      "drawer": true
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "0"
+            }
+          }
+        },
+        "value": "Overview"
+      }
+    ],
+    "slug": "/",
+    "children": [],
+    "options": {
+      "version": "v1.1.7",
+      "drawer": true
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "4"
+            }
+          }
+        },
+        "value": "Install or Update the Atlas CLI v1.1.7"
+      }
+    ],
+    "slug": "install-atlas-cli",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Check Compatibility"
+          }
+        ],
+        "slug": "compatibility",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "drawer": false,
+      "version": "v1.1.7"
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "4"
+            }
+          }
+        },
+        "value": "Connect from the Atlas CLI v1.1.7"
+      }
+    ],
+    "slug": "connect-atlas-cli",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Save Connection Settings"
+          }
+        ],
+        "slug": "atlas-cli-save-connection-settings",
+        "children": [],
+        "options": {
+          "drawer": true
+        }
+      },
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Atlas CLI Environment Variables"
+          }
+        ],
+        "slug": "atlas-cli-env-variables",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      },
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Migrate to the Atlas CLI"
+          }
+        ],
+        "slug": "migrate-to-atlas-cli",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "version": "v1.1.7",
+      "drawer": false
+    }
+  },
+  {
+    "title": [
+      {
+        "type": "text",
+        "position": {
+          "start": {
+            "line": {
+              "$numberInt": "3"
+            }
+          }
+        },
+        "value": "Configure Optional Settings"
+      }
+    ],
+    "slug": "configure-optional-settings",
+    "children": [
+      {
+        "title": [
+          {
+            "type": "text",
+            "position": {
+              "start": {
+                "line": {
+                  "$numberInt": "4"
+                }
+              }
+            },
+            "value": "Configure Telemetry v1.1.7"
+          }
+        ],
+        "slug": "telemetry",
+        "children": [],
+        "options": {
+          "drawer": false
+        }
+      }
+    ],
+    "options": {
+      "version": "v1.1.7",
+      "drawer": true
+    }
+  }]
+}

--- a/tests/context/toc-context.test.js
+++ b/tests/context/toc-context.test.js
@@ -1,0 +1,154 @@
+import React, { useContext } from 'react';
+import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import * as realm from '../../src/utils/realm';
+import * as siteMetadata from '../../src/hooks/use-site-metadata';
+import * as snootyMetadata from '../../src/utils/use-snooty-metadata';
+import { VersionContext } from '../../src/context/version-context';
+
+import { TocContext, TocContextProvider } from '../../src/context/toc-context';
+
+// set sample server data
+const siteMetadataMock = jest.spyOn(siteMetadata, 'useSiteMetadata');
+const snootyMetadataMock = jest.spyOn(snootyMetadata, 'default');
+const realmMock = jest.spyOn(realm, 'fetchDocument');
+const project = 'cloud-docs';
+const sampleTocTree = {
+  title: [{ type: 'text', position: { start: { line: 0 } }, value: 'MongoDB Atlas' }],
+  slug: '/',
+  children: [
+    {
+      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page' }],
+      slug: 'sample-page',
+      children: [],
+    },
+    {
+      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page2' }],
+      slug: 'sample-page2',
+      children: [],
+    },
+    {
+      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page3' }],
+      slug: 'sample-page3',
+      options: {
+        versions: ['v1.0'],
+        project: 'atlas-cli',
+      },
+      children: [
+        {
+          title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.0' }],
+          slug: 'sample-child-v1.0',
+          options: {
+            version: 'v1.0',
+          },
+        },
+      ],
+    },
+  ],
+};
+// set sample response data with deep copied sample toc
+const responseTree = JSON.parse(JSON.stringify(sampleTocTree));
+responseTree.children[responseTree.children.length - 1].options = {
+  versions: ['v1.0', 'v1.2', 'v0.8'],
+  project: 'atlas-cli',
+};
+responseTree.children[responseTree.children.length - 1].children.push({
+  title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.2' }],
+  slug: 'sample-child-v1.2',
+  options: {
+    version: 'v1.2',
+  },
+});
+
+responseTree.children[responseTree.children.length - 1].children.push({
+  title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v0.8' }],
+  slug: 'sample-child-v0.8',
+  options: {
+    version: 'v0.8',
+  },
+});
+
+const mockedResponse = {
+  toctree: responseTree,
+};
+
+const setMocks = () => {
+  // mock server metadata
+  siteMetadataMock.mockImplementation(() => ({
+    project: project,
+    database: 'snooty_dev',
+    parserUser: 'spark',
+    parserBranch: 'master',
+  }));
+
+  snootyMetadataMock.mockImplementation(() => ({
+    toctree: sampleTocTree,
+  }));
+
+  // mock realm
+  realmMock.mockResolvedValue(mockedResponse);
+};
+
+const TestConsumer = () => {
+  const { activeToc } = useContext(TocContext);
+  return <div>{JSON.stringify(activeToc)}</div>;
+};
+
+const mountConsumer = (
+  // mock version context by wrapping it with versions and activeToc
+  activeVersions = { 'atlas-cli': 'v1.0', 'cloud-docs': 'master' },
+  availableVersions = {
+    'atlas-cli': [{ gitBranchName: 'v1.0' }, { gitBranchName: 'v1.2' }],
+    'cloud-docs': [{ gitBranchName: 'master' }],
+  }
+) => {
+  return render(
+    <VersionContext.Provider value={{ activeVersions, availableVersions }}>
+      <TocContextProvider>
+        <TestConsumer></TestConsumer>
+      </TocContextProvider>
+    </VersionContext.Provider>
+  );
+};
+
+describe('ToC Context', () => {
+  let wrapper;
+
+  beforeEach(async () => {
+    setMocks();
+  });
+
+  it('sets ToC filtered by versioned nodes returned by realm call', async () => {
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    expect(wrapper.getByText(/options/g)).toBeTruthy();
+    expect(wrapper.getByText(/v1.0/g)).toBeTruthy();
+    expect(wrapper.getByText(/v1.2/g)).toBeTruthy();
+  });
+
+  it('initializes ToC without versioned nodes if not in available versions', async () => {
+    await act(async () => {
+      wrapper = mountConsumer({}, {});
+    });
+    expect(wrapper.queryByText(/options/g)).toBeNull();
+  });
+
+  it('calls realm function to fetch data', async () => {
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    expect(realmMock).toHaveBeenCalled();
+  });
+
+  it('falls back to server side metadata if realm call fails', async () => {
+    realmMock.mockRejectedValueOnce(new Error('test'));
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    expect(realmMock).toHaveBeenCalled();
+    expect(wrapper.getByText(/options/g)).toBeTruthy();
+    expect(wrapper.getByText(/v1.0/g)).toBeTruthy();
+    expect(wrapper.queryByText(/v1.2/g)).toBeNull();
+  });
+});

--- a/tests/context/toc-context.test.js
+++ b/tests/context/toc-context.test.js
@@ -8,68 +8,74 @@ import { VersionContext } from '../../src/context/version-context';
 
 import { TocContext, TocContextProvider } from '../../src/context/toc-context';
 
-// set sample server data
+// <------------------ START test data mocks ------------------>
 const siteMetadataMock = jest.spyOn(siteMetadata, 'useSiteMetadata');
 const snootyMetadataMock = jest.spyOn(snootyMetadata, 'default');
 const realmMock = jest.spyOn(realm, 'fetchDocument');
 const project = 'cloud-docs';
-const sampleTocTree = {
-  title: [{ type: 'text', position: { start: { line: 0 } }, value: 'MongoDB Atlas' }],
-  slug: '/',
-  children: [
-    {
-      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page' }],
-      slug: 'sample-page',
-      children: [],
-    },
-    {
-      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page2' }],
-      slug: 'sample-page2',
-      children: [],
-    },
-    {
-      title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page3' }],
-      slug: 'sample-page3',
-      options: {
-        versions: ['v1.0'],
-        project: 'atlas-cli',
+
+let sampleTocTree, responseTree, mockedResponse;
+
+const setResponse = () => {
+  sampleTocTree = {
+    title: [{ type: 'text', position: { start: { line: 0 } }, value: 'MongoDB Atlas' }],
+    slug: '/',
+    children: [
+      {
+        title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page' }],
+        slug: 'sample-page',
+        children: [],
       },
-      children: [
-        {
-          title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.0' }],
-          slug: 'sample-child-v1.0',
-          options: {
-            version: 'v1.0',
-          },
+      {
+        title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page2' }],
+        slug: 'sample-page2',
+        children: [],
+      },
+      {
+        title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample page3' }],
+        slug: 'sample-page3',
+        options: {
+          versions: ['v1.0'],
+          project: 'atlas-cli',
         },
-      ],
+        children: [
+          {
+            title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.0' }],
+            slug: 'sample-child-v1.0',
+            options: {
+              version: 'v1.0',
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  // set sample response data with deep copied sample toc
+  responseTree = JSON.parse(JSON.stringify(sampleTocTree));
+  responseTree.children[responseTree.children.length - 1].options = {
+    versions: ['v1.0', 'v1.2', 'v0.8'],
+    project: 'atlas-cli',
+  };
+  responseTree.children[responseTree.children.length - 1].children.push({
+    title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.2' }],
+    slug: 'sample-child-v1.2',
+    options: {
+      version: 'v1.2',
     },
-  ],
-};
-// set sample response data with deep copied sample toc
-const responseTree = JSON.parse(JSON.stringify(sampleTocTree));
-responseTree.children[responseTree.children.length - 1].options = {
-  versions: ['v1.0', 'v1.2', 'v0.8'],
-  project: 'atlas-cli',
-};
-responseTree.children[responseTree.children.length - 1].children.push({
-  title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v1.2' }],
-  slug: 'sample-child-v1.2',
-  options: {
-    version: 'v1.2',
-  },
-});
+  });
 
-responseTree.children[responseTree.children.length - 1].children.push({
-  title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v0.8' }],
-  slug: 'sample-child-v0.8',
-  options: {
-    version: 'v0.8',
-  },
-});
+  responseTree.children[responseTree.children.length - 1].children.push({
+    title: [{ type: 'text', position: { start: { line: 1 } }, value: 'sample child v0.8' }],
+    slug: 'sample-child-v0.8',
+    options: {
+      version: 'v0.8',
+    },
+  });
 
-const mockedResponse = {
-  toctree: responseTree,
+  mockedResponse = {
+    toctree: responseTree,
+  };
 };
 
 const setMocks = () => {
@@ -88,6 +94,10 @@ const setMocks = () => {
   // mock realm
   realmMock.mockResolvedValue(mockedResponse);
 };
+
+// <------------------ END test data mocks ------------------>
+
+// <------------------ START render helpers ------------------>
 
 const TestConsumer = () => {
   const { activeToc } = useContext(TocContext);
@@ -111,20 +121,14 @@ const mountConsumer = (
   );
 };
 
+// <------------------ END render helpers ------------------>
+
 describe('ToC Context', () => {
   let wrapper;
 
   beforeEach(async () => {
+    setResponse();
     setMocks();
-  });
-
-  it('sets ToC filtered by versioned nodes returned by realm call', async () => {
-    await act(async () => {
-      wrapper = mountConsumer();
-    });
-    expect(wrapper.getByText(/options/g)).toBeTruthy();
-    expect(wrapper.getByText(/v1.0/g)).toBeTruthy();
-    expect(wrapper.getByText(/v1.2/g)).toBeTruthy();
   });
 
   it('initializes ToC without versioned nodes if not in available versions', async () => {
@@ -132,6 +136,15 @@ describe('ToC Context', () => {
       wrapper = mountConsumer({}, {});
     });
     expect(wrapper.queryByText(/options/g)).toBeNull();
+  });
+
+  it('sets ToC based on response realm app service response', async () => {
+    await act(async () => {
+      wrapper = mountConsumer();
+    });
+    expect(wrapper.getByText(/options/g)).toBeTruthy();
+    expect(wrapper.getByText(/v1.0/g)).toBeTruthy();
+    expect(wrapper.getByText(/v1.2/g)).toBeTruthy();
   });
 
   it('calls realm function to fetch data', async () => {


### PR DESCRIPTION
### Stories/Links:

[DOP-3225](https://jira.mongodb.org/browse/DOP-3225)

### Current Behavior:

[atlas docs](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[atlas docs staged](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3225/getting-started/)

### Notes:
- using [mocked data](https://github.com/mongodb/snooty/pull/702/files#diff-1594a8cd87a233c31de3b28bc4b7639b66cd33e42ea4b28ae15a3800c8f129cc) for manifest metadata, as well as document uploaded to snooty_dev.metadata. filter by {page_id: /3225} to check out the document
- staged link has GATSBY_TEST_EMBED_VERSIONS environment variable set to true, and is reading from snooty_dev (see [changes](https://github.com/mongodb/snooty/pull/702/files#diff-67fd2be78a4e3484aedf9be9ed69bf5d5a356fa2a503d987deac14a4d2becfbeR64) )
- can optimize useEffect calls to use useMemo instead, to return a memoized version of state