### PR TITLE
Echo S3 url for staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_BUCKET=docs-mongodb-org-stg
-STAGING_URL="https://docs-mongodbcom-integration.corp.mongodb.com"
+STAGING_URL="https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com"
 -include .env.production
 
 .PHONY: stage
@@ -25,5 +25,5 @@ stage: prefix
 		echo "To stage changes to the Snooty frontend, ensure that GATSBY_SNOOTY_DEV=true in your production environment."; exit 1; \
 	else \
 		mut-publish public ${STAGING_BUCKET} --prefix=${PREFIX} --stage ${ARGS}; \
-		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/"; \
+		echo "Hosted at ${STAGING_URL}/${PREFIX}/${USER}/${GIT_BRANCH}/index.html"; \
 	fi


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Atlas App Services](https://www.mongodb.com/atlas/app-services/)

### Staging Links:

[Atlas App Services](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-app-services/raymundrodriguez/replace-staging-host/index.html), just as a control to help see Makefile output, but no changes applied.

### Notes:
* Updates the staging url hostname used by the Makefile.
* For now, we don't use the hostname that we had on Fastly for staging. We have to use the S3 bucket's url with `index.html` appended at the end of the page path.