### PR TITLE
DOP-3289: Moved button font styling to IOToggle styled div to overrid…

### DIFF
--- a/src/components/Code/CodeIO.js
+++ b/src/components/Code/CodeIO.js
@@ -12,10 +12,8 @@ import Output from '../Code/Output';
 
 const outputButtonStyling = LeafyCss`
   padding: 0px;
-  font-size: ${theme.fontSize.tiny};
   height: 24px;
   margin: 8px;
-  font-weight: bold;
 `;
 
 const CodeIO = ({ nodeData: { children }, ...rest }) => {
@@ -89,6 +87,10 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
 const IOToggle = styled.div`
   ${borderCodeStyle}
   border-top: none;
+  button {
+    font-size: ${theme.fontSize.tiny}; //Styling placed here to override Tabs styling precedence.
+    font-weight: normal;
+  }
 `;
 
 CodeIO.propTypes = {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -264,6 +264,11 @@ exports[`CodeIO renders correctly 1`] = `
   border-top: none;
 }
 
+.emotion-14 button {
+  font-size: 12px;
+  font-weight: normal;
+}
+
 .emotion-16 {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -298,10 +303,8 @@ exports[`CodeIO renders correctly 1`] = `
   font-weight: 500;
   height: 36px;
   padding: 0px;
-  font-size: 12px;
   height: 24px;
   margin: 8px;
-  font-weight: bold;
 }
 
 .emotion-16:focus {


### PR DESCRIPTION
…e Tab styling precedence. Comment added.

### Stories/Links:

DOP-3289

### Current Behavior:

[The HIDE OUTPUT/VIEW OUTPUT button in the IO code blocks is a big bold menace, and a stubborn one at that.
](https://www.mongodb.com/docs/guides/crud/read_operators/)
### Staging Links:

[Now unbolded and in a size 12!](https://docs-mongodbcom-integration.corp.mongodb.com/master/guides/cris.newsome/DOP-3289/crud/read_queries/)

### Notes:
