### PR TITLE
add nullish check for associated products value

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -203,7 +203,7 @@ exports.createPages = async ({ actions }) => {
       project: manifestMetadata.project,
       branch: manifestMetadata.branch,
     };
-    if (isAssociatedProduct || manifestMetadata?.associated_products.length) {
+    if (isAssociatedProduct || manifestMetadata?.associated_products?.length) {
       filter['is_merged_toc'] = true;
     }
     const findOptions = {


### PR DESCRIPTION
there exists a catch block that mitigates this error (thankfully) but we should be checking for nulls before calling `.length`

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63efbd0205dd3cc814e5335f