### PR TITLE
DOP-2591: fix styling on 'on this page'

### DIFF
--- a/src/components/Contents/ContentsList.js
+++ b/src/components/Contents/ContentsList.js
@@ -2,16 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Label } from '../Select';
+import { palette } from '@leafygreen-ui/palette';
 
 const List = styled('ul')`
   list-style-type: none;
   padding: 0;
 `;
 
+const StyledLabel = styled(Label)`
+  font-weight: 500;
+  color: ${palette.gray.dark1};
+`;
+
 const ContentsList = ({ children, label }) => {
   return (
     <>
-      <Label>{label}</Label>
+      <StyledLabel>{label}</StyledLabel>
       <List>{children}</List>
     </>
   );

--- a/src/components/Contents/ContentsList.js
+++ b/src/components/Contents/ContentsList.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { Label } from '../Select';
 import { palette } from '@leafygreen-ui/palette';
+import { Label } from '../Select';
 
 const List = styled('ul')`
   list-style-type: none;


### PR DESCRIPTION
### Stories/Links:

DOP-2591

### Current Behavior:

[right column in compass](https://www.mongodb.com/docs/compass/current/collections/)
[right column in guides](https://www.mongodb.com/docs/guides/)

### Staging Links:

[right column in compass](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-2591/compass/seung.park/DOP-2591/collections/)
[right column in guides](https://docs-mongodbcom-integration.corp.mongodb.com/master/guides/seung.park/DOP-2591/)

### Notes:
- the changes are evident in the `on this page` and `chapters` labels on the right column