### PR TITLE
DOP-3556: Switch Optimizely load type for (hopefully) the last time

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -16,7 +16,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
       }}
     />,
     // Optimizely
-    <script key="optimizely" async src="https://cdn.optimizely.com/js/20988630008.js" />,
+    <script key="optimizely" src="https://cdn.optimizely.com/js/20988630008.js" />,
     // Delighted
     <script
       key="delighted"


### PR DESCRIPTION
### Stories/Links:

DOP-3556

### Staging Links:

_Put a link to your staging environment(s), if applicable_

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/cassidy.schaufele/DOP-3556/index.html

### Notes:

Per discussion on 3556, this sets the Optimizely script to load synchronously. 