### PR TITLE
DOP-3388-B: Writer preview build conditioned on string "production" rather than "prd"

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,8 @@ const { siteMetadata } = require('./src/utils/site-metadata');
 const pathPrefix = generatePathPrefix(siteMetadata);
 
 // TODO: Gatsby v4 will enable code splitting automatically. Delete duplicate components, add conditional for consistent-nav UnifiedNav in DefaultLayout
-const isFullBuild = siteMetadata.snootyEnv !== 'prd' || process.env.PREVIEW_BUILD_ENABLED?.toUpperCase() !== 'TRUE';
+const isFullBuild =
+  siteMetadata.snootyEnv !== 'production' || process.env.PREVIEW_BUILD_ENABLED?.toUpperCase() !== 'TRUE';
 const layoutComponentRelativePath = `./src/layouts/${isFullBuild ? 'index' : `preview-layout`}.js`;
 
 module.exports = {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -203,7 +203,7 @@ exports.createPages = async ({ actions }) => {
 
       // TODO: Gatsby v4 will enable code splitting automatically. Delete duplicate component, add conditional for consistent-nav UnifiedFooter
       const isFullBuild =
-        siteMetadata.snootyEnv !== 'prd' || process.env.PREVIEW_BUILD_ENABLED.toUpperCase() !== 'TRUE';
+        siteMetadata.snootyEnv !== 'production' || process.env.PREVIEW_BUILD_ENABLED.toUpperCase() !== 'TRUE';
       const mainComponentRelativePath = `./src/components/DocumentBody${isFullBuild ? '' : 'Preview'}.js`;
 
       if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -203,7 +203,7 @@ exports.createPages = async ({ actions }) => {
 
       // TODO: Gatsby v4 will enable code splitting automatically. Delete duplicate component, add conditional for consistent-nav UnifiedFooter
       const isFullBuild =
-        siteMetadata.snootyEnv !== 'production' || process.env.PREVIEW_BUILD_ENABLED.toUpperCase() !== 'TRUE';
+        siteMetadata.snootyEnv !== 'production' || process.env.PREVIEW_BUILD_ENABLED?.toUpperCase() !== 'TRUE';
       const mainComponentRelativePath = `./src/components/DocumentBody${isFullBuild ? '' : 'Preview'}.js`;
 
       if (RESOLVED_REF_DOC_MAPPING[page] && Object.keys(RESOLVED_REF_DOC_MAPPING[page]).length > 0) {


### PR DESCRIPTION
### Stories/Links:

Original ticket
[DOP-3388](https://jira.mongodb.org/browse/DOP-3388)

### Notes:

Preview build is based off of two conditions being true: the exact environment name(`siteMetadata.snootyEnv`) being equal to "prd" and the `PREVIEW_BUILD_ENABLED` flag uppercased being strictly equal to "TRUE". 

The `PREVIEW_BUILD_ENABLED` flag is correctly set in a gitPush "writer's build" job [as seen in within the ECS instance](https://us-east-2.console.aws.amazon.com/ecs/v2/task-definitions/docs-worker-pool-prd/30/json?region=us-east-2).

However, the environment designated for preview build (prd) sets the environment string passed to `siteMetadata.snootyEnv` from `SNOOTY_ENV` which is not equal to "prd" but rather set to "production" [here](https://github.com/mongodb/docs-worker-pool/blob/master/infrastructure/ecs-main/serverless.yml#L145-L150).