### PR TITLE
return a deferred promise for login when calling realm functions

### DIFF
--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -5,15 +5,23 @@ const config = {
   id: SNOOTY_STITCH_ID,
 };
 const app = new Realm.App(config);
+let loginDefer;
 
-const loginAnonymous = async () => {
-  const credentials = Realm.Credentials.anonymous();
-  try {
-    const user = await app.logIn(credentials);
-    return user;
-  } catch (err) {
-    console.error('Failed to log in', err);
+const loginAnonymous = () => {
+  if (loginDefer) {
+    return loginDefer;
   }
+  loginDefer = new Promise(async (res, rej) => {
+    try {
+      const credentials = Realm.Credentials.anonymous();
+      const user = await app.logIn(credentials);
+      res(user);
+    } catch (err) {
+      console.error('Failed to log in', err);
+      rej(err);
+    }
+  });
+  return loginDefer;
 };
 
 const fetchData = async (funcName, ...argsList) => {


### PR DESCRIPTION
### Stories/Links:

[DOP-3473](https://jira.mongodb.org/browse/DOP-3473)

### Current Behavior:

current behavior when you (first load ie. incognito window) any docs website, is that you would see multiple network requests to `https://stitch.mongodb.com/api/client/v2.0/app/snooty-koueq/auth/providers/anon-user/login`:

![image](https://user-images.githubusercontent.com/13054820/215526932-8ca692a2-beff-435b-8ddb-0736d0998e10.png)

https://www.mongodb.com/docs/atlas/

### Staging Links:

on the staged link, you should see only one request to the above URL. (two, given feedback realm app requires a login as well)

https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3473/
