### PR TITLE
DOP-3697-follow up

### DIFF
--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -83,7 +83,7 @@ const createOption = (branch) => {
   const UIlabel = getUILabel(branch);
   const slug = getBranchSlug(branch);
   return (
-    <Option key={slug} value={slug}>
+    <Option key={slug} value={branch.gitBranchName}>
       {UIlabel}
     </Option>
   );


### PR DESCRIPTION
[see slack thread](https://mongodb.slack.com/archives/C018UTGP23T/p1683905669887079)

caused by referencing url slug instead of gitBranchName (expected by [VersionContext ](https://github.com/mongodb/snooty/blob/master/src/context/version-context.js#L209-L210) )

**staging link:**
https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/seung.park/gitbranchname-fix/index.html

verify that above dropdown leads to v7 URL (invalid URL for other S3 issues for staging links)