### PR TITLE
DOP-3541: Create node for remote metadata

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,10 +32,6 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
     await Promise.all(
       productList.map(async (product) => {
         associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
-        // filter all branches of associated repo by associated versions only
-        associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
-          return product.versions?.includes(branch.gitBranchName);
-        });
       })
     );
     // check if product is associated child product

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,6 +20,66 @@ const assets = new Map();
 
 let db;
 
+let isAssociatedProduct = false;
+const associatedReposInfo = {};
+
+// Creates node for RemoteMetadata, mostly used for Embedded Versions. If no associated products
+// or data are found, the node will be null
+const createRemoteMetadataNode = async ({ createNode, createNodeId, createContentDigest }) => {
+  if (process.env.GATSBY_TEST_EMBED_VERSIONS === 'true') {
+    // fetch associated child products
+    const productList = manifestMetadata?.associated_products || [];
+    await Promise.all(
+      productList.map(async (product) => {
+        associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
+        // filter all branches of associated repo by associated versions only
+        associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
+          return product.versions?.includes(branch.gitBranchName);
+        });
+      })
+    );
+    // check if product is associated child product
+    try {
+      const umbrellaProduct = await db.stitchInterface.getMetadata({
+        'associated_products.name': siteMetadata.project,
+      });
+      isAssociatedProduct = !!umbrellaProduct;
+    } catch (e) {
+      console.log('No umbrella product found. Not an associated product.');
+      isAssociatedProduct = false;
+    }
+  }
+
+  // get remote metadata for updated ToC in Atlas
+  try {
+    const filter = {
+      project: manifestMetadata.project,
+      branch: manifestMetadata.branch,
+    };
+    if (isAssociatedProduct || manifestMetadata?.associated_products?.length) {
+      filter['is_merged_toc'] = true;
+    }
+    const findOptions = {
+      sort: { build_id: -1 },
+    };
+    const remoteMetadata = await db.stitchInterface.getMetadata(filter, findOptions);
+
+    createNode({
+      children: [],
+      id: createNodeId('remoteMetadata'),
+      internal: {
+        contentDigest: createContentDigest(remoteMetadata),
+        type: 'RemoteMetadata',
+      },
+      parent: null,
+      remoteMetadata: remoteMetadata,
+    });
+  } catch (e) {
+    console.error('Error while fetching metadata from Atlas, falling back to manifest metadata');
+    console.error(e);
+  }
+};
+
 exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => {
   const { createNode } = actions;
 
@@ -98,6 +158,8 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
     });
   });
 
+  await createRemoteMetadataNode({ createNode, createNodeId, createContentDigest });
+
   await saveAssetFiles(assets, db);
   const { static_files: staticFiles, ...metadataMinusStatic } = await db.getMetadata();
 
@@ -126,36 +188,9 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => 
 exports.createPages = async ({ actions }) => {
   const { createPage } = actions;
 
-  let repoBranches = null,
-    isAssociatedProduct = false;
-  const associatedReposInfo = {};
+  let repoBranches = null;
   try {
     const repoInfo = await db.stitchInterface.fetchRepoBranches();
-
-    if (process.env.GATSBY_TEST_EMBED_VERSIONS === 'true') {
-      // fetch associated child products
-      const productList = manifestMetadata?.associated_products || [];
-      await Promise.all(
-        productList.map(async (product) => {
-          associatedReposInfo[product.name] = await db.stitchInterface.fetchRepoBranches(product.name);
-          // filter all branches of associated repo by associated versions only
-          associatedReposInfo[product.name].branches = associatedReposInfo[product.name].branches.filter((branch) => {
-            return product.versions?.includes(branch.gitBranchName);
-          });
-        })
-      );
-
-      // check if product is associated child product
-      try {
-        const umbrellaProduct = await db.stitchInterface.getMetadata({
-          'associated_products.name': siteMetadata.project,
-        });
-        isAssociatedProduct = !!umbrellaProduct;
-      } catch (e) {
-        console.log('No umbrella product found. Not an associated product.');
-        isAssociatedProduct = false;
-      }
-    }
     let errMsg;
 
     if (!repoInfo) {
@@ -196,26 +231,6 @@ exports.createPages = async ({ actions }) => {
     throw err;
   }
 
-  // get remote metadata for updated ToC in Atlas
-  let metadata = siteMetadata;
-  try {
-    const filter = {
-      project: manifestMetadata.project,
-      branch: manifestMetadata.branch,
-    };
-    if (isAssociatedProduct || manifestMetadata?.associated_products?.length) {
-      filter['is_merged_toc'] = true;
-    }
-    const findOptions = {
-      sort: { build_id: -1 },
-    };
-    metadata = await db.stitchInterface.getMetadata(filter, findOptions);
-  } catch (e) {
-    console.error('Error while fetching metadata from Atlas, falling back to manifest metadata');
-    console.error(e);
-    metadata = siteMetadata;
-  }
-
   return new Promise((resolve, reject) => {
     PAGES.forEach((page) => {
       const pageNodes = RESOLVED_REF_DOC_MAPPING[page]?.ast;
@@ -234,7 +249,6 @@ exports.createPages = async ({ actions }) => {
             slug,
             repoBranches,
             associatedReposInfo,
-            remoteMetadata: metadata,
             isAssociatedProduct,
             template: pageNodes?.options?.template,
             page: pageNodes,
@@ -289,7 +303,11 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type SnootyMetadata implements Node @dontInfer {
-        metadata: JSON!
+      metadata: JSON!
+    }
+
+    type RemoteMetadata implements Node @dontInfer {
+      remoteMetadata: JSON
     }
   `);
 };

--- a/src/hooks/use-remote-metadata.js
+++ b/src/hooks/use-remote-metadata.js
@@ -1,0 +1,17 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+// Return the remote metadata node
+export const useRemoteMetadata = () => {
+  const data = useStaticQuery(
+    graphql`
+      query RemoteMetadata {
+        allRemoteMetadata {
+          nodes {
+            remoteMetadata
+          }
+        }
+      }
+    `
+  );
+  return data.allRemoteMetadata.nodes[0].remoteMetadata;
+};

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
 import { theme } from '../theme/docsTheme';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { useRemoteMetadata } from '../hooks/use-remote-metadata';
 
 // TODO: Delete this as a part of the css cleanup
 // Currently used to preserve behavior and stop legacy css
@@ -75,10 +76,11 @@ const GlobalGrid = styled('div')`
 
 const DefaultLayout = ({
   children,
-  pageContext: { page, slug, repoBranches, template, associatedReposInfo, isAssociatedProduct, remoteMetadata },
+  pageContext: { page, slug, repoBranches, template, associatedReposInfo, isAssociatedProduct },
 }) => {
   const { sidenav } = getTemplate(template);
   const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol } = useSnootyMetadata();
+  const remoteMetadata = useRemoteMetadata();
 
   const pageTitle = React.useMemo(() => page?.options?.title || slugToTitle?.[slug === '/' ? 'index' : slug], [slug]); // eslint-disable-line react-hooks/exhaustive-deps
   useDelightedSurvey(slug);


### PR DESCRIPTION
### Stories/Links:

DOP-3541

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

* [Atlas](https://docs-mongodbcom-integration.corp.mongodb.com/master/cloud-docs/raymundrodriguez/DOP-3541/)
* [Atlas CLI](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-cli/raymundrodriguez/DOP-3541/)
* [Atlas App Services](https://docs-mongodbcom-integration.corp.mongodb.com/master/atlas-app-services/raymundrodriguez/DOP-3541/)
* [Server](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/raymundrodriguez/DOP-3541/)

### Notes:

* Uses a node for `remoteMetadata` instead of passing it in `pageContext`. Node schema is barebones for now. Logic changes are also minimal to ensure no differences in functionality.
* Merging this into the `gatsbyv4` branch for now since Gatsby v2 on the `master` branch is unaffected by `cloud-docs` not building. This is only on Gatsby v5. Might be good to cherry-pick this squashed commit into the `master` branch afterwards for consistency.