### PR TITLE
DOP-2077: add robots meta to Helmet

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,6 +3,7 @@ import { ThemeProvider } from '@emotion/react';
 import { renderStylesToString } from '@leafygreen-ui/emotion';
 import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { renderToString } from 'react-dom/server';
+import { Helmet } from 'react-helmet';
 import { theme } from './src/theme/docsTheme';
 
 export const onRenderBody = ({ setHeadComponents }) => {
@@ -23,6 +24,12 @@ export const onRenderBody = ({ setHeadComponents }) => {
         __html: `!function(e,t,r,n){if(!e[n]){for(var a=e[n]=[],i=["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],s=0;s<i.length;s++){var c=i[s];a[c]=a[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);a.push([e,t])}}(c)}a.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+r+"/"+n+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,"Dk30CC86ba0nATlK","delighted");`,
       }}
     />,
+    // Set meta on SSR here.
+    // Add dynamic meta, required on page render.
+    // React Helmet will override with any nested/latter tags from SSR'ed components.
+    <Helmet>
+      <meta name="robots" content="index"></meta>
+    </Helmet>,
   ]);
 };
 

--- a/src/html.js
+++ b/src/html.js
@@ -12,7 +12,6 @@ const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyCom
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
       <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-      <meta name="robots" content="index" />
       <meta name="release" content="1.0" />
       <meta name="version" content="master" />
       <meta property="og:image" content={metaUrl} />


### PR DESCRIPTION
### Stories/Links:

DOP-2077
This PR adds the `name="robots"`  meta tag to the Helmet package so it is overwrite-able by nested or latter components

### Current Behavior:

[staging link incoming with master branch](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-open-service-broker/seung.park/master/)
note above link has two meta tags with the above tag

### Staging Links:

[staged link with repo branch as noted below](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-open-service-broker/seung.park/DOP-2077/)

### Notes:
- both staged links are coming from[ this branch](https://github.com/schmalliso/cloud-docs-osb)
