### PR TITLE
DOP-3265: Update header colors for new hero image on Landing page

### DIFF
--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -120,6 +120,10 @@ const Landing = ({ children }) => {
           }
           main h1:first-of-type {
             color: ${palette.white};
+
+            @media ${screenSize.upToMedium} {
+              color: ${palette.green.dark2};
+            }
           }
           .span-columns {
             grid-column: 3 / -3 !important;
@@ -160,12 +164,18 @@ const Landing = ({ children }) => {
             grid-column: 2 / 8;
             grid-row: 2 / 3;
 
-            p {
-              color: ${palette.white};
-            }
-
             @media ${screenSize.upToMedium} {
               grid-column: 2 / -2;
+
+              p {
+                color: ${palette.black};
+              }
+            }
+
+            @media ${screenSize.mediumAndUp} {
+              p {
+                color: ${palette.white};
+              }
             }
           }
           @media ${screenSize.upToLarge} {

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -118,6 +118,9 @@ const Landing = ({ children }) => {
               grid-column: 2 / -2;
             }
           }
+          main h1:first-of-type {
+            color: ${palette.white};
+          }
           .span-columns {
             grid-column: 3 / -3 !important;
             margin: ${size.xlarge} 0;
@@ -156,6 +159,10 @@ const Landing = ({ children }) => {
           .introduction {
             grid-column: 2 / 8;
             grid-row: 2 / 3;
+
+            p {
+              color: ${palette.white};
+            }
 
             @media ${screenSize.upToMedium} {
               grid-column: 2 / -2;


### PR DESCRIPTION
### Stories/Links:

[DOP-3265](https://jira.mongodb.org/browse/DOP-3265)

### Current Behavior:

[Current Site](https://www.mongodb.com/docs/)

### Staging Links:

[Staging Site with this new text color](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-3265-illustrations/landing/matt.meigs/DOP-3265-landing/)

### Notes:

Overwrites leafygreen's h1 color to match the [figma designs](https://www.figma.com/file/2ZUCjznoCNNFhEzuaMTw8c/Docs-Homepage?node-id=532%3A3406) with the new hero image on the Landing page.
Alters the body's text over the hero image as well."

- Has media queries because below "medium" size screen, the text leaves the image and is on top of a white background.

Note: This PR is needed to deploy along with the new landing site hero image to ensure readability with its change as well.
