### PR TITLE
DOP-3716: dynamically fetches diff for OpenAPIChangelog

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -78,11 +78,11 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
 
 /* Creates node for ChangelogData, used only for OpenAPI Changelog in cloud-docs. */
 const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createContentDigest }) => {
-  const atlasAdminChangelogS3Prefix = 'https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi/';
+  const atlasAdminChangelogS3Prefix = 'https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi';
 
   try {
     /* Fetch OpenAPI Changelog metadata (index.yaml) */
-    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}index.yaml`);
+    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/index.yaml`);
     const indexText = await indexResp.text();
     const index = yaml.safeLoad(indexText, 'utf8');
 
@@ -93,7 +93,7 @@ const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createCont
     // TODO: Create fallback using cached runId of last successful run: might necessitate atlas collection
 
     /* Using metadata runId, fetch OpenAPI Changelog full change list */
-    const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}${runId}/changelog.yaml`);
+    const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/changelog.yaml`);
     const changelogText = await changelogResp.text();
     const changelog = yaml.safeLoad(changelogText, 'utf8');
 

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -5,12 +5,11 @@ import { Body, H2 } from '@leafygreen-ui/typography';
 import Button from '@leafygreen-ui/button';
 import { theme } from '../../theme/docsTheme';
 import useChangelogData from '../../utils/use-changelog-data';
-import { fetchOADiff } from '../../utils/realm';
 import FiltersPanel from './components/FiltersPanel';
 import ChangeList from './components/ChangeList';
+import { useFetchDiff } from './utils/useFetchDiff';
 import { ALL_VERSIONS, getDownloadChangelogUrl } from './utils/constants';
 import getDiffResourcesList from './utils/getDiffResourcesList';
-import { getDiffRequestFormat } from './utils/getDiffRequestFormat';
 
 const ChangelogPage = styled.div`
   width: 100%;
@@ -65,21 +64,11 @@ const OpenAPIChangelog = () => {
   const [resourceVersionOne, setResourceVersionOne] = useState(resourceVersions[0]);
   const [resourceVersionTwo, setResourceVersionTwo] = useState();
 
-  const [diff, setDiff] = useState([]);
+  const [diff] = useFetchDiff({ resourceVersionOne, resourceVersionTwo, index });
   const [diffResourcesList, setDiffResourcesList] = useState(getDiffResourcesList(diff));
 
   const [filteredDiff, setFilteredDiff] = useState(diff);
   const [filteredChangelog, setFilteredChangelog] = useState(changelog);
-
-  /* Fetch diff on selection of two Resources to compare */
-  useEffect(() => {
-    if (!resourceVersionOne || !resourceVersionTwo || !index.runId) return;
-    const fromAndToDiffString = getDiffRequestFormat(resourceVersionOne, resourceVersionTwo);
-
-    fetchOADiff(index.runId, fromAndToDiffString)
-      .then((response) => setDiff(response))
-      .catch((err) => console.error(err));
-  }, [resourceVersionOne, resourceVersionTwo, index.runId]);
 
   /* Update diffResourcesList on diff change */
   useEffect(() => {

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -5,11 +5,12 @@ import { Body, H2 } from '@leafygreen-ui/typography';
 import Button from '@leafygreen-ui/button';
 import { theme } from '../../theme/docsTheme';
 import useChangelogData from '../../utils/use-changelog-data';
+import { fetchOADiff } from '../../utils/realm';
 import FiltersPanel from './components/FiltersPanel';
 import ChangeList from './components/ChangeList';
-import { mockDiff } from './data/mockData';
 import { ALL_VERSIONS, getDownloadChangelogUrl } from './utils/constants';
 import getDiffResourcesList from './utils/getDiffResourcesList';
+import { getDiffRequestFormat } from './utils/getDiffRequestFormat';
 
 const ChangelogPage = styled.div`
   width: 100%;
@@ -54,28 +55,41 @@ const DownloadButton = styled(Button)`
   min-width: 182px;
 `;
 
-const OpenAPIChangelog = ({ diff = mockDiff }) => {
+const OpenAPIChangelog = () => {
   const { index = {}, changelog = [], changelogResourcesList = [] } = useChangelogData();
   const resourceVersions = index.versions?.length ? index.versions.slice().reverse() : [];
   const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId), [index]);
-  // TODO: Reminder: account for this on any diff fetch
-  if (resourceVersions.length) resourceVersions[0] += ' (latest)';
 
   const [versionMode, setVersionMode] = useState(ALL_VERSIONS);
   const [selectedResources, setSelectedResources] = useState([]);
   const [resourceVersionOne, setResourceVersionOne] = useState(resourceVersions[0]);
   const [resourceVersionTwo, setResourceVersionTwo] = useState();
 
-  // TODO: Fetch diff, getDiffResourcesList on changes to version selectors
-  const diffResourcesList = getDiffResourcesList(diff);
+  const [diff, setDiff] = useState([]);
+  const [diffResourcesList, setDiffResourcesList] = useState(getDiffResourcesList(diff));
 
   const [filteredDiff, setFilteredDiff] = useState(diff);
   const [filteredChangelog, setFilteredChangelog] = useState(changelog);
 
-  /*  
-    Clear filters on version mode change.
-    Different Resources are available in either mode, not always comparable.
-  */
+  /* Fetch diff on selection of two Resources to compare */
+  useEffect(() => {
+    if (!resourceVersionOne || !resourceVersionTwo || !index.runId) return;
+    const fromAndToDiffString = getDiffRequestFormat(resourceVersionOne, resourceVersionTwo);
+
+    fetchOADiff(index.runId, fromAndToDiffString)
+      .then((response) => setDiff(response))
+      .catch((err) => console.error(err));
+  }, [resourceVersionOne, resourceVersionTwo, index.runId]);
+
+  /* Update diffResourcesList on diff change */
+  useEffect(() => {
+    if (diff && diff.length) {
+      setDiffResourcesList(getDiffResourcesList(diff));
+    }
+  }, [diff]);
+
+  /*  Clear filters on version mode change.
+    Different Resources are available in either mode, not always comparable. */
   useEffect(() => {
     setSelectedResources([]);
   }, [versionMode]);

--- a/src/components/OpenAPIChangelog/components/ChangeList.js
+++ b/src/components/OpenAPIChangelog/components/ChangeList.js
@@ -15,7 +15,7 @@ const ChangeList = ({ versionMode, changes }) => {
   return (
     <Wrapper>
       {changes.map((data, i) => (
-        <ChangeListComponent key={`change-list-${i}`} {...data} />
+        <ChangeListComponent key={`change-list-${i}`} id={versionMode} {...data} />
       ))}
     </Wrapper>
   );

--- a/src/components/OpenAPIChangelog/components/FiltersPanel/components/DiffSelect.js
+++ b/src/components/OpenAPIChangelog/components/FiltersPanel/components/DiffSelect.js
@@ -28,11 +28,25 @@ export default function DiffSelect({
 }) {
   const versionOneOptions = resourceVersions
     .filter((version) => version !== resourceVersionTwo)
-    .map((version) => <ComboboxOption data-testid="version-one-option" key={version} value={version}></ComboboxOption>);
+    .map((version) => (
+      <ComboboxOption
+        data-testid="version-one-option"
+        key={version}
+        displayName={version === resourceVersions[0] ? `${version} (latest)` : version}
+        value={version}
+      ></ComboboxOption>
+    ));
 
   const versionTwoOptions = resourceVersions
     .filter((version) => version !== resourceVersionOne)
-    .map((version) => <ComboboxOption data-testid="version-two-option" key={version} value={version}></ComboboxOption>);
+    .map((version) => (
+      <ComboboxOption
+        data-testid="version-two-option"
+        key={version}
+        displayName={version === resourceVersions[0] ? `${version} (latest)` : version}
+        value={version}
+      ></ComboboxOption>
+    ));
 
   return (
     <DiffSelectContainer>

--- a/src/components/OpenAPIChangelog/components/FiltersPanel/components/FiltersPanel.js
+++ b/src/components/OpenAPIChangelog/components/FiltersPanel/components/FiltersPanel.js
@@ -54,10 +54,14 @@ const FiltersPanel = ({
   return (
     <Wrapper>
       <StyledSegmentedControl value={versionMode} onChange={setVersionMode}>
-        <SegmentedControlOption data-testid="all-versions-option" value={ALL_VERSIONS}>
+        <SegmentedControlOption data-testid="all-versions-option" value={ALL_VERSIONS} aria-controls={ALL_VERSIONS}>
           All Versions
         </SegmentedControlOption>
-        <SegmentedControlOption data-testid="compare-versions-option" value={COMPARE_VERSIONS}>
+        <SegmentedControlOption
+          data-testid="compare-versions-option"
+          value={COMPARE_VERSIONS}
+          aria-controls={COMPARE_VERSIONS}
+        >
           Compare Two Versions
         </SegmentedControlOption>
       </StyledSegmentedControl>

--- a/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
+++ b/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
@@ -35,17 +35,16 @@ const ChangeListUL = styled.ul`
   list-style-position: start;
 `;
 
-const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, changeType, versions }) => {
+const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, versions }) => {
   const metadata = useSiteMetadata();
   const { openapi_pages } = useSnootyMetadata();
-
   const resourceLinkUrl = getResourceLinkUrl(metadata, tag, operationId, openapi_pages);
+
   const allResourceChanges = changes || versions.map((version) => version.changes.map((change) => change)).flat();
   const publicResourceChanges = allResourceChanges.filter(
     (c) => c.changeCode !== 'operation-id-changed' || c.changeCode !== 'operation-tag-changed'
   );
-  // TODO: Removed third option below when Ciprian has re-added "changeType" to diff
-  const changeTypeBadge = changeTypeBadges[changeType || versions?.[0]?.changeType || 'release'];
+  const changeTypeBadge = versions?.[0]?.changeType ? changeTypeBadges[versions[0].changeType] : null;
 
   return (
     <Wrapper data-testid="resource-changes-block">

--- a/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
+++ b/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
@@ -40,8 +40,12 @@ const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, cha
   const { openapi_pages } = useSnootyMetadata();
 
   const resourceLinkUrl = getResourceLinkUrl(metadata, tag, operationId, openapi_pages);
-  const resourceChanges = changes || versions.map((version) => version.changes.map((change) => change)).flat();
-  const changeTypeBadge = changeTypeBadges[changeType || versions[0].changeType];
+  const allResourceChanges = changes || versions.map((version) => version.changes.map((change) => change)).flat();
+  const publicResourceChanges = allResourceChanges.filter(
+    (c) => c.changeCode !== 'operation-id-changed' || c.changeCode !== 'operation-tag-changed'
+  );
+  // TODO: Removed third option below when Ciprian has re-added "changeType" to diff
+  const changeTypeBadge = changeTypeBadges[changeType || versions?.[0]?.changeType || 'release'];
 
   return (
     <Wrapper data-testid="resource-changes-block">
@@ -56,7 +60,7 @@ const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, cha
         )}
       </FlexLinkWrapper>
       <ChangeListUL>
-        {resourceChanges.map((change, i) => (
+        {publicResourceChanges.map((change, i) => (
           <Change key={`change-${i}`} {...change} />
         ))}
       </ChangeListUL>

--- a/src/components/OpenAPIChangelog/utils/getDiffRequestFormat.js
+++ b/src/components/OpenAPIChangelog/utils/getDiffRequestFormat.js
@@ -1,0 +1,8 @@
+import { isAfter } from 'date-fns';
+
+export const getDiffRequestFormat = (resourceVersionOne, resourceVersionTwo) => {
+  const resourceVersionChoices = [resourceVersionOne, resourceVersionTwo].sort((a, b) =>
+    isAfter(new Date(b.split('-').join('/')), new Date(a.split('-').join('/'))) ? -1 : 1
+  );
+  return resourceVersionChoices.join('_');
+};

--- a/src/components/OpenAPIChangelog/utils/useFetchDiff.js
+++ b/src/components/OpenAPIChangelog/utils/useFetchDiff.js
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+import { fetchOADiff } from '../../../utils/realm';
+import { getDiffRequestFormat } from './getDiffRequestFormat';
+
+export const useFetchDiff = ({ resourceVersionOne, resourceVersionTwo, index }) => {
+  const [diff, setDiff] = useState([]);
+
+  useEffect(() => {
+    if (!resourceVersionOne || !resourceVersionTwo || !index.runId) return;
+    const fromAndToDiffString = getDiffRequestFormat(resourceVersionOne, resourceVersionTwo);
+
+    fetchOADiff(index.runId, fromAndToDiffString)
+      .then((response) => setDiff(response))
+      .catch((err) => console.error(err));
+  }, [resourceVersionOne, resourceVersionTwo, index.runId]);
+
+  return [diff, setDiff];
+};

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -54,3 +54,7 @@ export const fetchDocument = async (database, collectionName, query, projections
 export const fetchDocuments = async (database, collectionName, query, projections, options) => {
   return fetchData('fetchDocuments', database, collectionName, query, projections, options);
 };
+
+export const fetchOADiff = async (runId, diffString) => {
+  return fetchData('fetchOADiff', runId, diffString);
+};

--- a/tests/unit/ChangeList.test.js
+++ b/tests/unit/ChangeList.test.js
@@ -34,4 +34,23 @@ describe('OpenAPIChangelog ChangeList', () => {
     const tree = render(<ChangeList changes={mockDiff} versionMode={COMPARE_VERSIONS} />);
     expect(tree.asFragment()).toMatchSnapshot();
   });
+
+  it('changes with the changeCode "operation-id-changed" and "operation-tag-changed" should not be visible', () => {
+    const hiddenChanges = mockDiff.reduce((acc, resource) => {
+      resource.changes.forEach(
+        (change) =>
+          (change.changeCode === 'operation-id-changed' || change.changeCode === 'operation-tag-changed') &&
+          acc.push(change)
+      );
+      return acc;
+    }, []);
+
+    const { queryByText } = render(<ChangeList changes={mockDiff} versionMode={COMPARE_VERSIONS} />);
+
+    expect(hiddenChanges).toHaveLength(2);
+
+    hiddenChanges.forEach((change) => {
+      expect(queryByText(change.change)).toBeNull();
+    });
+  });
 });

--- a/tests/unit/__snapshots__/ChangeList.test.js.snap
+++ b/tests/unit/__snapshots__/ChangeList.test.js.snap
@@ -623,49 +623,20 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
 }
 
 .emotion-11 {
-  margin-top: 2px;
-}
-
-.emotion-13 {
-  font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-weight: 700;
-  font-size: 12px;
-  line-height: 16px;
-  border-radius: 5px;
-  height: 18px;
-  padding-left: 6px;
-  padding-right: 6px;
-  text-transform: uppercase;
-  border: 1px solid;
-  letter-spacing: 1px;
-  background-color: #E3FCF7;
-  border-color: #C0FAE6;
-  color: #00684A;
-}
-
-.emotion-14 {
   margin: 0;
   list-style-position: start;
 }
 
-.emotion-16 {
+.emotion-13 {
   margin-top: 12px;
   line-height: 28px;
 }
 
-.emotion-18 {
+.emotion-15 {
   position: relative;
 }
 
-.emotion-19 {
+.emotion-16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -678,33 +649,8 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
   margin-right: 5px;
 }
 
-.emotion-21 {
+.emotion-18 {
   color: #DB3030;
-}
-
-.emotion-35 {
-  font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-weight: 700;
-  font-size: 12px;
-  line-height: 16px;
-  border-radius: 5px;
-  height: 18px;
-  padding-left: 6px;
-  padding-right: 6px;
-  text-transform: uppercase;
-  border: 1px solid;
-  letter-spacing: 1px;
-  background-color: #FFEAE5;
-  border-color: #FFCDC7;
-  color: #970606;
 }
 
 <div
@@ -732,24 +678,19 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
             </h6>
           </span>
         </a>
-        <div
-          class="emotion-11 emotion-12 emotion-13"
-        >
-          Updated
-        </div>
       </div>
       <ul
-        class="emotion-14 emotion-15"
+        class="emotion-11 emotion-12"
       >
         <li
-          class="emotion-16 emotion-17"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-18 emotion-19 emotion-20"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-21"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -768,9 +709,40 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           Removed the non-success response with the status '400'.
         </li>
         <li
-          class="emotion-16 emotion-17"
+          class="emotion-13 emotion-14"
         >
           Added the new optional 'query' request parameter 'envelope'.
+        </li>
+        <li
+          class="emotion-13 emotion-14"
+        >
+          This change should be hidden!
+        </li>
+        <li
+          class="emotion-13 emotion-14"
+        >
+          <div
+            class="emotion-15 emotion-16 emotion-17"
+          >
+            <svg
+              aria-label="Important With Circle Icon"
+              class="emotion-18"
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M8 15A7 7 0 108 1a7 7 0 000 14zM7 4.5a1 1 0 012 0v4a1 1 0 01-2 0v-4zm2 7a1 1 0 11-2 0 1 1 0 012 0z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+          This change should be hidden!
         </li>
       </ul>
     </div>
@@ -796,24 +768,19 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
             </h6>
           </span>
         </a>
-        <div
-          class="emotion-11 emotion-12 emotion-35"
-        >
-          Removed
-        </div>
       </div>
       <ul
-        class="emotion-14 emotion-15"
+        class="emotion-11 emotion-12"
       >
         <li
-          class="emotion-16 emotion-17"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-18 emotion-19 emotion-20"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-21"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"

--- a/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
+++ b/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
@@ -889,6 +889,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               tabindex="-1"
             >
               <button
+                aria-controls="ALL_VERSIONS"
                 aria-selected="true"
                 class="emotion-21"
                 id="segmented-control-1-0"
@@ -918,6 +919,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               tabindex="-1"
             >
               <button
+                aria-controls="COMPARE_VERSIONS"
                 aria-selected="false"
                 class="emotion-21"
                 id="segmented-control-1-1"

--- a/tests/unit/data/OpenAPIChangelog.js
+++ b/tests/unit/data/OpenAPIChangelog.js
@@ -164,6 +164,16 @@ export const mockDiff = [
         changeCode: 'new-optional-request-parameter',
         backwardCompatible: true,
       },
+      {
+        change: 'this change should be hidden!',
+        changeCode: 'operation-id-changed',
+        backwardCompatible: true,
+      },
+      {
+        change: 'this change should be hidden!',
+        changeCode: 'operation-tag-changed',
+        backwardCompatible: false,
+      },
     ],
   },
   {


### PR DESCRIPTION
### Stories/Links:

DOP-3617

### Notes:

The `OpenAPIChangelog` now dynamically fetches the diff between two `Resource Versions` whenever a user chooses two `Resource Versions` to compare. 

Also:
- moves the appending of " (latest)" to a display value rather than modifying the value in state.
- deals with `SegmentedContro`l `aria-controls` warning
- removes the change badges from the diffs as referenced by the design
- hides any changes that have the `changeType` "operation-id-changed" or "operation-tag-changed" as desired by APIx
- creates an [Atlas App Services Function](https://realm.mongodb.com/groups/5bad1d3d96e82129f16c5df3/apps/5d41ef5e2de84772fc7c2de2/functions/646cc47cf571983e9ce0671e) `fetchOADiff` to enable this querying and to bypass CORS