### PR TITLE
DOP-3677: OpenAPIChangelog component structure, template

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -45,6 +45,7 @@ import LiteralBlock from './LiteralBlock';
 import LiteralInclude from './LiteralInclude';
 import MongoWebShell from './MongoWebShell';
 import OpenAPI from './OpenAPI';
+import OpenAPIChangelog from './OpenAPIChangelog';
 import Paragraph from './Paragraph';
 import Procedure from './Procedure';
 import QuizChoice from './Widgets/QuizWidget/QuizChoice';
@@ -173,6 +174,7 @@ const componentMap = {
   'mongo-web-shell': MongoWebShell,
   only: Cond,
   openapi: OpenAPI,
+  'openapi-changelog': OpenAPIChangelog,
   paragraph: Paragraph,
   procedure: Procedure,
   quiz: QuizWidget,

--- a/src/components/OpenAPIChangelog/ChangeList.js
+++ b/src/components/OpenAPIChangelog/ChangeList.js
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const ChangeList = () => {
+  return <Wrapper></Wrapper>;
+};
+
+export default ChangeList;

--- a/src/components/OpenAPIChangelog/FiltersPanel.js
+++ b/src/components/OpenAPIChangelog/FiltersPanel.js
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const FiltersPanel = () => {
+  return <Wrapper></Wrapper>;
+};
+
+export default FiltersPanel;

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import { H2 } from '@leafygreen-ui/typography';
+import Button from '@leafygreen-ui/button';
+import FiltersPanel from './FiltersPanel';
+import ChangeList from './ChangeList';
+
+const ChangelogPage = styled.div`
+  width: 100%;
+  margin-top: 60px;
+`;
+
+const ChangelogHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const OpenAPIChangelog = () => {
+  return (
+    <ChangelogPage>
+      <ChangelogHeader>
+        <H2>API Changelog</H2>
+        <Button>Download API Changelog</Button>
+      </ChangelogHeader>
+      <FiltersPanel />
+      <ChangeList />
+    </ChangelogPage>
+  );
+};
+
+export default OpenAPIChangelog;

--- a/src/components/OpenAPIChangelog/index.js
+++ b/src/components/OpenAPIChangelog/index.js
@@ -1,0 +1,3 @@
+import OpenAPIChangelog from './OpenAPIChangelog';
+
+export default OpenAPIChangelog;

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import MainColumn from '../components/MainColumn';
+
+const Wrapper = styled(MainColumn)`
+  max-width: unset;
+  margin-right: 64px;
+`;
+
+const Changelog = ({ children }) => <Wrapper>{children}</Wrapper>;
+
+Changelog.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node),
+};
+
+export default Changelog;

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -6,5 +6,6 @@ import Landing from './landing';
 import NotFound from './NotFound';
 import OpenAPITemplate from './openapi';
 import ProductLanding from './product-landing';
+import Changelog from './changelog';
 
-export { Blank, Document, DriversIndex, Instruqt, Landing, NotFound, OpenAPITemplate, ProductLanding };
+export { Blank, Document, DriversIndex, Instruqt, Landing, NotFound, OpenAPITemplate, ProductLanding, Changelog };

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -7,6 +7,7 @@ import {
   OpenAPITemplate,
   ProductLanding,
   NotFound,
+  Changelog,
 } from '../templates';
 
 const getTemplate = (templateName) => {
@@ -33,6 +34,10 @@ const getTemplate = (templateName) => {
       break;
     case 'openapi':
       template = OpenAPITemplate;
+      break;
+    case 'changelog':
+      template = Changelog;
+      sidenav = true;
       break;
     case 'product-landing':
       template = ProductLanding;


### PR DESCRIPTION
### Stories/Links:

DOP-3677

### Notes:

Net new template page, component directory, and OpenAPIChangelog component structured out for future work on the changelog.

[UI Design](https://www.figma.com/file/Tal3RZFxMEz6u1tnilxwRY/API-Change-Log?type=design&node-id=1-539&t=3o9XrD5Lijm9ighd-0).

<img width="1568" alt="Screenshot 2023-05-01 at 10 01 56 AM" src="https://user-images.githubusercontent.com/22421112/235462938-61e9e989-d394-4769-b7e1-0c4983a7559d.png">
