### PR TITLE
DOP-3403: guides

### DIFF
--- a/src/components/Chapters/Chapter.js
+++ b/src/components/Chapters/Chapter.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import Card from '@leafygreen-ui/card';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
 import ChapterNumberLabel from './ChapterNumberLabel';
@@ -13,7 +14,7 @@ import { getPlaintext } from '../../utils/get-plaintext';
 // Height and width of image
 const IMAGE_SIZE = 200;
 
-const Container = styled(Card)`
+const cardStyling = css`
   background-color: ${palette.white};
   border: 1px solid ${palette.gray.light3};
   padding: ${theme.size.large} ${theme.size.medium};
@@ -79,7 +80,7 @@ const ChapterTitle = styled('div')`
   margin-top: ${theme.size.small};
 `;
 
-const ChapterDescription = styled(Body)`
+const decriptionStyling = css`
   margin-top: ${theme.size.small};
 `;
 
@@ -152,7 +153,7 @@ const Chapter = ({ metadata, nodeData: { argument, options } }) => {
   return (
     // TODO: have to return specific typography here. card is explicit size 13 font
 
-    <Container id={currentChapter?.id}>
+    <Card className={cx(cardStyling)} id={currentChapter?.id}>
       {image ? (
         <ChapterImage
           src={withPrefix(image)}
@@ -166,7 +167,7 @@ const Chapter = ({ metadata, nodeData: { argument, options } }) => {
       <DescriptionContainer>
         <ChapterNumberLabel number={chapterNumber} />
         <ChapterTitle>{chapterTitle}</ChapterTitle>
-        <ChapterDescription>{description}</ChapterDescription>
+        <Body className={cx(decriptionStyling)}>{description}</Body>
       </DescriptionContainer>
       <GuidesList>
         {guides.map((guide, i) => {
@@ -183,7 +184,7 @@ const Chapter = ({ metadata, nodeData: { argument, options } }) => {
           );
         })}
       </GuidesList>
-    </Container>
+    </Card>
   );
 };
 

--- a/src/components/Contents/ContentsListItem.js
+++ b/src/components/Contents/ContentsListItem.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
+import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import Link from '../Link';
 import { theme } from '../../theme/docsTheme';
@@ -13,7 +12,7 @@ const activeBorderLeftCSS = css`
   padding-left: 0;
 `;
 
-const ListItem = styled('li')`
+const listItemStyling = ({ isActive }) => css`
   padding: 6px 0 6px 1px;
 
   &:hover,
@@ -22,7 +21,7 @@ const ListItem = styled('li')`
   }
 
   @media ${theme.screenSize.largeAndUp} {
-    ${({ isActive }) => (isActive ? activeBorderLeftCSS : `border-left: 1px solid ${palette.gray.light2};`)}
+    ${isActive ? activeBorderLeftCSS : `border-left: 1px solid ${palette.gray.light2};`}
 
     &:hover,
     &:active {
@@ -31,19 +30,20 @@ const ListItem = styled('li')`
   }
 `;
 
-const StyledLink = styled(Link)`
+const linkStyling = ({ depth, isActive }) => css`
   color: ${palette.black};
   font-size: ${theme.fontSize.small};
   line-height: ${theme.fontSize.default};
+  font-weight: normal;
 
-  ${({ isActive }) => (isActive ? `font-weight: 600;` : `font-weight: normal;`)}
+  ${isActive && ` font-weight: 600;`}
 
   display: inline-block;
-  padding-left: ${({ depth }) => `${depth * LINK_DEPTH_PADDING}px`};
+  padding-left: ${`${depth * LINK_DEPTH_PADDING}px`};
   width: 100%;
 
   @media ${theme.screenSize.largeAndUp} {
-    padding-left: calc(14px + ${({ depth }) => depth * LINK_DEPTH_PADDING}px);
+    padding-left: calc(14px + ${depth * LINK_DEPTH_PADDING}px);
   }
 
   :hover,
@@ -55,11 +55,11 @@ const StyledLink = styled(Link)`
 
 const ContentsListItem = ({ children, depth = 0, id, isActive = false }) => {
   return (
-    <ListItem isActive={isActive}>
-      <StyledLink to={`#${id}`} depth={depth} isActive={isActive}>
+    <li className={listItemStyling({ isActive })} isActive={isActive}>
+      <Link className={linkStyling({ depth, isActive })} to={`#${id}`} depth={depth} isActive={isActive}>
         {children}
-      </StyledLink>
-    </ListItem>
+      </Link>
+    </li>
   );
 };
 

--- a/src/components/DriversIndexTiles.js
+++ b/src/components/DriversIndexTiles.js
@@ -138,7 +138,7 @@ const DriversIndexTiles = () => {
     <StyledGrid>
       {tiles.map((t) => (
         <GatsbyLink key={t.title} to={t.slug}>
-          <LeafyGreenCard className={cx(cardStyling, 'styled-card-from-driver-index-tiles')}>
+          <LeafyGreenCard className={cx(cardStyling)}>
             <StyledIcon>{t.icon}</StyledIcon>
             {t.title}
           </LeafyGreenCard>

--- a/tests/unit/__snapshots__/Chapter.test.js.snap
+++ b/tests/unit/__snapshots__/Chapter.test.js.snap
@@ -3,6 +3,20 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  position: relative;
+  -webkit-transition: 150ms ease-in-out;
+  transition: 150ms ease-in-out;
+  transition-property: border,box-shadow;
+  border: 1px solid #E8EDEB;
+  box-shadow: 0 4px 10px -4px rgba(0,30,43,0.3);
+  background-color: white;
+  color: #1C2D38;
+  border-radius: 24px;
+  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 24px;
+  min-height: 68px;
   background-color: #FFFFFF;
   border: 1px solid #F9FBFA;
   padding: 32px 24px;
@@ -36,24 +50,7 @@ exports[`renders correctly 1`] = `
   }
 }
 
-.emotion-2 {
-  position: relative;
-  -webkit-transition: 150ms ease-in-out;
-  transition: 150ms ease-in-out;
-  transition-property: border,box-shadow;
-  border: 1px solid #E8EDEB;
-  box-shadow: 0 4px 10px -4px rgba(0,30,43,0.3);
-  background-color: white;
-  color: #1C2D38;
-  border-radius: 24px;
-  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
-  font-size: 13px;
-  line-height: 20px;
-  padding: 24px;
-  min-height: 68px;
-}
-
-.emotion-3 {
+.emotion-1 {
   display: block;
   margin: 0 auto 24px auto;
   height: auto;
@@ -61,13 +58,13 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-3 {
+  .emotion-1 {
     grid-area: image;
     margin-bottom: 0;
   }
 }
 
-.emotion-5 {
+.emotion-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,12 +79,12 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-5 {
+  .emotion-3 {
     grid-area: description;
   }
 }
 
-.emotion-7 {
+.emotion-5 {
   background-color: #E3FCF7;
   border-radius: 4px;
   color: #001E2B;
@@ -99,17 +96,13 @@ exports[`renders correctly 1`] = `
   width: 83px;
 }
 
-.emotion-9 {
+.emotion-7 {
   font-size: 18px;
   font-weight: bold;
   margin-top: 8px;
 }
 
-.emotion-11 {
-  margin-top: 8px;
-}
-
-.emotion-13 {
+.emotion-9 {
   margin: unset;
   font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -117,14 +110,15 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
   color: #001E2B;
   font-weight: 400;
+  margin-top: 8px;
 }
 
-.emotion-13 strong,
-.emotion-13 b {
+.emotion-9 strong,
+.emotion-9 b {
   font-weight: 700;
 }
 
-.emotion-14 {
+.emotion-10 {
   list-style-type: none;
   list-style-image: url(/assets/lightning-bolt.svg);
   margin-bottom: 0;
@@ -134,12 +128,12 @@ exports[`renders correctly 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-14 {
+  .emotion-10 {
     grid-area: guides;
   }
 }
 
-.emotion-17 {
+.emotion-13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -166,15 +160,15 @@ exports[`renders correctly 1`] = `
   line-height: 24px;
 }
 
-.emotion-17:focus {
+.emotion-13:focus {
   outline: none;
 }
 
-.emotion-17>code {
+.emotion-13>code {
   color: #016BF8;
 }
 
-.emotion-17::after {
+.emotion-13::after {
   content: '';
   position: absolute;
   width: 100%;
@@ -184,25 +178,25 @@ exports[`renders correctly 1`] = `
   border-radius: 2px;
 }
 
-.emotion-17:focus .emotion-17::after {
+.emotion-13:focus .emotion-13::after {
   background-color: #0498EC;
 }
 
-.emotion-17:hover::after {
+.emotion-13:hover::after {
   background-color: #E8EDEB;
 }
 
-.emotion-17:hover {
+.emotion-13:hover {
   background-color: #E8EDEB;
   color: unset;
 }
 
-.emotion-17:hover::after {
+.emotion-13:hover::after {
   content: none;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: center;
     -webkit-box-align: center;
     -ms-flex-align: center;
@@ -218,40 +212,40 @@ exports[`renders correctly 1`] = `
 }
 
 <div
-    class="emotion-0 emotion-1 emotion-2"
+    class="emotion-0"
     id="atlas"
   >
     <img
-      class="emotion-3 emotion-4"
+      class="emotion-1 emotion-2"
       height="200"
       src="/images/chapter-image-atlas.png"
       width="200"
     />
     <div
-      class="emotion-5 emotion-6"
+      class="emotion-3 emotion-4"
     >
       <div
-        class="emotion-7 emotion-8"
+        class="emotion-5 emotion-6"
       >
         Chapter 1
       </div>
       <div
-        class="emotion-9 emotion-10"
+        class="emotion-7 emotion-8"
       >
         Atlas
       </div>
       <p
-        class="emotion-11 emotion-12 emotion-13"
+        class="emotion-9"
       >
         Get up and running with MongoDB Atlas. Learn how to create a cluster, load a sample dataset, and get your connection information.
       </p>
     </div>
     <ul
-      class="emotion-14 emotion-15"
+      class="emotion-10 emotion-11"
     >
       <li>
         <a
-          class="emotion-16 emotion-17"
+          class="emotion-12 emotion-13"
           href="/cloud/account/"
         >
           <span>
@@ -264,7 +258,7 @@ exports[`renders correctly 1`] = `
       </li>
       <li>
         <a
-          class="emotion-16 emotion-17"
+          class="emotion-12 emotion-13"
           href="/cloud/connectionstring/"
         >
           <span>
@@ -275,7 +269,7 @@ exports[`renders correctly 1`] = `
       </li>
       <li>
         <a
-          class="emotion-16 emotion-17"
+          class="emotion-12 emotion-13"
           href="/cloud/migrate-from-aws-to-atlas/"
         >
           <span>


### PR DESCRIPTION
### Stories/Links:

DOP-3403
Goal is to convert any `styled` leafygreen components into classNames so that this can be SSR'ed and not hydrated. 
This PR aims to only affect guides, given the scope of these components (chapters, contentlistitem -> is this used elsewhere? 

### Current Behavior:

guides on prod
https://www.mongodb.com/docs/guides/

### Staging Links:

guides with staged changes
https://docs-mongodbcom-integration.corp.mongodb.com/master/guides/seung.park/DOP-3403-guides/

regression check for ContentListItem
https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/seung.park/DOP-3403-guides/crud/

### Notes:
see prod version for a flash of styles that should be overwritten (ie. card padding, right column link styling)

