### PR TITLE
DOP-3513 style version selector for overflow and mobile

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -72,7 +72,7 @@ const Select = ({
   }, [showSelect]);
 
   return (
-    <PortalContainer className={className} ref={portalContainer}>
+    <PortalContainer className={`${className} ${cx(selectStyle)}`} ref={portalContainer}>
       {showSelect && (
         <LGSelect
           data-testid="lg-select"

--- a/src/components/Sidenav/VersionSelector.js
+++ b/src/components/Sidenav/VersionSelector.js
@@ -24,8 +24,14 @@ const StyledSelect = styled(Select)`
   }
 
   > div:nth-of-type(2) {
-    min-width: 150px;
-    width: max-content;
+    width: 150px;
+    right: 0px;
+    left: unset;
+
+    @media ${theme.screenSize.upToLarge} {
+      width: max-content;
+      max-width: calc(100vw - (${theme.size.medium} * 2));
+    }
   }
 
   button {
@@ -36,6 +42,13 @@ const StyledSelect = styled(Select)`
       }
     }
     z-index: 3;
+  }
+
+  span {
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
   }
 `;
 

--- a/src/components/Sidenav/VersionSelector.js
+++ b/src/components/Sidenav/VersionSelector.js
@@ -31,6 +31,7 @@ const StyledSelect = styled(Select)`
     @media ${theme.screenSize.upToLarge} {
       width: max-content;
       max-width: calc(100vw - (${theme.size.medium} * 2));
+      // (max viewport width - padding) inferred from the max width of the side nav in mobile
     }
   }
 

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -443,11 +443,21 @@ exports[`Search Results Page considers a given search filter query param and dis
 }
 
 .emotion-44 {
+  width: 175px;
+}
+
+.emotion-46 {
   position: relative;
 }
 
-.emotion-45 {
-  width: 175px;
+@media only screen and (max-width: 1024px) {
+  .emotion-46 label,
+  .emotion-46 p,
+  .emotion-46 button,
+  .emotion-46 div,
+  .emotion-46 span {
+    font-size: 13px;
+  }
 }
 
 .emotion-47 {
@@ -1411,11 +1421,21 @@ exports[`Search Results Page does not return results for a given search term wit
 }
 
 .emotion-34 {
+  width: 175px;
+}
+
+.emotion-36 {
   position: relative;
 }
 
-.emotion-35 {
-  width: 175px;
+@media only screen and (max-width: 1024px) {
+  .emotion-36 label,
+  .emotion-36 p,
+  .emotion-36 button,
+  .emotion-36 div,
+  .emotion-36 span {
+    font-size: 13px;
+  }
 }
 
 .emotion-37 {
@@ -4178,11 +4198,21 @@ exports[`Search Results Page renders results from a given search term query para
 }
 
 .emotion-38 {
+  width: 175px;
+}
+
+.emotion-40 {
   position: relative;
 }
 
-.emotion-39 {
-  width: 175px;
+@media only screen and (max-width: 1024px) {
+  .emotion-40 label,
+  .emotion-40 p,
+  .emotion-40 button,
+  .emotion-40 div,
+  .emotion-40 span {
+    font-size: 13px;
+  }
 }
 
 .emotion-41 {

--- a/tests/unit/__snapshots__/Select.test.js.snap
+++ b/tests/unit/__snapshots__/Select.test.js.snap
@@ -6,6 +6,16 @@ exports[`Select renders select correctly 1`] = `
   position: relative;
 }
 
+@media only screen and (max-width: 1024px) {
+  .emotion-0 label,
+  .emotion-0 p,
+  .emotion-0 button,
+  .emotion-0 div,
+  .emotion-0 span {
+    font-size: 13px;
+  }
+}
+
 .emotion-1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -201,7 +211,7 @@ exports[`Select renders select correctly 1`] = `
 }
 
 <div
-    class="emotion-0"
+    class="undefined emotion-0"
   >
     <div
       class="emotion-1"


### PR DESCRIPTION
### Stories/Links:

DOP-3513

styling version dropdown for overflow and mobile views.
this PR only addresses styling so navigation via select dropdown is being addressed in DOP-3500

### Current Behavior:

[master branch cloud docs with embedded flag turned on](https://docs-mongodbcom-integration.corp.mongodb.com/5aae0f7ee5aa0cbcc5d9ddf591fdcd31b349b35e/master/cloud-docs/seung.park/HEAD/)

### Staging Links:

[atlas cli docs with version dropdown styled](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/seung.park/DOP-3513/)
[cloud docs with version dropdown styled](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/seung.park/DOP-3513/)

### Notes:
- the test data was produced by repeating the [text for the Select Option choice](https://github.com/mongodb/snooty/blob/master/src/components/Sidenav/VersionSelector.js#L9)
- there exist a bug where ToC tree has uncleared nodes appearing at top of tree addressed in [this PR](https://github.com/mongodb/snooty/pull/770) (due to non unique keys on toc items)
- mobile was styled to be (max width - padding) inferred from the max width of the side nav in general