### PR TITLE
DOP-2863: escape HTML characters in search preview

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -13,6 +13,7 @@ import useScreenSize from '../../hooks/useScreenSize';
 import { theme } from '../../theme/docsTheme';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { getSearchbarResultsFromJSON } from '../../utils/get-searchbar-results-from-json';
+import { escapeHtml } from '../../utils/escape-reserved-html-characters';
 import { searchParamsToURL } from '../../utils/search-params-to-url';
 import SearchContext from '../Searchbar/SearchContext';
 import SearchFilters from '../Searchbar/SearchFilters';
@@ -349,7 +350,7 @@ const SearchResults = () => {
                         reportAnalytics('SearchSelection', { areaFrom: 'ResultsPage', rank: index, selectionUrl: url })
                       }
                       title={title}
-                      preview={preview}
+                      preview={escapeHtml(preview)}
                       url={url}
                       useLargeTitle
                       searchProperty={searchProperty?.[0]}

--- a/src/utils/escape-reserved-html-characters.js
+++ b/src/utils/escape-reserved-html-characters.js
@@ -1,0 +1,13 @@
+/**
+ * Replaces HTML-reserved characters with safe equivalents when
+ * dangerously setting inner HTML (e.g. for search previews).
+ * See DOP-2863 for rationale.
+ */
+export const escapeHtml = (unsafe) => {
+  return unsafe
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+};


### PR DESCRIPTION
### Stories/Links:

DOP-2863

### Current Behavior:

[\<boolean\> left out of search preview in prod](https://www.mongodb.com/docs/search/?q=exists)

### Staging Links:

[Landing with "exists" search query and visible \<boolean\>](https://docs-mongodbcom-integration.corp.mongodb.com/master/landing/allison/master/search/?q=exists)

### Notes:
I am not attached to the naming of the util if folks have better ideas. `replaceAll` is apparently great on all 2020+ browsers; if we need to support older ones, I can swap it to `replace` with a regex, but this seems reasonable to me (particularly since I don't think we *have* an official list of supported browsers?).