### PR TITLE
unrequire associated_products.versions on front end

### DIFF
--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -58,10 +58,8 @@ const getBranches = async (metadata, repoBranches, associatedReposInfo, associat
       const childRepoBranches = await fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, {
         project: product.name,
       });
-      // filter all branches of associated repo by associated versions only
-      versions[product.name] = childRepoBranches.branches.filter((branch) => {
-        return branch.active && product.versions.includes(branch.gitBranchName);
-      });
+      // filter all branches of associated repo by active property
+      versions[product.name] = childRepoBranches.branches.filter((branch) => branch.active);
     });
     promises.push(
       fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, { project: metadata.project }).then((res) => {


### PR DESCRIPTION
minor change to unrequire versions in snooty.toml  associated_products property

was testing couple PR's with [this line](https://github.com/10gen/cloud-docs/blob/b86dad571aac1116beec159313dbab7bfaa9bcf3/snooty.toml#L1111) removed and noticed the front end was still cross checking for options specified in snooty.toml