### PR TITLE
DOP-3720: OpenAPI Changelog fallback to RunId

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -109,7 +109,7 @@ const fetchChangelogData = async (runId, versions) => {
     };
   } catch (error) {
     console.warn('Changelog error: Most recent runId not successful. Using last successful runId to build Changelog.');
-    throw new Error(error);
+    throw error;
   }
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -103,8 +103,8 @@ const fetchChangelogData = async (runId, versions) => {
       changelog,
       changelogResourcesList,
       mostRecentDiff: {
-        mostRecentDiffData,
         mostRecentDiffLabel,
+        mostRecentDiffData,
       },
     };
   } catch (error) {
@@ -130,8 +130,8 @@ const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createCont
       index,
     };
     try {
-      const { changelog, changelogResourcesList, mostRecentDiff } = await fetchChangelogData(runId, versions);
-      changelogData = { ...changelogData, changelog, changelogResourcesList, mostRecentDiff };
+      const receivedChangelogData = await fetchChangelogData(runId, versions);
+      changelogData = { ...changelogData, ...receivedChangelogData };
       await db.stitchInterface.updateOAChangelogMetadata(index);
     } catch (error) {
       /* If any error occurs, fetch last successful metadata and build changelog node */
@@ -141,8 +141,8 @@ const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createCont
         {}
       );
       const { runId: lastRunId, versions: lastVersions } = lastSuccessfulIndex;
-      const oldChangelogData = fetchChangelogData(lastRunId, lastVersions);
-      changelogData = { index: lastSuccessfulIndex, ...oldChangelogData };
+      const receivedChangelogData = fetchChangelogData(lastRunId, lastVersions);
+      changelogData = { index: lastSuccessfulIndex, ...receivedChangelogData };
     }
 
     /* Create Node for useStaticQuery with all Changelog data */

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -151,7 +151,7 @@ const OpenAPIChangelog = () => {
         setResourceVersionOne={setResourceVersionOne}
         setResourceVersionTwo={setResourceVersionTwo}
       />
-      {(versionMode === ALL_VERSIONS || (resourceVersionOne && resourceVersionTwo)) && (
+      {!isLoading && (versionMode === ALL_VERSIONS || (resourceVersionOne && resourceVersionTwo)) && (
         <ChangeList
           versionMode={versionMode}
           changes={versionMode === ALL_VERSIONS ? filteredChangelog : filteredDiff}

--- a/src/components/OpenAPIChangelog/utils/getDiffRequestFormat.js
+++ b/src/components/OpenAPIChangelog/utils/getDiffRequestFormat.js
@@ -2,7 +2,7 @@ import { isAfter } from 'date-fns';
 
 export const getDiffRequestFormat = (resourceVersionOne, resourceVersionTwo) => {
   const resourceVersionChoices = [resourceVersionOne, resourceVersionTwo].sort((a, b) =>
-    isAfter(new Date(b.split('-').join('/')), new Date(a.split('-').join('/'))) ? -1 : 1
+    isAfter(new Date(b.slice(0, 10).split('-').join('/')), new Date(a.slice(0, 10).split('-').join('/'))) ? -1 : 1
   );
   return resourceVersionChoices.join('_');
 };

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -48,6 +48,14 @@ class StitchInterface {
       findOptions,
     ]);
   }
+
+  async fetchDocument(database, collectionName, query) {
+    return this.stitchClient.callFunction('fetchDocument', [database, collectionName, query]);
+  }
+
+  async updateOAChangelogMetadata(metadata) {
+    return this.stitchClient.callFunction('updateOAChangelogMetadata', [metadata]);
+  }
 }
 
 class ManifestDocumentDatabase {
@@ -119,6 +127,14 @@ class StitchDocumentDatabase {
 
   async fetchAllProducts() {
     return this.stitchInterface.fetchAllProducts();
+  }
+
+  async fetchDocument(database, collectionName, query) {
+    return this.stitchInterface.fetchDocument(database, collectionName, query);
+  }
+
+  async updateOAChangelogMetadata(metadata) {
+    return this.stitchInterface.updateOAChangelogMetadata(metadata);
   }
 }
 


### PR DESCRIPTION
### Stories/Links:

DOP-3720

### Notes:

On the event of any error in fetching OpenAPI Changelog data, Snooty should read the last successful runId from Atlas to gain valid data for the build.

The `openapi_changelog.atlas_admin_metadata` collection in Atlas will hold the last successful run's metadata.

On a successful build of changelog data, Snooty will upsert the metadata object directly into this collection. 
On errored builds of changelog data, Snooty will fallback to read this older metadata from Atlas and use the requisite data to successfully build the Atlas Admin Changelog.

Note: Also two bugs are fixed in this PR:
- on diff loading state, ensure that the previous diff is not shown along with the loading skeleton
- when sorting Resource Versions by date, slice Resource Version string down to a simple date (there were edge cases on naming conventions such as '2023-08-11~preview')