### PR TITLE
DOP-3459: Bump Consistent Nav Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@leafygreen-ui/tooltip": "^7.1.0",
         "@leafygreen-ui/typography": "^13.0.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "1.2.16",
+        "@mdb/consistent-nav": "1.2.27",
         "@mdb/flora": "^0.20.5",
         "@mdx-js/react": "^1.6.22",
         "adm-zip": "^0.5.9",
@@ -4772,9 +4772,9 @@
       }
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.2.16",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.16.tgz",
-      "integrity": "sha1-k+7iwo2qtuUZSIi9UoQVGfvW8C4=",
+      "version": "1.2.27",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.27.tgz",
+      "integrity": "sha512-SnhdhN62UEf7cRB6W9BFAF0vzJpt80LnpgbW89n+Z7ywusmeJ/iYt511mWgBWoRGcXZaNtzcifRe9yocRkXBcA==",
       "license": "ISC",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
@@ -40175,9 +40175,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "1.2.16",
-      "resolved": "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.16.tgz",
-      "integrity": "sha1-k+7iwo2qtuUZSIi9UoQVGfvW8C4=",
+      "version": "1.2.27",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.27.tgz",
+      "integrity": "sha512-SnhdhN62UEf7cRB6W9BFAF0vzJpt80LnpgbW89n+Z7ywusmeJ/iYt511mWgBWoRGcXZaNtzcifRe9yocRkXBcA==",
       "requires": {}
     },
     "@mdb/flora": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@leafygreen-ui/tooltip": "^7.1.0",
     "@leafygreen-ui/typography": "^13.0.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "1.2.16",
+    "@mdb/consistent-nav": "1.2.27",
     "@mdb/flora": "^0.20.5",
     "@mdx-js/react": "^1.6.22",
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
### Stories/Links:

DOP-3459

### Staging Links:

_Put a link to your staging environment(s), if applicable_

#### Guides
https://docs-mongodbcom-integration.corp.mongodb.com/master/guides/cassidy.schaufele/DOP-3459/

#### Atlas
https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/cassidy.schaufele/DOP-3459/

### Notes:
Bumps us to 1.2.27 of the `consistent-nav`. See [conversation 1](https://mongodb.slack.com/archives/C020RL04PS7/p1673301365715419) and [conversation 2](https://mongodb.slack.com/archives/C02BMJU3K36/p1674072730455029) for additional context.

New version changes some links to promote Developer Data Platform positioning.


