### PR TITLE
DOP-3651: version context cleanup, use local storage only on front end

### DIFF
--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -4,9 +4,7 @@ import { css } from '@emotion/react';
 import { cx, css as LeafyCSS } from '@leafygreen-ui/emotion';
 import { SideNavItem } from '@leafygreen-ui/side-nav';
 import { palette } from '@leafygreen-ui/palette';
-import Box from '@leafygreen-ui/box';
 import Icon from '@leafygreen-ui/icon';
-import { theme } from '../../theme/docsTheme';
 import Link from '../Link';
 import { NavigationContext } from '../../context/navigation-context';
 import { VersionContext } from '../../context/version-context';
@@ -27,24 +25,6 @@ const caretStyle = LeafyCSS`
   min-width: 16px;
 `;
 
-const wrapperStyle = LeafyCSS`
-  display: flex;
-  align-items: center;
-  scroll-margin-bottom: ${theme.size.xxlarge};
-
-  &:hover {
-    background: ${palette.gray.light2};
-  }
-
-  > li {
-    flex: 1 1 auto;
-  }
-`;
-
-const wrapperPadding = LeafyCSS`
-  padding-right: ${theme.size.medium};
-`;
-
 const overwriteLinkStyle = LeafyCSS`
   span {
     display: flex;
@@ -63,6 +43,7 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
   const target = options.urls?.[activeVersions[options.project]] || slug || url;
   const hasChildren = !!children?.length;
   const hasVersions = !!(options?.versions?.length > 1);
+
   const isActive = isActiveTocNode(activeSection, slug, children);
   const isSelected = isSelectedTocNode(activeSection, slug);
   const isDrawer = !!(options && (options.drawer || options.versions)); // TODO: convert versions option to drawer in backend
@@ -119,45 +100,43 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
 
     if (isDrawer && hasChildren) {
       return (
-        <Box ref={tocNodeRef} className={cx(wrapperStyle, { [wrapperPadding]: hasVersions })}>
-          <SideNavItem
-            className={cx(sideNavItemTOCStyling({ level }))}
-            onClick={() => {
-              setIsOpen(!isOpen);
-            }}
-          >
-            <Icon className={cx(caretStyle)} glyph={iconType} fill={palette.gray.base} onClick={onCaretClick} />
-            {isTocIcon && <SyncCloud />}
-            {formattedTitle}
-          </SideNavItem>
+        <SideNavItem
+          className={cx(sideNavItemTOCStyling({ level }))}
+          as="a"
+          onClick={() => {
+            setIsOpen(!isOpen);
+          }}
+        >
+          <Icon className={cx(caretStyle)} glyph={iconType} fill={palette.gray.base} onClick={onCaretClick} />
+          {isTocIcon && <SyncCloud />}
+          {formattedTitle}
           {hasVersions && activeVersions[options.project] && (
             <VersionSelector versionedProject={options.project} tocVersionNames={options.versions} />
           )}
-        </Box>
+        </SideNavItem>
       );
     }
+
     return (
-      <Box ref={tocNodeRef} className={cx(wrapperStyle, { [wrapperPadding]: hasVersions })}>
-        <SideNavItem
-          as={Link}
-          to={target}
-          active={isSelected}
-          className={cx(sideNavItemTOCStyling({ level }), overwriteLinkStyle)}
-          onClick={(e) => {
-            setIsOpen(!isOpen);
-          }}
-          hideExternalIcon={true}
-        >
-          {hasChildren && (
-            <Icon className={cx(caretStyle)} glyph={iconType} fill={palette.gray.base} onClick={onCaretClick} />
-          )}
-          {isTocIcon && <SyncCloud />}
-          {formattedTitle}
-        </SideNavItem>
+      <SideNavItem
+        as={Link}
+        to={target}
+        active={isSelected}
+        className={cx(sideNavItemTOCStyling({ level }), overwriteLinkStyle)}
+        onClick={(e) => {
+          setIsOpen(!isOpen);
+        }}
+        hideExternalIcon={true}
+      >
+        {hasChildren && (
+          <Icon className={cx(caretStyle)} glyph={iconType} fill={palette.gray.base} onClick={onCaretClick} />
+        )}
+        {isTocIcon && <SyncCloud />}
+        {formattedTitle}
         {hasVersions && activeVersions[options.project] && (
           <VersionSelector versionedProject={options.project} tocVersionNames={options.versions} />
         )}
-      </Box>
+      </SideNavItem>
     );
   };
 

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -5,6 +5,7 @@ import { cx, css as LeafyCSS } from '@leafygreen-ui/emotion';
 import { SideNavItem } from '@leafygreen-ui/side-nav';
 import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
+import { theme } from '../../theme/docsTheme';
 import Link from '../Link';
 import { NavigationContext } from '../../context/navigation-context';
 import { VersionContext } from '../../context/version-context';
@@ -90,7 +91,9 @@ const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, pa
         css={css`
           margin-left: ${hasChildren || isTocIcon ? '0px' : '21px'};
           color: ${isActive ? `${palette.green.dark3};` : `${palette.gray.dark3};`};
+          scroll-margin-bottom: ${theme.size.xxlarge};
         `}
+        ref={tocNodeRef}
       >
         {formatText(title, formatTextOptions)}
       </div>

--- a/src/components/Sidenav/VersionSelector.js
+++ b/src/components/Sidenav/VersionSelector.js
@@ -52,7 +52,7 @@ const selectStyle = css`
   }
 `;
 
-const WrapperStyle = css`
+const wrapperStyle = css`
   margin-left: auto;
 `;
 
@@ -76,7 +76,7 @@ const VersionSelector = ({ versionedProject = '', tocVersionNames = [] }) => {
   }, []);
 
   return (
-    <div onClick={onClick} className={cx(WrapperStyle)}>
+    <div onClick={onClick} className={cx(wrapperStyle)}>
       <Select
         value={activeVersions[versionedProject]}
         className={cx(selectStyle)}

--- a/src/components/Sidenav/VersionSelector.js
+++ b/src/components/Sidenav/VersionSelector.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import styled from '@emotion/styled';
+import { cx, css } from '@leafygreen-ui/emotion';
 import Select from '../Select';
 import { VersionContext } from '../../context/version-context';
 import { theme } from '../../theme/docsTheme';
@@ -15,7 +15,7 @@ const buildChoices = (branches, tocVersionNames) => {
   return !branches ? [] : branches.filter((branch) => tocVersionNames.includes(branch.gitBranchName)).map(buildChoice);
 };
 
-const StyledSelect = styled(Select)`
+const SelectStyle = css`
   flex: 1 0 auto;
 
   > div:first-of-type {
@@ -42,7 +42,6 @@ const StyledSelect = styled(Select)`
         transform: rotate(180deg);
       }
     }
-    z-index: 3;
   }
 
   span {
@@ -51,6 +50,10 @@ const StyledSelect = styled(Select)`
     display: -webkit-box;
     -webkit-box-orient: vertical;
   }
+`;
+
+const WrapperStyle = css`
+  margin-left: auto;
 `;
 
 const VersionSelector = ({ versionedProject = '', tocVersionNames = [] }) => {
@@ -68,15 +71,22 @@ const VersionSelector = ({ versionedProject = '', tocVersionNames = [] }) => {
     [onVersionSelect, versionedProject]
   );
 
+  const onClick = useCallback((e) => {
+    e.stopPropagation();
+  }, []);
+
   return (
-    <StyledSelect
-      value={activeVersions[versionedProject]}
-      onChange={onChange}
-      aria-labelledby={'select'}
-      popoverZIndex={2}
-      allowDeselect={false}
-      choices={options}
-    ></StyledSelect>
+    <div onClick={onClick} className={cx(WrapperStyle)}>
+      <Select
+        value={activeVersions[versionedProject]}
+        className={cx(SelectStyle)}
+        onChange={onChange}
+        aria-labelledby={'select'}
+        popoverZIndex={2}
+        allowDeselect={false}
+        choices={options}
+      ></Select>
+    </div>
   );
 };
 

--- a/src/components/Sidenav/VersionSelector.js
+++ b/src/components/Sidenav/VersionSelector.js
@@ -15,7 +15,7 @@ const buildChoices = (branches, tocVersionNames) => {
   return !branches ? [] : branches.filter((branch) => tocVersionNames.includes(branch.gitBranchName)).map(buildChoice);
 };
 
-const SelectStyle = css`
+const selectStyle = css`
   flex: 1 0 auto;
 
   > div:first-of-type {
@@ -79,7 +79,7 @@ const VersionSelector = ({ versionedProject = '', tocVersionNames = [] }) => {
     <div onClick={onClick} className={cx(WrapperStyle)}>
       <Select
         value={activeVersions[versionedProject]}
-        className={cx(SelectStyle)}
+        className={cx(selectStyle)}
         onChange={onChange}
         aria-labelledby={'select'}
         popoverZIndex={2}

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -50,13 +50,10 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
       // if it doesn't already exist
       // NOTE: do we need to traverse full ToC tree? for now just immediate children
       for (let node of tocNode.children) {
-        if (!node?.options?.versions || !node?.options?.project) {
+        if (!node?.options?.versions || !node?.options?.project || !activeVersions[node.options.project]) {
           continue;
         }
-        if (
-          !activeVersions[node.options.project] ||
-          !node.options.versions.includes(activeVersions[node.options.project])
-        ) {
+        if (!node.options.versions.includes(activeVersions[node.options.project])) {
           // assumption is that first branch in pool.repos_branches
           // exists as a toc node here. otherwise, fallback to first ToC option
           const gitBranchNames = availableVersions[node.options.project].map((b) => b.gitBranchName);

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -103,7 +103,7 @@ const getDefaultGroups = (project, repoBranches) => {
   return groups;
 };
 
-const getDefaultActiveVersions = ([metadata, associatedReposInfo]) => {
+const getDefaultActiveVersions = (metadata) => {
   // for current metadata.project, should always default to metadata.parserBranch
   const { project, parserBranch } = metadata;
   let versions = {};
@@ -147,11 +147,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
 
   // TODO check whats going on here for 404 pages
   // tracks active versions across app
-  const [activeVersions, setActiveVersions] = useReducer(
-    versionStateReducer,
-    [metadata, associatedReposInfo],
-    getDefaultActiveVersions
-  );
+  const [activeVersions, setActiveVersions] = useReducer(versionStateReducer, metadata, getDefaultActiveVersions);
   // update local storage when active versions change
   useEffect(() => {
     const existing = getLocalValue(STORAGE_KEY);

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -21,11 +21,8 @@ const getInitBranchName = (branches) => {
 };
 
 const getInitVersions = (branchListByProduct) => {
-  console.log('getInitVersions');
   const initState = {};
   const localStorage = getLocalValue(STORAGE_KEY);
-  console.log('localStorage');
-  console.log(localStorage);
   for (const productName in branchListByProduct) {
     initState[productName] = localStorage?.[productName] || getInitBranchName(branchListByProduct[productName]);
   }
@@ -147,7 +144,6 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
   const metadata = useSiteMetadata();
   const { associated_products: associatedProducts } = useSnootyMetadata();
   const mountRef = useRef(true);
-  const firstLoad = useRef(true);
 
   // TODO check whats going on here for 404 pages
   // tracks active versions across app
@@ -158,15 +154,12 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
   );
   // update local storage when active versions change
   useEffect(() => {
-    if (firstLoad.current) {
-      firstLoad.current = false;
-      return;
-    }
-    setLocalValue(STORAGE_KEY, activeVersions);
+    const existing = getLocalValue(STORAGE_KEY);
+    setLocalValue(STORAGE_KEY, { ...existing, ...activeVersions });
     return () => {
       mountRef.current = false;
     };
-  }, [activeVersions, firstLoad]);
+  }, [activeVersions]);
 
   // expose the available versions for current and associated products
   const [availableVersions, setAvailableVersions] = useState(

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -21,8 +21,11 @@ const getInitBranchName = (branches) => {
 };
 
 const getInitVersions = (branchListByProduct) => {
+  console.log('getInitVersions');
   const initState = {};
   const localStorage = getLocalValue(STORAGE_KEY);
+  console.log('localStorage');
+  console.log(localStorage);
   for (const productName in branchListByProduct) {
     initState[productName] = localStorage?.[productName] || getInitBranchName(branchListByProduct[productName]);
   }
@@ -155,7 +158,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
   );
   // update local storage when active versions change
   useEffect(() => {
-    if (firstLoad) {
+    if (firstLoad.current) {
       firstLoad.current = false;
       return;
     }

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -24,7 +24,7 @@ const getInitVersions = (branchListByProduct) => {
   const initState = {};
   const localStorage = getLocalValue(STORAGE_KEY);
   for (const productName in branchListByProduct) {
-    initState[productName] = localStorage[productName] || getInitBranchName(branchListByProduct[productName]);
+    initState[productName] = localStorage?.[productName] || getInitBranchName(branchListByProduct[productName]);
   }
   return initState;
 };
@@ -144,6 +144,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
   const metadata = useSiteMetadata();
   const { associated_products: associatedProducts } = useSnootyMetadata();
   const mountRef = useRef(true);
+  const firstLoad = useRef(true);
 
   // TODO check whats going on here for 404 pages
   // tracks active versions across app
@@ -154,11 +155,15 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
   );
   // update local storage when active versions change
   useEffect(() => {
+    if (firstLoad) {
+      firstLoad.current = false;
+      return;
+    }
     setLocalValue(STORAGE_KEY, activeVersions);
     return () => {
       mountRef.current = false;
     };
-  }, [activeVersions]);
+  }, [activeVersions, firstLoad]);
 
   // expose the available versions for current and associated products
   const [availableVersions, setAvailableVersions] = useState(

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -141,7 +141,7 @@ describe('Version Context', () => {
   let wrapper,
     mockedBrowserStorageSetter,
     mockedBrowserStorageGetter,
-    mockedLocalStorage,
+    mockedLocalStorage = {},
     mockedFetchDocument,
     mockFetchDocuments;
 
@@ -224,13 +224,13 @@ describe('Version Context', () => {
     }
 
     // active checks
-    const expectedActive = { 'cloud-docs': 'master' };
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'master' };
     expect(await wrapper.findByText(JSON.stringify(expectedActive))).toBeTruthy();
   });
 
   it('initializes with values from local storage', async () => {
     mockedLocalStorage[STORAGE_KEY] = { 'atlas-cli': 'v1.2' };
-    const expectedActive = { 'atlas-cli': 'v1.2', 'cloud-docs': 'master' };
+    const expectedActive = { 'cloud-docs': 'master', 'atlas-cli': 'v1.2' };
     await act(async () => {
       wrapper = mountConsumer();
     });

--- a/tests/unit/Toctree.test.js
+++ b/tests/unit/Toctree.test.js
@@ -43,9 +43,9 @@ describe('Toctree', () => {
 
   it('clicking on a drawer changes carat arrow', async () => {
     const wrapper = mountToctree('/');
-    const parentDrawer = wrapper.queryAllByRole('button');
+    const parentDrawer = wrapper.getByText('Get Started');
     expect(wrapper.getAllByRole('img')[0]).toHaveAttribute('aria-label', 'Caret Right Icon');
-    userEvent.click(parentDrawer[0]);
+    userEvent.click(parentDrawer);
     await tick();
     expect(wrapper.getAllByRole('img')[0]).toHaveAttribute('aria-label', 'Caret Down Icon');
   });


### PR DESCRIPTION
### Stories/Links:

DOP-3651

console logs in atlas docs show react hydration errors

### Current Behavior:

[atlas docs](https://www.mongodb.com/docs/atlas/)
[atlas cli docs](https://www.mongodb.com/docs/atlas/cli/upcoming/)

### Staging Links:

[atlas docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-3651/)
[atlas cli docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-cli/seung.park/DOP-3651/index.html)

### Notes:
two fixes to address these issues:
- [react error](https://legacy.reactjs.org/docs/error-decoder.html/?invariant=418) -> ie. `build time component does not match client side initial render` this was due to attempting to read local storage for initial values, which the server side does not. removed any local storage assumptions for init values. **note** this results in associated ToC being rendered on client side only (this is fail safe-d with regards to server side fallback values)
- also cleaned up SideNav component, removing unnecessary div wrapper around `SideNavItem<li>`, converting wrong `<button>` wrapper to an `<a>` wrapper:

previously shows nested `<divs>` inside `ul`:
![image](https://github.com/mongodb/snooty/assets/13054820/e2dd5303-f141-4c21-ac74-966fabe5ae2b)


on branch (cleaned up with `<li>` elements with no `<button>` wrapper:
![image](https://github.com/mongodb/snooty/assets/13054820/086eca65-7c4b-430a-b520-8c2d8b7bb0d8)


