### PR TITLE
DOP-3362: include slug in url when changing versions

### DIFF
--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -12,6 +12,7 @@ const RootProvider = ({
   children,
   headingNodes,
   selectors,
+  slug,
   repoBranches,
   associatedReposInfo,
   isAssociatedProduct,
@@ -21,6 +22,7 @@ const RootProvider = ({
       <HeaderContextProvider>
         <VersionContextProvider
           repoBranches={repoBranches}
+          slug={slug}
           associatedReposInfo={associatedReposInfo}
           isAssociatedProduct={isAssociatedProduct}
         >

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -116,7 +116,7 @@ const VersionDropdown = ({ repoBranches: { branches, groups, siteBasePrefix }, s
   // Used exclusively by the LG Select component's onChange function, which receives
   // the 'value' prop from the selected Option component
   const navigate = (optionValue) => {
-    const destination = getUrl(optionValue, project, siteMetadata, siteBasePrefix);
+    const destination = getUrl(optionValue, project, siteMetadata, siteBasePrefix, slug);
     reachNavigate(destination);
   };
 

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -100,7 +100,7 @@ const VersionContext = createContext({
   onVersionSelect: () => {},
 });
 
-const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociatedProduct, children }) => {
+const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociatedProduct, slug, children }) => {
   const metadata = useSiteMetadata();
   const mountRef = useRef(true);
 
@@ -165,10 +165,10 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
         return;
       }
       const target = targetBranch.urlSlug || targetBranch.urlAliases[0] || targetBranch.gitBranchName;
-      const urlTarget = getUrl(target, metadata.project, metadata, repoBranches?.siteBasePrefix);
+      const urlTarget = getUrl(target, metadata.project, metadata, repoBranches?.siteBasePrefix, slug);
       navigate(urlTarget);
     },
-    [availableVersions, metadata, repoBranches]
+    [availableVersions, metadata, repoBranches.siteBasePrefix, slug]
   );
 
   // attempts to find branch by given url alias. can be alias, urlAliases, or gitBranchName

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -89,6 +89,7 @@ const DefaultLayout = ({
       <Global styles={globalCSS} />
       <SiteMetadata siteTitle={title} />
       <RootProvider
+        slug={slug}
         repoBranches={repoBranches}
         associatedReposInfo={associatedReposInfo}
         headingNodes={page?.options?.headings}

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -3,10 +3,10 @@ import { generatePrefix } from '../components/VersionDropdown/utils';
 import { assertTrailingSlash } from './assert-trailing-slash';
 import { normalizePath } from './normalize-path';
 
-export const getUrl = (branchUrlSlug, project, siteMetadata, siteBasePrefix) => {
+export const getUrl = (branchUrlSlug, project, siteMetadata, siteBasePrefix, slug) => {
   if (branchUrlSlug === 'legacy') {
     return `${baseUrl()}legacy/?site=${project}`;
   }
   const prefixWithVersion = generatePrefix(branchUrlSlug, siteMetadata, siteBasePrefix);
-  return assertTrailingSlash(normalizePath(`${prefixWithVersion}`));
+  return assertTrailingSlash(normalizePath(`${prefixWithVersion}/${slug}`));
 };


### PR DESCRIPTION
### Stories/Links:

DOP-3362

### Current Behavior:

[prod behavior](https://www.mongodb.com/docs/manual/core/data-modeling-introduction/)
flipping the version on the left side does not automatically take you to the **same page** on a different version of the doc

### Staging Links:

[staged changes](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/seung.park/DOP-3362/core/data-modeling-introduction/)
changing the version on the left side leads to a 404 (but this is desired) since url parsing is not working well between environments, but correct slug is being appended to the destination URL

### Notes:
- would be neat to clean up url parse to work interchangeably with environments, as a follow up to env cleanups