### PR TITLE
DOP-3469: Do not build OpenAPI pages using snooty except for :preview: page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -76,7 +76,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       });
     }
 
-    if (filename.endsWith('.txt') && !isOpenApiCliPage(RESOLVED_REF_DOC_MAPPING[key], filename)) {
+    if (filename.endsWith('.txt') && !isOpenApiCliPage(filename, manifestMetadata)) {
       PAGES.push(key);
     }
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,6 +8,7 @@ const { getPageSlug } = require('./src/utils/get-page-slug');
 const { manifestMetadata, siteMetadata } = require('./src/utils/site-metadata');
 const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
+const { isOpenApiCliPage } = require('./src/utils/is-openapi-cli-page');
 const { manifestDocumentDatabase, stitchDocumentDatabase } = require('./src/init/DocumentDatabase.js');
 
 // different types of references
@@ -75,10 +76,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       });
     }
 
-    if (
-      filename.endsWith('.txt') &&
-      (pageNode?.options?.template !== 'openapi' || filename.match(/openapi\/preview/))
-    ) {
+    if (filename.endsWith('.txt') && !isOpenApiCliPage(RESOLVED_REF_DOC_MAPPING[key], filename)) {
       PAGES.push(key);
     }
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -75,7 +75,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       });
     }
 
-    if (filename.endsWith('.txt')) {
+    if (
+      filename.endsWith('.txt') &&
+      (pageNode?.options?.template !== 'openapi' || filename.match(/openapi\/preview/))
+    ) {
       PAGES.push(key);
     }
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,6 @@ const { getPageSlug } = require('./src/utils/get-page-slug');
 const { manifestMetadata, siteMetadata } = require('./src/utils/site-metadata');
 const { assertTrailingSlash } = require('./src/utils/assert-trailing-slash');
 const { constructPageIdPrefix } = require('./src/utils/setup/construct-page-id-prefix');
-const { isOpenApiCliPage } = require('./src/utils/is-openapi-cli-page');
 const { manifestDocumentDatabase, stitchDocumentDatabase } = require('./src/init/DocumentDatabase.js');
 
 // different types of references
@@ -76,7 +75,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
       });
     }
 
-    if (filename.endsWith('.txt') && !isOpenApiCliPage(filename, manifestMetadata)) {
+    if (filename.endsWith('.txt') && !manifestMetadata.openapi_pages?.[key]) {
       PAGES.push(key);
     }
   });

--- a/src/utils/is-openapi-cli-page.js
+++ b/src/utils/is-openapi-cli-page.js
@@ -1,7 +1,0 @@
-const isOpenApiCliPage = (filename, manifestMetadata) => {
-  const openapi_pages = Object.keys(manifestMetadata.openapi_pages);
-  const trimmedFilename = filename.slice(0, -4);
-  return openapi_pages.some((name) => name === trimmedFilename);
-};
-
-module.exports.isOpenApiCliPage = isOpenApiCliPage;

--- a/src/utils/is-openapi-cli-page.js
+++ b/src/utils/is-openapi-cli-page.js
@@ -1,5 +1,7 @@
-const isOpenApiCliPage = (pageNode, filename) => {
-  return pageNode?.ast?.options?.template === 'openapi' && !filename.match(/openapi\/preview/);
+const isOpenApiCliPage = (filename, manifestMetadata) => {
+  const openapi_pages = Object.keys(manifestMetadata.openapi_pages);
+  const trimmedFilename = filename.slice(0, -4);
+  return openapi_pages.some((name) => name === trimmedFilename);
 };
 
 module.exports.isOpenApiCliPage = isOpenApiCliPage;

--- a/src/utils/is-openapi-cli-page.js
+++ b/src/utils/is-openapi-cli-page.js
@@ -1,0 +1,5 @@
+const isOpenApiCliPage = (pageNode, filename) => {
+  return pageNode?.ast?.options?.template === 'openapi' && !filename.match(/openapi\/preview/);
+};
+
+module.exports.isOpenApiCliPage = isOpenApiCliPage;


### PR DESCRIPTION
### Stories/Links:

[DOP-3469](https://jira.mongodb.org/browse/DOP-3469)

### Notes:

The current SSR OpenAPI implementation using Redoc CLI is up and running. For safety, this was enabled to overwrite the file that Snooty currently still builds using the frontend Redoc component. We have no need to build the client-side page anymore. 

This PR disables a snooty frontend page build on all openapi pages except for one - [the docs-landing preview page](https://www.mongodb.com/docs/openapi/preview/).