### PR TITLE
DOP-3343: fix ToC styling

### DIFF
--- a/src/components/Sidenav/GuidesLandingTree.js
+++ b/src/components/Sidenav/GuidesLandingTree.js
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { cx } from '@leafygreen-ui/emotion';
 import { SideNavItem } from '@leafygreen-ui/side-nav';
 import { sideNavItemBasePadding, sideNavItemFontSize } from './styles/sideNavItem';
 import Link from '../Link';
@@ -25,7 +24,7 @@ const GuidesLandingTree = ({ chapters, handleClick }) => {
         <SideNavItem
           active={to === '/'}
           as={Link}
-          className={cx(sideNavItemBasePadding, sideNavItemFontSize)}
+          css={[sideNavItemBasePadding, sideNavItemFontSize]}
           key={to}
           onClick={handleClick}
           to={to}

--- a/src/components/Sidenav/GuidesTOCTree.js
+++ b/src/components/Sidenav/GuidesTOCTree.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { cx } from '@leafygreen-ui/emotion';
 import { SideNavItem } from '@leafygreen-ui/side-nav';
 import { sideNavItemTOCStyling } from './styles/sideNavItem';
 import Link from '../Link';
@@ -26,7 +25,7 @@ const GuidesTOCTree = ({ chapters, guides, handleClick, slug }) => {
               <SideNavItem
                 active={isActiveGuide}
                 as={Link}
-                className={cx(sideNavItemTOCStyling({ level: 1 }))}
+                css={[sideNavItemTOCStyling({ level: 1 })]}
                 onClick={handleClick}
                 to={guide}
               >
@@ -37,7 +36,7 @@ const GuidesTOCTree = ({ chapters, guides, handleClick, slug }) => {
                   <SideNavItem
                     active={activeHeadingId === id}
                     as={Link}
-                    className={cx(sideNavItemTOCStyling({ level: 2 }))}
+                    css={[sideNavItemTOCStyling({ level: 2 })]}
                     key={id}
                     onClick={handleClick}
                     to={`#${id}`}

--- a/src/components/Sidenav/IA.js
+++ b/src/components/Sidenav/IA.js
@@ -18,7 +18,7 @@ const IA = ({ handleClick, header, ia }) => (
       const target = slug || url;
       return (
         <SideNavItem
-          className={cx(sideNavItemBasePadding, sideNavItemFontSize)}
+          css={[sideNavItemBasePadding, sideNavItemFontSize]}
           key={target}
           as={Link}
           onClick={handleClick}

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -74,7 +74,7 @@ const sideNavStyling = ({ hideMobile, isCollapsed }) => LeafyCSS`
 
 `;
 
-const titleStyle = LeafyCSS`
+const titleStyle = css`
   color: ${palette.gray.dark3};
   font-size: ${theme.fontSize.small};
   font-weight: bold;
@@ -243,7 +243,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
             <IATransition back={back} hasIA={!!ia} slug={slug} isMobile={isMobile}>
               <NavTopContainer>
                 <ArtificialPadding />
-                <SideNavItem className={cx(titleStyle, sideNavItemBasePadding)} as={Link} to={baseUrl()}>
+                <SideNavItem css={[titleStyle, sideNavItemBasePadding]} as={Link} to={baseUrl()}>
                   MongoDB Documentation
                 </SideNavItem>
                 <Border />
@@ -260,7 +260,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 />
                 {ia && (
                   <IA
-                    header={<span className={cx(titleStyle)}>{formatText(pageTitle)}</span>}
+                    header={<span css={[titleStyle]}>{formatText(pageTitle)}</span>}
                     handleClick={() => {
                       setBack(false);
                       hideMobileSidenav();
@@ -282,11 +282,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
             {!ia && !showAllProducts && (
               <>
                 {isGuidesTemplate && <StyledChapterNumberLabel number={guidesChapterNumber} />}
-                <SideNavItem
-                  className={cx(titleStyle, sideNavItemBasePadding)}
-                  as={Link}
-                  to={isGuidesTemplate ? slug : '/'}
-                >
+                <SideNavItem css={[titleStyle, sideNavItemBasePadding]} as={Link} to={isGuidesTemplate ? slug : '/'}>
                   {navTitle}
                 </SideNavItem>
               </>
@@ -300,7 +296,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 {/* Represents the generic links at the bottom of the side nav (e.g. "Contact Support") */}
                 {additionalLinks.map(({ glyph, title, url }) => (
                   <SideNavItem
-                    className={cx(sideNavItemBasePadding, sideNavItemFontSize)}
+                    css={[sideNavItemBasePadding, sideNavItemFontSize]}
                     key={url}
                     glyph={<Icon glyph={glyph} />}
                     href={url}

--- a/src/components/Sidenav/SidenavBackButton.js
+++ b/src/components/Sidenav/SidenavBackButton.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { css as emotionCSS } from '@emotion/react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
@@ -23,7 +24,7 @@ const Placeholder = styled(SideNavItem)`
   margin-bottom: 16px;
 `;
 
-const backButtonStyling = css`
+const backButtonStyling = emotionCSS`
   font-size: ${theme.fontSize.small};
   margin-bottom: 16px;
   font-weight: 400;
@@ -95,7 +96,7 @@ const SidenavBackButton = ({
     <>
       <SideNavItem
         as={Link}
-        className={cx(sideNavItemBasePadding, backButtonStyling)}
+        css={[sideNavItemBasePadding, backButtonStyling]}
         to={url}
         glyph={glyph}
         onClick={handleClick}

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -90,7 +90,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
     if (isDrawer && hasChildren) {
       return (
         <SideNavItem
-          className={cx(sideNavItemTOCStyling({ level }))}
+          css={[sideNavItemTOCStyling({ level })]}
           onClick={() => {
             setIsOpen(!isOpen);
           }}
@@ -107,7 +107,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
           as={Link}
           to={target}
           active={isSelected}
-          className={cx(sideNavItemTOCStyling({ level }))}
+          css={[sideNavItemTOCStyling({ level })]}
           onClick={(e) => {
             setIsOpen(!isOpen);
           }}

--- a/src/components/Sidenav/styles/sideNavItem.js
+++ b/src/components/Sidenav/styles/sideNavItem.js
@@ -1,4 +1,4 @@
-import { css } from '@leafygreen-ui/emotion';
+import { css } from '@emotion/react';
 import { theme } from '../../../theme/docsTheme';
 
 export const sideNavItemBasePadding = css`

--- a/tests/unit/__snapshots__/GuidesLandingTree.test.js.snap
+++ b/tests/unit/__snapshots__/GuidesLandingTree.test.js.snap
@@ -46,11 +46,6 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   color: #00684A;
   position: relative;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  font-size: 13px;
 }
 
 .emotion-1:hover {
@@ -126,6 +121,11 @@ exports[`renders correctly 1`] = `
   line-height: 13px;
   outline: none;
   color: #016BF8;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-size: 13px;
 }
 
 .emotion-2:focus {
@@ -205,11 +205,6 @@ exports[`renders correctly 1`] = `
   font-size: 13px;
   line-height: 20px;
   position: relative;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  font-size: 13px;
 }
 
 .emotion-1:hover {
@@ -272,6 +267,11 @@ exports[`renders correctly 1`] = `
   line-height: 13px;
   outline: none;
   color: #016BF8;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-size: 13px;
 }
 
 .emotion-2:focus {
@@ -351,11 +351,6 @@ exports[`renders correctly 1`] = `
   font-size: 13px;
   line-height: 20px;
   position: relative;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  font-size: 13px;
 }
 
 .emotion-1:hover {
@@ -418,6 +413,11 @@ exports[`renders correctly 1`] = `
   line-height: 13px;
   outline: none;
   color: #016BF8;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-size: 13px;
 }
 
 .emotion-2:focus {


### PR DESCRIPTION
### Stories/Links:

DOP-3343

### Current Behavior:

[drivers](https://www.mongodb.com/docs/drivers/)
[landing](https://www.mongodb.com/docs/)
[app services](https://www.mongodb.com/docs/atlas/app-services/)
[tutorials](https://www.mongodb.com/docs/guides/)

### Staging Links:

[drivers](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-3343/drivers/seung.park/DOP-3343/)
[landing](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/seung.park/DOP-3343/)
[app services](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-3343/atlas-app-services/seung.park/DOP-3343/)
[tutorials](https://docs-mongodbcom-integration.corp.mongodb.com/f81f5376b71fbcec68989e99960e545694b29098/DOP-3343/guides/seung.park/DOP-3343/atlas/account/)

### Notes:
this change may have resulted in the change of [LG/emotion ](https://github.com/mongodb/snooty/compare/v0.13.28...v0.13.28-branding#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R3887). classNames are taking precedence in the more granular definition of components

screenshot (from prod) shows that LGLink styling is taking precedence over wrapper `<SideNavItem as={Link}>` styling
![image](https://user-images.githubusercontent.com/13054820/200419909-c655f02d-1cd5-4ef6-8595-3e1a76c1c925.png)
 