### PR TITLE
DOP-3549 DOP-3550

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef, useEffect, useState } from 'react';
+import React, { useRef, forwardRef } from 'react';
 import { cx, css } from '@leafygreen-ui/emotion';
 import styled from '@emotion/styled';
 import { Option, Select as LGSelect } from '@leafygreen-ui/select';
@@ -64,43 +64,35 @@ const Select = ({
 }) => {
   // show select after portal container has loaded for scroll + zindex consistency
   const portalContainer = useRef();
-  const [showSelect, setShowSelect] = useState(false);
-  useEffect(() => {
-    if (portalContainer.current && !showSelect) {
-      setShowSelect(true);
-    }
-  }, [showSelect]);
 
   return (
     <PortalContainer className={`${className} ${cx(selectStyle)}`} ref={portalContainer}>
-      {showSelect && (
-        <LGSelect
-          data-testid="lg-select"
-          value={value || ''}
-          label={label}
-          aria-labelledby={(!label && 'select') || null}
-          size="default"
-          allowDeselect={false}
-          disabled={disabled}
-          portalContainer={portalContainer.current}
-          scrollContainer={portalContainer.current}
-          popoverZIndex={2}
-          placeholder={defaultText}
-          defaultValue={value ? String(value) : ''}
-          onChange={(value) => {
-            onChange({ value });
-          }}
-          className={cx(selectStyle)}
-          {...props}
-        >
-          {choices.map((choice) => (
-            <Option className={cx(optionStyling)} key={choice.value} value={choice.value} role="option">
-              {choice.icon && <choice.icon className={cx(iconStyling)} />}
-              {choice.text}
-            </Option>
-          ))}
-        </LGSelect>
-      )}
+      <LGSelect
+        data-testid="lg-select"
+        value={value || ''}
+        label={label}
+        aria-labelledby={(!label && 'select') || null}
+        size="default"
+        allowDeselect={false}
+        disabled={disabled}
+        portalContainer={portalContainer.current}
+        scrollContainer={portalContainer.current}
+        popoverZIndex={2}
+        placeholder={defaultText}
+        defaultValue={value ? String(value) : ''}
+        onChange={(value) => {
+          onChange({ value });
+        }}
+        className={cx(selectStyle)}
+        {...props}
+      >
+        {choices.map((choice) => (
+          <Option className={cx(optionStyling)} key={choice.value} value={choice.value} role="option">
+            {choice.icon && <choice.icon className={cx(iconStyling)} />}
+            {choice.text}
+          </Option>
+        ))}
+      </LGSelect>
     </PortalContainer>
   );
 };

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -147,7 +147,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
 
   // project prop is passed down from parent ToC node
   // hide node if not active according to version context
-  if (parentProj && activeVersions[parentProj] && activeVersions[parentProj] !== options.version) {
+  if (parentProj && (!activeVersions[parentProj] || activeVersions[parentProj] !== options.version)) {
     return <></>;
   }
 

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -65,7 +65,7 @@ const Wrapper = ({ children, hasVersions, project, versions }) => {
  * Potential leaf node for the Table of Contents. May have children which are also
  * recursively TOCNodes.
  */
-const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) => {
+const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, parentProj = '' }) => {
   const { title, slug, url, children, options = {} } = node;
   const { activeVersions } = useContext(VersionContext);
   const target = options.urls?.[activeVersions[options.project]] || slug || url;
@@ -145,6 +145,12 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
     );
   };
 
+  // project prop is passed down from parent ToC node
+  // hide node if not active according to version context
+  if (parentProj && activeVersions[parentProj] && activeVersions[parentProj] !== options.version) {
+    return <></>;
+  }
+
   return (
     <>
       <NodeLink />
@@ -152,7 +158,14 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node }) 
         children.map((c) => {
           const key = `${c?.options?.version || ''}-${c.slug || c.url}`;
           return (
-            <TOCNode activeSection={activeSection} handleClick={handleClick} node={c} level={level + 1} key={key} />
+            <TOCNode
+              activeSection={activeSection}
+              handleClick={handleClick}
+              node={c}
+              level={level + 1}
+              key={key}
+              parentProj={options.project}
+            />
           );
         })}
     </>

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -83,6 +83,12 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
     setIsOpen(isActive);
   }, [isActive, isDrawer || hasChildren ? activeSection : null]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // project prop is passed down from parent ToC node
+  // hide node if not active according to version context
+  if (parentProj && (!activeVersions[parentProj] || activeVersions[parentProj] !== options.version)) {
+    return null;
+  }
+
   const onCaretClick = (event) => {
     event.preventDefault();
     setIsOpen(!isOpen);
@@ -144,12 +150,6 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
       </Wrapper>
     );
   };
-
-  // project prop is passed down from parent ToC node
-  // hide node if not active according to version context
-  if (parentProj && (!activeVersions[parentProj] || activeVersions[parentProj] !== options.version)) {
-    return <></>;
-  }
 
   return (
     <>

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -13,7 +13,7 @@ const TocContext = createContext({
 // ToC context that provides ToC content in form of *above*
 // filters all available ToC by currently selected version via VersionContext
 const TocContextProvider = ({ children, remoteMetadata }) => {
-  const { activeVersions, setActiveVersions, showVersionDropdown } = useContext(VersionContext);
+  const { activeVersions, showVersionDropdown } = useContext(VersionContext);
   const { toctree, associated_products: associatedProducts } = useSnootyMetadata();
   const { database, project, parserBranch } = useSiteMetadata();
   const [remoteToc, setRemoteToc] = useState();
@@ -75,27 +75,6 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
     return clonedToc;
   }, [activeVersions, remoteToc]);
 
-  const correctActiveVersion = useCallback(
-    (tocNode) => {
-      // go through toc tree and see if any active versions are not available
-      // fall back to most recent if not available
-      const newVersions = {};
-      for (let node of tocNode.children) {
-        if (!node?.options?.versions || !node?.options?.project) {
-          continue;
-        }
-        if (!node.options.versions.includes(activeVersions[node.options.project])) {
-          newVersions[node.options.project] = node.options.versions[0];
-        }
-      }
-
-      if (Object.keys(newVersions).length) {
-        setActiveVersions(newVersions);
-      }
-    },
-    [activeVersions, setActiveVersions]
-  );
-
   // initial effect is to fetch metadata
   // should only run once on init
   useEffect(() => {
@@ -103,10 +82,9 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
       return;
     }
     getTocMetadata().then((tocTreeResponse) => {
-      correctActiveVersion(tocTreeResponse);
       setRemoteToc(tocTreeResponse);
     });
-  }, [remoteToc, setRemoteToc, getTocMetadata, correctActiveVersion]);
+  }, [remoteToc, setRemoteToc, getTocMetadata]);
 
   // one effect depends on activeVersions
   // if activeVersion changes -> setActiveToc

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -97,6 +97,7 @@ const VersionContext = createContext({
   // active version for each product is marked is {[product name]: active version} pair
   setActiveVersions: () => {},
   availableVersions: {},
+  setAvailableVersions: () => {},
   showVersionDropdown: false,
   onVersionSelect: () => {},
 });

--- a/tests/context/toc-context.test.js
+++ b/tests/context/toc-context.test.js
@@ -148,13 +148,6 @@ describe('ToC Context', () => {
     setMocks();
   });
 
-  it('initializes ToC without versioned nodes if not in available versions', async () => {
-    await act(async () => {
-      wrapper = mountConsumer({}, {});
-    });
-    expect(wrapper.queryByText(/options/g)).toBeNull();
-  });
-
   it('sets ToC based on response realm app service response', async () => {
     await act(async () => {
       wrapper = mountConsumer();

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -223,7 +223,7 @@ describe('Version Context', () => {
     }
 
     // active checks
-    const expectedActive = { 'atlas-cli': 'master', 'cloud-docs': 'master' };
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'master' };
     expect(await wrapper.findByText(JSON.stringify(expectedActive))).toBeTruthy();
   });
 
@@ -242,7 +242,7 @@ describe('Version Context', () => {
     });
     const option = wrapper.getByText('atlas-cli-master');
     userEvent.click(option);
-    const expectedActive = { 'atlas-cli': 'master', 'cloud-docs': 'master' };
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'master' };
     expect(await wrapper.findByText(JSON.stringify(expectedActive))).toBeTruthy();
   });
 

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -899,8 +899,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-47"
             >
               <button
-                aria-controls="select-57-menu"
-                aria-describedby="select-57-description"
+                aria-controls="select-81-menu"
+                aria-describedby="select-81-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -908,7 +908,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 class="emotion-48"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-58"
+                id="select-82"
                 type="button"
                 value="Realm"
               >
@@ -956,8 +956,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-47"
             >
               <button
-                aria-controls="select-59-menu"
-                aria-describedby="select-59-description"
+                aria-controls="select-83-menu"
+                aria-describedby="select-83-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -966,7 +966,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-60"
+                id="select-84"
                 type="button"
                 value="Latest"
               >
@@ -1848,8 +1848,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-37"
             >
               <button
-                aria-controls="select-73-menu"
-                aria-describedby="select-73-description"
+                aria-controls="select-101-menu"
+                aria-describedby="select-101-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -1857,7 +1857,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 class="emotion-38"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-74"
+                id="select-102"
                 type="button"
                 value=""
               >
@@ -1905,8 +1905,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-37"
             >
               <button
-                aria-controls="select-75-menu"
-                aria-describedby="select-75-description"
+                aria-controls="select-103-menu"
+                aria-describedby="select-103-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -1915,7 +1915,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-76"
+                id="select-104"
                 type="button"
                 value=""
               >
@@ -4625,8 +4625,8 @@ exports[`Search Results Page renders results from a given search term query para
               class="emotion-41"
             >
               <button
-                aria-controls="select-41-menu"
-                aria-describedby="select-41-description"
+                aria-controls="select-61-menu"
+                aria-describedby="select-61-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -4634,7 +4634,7 @@ exports[`Search Results Page renders results from a given search term query para
                 class="emotion-42"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-42"
+                id="select-62"
                 type="button"
                 value=""
               >
@@ -4682,8 +4682,8 @@ exports[`Search Results Page renders results from a given search term query para
               class="emotion-41"
             >
               <button
-                aria-controls="select-43-menu"
-                aria-describedby="select-43-description"
+                aria-controls="select-63-menu"
+                aria-describedby="select-63-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -4692,7 +4692,7 @@ exports[`Search Results Page renders results from a given search term query para
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-44"
+                id="select-64"
                 type="button"
                 value=""
               >


### PR DESCRIPTION
### Stories/Links:

DOP-3550
DOP-3549

### Current Behavior:

[atlas cli](https://www.mongodb.com/docs/atlas/cli/upcoming/)
[atlas](https://www.mongodb.com/docs/atlas/)
[server docs](https://www.mongodb.com/docs/manual/)

### Staging Links:

[atlas cli](https://docs-mongodbcom-integration.corp.mongodb.com/3e2e1d8c5b30dee0c7fb0d80a29ce96f1e0f0e1f/master/atlas-cli/seung.park/DOP-3549/)
[atlas](https://docs-mongodbcom-integration.corp.mongodb.com/3e2e1d8c5b30dee0c7fb0d80a29ce96f1e0f0e1f/master/cloud-docs/seung.park/DOP-3549/)
[server docs (select component regression test)](https://docs-mongodbcom-integration.corp.mongodb.com/3e2e1d8c5b30dee0c7fb0d80a29ce96f1e0f0e1f/master/docs/seung.park/DOP-3549/)

### Notes:

- addresses DOP-3550 by removing the logic to `correct the active version` <- this was a race between version context and toc context, and [toc-context would attempt to correct the wrongly selected version](https://github.com/mongodb/snooty/pull/782/files#diff-67fd2be78a4e3484aedf9be9ed69bf5d5a356fa2a503d987deac14a4d2becfbeL78) before version context was loaded. updated the logic to `wait for version context, if ToC doesn't contain default version (according to repos_branches), fallback to first one in ToC`
- as for DOP-3549, we were seeing duplicated ToC nodes when navigating to the page because we are defaulting to the full toc tree, and then filtering based on version context. changed this logic to remove the filter (costly tree traversal) and a more react-like approach, to [return an empty JSX element for a flagged ToC node](https://github.com/mongodb/snooty/pull/782/files#diff-2d7a96ba34af02c762677b1fb55a5211639cdc8864420ff53db587e367a306f8R150)
- also improved initial load by initializing states with server side values passed down to context at build time, which were previously missing. this allows for SRR'ed pages with version dropdown:
[S3 file for atlas CLI](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/3e2e1d8c5b30dee0c7fb0d80a29ce96f1e0f0e1f/master/atlas-cli/seung.park/DOP-3549/?response-content-disposition=inline&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEB4aCXVzLWVhc3QtMSJHMEUCIQCOdgNVvi89R7Ocfey4VA2LFONLeaSgEEEMS2TtrTdgyAIgYidrhpBhRNI2nrJAavjNvqm6%2Bs25mhNSmwCn6Vw%2BV6IqngQI1v%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARACGgwyMTY2NTYzNDc4NTgiDPABnPo2QLhYeNhtwyryA5oCaHfrUusEOcYhmlFBHy6U2W2yUxLjDDaZS8FbxR18SwN%2B1rp7%2FpOH0KLfr9JVeLYSkc2H2EuL0XNktDFcXix5tEP%2Fjv4fjrcQQ0OXsWBd8odsQ2GIkMW5i6ARgBw18wsbdn1ZkxVULmxFUeBd%2FsYhkvX3VynH0Y4fuBSsHNcZsGoAt57rqL6CxT6bzatjBWAVyc7YopT4Q8U%2BzCRS2wddAqASI%2BnVUivUlTKjMFZStzB%2FlbPGoZZwwnpz9PRcEM0yhyxMLUDO2Ht%2BuaC4KSSsxgPYhjXkvjJkIr27zQfcMGXBhmFDuSE97leU29h6GaaEDVvwJ%2FV2gny63ozRtD8NxBKQYJrxJOImaHs9pUHqL%2BVrTTYZRi31mws%2F9tvgEhmK8A55nZgfNSRf%2BW1ZrMmy7Q14FRCietTpUMJqgVuxvKoGafkLWCw4ghl3Kt3W7aNh8okGVfPA32hfJkbtwl3w1tX49pFVVUflbraRGa%2B8HhPsYiEnDj9nkLLpy%2Bdo8952o3jHBQ1Ho2q4NsJSb5kkLbE%2Fx6BEOOBS1NIdl4yAaFcS%2B3PV2UQJqHoyRspGDSl5%2Fm5kAITvvWcwxwwMXbG6FBB2yb1Kz%2FqeNRMHQfKTL0CW8snpHYltyCwYdkwkA5cihTWBc%2B42jSPp0%2FiJD%2BKttDDK5cGgBjqUArtp9le8vA0k6WK7nlX1jod5PeMtG2nTxzOmSkni980KBieNWxzVnlsy7oUNESA9hVg8UhegnbdaKlBqKQeB812rnv6uuSnCx6f864aCtcd71nvGgJhJMzAv5TIuonCwzqfoHUhswPQGTvJQRbUO4crYBssgSUHpdXXgAZ2X6cMuijHzLNCmDELPMTG2pWORaKAtY141mjdTlMkuI0MV%2FklB4LiTVX4UV5OUwKTsYqfiB05lltqSTaZ4NOtLd%2FIbj3gTLkYpk%2B5Y90gTrA1xkKGHo15DnIZFVBNqwVj%2BpQwodIMxbHVt3JkT8hrkx0GuoA1fquU3%2FhKZAyUXg18S51SRcvo2Fa0MCoLK6Mp%2BiR19v4dMYw%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230314T131722Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=ASIATE4NZQLJO3JC6WNU%2F20230314%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Signature=12329a93b05c89182d24c9fe59478b3c5a48bf477827e285b6f37717e8427237)
[S3 index.html for atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/3e2e1d8c5b30dee0c7fb0d80a29ce96f1e0f0e1f/master/cloud-docs/seung.park/DOP-3549/?response-content-disposition=inline&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEB4aCXVzLWVhc3QtMSJHMEUCIQCOdgNVvi89R7Ocfey4VA2LFONLeaSgEEEMS2TtrTdgyAIgYidrhpBhRNI2nrJAavjNvqm6%2Bs25mhNSmwCn6Vw%2BV6IqngQI1v%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARACGgwyMTY2NTYzNDc4NTgiDPABnPo2QLhYeNhtwyryA5oCaHfrUusEOcYhmlFBHy6U2W2yUxLjDDaZS8FbxR18SwN%2B1rp7%2FpOH0KLfr9JVeLYSkc2H2EuL0XNktDFcXix5tEP%2Fjv4fjrcQQ0OXsWBd8odsQ2GIkMW5i6ARgBw18wsbdn1ZkxVULmxFUeBd%2FsYhkvX3VynH0Y4fuBSsHNcZsGoAt57rqL6CxT6bzatjBWAVyc7YopT4Q8U%2BzCRS2wddAqASI%2BnVUivUlTKjMFZStzB%2FlbPGoZZwwnpz9PRcEM0yhyxMLUDO2Ht%2BuaC4KSSsxgPYhjXkvjJkIr27zQfcMGXBhmFDuSE97leU29h6GaaEDVvwJ%2FV2gny63ozRtD8NxBKQYJrxJOImaHs9pUHqL%2BVrTTYZRi31mws%2F9tvgEhmK8A55nZgfNSRf%2BW1ZrMmy7Q14FRCietTpUMJqgVuxvKoGafkLWCw4ghl3Kt3W7aNh8okGVfPA32hfJkbtwl3w1tX49pFVVUflbraRGa%2B8HhPsYiEnDj9nkLLpy%2Bdo8952o3jHBQ1Ho2q4NsJSb5kkLbE%2Fx6BEOOBS1NIdl4yAaFcS%2B3PV2UQJqHoyRspGDSl5%2Fm5kAITvvWcwxwwMXbG6FBB2yb1Kz%2FqeNRMHQfKTL0CW8snpHYltyCwYdkwkA5cihTWBc%2B42jSPp0%2FiJD%2BKttDDK5cGgBjqUArtp9le8vA0k6WK7nlX1jod5PeMtG2nTxzOmSkni980KBieNWxzVnlsy7oUNESA9hVg8UhegnbdaKlBqKQeB812rnv6uuSnCx6f864aCtcd71nvGgJhJMzAv5TIuonCwzqfoHUhswPQGTvJQRbUO4crYBssgSUHpdXXgAZ2X6cMuijHzLNCmDELPMTG2pWORaKAtY141mjdTlMkuI0MV%2FklB4LiTVX4UV5OUwKTsYqfiB05lltqSTaZ4NOtLd%2FIbj3gTLkYpk%2B5Y90gTrA1xkKGHo15DnIZFVBNqwVj%2BpQwodIMxbHVt3JkT8hrkx0GuoA1fquU3%2FhKZAyUXg18S51SRcvo2Fa0MCoLK6Mp%2BiR19v4dMYw%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230314T131856Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=ASIATE4NZQLJO3JC6WNU%2F20230314%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Signature=e02beede6beb652c67fd88e96946e2167182260762cf6af7a12cc10ddd648f3d)
