### PR TITLE
DOP-3236: add font size for field component

### DIFF
--- a/src/components/FieldList/Field.js
+++ b/src/components/FieldList/Field.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import ComponentFactory from '../ComponentFactory';
+import { theme } from '../../theme/docsTheme';
 
 const Field = ({ nodeData: { children, label, name }, ...rest }) => (
   <tr
     css={css`
+      font-size: ${theme.fontSize.default};
       > th,
       > td {
         padding: 11px 5px 12px;

--- a/tests/unit/__snapshots__/FieldList.test.js.snap
+++ b/tests/unit/__snapshots__/FieldList.test.js.snap
@@ -14,6 +14,10 @@ exports[`renders correctly 1`] = `
   vertical-align: top;
 }
 
+.emotion-2 {
+  font-size: 16px;
+}
+
 .emotion-2>th,
 .emotion-2>td {
   padding: 11px 5px 12px;


### PR DESCRIPTION
### Stories/Links:

DOP-3236
updating font size on `return` statements for Code examples

### Current Behavior:

[server docs example](https://www.mongodb.com/docs/manual/reference/method/KeyVault.addKeyAlternateName/#mongodb-method-KeyVault.addKeyAlternateName)
[server docs example 2](https://www.mongodb.com/docs/manual/reference/method/db.collection.replaceOne/#definition)

### Staging Links:

[staged server docs example 1](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/seung.park/DOP-3236/reference/method/KeyVault.addKeyAlternateName/#mongodb-method-KeyVault.addKeyAlternateName)
[staged server docs example 2](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/seung.park/DOP-3236/reference/method/db.collection.replaceOne/#definition)

