### PR TITLE
DOP-3608: wait for manifest to fire search

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -386,7 +386,6 @@ const SearchResults = () => {
                         margin-top: 80px;
                       `}
                     >
-                      empty res here at 388
                       <EmptyResults />
                     </EmptyResultsContainer>
                     <FiltersContainer>

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -280,15 +280,16 @@ const SearchResults = () => {
   // Update results on a new search query or filters
   // When the filter is changed, find the corresponding property to display
   useEffect(() => {
+    if (!searchTerm || !Object.keys(searchPropertyMapping).length) {
+      return;
+    }
     const fetchNewSearchResults = async () => {
-      if (searchTerm) {
-        const result = await fetch(searchParamsToURL(searchTerm, searchFilter));
-        const resultJson = await result.json();
-        if (!!resultJson?.results) {
-          setSearchResults(getSearchbarResultsFromJSON(resultJson, searchPropertyMapping));
-        }
-        setSearchFinished(true);
+      const result = await fetch(searchParamsToURL(searchTerm, searchFilter));
+      const resultJson = await result.json();
+      if (!!resultJson?.results) {
+        setSearchResults(getSearchbarResultsFromJSON(resultJson, searchPropertyMapping));
       }
+      setSearchFinished(true);
     };
     fetchNewSearchResults();
   }, [searchFilter, searchPropertyMapping, searchTerm]);
@@ -385,6 +386,7 @@ const SearchResults = () => {
                         margin-top: 80px;
                       `}
                     >
+                      empty res here at 388
                       <EmptyResults />
                     </EmptyResultsContainer>
                     <FiltersContainer>

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -903,8 +903,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-47"
             >
               <button
-                aria-controls="select-37-menu"
-                aria-describedby="select-37-description"
+                aria-controls="select-33-menu"
+                aria-describedby="select-33-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -912,7 +912,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 class="emotion-48"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-38"
+                id="select-34"
                 type="button"
                 value="Realm"
               >
@@ -960,8 +960,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-47"
             >
               <button
-                aria-controls="select-39-menu"
-                aria-describedby="select-39-description"
+                aria-controls="select-35-menu"
+                aria-describedby="select-35-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -970,7 +970,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-40"
+                id="select-36"
                 type="button"
                 value="Latest"
               >
@@ -1856,8 +1856,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-37"
             >
               <button
-                aria-controls="select-61-menu"
-                aria-describedby="select-61-description"
+                aria-controls="select-53-menu"
+                aria-describedby="select-53-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -1865,7 +1865,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 class="emotion-38"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-62"
+                id="select-54"
                 type="button"
                 value=""
               >
@@ -1913,8 +1913,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-37"
             >
               <button
-                aria-controls="select-63-menu"
-                aria-describedby="select-63-description"
+                aria-controls="select-55-menu"
+                aria-describedby="select-55-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -1923,7 +1923,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-64"
+                id="select-56"
                 type="button"
                 value=""
               >


### PR DESCRIPTION
### Stories/Links:

DOP-3608

### Current Behavior:

[prod link with search results](https://www.mongodb.com/docs/search/?q=test)
opening the above link may flash a `no results found` before actually showing results
**NOTE:** opening network tab and refreshing this page shows **two** requests to `https://docs-search-transport.mongodb.com/search?q=test`

### Staging Links:

[staging link for search page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-3608/search/index.html?q=test)
(cannot refresh above link due to S3 hosting issues). can test refresh by copying and pasting link https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-3608/search/index.html?q=test
- does not show `no results found` when opening link, should only fire one request to search transport server for the query

### Notes:
- this was due to the dependencies passed to React.useEffect `[searchFilter, searchPropertyMapping, searchTerm]`. the `searchPropertyMapping` is required before showing search results but this effect was being fired without checking existence of it, and also again when it changed, resulting in a `no results found` briefly