### PR TITLE
DOP-3697

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -171,6 +171,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
   let showVersions = repoBranches?.branches?.filter((b) => b.active)?.length > 1;
 
   const { showVersionDropdown } = useContext(VersionContext);
+  // showVersionDropdown === isAssociatedProduct
   if (showVersionDropdown) {
     showVersions = false;
   }

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -171,7 +171,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
   let showVersions = repoBranches?.branches?.filter((b) => b.active)?.length > 1;
 
   const { showVersionDropdown } = useContext(VersionContext);
-  // showVersionDropdown === isAssociatedProduct
   if (showVersionDropdown) {
     showVersions = false;
   }

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -26,12 +26,6 @@ const StyledSelect = styled(Select)`
   }
 `;
 
-// Returns true if there are any inactive (EOL'd/'legacy') branches
-const needsLegacyDropdown = (branches = []) => {
-  const isLegacy = (branch = {}) => !branch['active'];
-  return branches.some(isLegacy);
-};
-
 // Gets UI labels for supplied active branch names
 export const getUILabel = (branch) => {
   if (!branch['active']) {
@@ -95,10 +89,10 @@ const createOption = (branch) => {
   );
 };
 
-const VersionDropdown = ({ repoBranches: { siteBasePrefix }, slug, eol }) => {
+const VersionDropdown = ({ eol }) => {
   const siteMetadata = useSiteMetadata();
   const { parserBranch, project } = siteMetadata;
-  const { availableVersions, availableGroups, onVersionSelect } = useContext(VersionContext);
+  const { availableVersions, availableGroups, onVersionSelect, showEol } = useContext(VersionContext);
   let branches = availableVersions[siteMetadata.project];
   let groups = availableGroups[siteMetadata.project];
 
@@ -173,7 +167,7 @@ const VersionDropdown = ({ repoBranches: { siteBasePrefix }, slug, eol }) => {
           </OptionGroup>
         );
       })}
-      {needsLegacyDropdown(branches) && <Option value="legacy">Legacy Docs</Option>}
+      {showEol && <Option value="legacy">Legacy Docs</Option>}
     </StyledSelect>
   );
 };

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -165,7 +165,7 @@ const VersionDropdown = ({ repoBranches: { siteBasePrefix }, slug, eol }) => {
               {groupedBranchNames?.reduce((res, bn) => {
                 const branch = getBranch(bn, branches);
                 if (branch) {
-                  res.push(createOption(bn, branches));
+                  res.push(createOption(branch));
                 }
                 return res;
               }, [])}

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -161,7 +161,15 @@ const VersionDropdown = ({ repoBranches: { siteBasePrefix }, slug, eol }) => {
         const { groupLabel, includedBranches: groupedBranchNames = [] } = group;
         return (
           <OptionGroup key={groupLabel} label={groupLabel}>
-            <>{groupedBranchNames?.map((bn) => createOption(getBranch(bn, branches)))}</>
+            <>
+              {groupedBranchNames?.reduce((res, bn) => {
+                const branch = getBranch(bn, branches);
+                if (branch) {
+                  res.push(createOption(bn, branches));
+                }
+                return res;
+              }, [])}
+            </>
           </OptionGroup>
         );
       })}

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { cx, css as LeafyCSS } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { Option, OptionGroup, Select } from '@leafygreen-ui/select';
-import { navigate as reachNavigate } from '@gatsbyjs/reach-router';
+import { VersionContext } from '../../context/version-context';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { theme } from '../../theme/docsTheme';
-import { getUrl } from '../../utils/url-utils';
 import { useCurrentUrlSlug, getBranchSlug } from '../../hooks/use-current-url-slug';
 
 const StyledSelect = styled(Select)`
@@ -96,9 +95,19 @@ const createOption = (branch) => {
   );
 };
 
-const VersionDropdown = ({ repoBranches: { branches, groups, siteBasePrefix }, slug, eol }) => {
+const VersionDropdown = ({ repoBranches: { siteBasePrefix }, slug, eol }) => {
   const siteMetadata = useSiteMetadata();
   const { parserBranch, project } = siteMetadata;
+  const { availableVersions, availableGroups, onVersionSelect } = useContext(VersionContext);
+  let branches = availableVersions[siteMetadata.project];
+  let groups = availableGroups[siteMetadata.project];
+
+  const onSelectChange = useCallback(
+    (value) => {
+      onVersionSelect(project, value);
+    },
+    [onVersionSelect, project]
+  );
 
   // Attempts to reconcile differences between urlSlug and the parserBranch provided to this component
   // Used to ensure that the value of the select is set to the urlSlug if the urlSlug is present and differs from the gitBranchName
@@ -121,13 +130,6 @@ const VersionDropdown = ({ repoBranches: { branches, groups, siteBasePrefix }, s
     }
   }
 
-  // Used exclusively by the LG Select component's onChange function, which receives
-  // the 'value' prop from the selected Option component
-  const navigate = (optionValue) => {
-    const destination = getUrl(optionValue, project, siteMetadata, siteBasePrefix, slug);
-    reachNavigate(destination);
-  };
-
   const activeUngroupedBranches = getActiveUngroupedBranches(branches, groups) || [];
 
   const eolVersionFlipperStyle = LeafyCSS`
@@ -147,7 +149,7 @@ const VersionDropdown = ({ repoBranches: { branches, groups, siteBasePrefix }, s
       className={cx(eol ? eolVersionFlipperStyle : '')}
       aria-labelledby="View a different version of documentation."
       defaultValue="master"
-      onChange={navigate}
+      onChange={onSelectChange}
       placeholder={'Select a version'}
       popoverZIndex={3}
       value={currentUrlSlug}

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -64,7 +64,7 @@ const getBranches = async (metadata, repoBranches, associatedReposInfo, associat
     });
     promises.push(
       fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, { project: metadata.project }).then((res) => {
-        versions[metadata.project] = res.branches.filter((branch) => branch.active);
+        versions[metadata.project] = res.branches?.filter((branch) => branch.active) || [];
         groups[metadata.project] = res.groups || [];
       })
     );

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -53,39 +53,53 @@ const versionStateReducer = (state, newState) => {
  * @returns versions{} <product_name: branch_object[]>
  */
 const getBranches = async (metadata, repoBranches, associatedReposInfo, associatedProducts) => {
+  let hasEolBranches = false;
   try {
-    const versions = {};
-    const groups = {};
-    let hasEolBranches = false;
-    const promises = associatedProducts.map(async (product) => {
-      const childRepoBranches = await fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, {
-        project: product.name,
-      });
-      // filter all branches of associated repo by active property
-      versions[product.name] = childRepoBranches.branches.filter((branch) => branch.active);
-    });
-    promises.push(
-      fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, { project: metadata.project }).then((res) => {
-        versions[metadata.project] = res.branches?.filter((branch) => branch.active) || [];
-        groups[metadata.project] = res.groups || [];
-        hasEolBranches = res.branches.some((b) => !b.active);
-      })
-    );
-    await Promise.all(promises);
+    const promises = [fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, { project: metadata.project })];
+    for (let associatedProduct of associatedProducts) {
+      promises.push(
+        fetchDocument(metadata.reposDatabase, BRANCHES_COLLECTION, {
+          project: associatedProduct.name,
+        })
+      );
+    }
+    const allBranches = await Promise.all(promises);
+    const fetchedRepoBranches = allBranches[0];
+    hasEolBranches = fetchedRepoBranches?.branches?.some((b) => !b.active);
+    const fetchedAssociatedReposInfo = allBranches.slice(1).reduce((res, repoBranch) => {
+      res[repoBranch.project] = repoBranch;
+      return res;
+    }, {});
+    const versions = getDefaultVersions(metadata.project, fetchedRepoBranches, fetchedAssociatedReposInfo);
+    const groups = getDefaultGroups(metadata.project, fetchedRepoBranches);
+
     return { versions, groups, hasEolBranches };
   } catch (e) {
-    return getDefaults(metadata.project, repoBranches, associatedReposInfo);
+    return {
+      versions: getDefaultVersions(metadata.project, repoBranches, associatedReposInfo),
+      groups: getDefaultGroups(metadata.project, repoBranches),
+      hasEolBranches,
+    };
     // on error of realm function, fall back to build time fetches
   }
 };
 
-const getDefaults = (project, repoBranches, associatedReposInfo, key = 'branches') => {
+const getDefaultVersions = (project, repoBranches, associatedReposInfo) => {
   const versions = {};
-  versions[project] = repoBranches?.[key] || [];
+  const VERSION_KEY = 'branches';
+  const activeFilter = (b) => b.active;
+  versions[project] = (repoBranches?.[VERSION_KEY] || []).filter(activeFilter);
   for (const productName in associatedReposInfo) {
-    versions[productName] = associatedReposInfo[productName][key] || [];
+    versions[productName] = (associatedReposInfo[productName][VERSION_KEY] || []).filter(activeFilter);
   }
   return versions;
+};
+
+const getDefaultGroups = (project, repoBranches) => {
+  const groups = {};
+  const GROUP_KEY = 'groups';
+  groups[project] = repoBranches?.[GROUP_KEY] || [];
+  return groups;
 };
 
 const getDefaultActiveVersions = ([metadata]) => {
@@ -154,10 +168,10 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
 
   // expose the available versions for current and associated products
   const [availableVersions, setAvailableVersions] = useState(
-    getDefaults(metadata.project, repoBranches, associatedReposInfo)
+    getDefaultVersions(metadata.project, repoBranches, associatedReposInfo)
   );
   const [availableGroups, setAvailableGroups] = useState(
-    getDefaults(metadata.project, repoBranches, associatedReposInfo, 'groups')
+    getDefaultGroups(metadata.project, repoBranches, associatedReposInfo)
   );
   const [showEol, setShowEol] = useState(repoBranches['branches']?.some((b) => !b.active) || false);
 


### PR DESCRIPTION
### Stories/Links:

DOP-3697

### Current Behavior:

[server docs](https://www.mongodb.com/docs/manual/)
above issue has been addressed by redeploy

### Staging Links:

[server docs with bad data](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/b9dbfee6ea693f63f75f7868ae8ed1434d15ae6b/master/docs/seung.park/DOP-3697/index.html)
Above has been updated with pool_test.repo_branches with "incorrect" data: (branches[] with version 4.2 is inactive, but still included in groups)
[atlas docs with changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/b9dbfee6ea693f63f75f7868ae8ed1434d15ae6b/master/cloud-docs/seung.park/DOP-3697/index.html)

![image](https://user-images.githubusercontent.com/13054820/236263854-b1afc60b-fc53-4566-8833-9caa60cfa11e.png)


### Notes:
The root of the problem was that we were not referencing the VersionContext (which should handle all version related logic, including initial versions at build time and updating via app service on initial load) in the VersionDropdown component.

References to `branches` and `groups` have been updated to be from VersionContext.

**Follow up in Hapley:** Throw a client side error when `repos_branches[].groups[].includedBranches[]` contains an inactive branch