### PR TITLE
DOP-3361: moving around metadata

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,8 +135,9 @@ exports.createPages = async ({ actions }) => {
 
     if (process.env.GATSBY_TEST_EMBED_VERSIONS) {
       // fetch associated child products
+      const productList = manifestMetadata?.associated_products || [];
       await Promise.all(
-        siteMetadata.associatedProducts.map(async (product) => {
+        productList.map(async (product) => {
           associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
           // filter all branches of associated repo by associated versions only
           associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
@@ -268,15 +269,5 @@ exports.createSchemaCustomization = ({ actions }) => {
     type SnootyMetadata implements Node @dontInfer {
         metadata: JSON!
     }
-
-    type AssociatedProduct {
-      name: String,
-      versions: [String]
-    }
-
-    type SiteSiteMetadata implements Node {
-      associatedProducts: [AssociatedProduct],
-    }
-
   `);
 };

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -18,10 +18,6 @@ export const useSiteMetadata = () => {
             snootyBranch
             snootyEnv
             user
-            associatedProducts {
-              name
-              versions
-            }
           }
         }
       }

--- a/src/utils/site-metadata.js
+++ b/src/utils/site-metadata.js
@@ -60,7 +60,6 @@ const getPathPrefix = (pathPrefix) => {
  * Get site metadata used to identify this build and query correct documents
  */
 const siteMetadata = {
-  associatedProducts: manifestMetadata['associated_products'] || [],
   commitHash: process.env.COMMIT_HASH || '',
   database: getDatabase(process.env.SNOOTY_ENV),
   reposDatabase: getReposDatabase(process.env.SNOOTY_ENV),

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -14,13 +14,21 @@ const setProjectAndAssociatedProducts = () => {
     site: {
       siteMetadata: {
         project: project,
-        associatedProducts: [
-          {
-            name: 'atlas-cli',
-            versions: ['v1.1', 'v1.2', 'master'],
-          },
-        ],
       },
+    },
+    allSnootyMetadata: {
+      nodes: [
+        {
+          metadata: {
+            associated_products: [
+              {
+                name: 'atlas-cli',
+                versions: ['v1.1', 'v1.2', 'master'],
+              },
+            ],
+          },
+        },
+      ],
     },
   }));
 };


### PR DESCRIPTION
Minor clean up: Follow up to DOP-3361:

Moving the `associated_products` property from front end graphql's `siteMetadata` to `snootyMetadata` as it should be.

SiteMetadata should contain info about the site being built and all other metadata should be obtainable from snootyMetadata node

**status:** ready for review

**regression staging links** :
[cloud docs](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3361-follow-up/)
[atlas cli](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/seung.park/DOP-3361-follow-up/)
[docs landing](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/seung.park/DOP-3361-follow-up/)