### PR TITLE
fixup: make unique key for toc node with versions

### DIFF
--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -150,7 +150,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
       <NodeLink />
       {isOpen &&
         children.map((c) => {
-          const key = c.slug || c.url;
+          const key = `${c?.options?.version || ''}-${c.slug || c.url}`;
           return (
             <TOCNode activeSection={activeSection} handleClick={handleClick} node={c} level={level + 1} key={key} />
           );


### PR DESCRIPTION
minor fix. was encountering React error warnings for non unique key, with ToC nodes having same slug in associated metadata:

below metadata shows two ToC nodes with same slug with different options. key of Node JSX was throwing errors on master branch

![image](https://user-images.githubusercontent.com/13054820/218823878-dde36c61-0dfb-4147-b899-beb5e3a1b7f7.png)

produces errors on front end:

[staged changes](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/seung.park/unique-key-for-toc/)
[master branch with test data](https://docs-mongodbcom-integration.corp.mongodb.com/5aae0f7ee5aa0cbcc5d9ddf591fdcd31b349b35e/master/atlas-cli/seung.park/master/) (embedded version flag turned on) - nodes are failing to be removed because of their non unique keys. was encountering console issues as:

```
Warning: Encountered two children with the same key, `/`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    at TOCNode (webpack-internal:///./src/components/Sidenav/TOCNode.js:101:29)
    at Toctree (webpack-internal:///./src/components/Sidenav/Toctree.js:20:26)
    ...
```