### PR TITLE
DOP-3268: Make Optimizely Async

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -8,7 +8,7 @@ import { theme } from './src/theme/docsTheme';
 export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([
     // Optimizely
-    <script defer src="https://cdn.optimizely.com/js/20988630008.js" />,
+    <script async src="https://cdn.optimizely.com/js/20988630008.js" />,
     // Delighted
     <script
       type="text/javascript"


### PR DESCRIPTION
### Stories/Links:

DOP-3268

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_
[Atlas](www.mongodb.com/docs/cloud)

### Staging Links:

_Put a link to your staging environment(s), if applicable_
https://docs-mongodbcom-integration.corp.mongodb.com/master/realm/cassidy.schaufele/DOP-3268/

### Notes:
Switches the `defer` in our Optimizely import to `async`. See discussion in ticket for additional context.