### PR TITLE
DOP-3548

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -82,6 +82,10 @@ const titleStyle = LeafyCSS`
   text-transform: none;
   :hover {
     background-color: inherit;
+
+    &:after, span:after {
+      display: none;
+    }
   }
 `;
 
@@ -287,7 +291,8 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 <SideNavItem
                   className={cx(titleStyle, sideNavItemBasePadding)}
                   as={Link}
-                  to={isGuidesTemplate ? slug : '/'}
+                  to={isGuidesTemplate ? slug : activeToc.url || activeToc.slug || '/'}
+                  hideExternalIcon={true}
                 >
                   {navTitle}
                 </SideNavItem>

--- a/src/components/Sidenav/styles/sideNavItem.js
+++ b/src/components/Sidenav/styles/sideNavItem.js
@@ -17,6 +17,15 @@ export const sideNavItemTOCStyling = ({ level = 1 }) => css`
   font-size: ${theme.fontSize.small};
   text-transform: none;
   line-height: 20px !important;
+
+  // overwrite LG link underlines
+  // @leafygreen-ui/typography v13.0.0
+  :hover {
+    &:after,
+    span:after {
+      display: none;
+    }
+  }
 `;
 
 export const sideNavItemFontSize = css`


### PR DESCRIPTION
### Stories/Links:

DOP-3548

### Current Behavior:

[atlas cli](https://www.mongodb.com/docs/atlas/cli/upcoming/)
the ToC header in the sidenav `MongoDB Atlas` links to the index page of project (https://www.mongodb.com/docs/atlas/cli/upcoming/) when it should link to (https://www.mongodb.com/docs/atlas/)

### Staging Links:

[staged changes](https://docs-mongodbcom-integration.corp.mongodb.com/4c618dcf840a7a75c4b79756547dca71e2f7720a/master/atlas-cli/seung.park/DOP-3548/)
note above has link leading to docs-qa since integration env points to these in pool_test.repos_branches
![image](https://user-images.githubusercontent.com/13054820/225122512-ff7f6659-1263-47e9-bd5a-f6c8f9f4fd6a.png)


### Notes:
- the backend data is correct from persistence module. DOP-3515 [had the change](https://github.com/mongodb/snooty/pull/773/files#diff-2b26804c8d18746c714873719e0aade9fe1fa72956ae0398be36bee1075928e3L220) to display the correct text, but it was not leading to the right link
- noticed some LG link highlighting css going on in the ToC (due to them being external links) - removed thees underlines on hover