### PR TITLE
Embedded minor fixup: include empty toc

### DIFF
--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -70,9 +70,7 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
         }
       }
 
-      if (clonedNode.children?.length) {
-        clonedToc.children.push(clonedNode);
-      }
+      clonedToc.children.push(clonedNode);
     }
     return clonedToc;
   }, [activeVersions, remoteToc]);


### PR DESCRIPTION
minor fix up on filtering ToC.

while investigating https://jira.mongodb.org/browse/DOP-3499, I noticed that we are hiding a ToC node if it's children list was empty. although the children list should ideally not be empty (this was a bug as noted in DOP-3499), it should still render the original ToC node without the children list.

**note**: bad data highlighted in DOP-3499 is used in the staging links below

[staged master branch with embedded flag on](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/master/) (notice atlas-cli is completely missing, due to bad data)
[staged change (notice atlas-cli ToC is present, but missing children due to bad data)](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/minor-toc-fix/)