### PR TITLE
DOP-3515

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -217,7 +217,9 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
     return <Toctree handleClick={() => hideMobileSidenav()} slug={slug} toctree={toctree} />;
   }, [chapters, guides, hideMobileSidenav, isGuidesLanding, isGuidesTemplate, page, slug, toctree, activeToc]);
 
-  const navTitle = isGuidesTemplate ? guides?.[slug]?.['chapter_name'] : siteTitle;
+  const navTitle = isGuidesTemplate
+    ? guides?.[slug]?.['chapter_name']
+    : formatText(process.env.GATSBY_TEST_EMBED_VERSIONS === 'true' ? activeToc.title : toctree.title);
 
   const guidesChapterNumber = useMemo(() => {
     if (!isGuidesTemplate) {


### PR DESCRIPTION
### Stories/Links:

DOP-3515
Upon investigation, found out that the root ToC node gets its `title.value` from the title field in snooty.toml.
Hence, we can use the root ToC's title field for both merged and non merged toc - merged ToC will have the root value of the umbrella project, which is the target change

### Current Behavior:

[atlas cli sourcing title from metadata.siteTitle on master branch](https://docs-mongodbcom-integration.corp.mongodb.com/81b3889cbaddf254120600b1342ff51b4a3848e8/master/atlas-cli/seung.park/HEAD/)

### Staging Links:

[atlas cli sourcing title from root ToC node on branch](https://docs-mongodbcom-integration.corp.mongodb.com/4bf10fb7fd84ee180bd3e37a4015d83e062a9b6c/master/atlas-cli/seung.park/DOP-3515-simple/) **the diff is in the header for the ToC tree**
