### PR TITLE
DOP-3666 add bottom margin for instruqt labs

### DIFF
--- a/src/components/Instruqt.js
+++ b/src/components/Instruqt.js
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react';
 import { css } from '@emotion/react';
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
+import { theme } from '../theme/docsTheme';
 
 const controlsStyle = css`
   width: 100%;
@@ -12,6 +13,7 @@ const controlsStyle = css`
   justify-content: flex-end;
   align-items: center;
   padding: 0 1rem;
+  margin-bottom: ${theme.size.default};
 `;
 
 const Instruqt = ({ nodeData: { argument }, nodeData }) => {


### PR DESCRIPTION
### Stories/Links:

DOP-3666

minor margin below instruqt labs controls to account for paragraphs under iframes.
sourced repository is from @rayangler 's SW sample: https://github.com/rayangler/docs/tree/sw-2023-instruqt

### Current Behavior:

[staged above repo on master branch
](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sw-2023-instruqt/docs/seung.park/master/instruqt-sample/index.html)

### Staging Links:

[staged changes on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sw-2023-instruqt/docs/seung.park/DOP-3666/instruqt-sample/index.html)
