### PR TITLE
Dop 3567

### DIFF
--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -6,6 +6,7 @@ import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
 import { theme } from '../../theme/docsTheme';
 import Tag, { searchTagStyle } from '../Tag';
+import { tempKey } from '../../utils/get-temp-mapping';
 import SearchContext from './SearchContext';
 
 const LINK_COLOR = '#494747';
@@ -117,11 +118,6 @@ const sanitizePreviewHtml = (text) =>
     allowedStyles: { span: { 'background-color': [new RegExp(`^${palette.yellow.light2}$`, 'i')] } },
   });
 
-const setAliasesKey = {
-  'manual-upcoming': 'manual-v6.3',
-  'manual-manual': 'manual-v6.2',
-};
-
 const SearchResult = React.memo(
   ({
     learnMoreLink = false,
@@ -138,7 +134,7 @@ const SearchResult = React.memo(
     const highlightedTitle = highlightSearchTerm(title, searchTerm);
     const highlightedPreviewText = highlightSearchTerm(preview, searchTerm);
     const resultLinkRef = useRef(null);
-    const key = setAliasesKey[searchProperty] ? setAliasesKey[searchProperty] : searchProperty;
+    const key = tempKey(searchProperty);
     const category = searchPropertyMapping?.[key]?.['categoryTitle'];
     const version = searchPropertyMapping?.[key]?.['versionSelectorLabel'];
 

--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -117,6 +117,11 @@ const sanitizePreviewHtml = (text) =>
     allowedStyles: { span: { 'background-color': [new RegExp(`^${palette.yellow.light2}$`, 'i')] } },
   });
 
+const setAliasesKey = {
+  'manual-upcoming': 'manual-v6.3',
+  'manual-manual': 'manual-v6.2',
+};
+
 const SearchResult = React.memo(
   ({
     learnMoreLink = false,
@@ -133,8 +138,9 @@ const SearchResult = React.memo(
     const highlightedTitle = highlightSearchTerm(title, searchTerm);
     const highlightedPreviewText = highlightSearchTerm(preview, searchTerm);
     const resultLinkRef = useRef(null);
-    const category = searchPropertyMapping?.[searchProperty]?.['categoryTitle'];
-    const version = searchPropertyMapping?.[searchProperty]?.['versionSelectorLabel'];
+    const key = setAliasesKey[searchProperty] ? setAliasesKey[searchProperty] : searchProperty;
+    const category = searchPropertyMapping?.[key]?.['categoryTitle'];
+    const version = searchPropertyMapping?.[key]?.['versionSelectorLabel'];
 
     return (
       <SearchResultLink ref={resultLinkRef} href={url} onClick={onClick} {...props}>

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -284,7 +284,6 @@ const SearchResults = () => {
       if (searchTerm) {
         const result = await fetch(searchParamsToURL(searchTerm, searchFilter));
         const resultJson = await result.json();
-        console.log('search result json', resultJson);
         if (!!resultJson?.results) {
           setSearchResults(getSearchbarResultsFromJSON(resultJson, searchPropertyMapping));
         }
@@ -293,8 +292,6 @@ const SearchResults = () => {
     };
     fetchNewSearchResults();
   }, [searchFilter, searchPropertyMapping, searchTerm]);
-
-  console.log('searchResults', searchResults);
 
   return (
     <>

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -284,6 +284,7 @@ const SearchResults = () => {
       if (searchTerm) {
         const result = await fetch(searchParamsToURL(searchTerm, searchFilter));
         const resultJson = await result.json();
+        console.log('search result json', resultJson);
         if (!!resultJson?.results) {
           setSearchResults(getSearchbarResultsFromJSON(resultJson, searchPropertyMapping));
         }
@@ -292,6 +293,8 @@ const SearchResults = () => {
     };
     fetchNewSearchResults();
   }, [searchFilter, searchPropertyMapping, searchTerm]);
+
+  console.log('searchResults', searchResults);
 
   return (
     <>

--- a/src/utils/get-searchbar-results-from-json.js
+++ b/src/utils/get-searchbar-results-from-json.js
@@ -1,16 +1,12 @@
+import { tempKey } from './get-temp-mapping';
 // Helper function which extracts a marian title based on the format
 // title — property. Also optionally only parse the first 9 results for the dropdown
-const setAliasesKey = {
-  'manual-upcoming': 'manual-v6.3',
-  'manual-manual': 'manual-v6.2',
-};
-
 export const getSearchbarResultsFromJSON = (resultJSON, searchPropertyMapping = {}, limitResults) => {
   const resultsWithoutProperty = resultJSON.results
     .filter((r) => {
       const searchProperty = r.searchProperty?.[0];
       const endsWithDash = searchProperty?.endsWith('-');
-      const key = setAliasesKey[searchProperty] ? setAliasesKey[searchProperty] : searchProperty;
+      const key = tempKey(searchProperty);
       const isInMapping = !!searchPropertyMapping[key];
       return !endsWithDash && isInMapping;
     })
@@ -18,5 +14,6 @@ export const getSearchbarResultsFromJSON = (resultJSON, searchPropertyMapping = 
   if (limitResults) {
     return resultsWithoutProperty.slice(0, limitResults);
   }
+
   return resultsWithoutProperty;
 };

--- a/src/utils/get-searchbar-results-from-json.js
+++ b/src/utils/get-searchbar-results-from-json.js
@@ -1,12 +1,17 @@
 // Helper function which extracts a marian title based on the format
 // title — property. Also optionally only parse the first 9 results for the dropdown
+const setAliasesKey = {
+  'manual-upcoming': 'manual-v6.3',
+  'manual-manual': 'manual-v6.2',
+};
 
 export const getSearchbarResultsFromJSON = (resultJSON, searchPropertyMapping = {}, limitResults) => {
   const resultsWithoutProperty = resultJSON.results
     .filter((r) => {
       const searchProperty = r.searchProperty?.[0];
       const endsWithDash = searchProperty?.endsWith('-');
-      const isInMapping = !!searchPropertyMapping[searchProperty];
+      const key = setAliasesKey[searchProperty] ? setAliasesKey[searchProperty] : searchProperty;
+      const isInMapping = !!searchPropertyMapping[key];
       return !endsWithDash && isInMapping;
     })
     .map((r) => ({ ...r, title: r.title.split(' —')[0] }));

--- a/src/utils/get-temp-mapping.js
+++ b/src/utils/get-temp-mapping.js
@@ -1,4 +1,5 @@
 // My need to update if aliases change
+//TODO: should remove when root cause is fixed
 export const setAliasesKeys = {
   'manual-upcoming': 'manual-v6.0',
   'manual-manual': 'manual-v6.2',

--- a/src/utils/get-temp-mapping.js
+++ b/src/utils/get-temp-mapping.js
@@ -1,3 +1,4 @@
+// My need to update if aliases change
 export const setAliasesKeys = {
   'manual-upcoming': 'manual-v6.0',
   'manual-manual': 'manual-v6.2',

--- a/src/utils/get-temp-mapping.js
+++ b/src/utils/get-temp-mapping.js
@@ -1,0 +1,9 @@
+export const setAliasesKeys = {
+  'manual-upcoming': 'manual-v6.0',
+  'manual-manual': 'manual-v6.2',
+  'manual-master': 'manual-v6.3',
+};
+
+export const tempKey = (manifest) => {
+  return setAliasesKeys[manifest] ? setAliasesKeys[manifest] : manifest;
+};

--- a/src/utils/parse-marian-manifests.js
+++ b/src/utils/parse-marian-manifests.js
@@ -1,12 +1,8 @@
 import { compareBranchesWithVersionNumbers } from './compare-branches-with-version-numbers';
+import { tempKey } from './get-temp-mapping';
 
 const locatedOutdatedTemporaryFile = (outDatedManifest) => {
   return ['manual-manual', 'manual-upcoming'].includes(outDatedManifest);
-};
-
-const setAliasesKey = {
-  'manual-upcoming': 'manual-v6.3',
-  'manual-manual': 'manual-v6.2',
 };
 
 export const getSortedBranchesForProperty = (parsedManifest, property) => {
@@ -19,9 +15,6 @@ export const getSortedBranchesForProperty = (parsedManifest, property) => {
 export const parseMarianManifests = (manifests, searchPropertyMapping = {}) => {
   const result = {};
 
-  console.log('manifest', manifests);
-  console.log('searchPropertyMapping', searchPropertyMapping);
-
   manifests.forEach((manifest) => {
     // Temporarily handling Aliases for manual-manual and manual-master
     // We should only include categories and versions in the filter dropdowns if they
@@ -31,7 +24,7 @@ export const parseMarianManifests = (manifests, searchPropertyMapping = {}) => {
       return;
     }
 
-    const key = setAliasesKey[manifest] ? setAliasesKey[manifest] : manifest;
+    const key = tempKey(manifest);
     const { categoryTitle: category, versionSelectorLabel: version } = searchPropertyMapping[key];
     // organize by property / category (ex. { Atlas : { Latest : atlas-master }})
     if (!(category in result)) {
@@ -39,8 +32,6 @@ export const parseMarianManifests = (manifests, searchPropertyMapping = {}) => {
     }
     result[category][version] = manifest;
   });
-
-  console.log('result', result);
 
   return result;
 };

--- a/src/utils/parse-marian-manifests.js
+++ b/src/utils/parse-marian-manifests.js
@@ -1,5 +1,14 @@
 import { compareBranchesWithVersionNumbers } from './compare-branches-with-version-numbers';
 
+const locatedOutdatedTemporaryFile = (outDatedManifest) => {
+  return ['manual-manual', 'manual-upcoming'].includes(outDatedManifest);
+};
+
+const setAliasesKey = {
+  'manual-upcoming': 'manual-v6.3',
+  'manual-manual': 'manual-v6.2',
+};
+
 export const getSortedBranchesForProperty = (parsedManifest, property) => {
   const branches = Object.keys(parsedManifest[property]);
   branches.sort(compareBranchesWithVersionNumbers);
@@ -10,21 +19,28 @@ export const getSortedBranchesForProperty = (parsedManifest, property) => {
 export const parseMarianManifests = (manifests, searchPropertyMapping = {}) => {
   const result = {};
 
+  console.log('manifest', manifests);
+  console.log('searchPropertyMapping', searchPropertyMapping);
+
   manifests.forEach((manifest) => {
+    // Temporarily handling Aliases for manual-manual and manual-master
     // We should only include categories and versions in the filter dropdowns if they
     // have category/version data associated with them. This will prevent unexpected
     // or new manifests without proper titles from appearing in the dropdowns.
-    if (!searchPropertyMapping[manifest]) {
+    if (!searchPropertyMapping[manifest] && !locatedOutdatedTemporaryFile(manifest)) {
       return;
     }
 
-    const { categoryTitle: category, versionSelectorLabel: version } = searchPropertyMapping[manifest];
+    const key = setAliasesKey[manifest] ? setAliasesKey[manifest] : manifest;
+    const { categoryTitle: category, versionSelectorLabel: version } = searchPropertyMapping[key];
     // organize by property / category (ex. { Atlas : { Latest : atlas-master }})
     if (!(category in result)) {
       result[category] = {};
     }
     result[category][version] = manifest;
   });
+
+  console.log('result', result);
 
   return result;
 };


### PR DESCRIPTION
### Stories/Links:

DOP-3567

### Current Behavior:

[Prod link](https://www.mongodb.com/docs/search/?q=setProfilingLevel)

Searching in the current prod does not show all results that are not mapped or not find the correct aliases between `/status` and fetching from realm (i.e. `fetchSearchPropertyMapping`)

### Staging Links:

[Stage link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/871f224b22b05294098027c6ff5a1d548836cac1/master/landing/caesarbell/DOP-3567/search/index.html?q=setProfilingLevel)

We are providing a temporary solution that allows mapping the aliases on the client

### Notes:

In this PR or a follow-up, we want to see if we can order the results slightly better. 
