### PR TITLE
DOP-3327: Move entire dangling node in appendTrailingPunctuation() rather than just value

### DIFF
--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -26,13 +26,7 @@ export const appendTrailingPunctuation = (nodes) => {
 function deepCopyNodesChildren(refNode) {
   if (!refNode.children || !refNode.children.length) return { ...refNode };
   const copyOfChildren = [...refNode.children];
-  const lastChild = copyOfChildren.pop();
 
-  const deepCopyLastChild = {
-    ...lastChild,
-  };
-
-  copyOfChildren.push(deepCopyLastChild);
   const copyOfNode = {
     ...refNode,
     children: copyOfChildren,

--- a/src/utils/append-trailing-punctuation.js
+++ b/src/utils/append-trailing-punctuation.js
@@ -11,7 +11,8 @@ export const appendTrailingPunctuation = (nodes) => {
     // ie: regex match for  .?!,:;)*"']}`
 
     if (isReference && hasDanglingSibling) {
-      const copyOfNodeWithDeepCopiedChildren = deepCopyNodesChildren(currNode, nextNode.value);
+      const copyOfNodeWithDeepCopiedChildren = deepCopyNodesChildren(currNode);
+      copyOfNodeWithDeepCopiedChildren.children.push(nextNode);
       truncatedNodes.push(copyOfNodeWithDeepCopiedChildren);
       i++;
       continue;
@@ -21,15 +22,14 @@ export const appendTrailingPunctuation = (nodes) => {
   return truncatedNodes;
 };
 
-// Make a copy of node with a deep copy of the new child node with added punctuation
-function deepCopyNodesChildren(refNode, additionalValue) {
+// Make a copy of node with a deep copy of the new child node
+function deepCopyNodesChildren(refNode) {
   if (!refNode.children || !refNode.children.length) return { ...refNode };
   const copyOfChildren = [...refNode.children];
   const lastChild = copyOfChildren.pop();
 
   const deepCopyLastChild = {
     ...lastChild,
-    value: lastChild.value + additionalValue,
   };
 
   copyOfChildren.push(deepCopyLastChild);

--- a/tests/unit/utils/append-trailing-punctuation.test.js
+++ b/tests/unit/utils/append-trailing-punctuation.test.js
@@ -1,0 +1,114 @@
+import { appendTrailingPunctuation } from '../../../src/utils/append-trailing-punctuation';
+
+describe('appendTrailingPunctuation()', () => {
+  it('does not strip trailing periods from sentences ending with a link', () => {
+    // See: https://jira.mongodb.org/browse/DOP-3327
+    const data = [
+      {
+        type: 'ref_role',
+        position: {
+          start: {
+            line: {
+              $numberInt: '65',
+            },
+          },
+        },
+        children: [
+          {
+            type: 'literal',
+            position: {
+              start: {
+                line: {
+                  $numberInt: '65',
+                },
+              },
+            },
+            children: [
+              {
+                type: 'text',
+                position: {
+                  start: {
+                    line: {
+                      $numberInt: '65',
+                    },
+                  },
+                },
+                value: 'mongosh',
+              },
+            ],
+          },
+        ],
+        domain: 'mongodb',
+        name: 'binary',
+        target: 'bin.mongosh',
+        flag: '~',
+        url: 'https://www.mongodb.com/docs/mongodb-shell/#mongodb-binary-bin.mongosh',
+      },
+      {
+        type: 'text',
+        position: {
+          start: {
+            line: {
+              $numberInt: '65',
+            },
+          },
+        },
+        value: '.',
+      },
+    ];
+    const result = appendTrailingPunctuation(data);
+    expect(result).toEqual([
+      {
+        type: 'ref_role',
+        position: {
+          start: {
+            line: {
+              $numberInt: '65',
+            },
+          },
+        },
+        children: [
+          {
+            type: 'literal',
+            position: {
+              start: {
+                line: {
+                  $numberInt: '65',
+                },
+              },
+            },
+            children: [
+              {
+                type: 'text',
+                position: {
+                  start: {
+                    line: {
+                      $numberInt: '65',
+                    },
+                  },
+                },
+                value: 'mongosh',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            position: {
+              start: {
+                line: {
+                  $numberInt: '65',
+                },
+              },
+            },
+            value: '.',
+          },
+        ],
+        domain: 'mongodb',
+        name: 'binary',
+        target: 'bin.mongosh',
+        flag: '~',
+        url: 'https://www.mongodb.com/docs/mongodb-shell/#mongodb-binary-bin.mongosh',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This fixes an issue where a trailing period would be appended in to the value of a node type with no value field, effectively causing the period to be truncated.

### Stories/Links:

DOP-3327

### Current Behavior:

* https://www.mongodb.com/docs/atlas/cli/stable/

### Staging Links:

* https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/heli/DOP-3327/

### Notes:
