### PR TITLE
DOP-3758: Changelog: Change chip size

### DIFF
--- a/src/components/OpenAPIChangelog/components/FiltersPanel/components/FiltersPanel.js
+++ b/src/components/OpenAPIChangelog/components/FiltersPanel/components/FiltersPanel.js
@@ -4,6 +4,7 @@ import { Combobox, ComboboxOption } from '@leafygreen-ui/combobox';
 import { SegmentedControl, SegmentedControlOption } from '@leafygreen-ui/segmented-control';
 import { ALL_VERSIONS, COMPARE_VERSIONS } from '../../../utils/constants';
 import { theme } from '../../../../../theme/docsTheme';
+import useScreenSize from '../../../../../hooks/useScreenSize';
 import DiffSelect from './DiffSelect';
 
 const Wrapper = styled.div`
@@ -51,6 +52,8 @@ const FiltersPanel = ({
   setResourceVersionOne,
   setResourceVersionTwo,
 }) => {
+  const { isMobile } = useScreenSize();
+
   return (
     <Wrapper>
       <StyledSegmentedControl value={versionMode} onChange={setVersionMode}>
@@ -82,6 +85,7 @@ const FiltersPanel = ({
           onChange={setSelectedResources}
           popoverZIndex={3}
           searchEmptyMessage="To see results, select two versions to compare"
+          chipCharacterLimit={isMobile ? 12 : 50}
           multiselect
         >
           {resources.map((version) => (


### PR DESCRIPTION
### Stories/Links:

DOP-3758

<img width="1364" alt="Screenshot 2023-06-06 at 11 21 23 AM" src="https://github.com/mongodb/snooty/assets/22421112/0471c1b6-7aac-4da9-aebd-d77507aa43f5">

### Notes:

From UAT feedback:
The small chips could be confusing for users. Alas, LG cannot change the text in the Chip. However, this PR allows non-mobile users to see much longer Chips to have more context on what's chosen. The hover tooltip further clarifies.
