### PR TITLE
DOP-3515

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -127,10 +127,15 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
   if (process.env.GATSBY_TEST_EMBED_VERSIONS === 'true') {
     let umbrellaMetadata;
     try {
-      umbrellaMetadata = await db.stitchInterface.getMetadata({
-        'associated_products.name': siteMetadata.project,
-        is_merged_toc: true,
-      });
+      umbrellaMetadata = await db.stitchInterface.getMetadata(
+        {
+          'associated_products.name': siteMetadata.project,
+          is_merged_toc: true,
+        },
+        {
+          sort: { build_id: -1 },
+        }
+      );
       isAssociatedProduct = !!umbrellaMetadata;
     } catch (e) {
       console.log('No umbrella product found. Not an associated product.');
@@ -228,7 +233,6 @@ exports.createPages = async ({ actions }) => {
   } catch (e) {
     console.error('Error while fetching metadata from Atlas, falling back to manifest metadata');
     console.error(e);
-    metadata = siteMetadata;
   }
 
   return new Promise((resolve, reject) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -19,6 +19,7 @@ let RESOLVED_REF_DOC_MAPPING = {};
 const assets = new Map();
 
 let db;
+let isAssociatedProduct;
 
 exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => {
   const { createNode } = actions;
@@ -130,6 +131,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
         'associated_products.name': siteMetadata.project,
         is_merged_toc: true,
       });
+      isAssociatedProduct = !!umbrellaMetadata;
     } catch (e) {
       console.log('No umbrella product found. Not an associated product.');
     }
@@ -151,8 +153,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
 exports.createPages = async ({ actions }) => {
   const { createPage } = actions;
 
-  let repoBranches = null,
-    isAssociatedProduct = false;
+  let repoBranches = null;
   const associatedReposInfo = {};
   try {
     const repoInfo = await db.stitchInterface.fetchRepoBranches();
@@ -169,17 +170,6 @@ exports.createPages = async ({ actions }) => {
           });
         })
       );
-
-      // check if product is associated child product
-      try {
-        const umbrellaProduct = await db.stitchInterface.getMetadata({
-          'associated_products.name': siteMetadata.project,
-        });
-        isAssociatedProduct = !!umbrellaProduct;
-      } catch (e) {
-        console.log('No umbrella product found. Not an associated product.');
-        isAssociatedProduct = false;
-      }
     }
     let errMsg;
 
@@ -260,7 +250,6 @@ exports.createPages = async ({ actions }) => {
             repoBranches,
             associatedReposInfo,
             remoteMetadata: metadata,
-            isAssociatedProduct,
             template: pageNodes?.options?.template,
             page: pageNodes,
           },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -120,7 +120,32 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
     },
     parent: null,
     metadata: metadataMinusStatic,
+    isRoot: true,
   });
+
+  if (process.env.GATSBY_TEST_EMBED_VERSIONS === 'true') {
+    let umbrellaMetadata;
+    try {
+      umbrellaMetadata = await db.stitchInterface.getMetadata({
+        'associated_products.name': siteMetadata.project,
+        is_merged_toc: true,
+      });
+    } catch (e) {
+      console.log('No umbrella product found. Not an associated product.');
+    }
+
+    createNode({
+      children: [],
+      id: createNodeId('umbrella'),
+      internal: {
+        contentDigest: createContentDigest(umbrellaMetadata),
+        type: 'SnootyMetadata',
+      },
+      parent: null,
+      metadata: umbrellaMetadata,
+      isUmbrella: true,
+    });
+  }
 };
 
 exports.createPages = async ({ actions }) => {
@@ -272,7 +297,9 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type SnootyMetadata implements Node @dontInfer {
-        metadata: JSON!
+      metadata: JSON!
+      isRoot: Boolean
+      isUmbrella: Boolean
     }
   `);
 };

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -96,12 +96,14 @@ const Link = ({
   const shouldHideExternalIcon =
     !anchor && !(to.includes('www.mongodb.com/docs/') || to.match(/docs.*mongodb.com/)) ? false : true;
   const hideExternalIcon = hideExternalIconProp ?? shouldHideExternalIcon;
+  const target = hideExternalIcon ? '_self' : undefined;
 
   return (
     <LGLink
       className={joinClassNames(LGlinkStyling, className)}
       href={to}
       hideExternalIcon={hideExternalIcon}
+      target={target}
       {...other}
     >
       {children}

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -15,18 +15,12 @@ const RootProvider = ({
   slug,
   repoBranches,
   associatedReposInfo,
-  isAssociatedProduct,
   remoteMetadata,
 }) => (
   <TabProvider selectors={selectors}>
     <ContentsProvider headingNodes={headingNodes}>
       <HeaderContextProvider>
-        <VersionContextProvider
-          repoBranches={repoBranches}
-          slug={slug}
-          associatedReposInfo={associatedReposInfo}
-          isAssociatedProduct={isAssociatedProduct}
-        >
+        <VersionContextProvider repoBranches={repoBranches} slug={slug} associatedReposInfo={associatedReposInfo}>
           <TocContextProvider remoteMetadata={remoteMetadata}>
             <NavigationProvider>
               <SidenavContextProvider>{children}</SidenavContextProvider>

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -12,6 +12,7 @@ import ChapterNumberLabel from '../Chapters/ChapterNumberLabel';
 import VersionDropdown from '../VersionDropdown';
 import useStickyTopValues from '../../hooks/useStickyTopValues';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
+import { useUmbrellaMetadata } from '../../hooks/use-umbrella-metadata';
 import { theme } from '../../theme/docsTheme';
 import { formatText } from '../../utils/format-text';
 import { baseUrl } from '../../utils/base-url';
@@ -217,7 +218,9 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
     return <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={toctree} />;
   }, [chapters, guides, hideMobileSidenav, isGuidesLanding, isGuidesTemplate, page, slug, toctree, activeToc]);
 
-  const navTitle = isGuidesTemplate ? guides?.[slug]?.['chapter_name'] : siteTitle;
+  // TODO: update navTitle value here based on new useUmbrellaMetadata
+  const { title: umbrellaTitle } = useUmbrellaMetadata();
+  const navTitle = isGuidesTemplate ? guides?.[slug]?.['chapter_name'] : umbrellaTitle || siteTitle;
 
   const guidesChapterNumber = useMemo(() => {
     if (!isGuidesTemplate) {

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -288,7 +288,8 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 <SideNavItem
                   className={cx(titleStyle, sideNavItemBasePadding)}
                   as={Link}
-                  to={isGuidesTemplate ? slug : '/'}
+                  to={isGuidesTemplate ? slug : activeToc?.url || '/'}
+                  hideExternalIcon={true}
                 >
                   {navTitle}
                 </SideNavItem>

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -150,7 +150,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
       <NodeLink />
       {isOpen &&
         children.map((c) => {
-          const key = c.slug || c.url;
+          const key = `${c?.options?.version || ''}-${c.slug || c.url}`;
           return (
             <TOCNode activeSection={activeSection} handleClick={handleClick} node={c} level={level + 1} key={key} />
           );

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -3,6 +3,7 @@ import { navigate } from '@reach/router';
 import { BRANCHES_COLLECTION, METADATA_COLLECTION } from '../build-constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useCurrentUrlSlug } from '../hooks/use-current-url-slug';
+import { useUmbrellaMetadata } from '../hooks/use-umbrella-metadata';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { fetchDocument, fetchDocuments } from '../utils/realm';
 import { getUrl } from '../utils/url-utils';
@@ -103,7 +104,7 @@ const VersionContext = createContext({
   onVersionSelect: () => {},
 });
 
-const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociatedProduct, slug, children }) => {
+const VersionContextProvider = ({ repoBranches, associatedReposInfo, slug, children }) => {
   const metadata = useSiteMetadata();
   const { associated_products: associatedProducts } = useSnootyMetadata();
   const mountRef = useRef(true);
@@ -137,7 +138,8 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [showVersionDropdown, setShowVersionDropdown] = useState(isAssociatedProduct);
+  const umbrellaMetadata = useUmbrellaMetadata();
+  const [showVersionDropdown, setShowVersionDropdown] = useState(Object.keys(umbrellaMetadata).length > 0);
   useEffect(() => {
     getUmbrellaProject(metadata.project, metadata.database).then((metadataList) => {
       if (!mountRef.current) {

--- a/src/hooks/use-umbrella-metadata.js
+++ b/src/hooks/use-umbrella-metadata.js
@@ -1,0 +1,13 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+export const useUmbrellaMetadata = () => {
+  const data = useStaticQuery(graphql`
+    query UmbrellaMetadata {
+      snootyMetadata(isUmbrella: { eq: true }) {
+        metadata
+      }
+    }
+  `);
+
+  return data.snootyMetadata?.metadata || {};
+};

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -76,7 +76,7 @@ const GlobalGrid = styled('div')`
 
 const DefaultLayout = ({
   children,
-  pageContext: { page, slug, repoBranches, template, associatedReposInfo, isAssociatedProduct, remoteMetadata },
+  pageContext: { page, slug, repoBranches, template, associatedReposInfo, remoteMetadata },
 }) => {
   const { sidenav } = getTemplate(template);
   const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol } = useSnootyMetadata();
@@ -94,7 +94,6 @@ const DefaultLayout = ({
         associatedReposInfo={associatedReposInfo}
         headingNodes={page?.options?.headings}
         selectors={page?.options?.selectors}
-        isAssociatedProduct={isAssociatedProduct}
         remoteMetadata={remoteMetadata}
       >
         <GlobalGrid>

--- a/src/layouts/preview-layout.js
+++ b/src/layouts/preview-layout.js
@@ -155,10 +155,7 @@ const GlobalGrid = styled('div')`
   grid-template-rows: auto 1fr;
 `;
 
-const DefaultLayout = ({
-  children,
-  pageContext: { page, slug, repoBranches, template, associatedReposInfo, isAssociatedProduct },
-}) => {
+const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, template, associatedReposInfo } }) => {
   const { sidenav } = getTemplate(template);
   const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol } = useSnootyMetadata();
 
@@ -175,7 +172,6 @@ const DefaultLayout = ({
         associatedReposInfo={associatedReposInfo}
         headingNodes={page?.options?.headings}
         selectors={page?.options?.selectors}
-        isAssociatedProduct={isAssociatedProduct}
       >
         <GlobalGrid>
           <PreviewHeader sidenav={sidenav} />

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -8,6 +8,7 @@ import MainColumn from '../components/MainColumn';
 import RightColumn from '../components/RightColumn';
 import TabSelectors from '../components/Tabs/TabSelectors';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { useUmbrellaMetadata } from '../hooks/use-umbrella-metadata';
 import { getNestedValue } from '../utils/get-nested-value';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
 import AssociatedVersionSelector from '../components/AssociatedVersionSelector';
@@ -28,9 +29,10 @@ const StyledRightColumn = styled(RightColumn)`
   grid-area: right;
 `;
 
-const Document = ({ children, pageContext: { slug, page, repoBranches, isAssociatedProduct } }) => {
+const Document = ({ children, pageContext: { slug, page, repoBranches } }) => {
   const { project } = useSiteMetadata();
   const { parentPaths, slugToTitle, title, toctreeOrder } = useSnootyMetadata();
+  const { project: umbrellaProject } = useUmbrellaMetadata();
   const pageOptions = page?.options;
   const showPrevNext = !(pageOptions?.noprevnext === '' || pageOptions?.template === 'guide');
   const isLanding = project === 'landing';
@@ -53,7 +55,7 @@ const Document = ({ children, pageContext: { slug, page, repoBranches, isAssocia
         </div>
       </StyledMainColumn>
       <StyledRightColumn>
-        {isAssociatedProduct && <AssociatedVersionSelector />}
+        {umbrellaProject && <AssociatedVersionSelector />}
         <TabSelectors />
         <Contents displayOnDesktopOnly={true} />
       </StyledRightColumn>

--- a/src/utils/use-snooty-metadata.js
+++ b/src/utils/use-snooty-metadata.js
@@ -3,13 +3,11 @@ import { useStaticQuery, graphql } from 'gatsby';
 export default function useSnootyMetadata() {
   const data = useStaticQuery(graphql`
     query Metadata {
-      allSnootyMetadata {
-        nodes {
-          metadata
-        }
+      snootyMetadata(isRoot: { eq: true }) {
+        metadata
       }
     }
   `);
 
-  return data.allSnootyMetadata.nodes[0].metadata;
+  return data.snootyMetadata.metadata;
 }

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -16,19 +16,15 @@ const setProjectAndAssociatedProducts = () => {
         project: project,
       },
     },
-    allSnootyMetadata: {
-      nodes: [
-        {
-          metadata: {
-            associated_products: [
-              {
-                name: 'atlas-cli',
-                versions: ['v1.1', 'v1.2', 'master'],
-              },
-            ],
+    snootyMetadata: {
+      metadata: {
+        associated_products: [
+          {
+            name: 'atlas-cli',
+            versions: ['v1.1', 'v1.2', 'master'],
           },
-        },
-      ],
+        ],
+      },
     },
   }));
 };

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -69,8 +69,7 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 <a
     class="constant-classname emotion-0"
     href="https://www.mongodb.com/docs/"
-    rel="noopener noreferrer"
-    target="_blank"
+    target="_self"
   >
     <span
       class="emotion-1"
@@ -158,8 +157,7 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 <a
     class="constant-classname emotion-0"
     href="https://www.mongodb.com/docs/view-analyze"
-    rel="noopener noreferrer"
-    target="_blank"
+    target="_self"
   >
     <span
       class="emotion-1"
@@ -317,8 +315,7 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 <a
     class="constant-classname emotion-0"
     href="https://www.mongodb.com/docs/"
-    rel="noopener noreferrer"
-    target="_blank"
+    target="_self"
   >
     <span
       class="emotion-1"

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -159,8 +159,7 @@ exports[`renders correctly with pageTitle 1`] = `
     <a
       class="constant-classname emotion-1"
       href="https://www.mongodb.com/docs/"
-      rel="noopener noreferrer"
-      target="_blank"
+      target="_self"
     >
       <span
         class="emotion-2"
@@ -342,8 +341,7 @@ exports[`renders correctly with siteTitle 1`] = `
     <a
       class="constant-classname emotion-1"
       href="https://www.mongodb.com/docs/"
-      rel="noopener noreferrer"
-      target="_blank"
+      target="_self"
     >
       <span
         class="emotion-2"

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -243,8 +243,7 @@ exports[`renders correctly 1`] = `
           <a
             class="constant-classname emotion-9"
             href="https://docs.atlas.mongodb.com/getting-started/"
-            rel="noopener noreferrer"
-            target="_blank"
+            target="_self"
           >
             <span
               class="emotion-10"
@@ -329,8 +328,7 @@ exports[`renders correctly 1`] = `
           <a
             class="constant-classname emotion-9"
             href="https://docs.mongodb.com/manual/tutorial/getting-started/"
-            rel="noopener noreferrer"
-            target="_blank"
+            target="_self"
           >
             <span
               class="emotion-10"

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -420,8 +420,7 @@ exports[`card correctly with and without url 1`] = `
           <a
             class="constant-classname emotion-30"
             href="https://docs.mongodb.com/realm/services/"
-            rel="noopener noreferrer"
-            target="_blank"
+            target="_self"
           >
             <span
               class="emotion-31"

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -396,8 +396,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         class="constant-classname emotion-8"
         data-leafygreen-ui="button"
         href="https://university.mongodb.com/certification/developer/about"
-        rel="noopener noreferrer"
-        target="_blank"
+        target="_self"
         type="button"
       >
         <span

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -143,8 +143,7 @@ exports[`Link component renders a variety of strings correctly external MDB docs
 <a
     class="constant-classname emotion-0"
     href="https://www.mongodb.com/docs/atlas/"
-    rel="noopener noreferrer"
-    target="_blank"
+    target="_self"
   >
     <span
       class="emotion-1"
@@ -394,8 +393,7 @@ exports[`Link component renders a variety of strings correctly external URL with
 <a
     class="constant-classname emotion-0"
     href="http://mongodb.com"
-    rel="noopener noreferrer"
-    target="_blank"
+    target="_self"
   >
     <span
       class="emotion-1"


### PR DESCRIPTION
### Stories/Links:

DOP-3515

**Goal:** include the title for umbrella project in ToC tree when it is a merged ToC tree of an associated product

### Current Behavior:

[previous staging link shows ToC header as link to atlas cli](https://docs-mongodbcom-integration.corp.mongodb.com/6b45acf4d24091d060809a4350fbe4a7ec8a51a2/master/atlas-cli/seung.park/DOP-3468/)

### Staging Links:

[atlas cli with atlas header for ToC tree](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/seung.park/DOP-3515/)

### Notes:
- refactored values being passed as context values down pages, as a separate graphql node using gatsby's `createNode` api. previously was passing `context.isAssociatedProduct` down the page components, but moved this to graphql service so components can query at build time but don't have to pass the context down the component line (document body, layout, etc)

- **QQ:** this data also lives in ToC tree as the root node as shown below, so wondering if showing the title from the root node would be a better choice than to store the umbrella project into graphql at build time
![image](https://user-images.githubusercontent.com/13054820/218836527-6b15b4ec-49f3-4cf4-9418-6f977c33ad58.png)

