### PR TITLE
DOP-3756: update S3 bucket for Changelog to prod

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -75,7 +75,7 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
   }
 };
 
-const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog';
+const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog';
 
 const fetchChangelogData = async (runId, versions) => {
   try {
@@ -114,7 +114,7 @@ const fetchChangelogData = async (runId, versions) => {
 const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createContentDigest }) => {
   try {
     /* Fetch OpenAPI Changelog metadata */
-    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/dev.json`);
+    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/prod.json`);
     const index = await indexResp.json();
 
     const { runId, versions } = index;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -76,7 +76,8 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
   }
 };
 
-const atlasAdminChangelogS3Prefix = 'https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi';
+// const atlasAdminChangelogS3Prefix = 'https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi';
+const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog';
 
 const fetchChangelogData = async (runId, versions) => {
   try {
@@ -117,7 +118,7 @@ const fetchChangelogData = async (runId, versions) => {
 const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createContentDigest }) => {
   try {
     /* Fetch OpenAPI Changelog metadata */
-    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/index.yaml`);
+    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/dev.yaml`);
     const indexText = await indexResp.text();
     const index = yaml.safeLoad(indexText, 'utf8');
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,3 @@
-const yaml = require('js-yaml');
 const path = require('path');
 const { transformBreadcrumbs } = require('./src/utils/setup/transform-breadcrumbs.js');
 const { baseUrl } = require('./src/utils/base-url');
@@ -76,15 +75,13 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
   }
 };
 
-// const atlasAdminChangelogS3Prefix = 'https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi';
 const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog';
 
 const fetchChangelogData = async (runId, versions) => {
   try {
     /* Using metadata runId, fetch OpenAPI Changelog full change list */
-    const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/changelog.yaml`);
-    const changelogText = await changelogResp.text();
-    const changelog = yaml.safeLoad(changelogText, 'utf8');
+    const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/changelog.json`);
+    const changelog = await changelogResp.json();
 
     /* Aggregate all Resources in changelog for frontend filter */
     const resourcesListSet = new Set();
@@ -96,9 +93,8 @@ const fetchChangelogData = async (runId, versions) => {
     /* Fetch most recent Resource Versions' diff */
     const mostRecentResourceVersions = versions.slice(-2);
     const mostRecentDiffLabel = mostRecentResourceVersions.join('_');
-    const mostRecentDiffResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/${mostRecentDiffLabel}.yaml`);
-    const mostRecentDiffText = await mostRecentDiffResp.text();
-    const mostRecentDiffData = yaml.safeLoad(mostRecentDiffText, 'utf8');
+    const mostRecentDiffResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/${mostRecentDiffLabel}.json`);
+    const mostRecentDiffData = await mostRecentDiffResp.json();
 
     return {
       changelog,
@@ -118,14 +114,13 @@ const fetchChangelogData = async (runId, versions) => {
 const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createContentDigest }) => {
   try {
     /* Fetch OpenAPI Changelog metadata */
-    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/dev.yaml`);
-    const indexText = await indexResp.text();
-    const index = yaml.safeLoad(indexText, 'utf8');
+    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/dev.json`);
+    const index = await indexResp.json();
 
     const { runId, versions } = index;
 
     if (!runId || typeof runId !== 'string')
-      throw new Error('OpenAPI Changelog Error: `runId` not available in S3 index.yaml!');
+      throw new Error('OpenAPI Changelog Error: `runId` not available in S3 index.json!');
 
     let changelogData = {
       index,

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -73,6 +73,9 @@ const OpenAPIChangelog = () => {
   const resourceVersions = index.versions?.length ? index.versions.slice().reverse() : [];
   const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId), [index]);
 
+  console.log(index.runId);
+  console.log(downloadChangelogUrl);
+
   const [versionMode, setVersionMode] = useState(ALL_VERSIONS);
   const [selectedResources, setSelectedResources] = useState([]);
   const [resourceVersionOne, setResourceVersionOne] = useState(resourceVersions[0]);
@@ -136,7 +139,7 @@ const OpenAPIChangelog = () => {
           <Body>(2.0{!!index.specRevisionShort && `~${index.specRevisionShort}`})</Body>
         </Title>
         <DownloadButton href={downloadChangelogUrl} disabled={!index.runId}>
-          Download API Changelog
+          Download Full API Changelog
         </DownloadButton>
       </ChangelogHeader>
       <FiltersPanel

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -73,9 +73,6 @@ const OpenAPIChangelog = () => {
   const resourceVersions = index.versions?.length ? index.versions.slice().reverse() : [];
   const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId), [index]);
 
-  console.log(index.runId);
-  console.log(downloadChangelogUrl);
-
   const [versionMode, setVersionMode] = useState(ALL_VERSIONS);
   const [selectedResources, setSelectedResources] = useState([]);
   const [resourceVersionOne, setResourceVersionOne] = useState(resourceVersions[0]);

--- a/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
+++ b/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
@@ -40,11 +40,14 @@ const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, ver
   const { openapi_pages } = useSnootyMetadata();
   const resourceLinkUrl = getResourceLinkUrl(metadata, tag, operationId, openapi_pages);
 
-  const allResourceChanges = changes || versions.map((version) => version.changes.map((change) => change)).flat();
+  const allResourceChanges =
+    changes || versions.map((version) => (version.changes ? version.changes.map((change) => change) : null)).flat();
   const publicResourceChanges = allResourceChanges.filter(
-    (c) => c.changeCode !== 'operation-id-changed' || c.changeCode !== 'operation-tag-changed'
+    (c) => c && (c.changeCode !== 'operation-id-changed' || c.changeCode !== 'operation-tag-changed')
   );
   const changeTypeBadge = versions?.[0]?.changeType ? changeTypeBadges[versions[0].changeType] : null;
+
+  console.log('publicResourceChanges ', publicResourceChanges);
 
   return (
     <Wrapper data-testid="resource-changes-block">

--- a/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
+++ b/src/components/OpenAPIChangelog/components/ResourceChangesBlock.js
@@ -42,12 +42,11 @@ const ResourceChangesBlock = ({ path, httpMethod, operationId, tag, changes, ver
 
   const allResourceChanges =
     changes || versions.map((version) => (version.changes ? version.changes.map((change) => change) : null)).flat();
+  /* Filter out all null changes or non-public-facing changes */
   const publicResourceChanges = allResourceChanges.filter(
     (c) => c && (c.changeCode !== 'operation-id-changed' || c.changeCode !== 'operation-tag-changed')
   );
   const changeTypeBadge = versions?.[0]?.changeType ? changeTypeBadges[versions[0].changeType] : null;
-
-  console.log('publicResourceChanges ', publicResourceChanges);
 
   return (
     <Wrapper data-testid="resource-changes-block">

--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -6,8 +6,6 @@ export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 export const getDownloadChangelogUrl = (runId) =>
   `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
 
-// https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/20230516174500/changelog.json
-
 export const changeTypeBadges = {
   release: {
     variant: Variant.Green,

--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -4,7 +4,7 @@ export const ALL_VERSIONS = 'ALL_VERSIONS';
 export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 
 export const getDownloadChangelogUrl = (runId) =>
-  `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+  `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
 
 export const changeTypeBadges = {
   release: {

--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -4,7 +4,9 @@ export const ALL_VERSIONS = 'ALL_VERSIONS';
 export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 
 export const getDownloadChangelogUrl = (runId) =>
-  `https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi/${runId}/changelog.yaml`;
+  `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+
+// https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/20230516174500/changelog.json
 
 export const changeTypeBadges = {
   release: {

--- a/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
+++ b/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
@@ -855,7 +855,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
         aria-disabled="false"
         class="emotion-8 emotion-9 emotion-10"
         data-leafygreen-ui="button"
-        href="https://mms-openapi-poc.s3.eu-west-1.amazonaws.com/openapi/20230403105948111/changelog.yaml"
+        href="https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/20230403105948111/changelog.json"
       >
         <div
           class="emotion-11"
@@ -863,7 +863,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
         <div
           class="emotion-12"
         >
-          Download API Changelog
+          Download Full API Changelog
         </div>
       </a>
     </div>


### PR DESCRIPTION
### Stories/Links:

DOP-3756

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/changelog/cloud-docs/matt.meigs/DOP-3756-download/reference/api-changelog/index.html)

### Notes:

Updates all references to Changelog data fetching to new S3 bucket address for prod data. 
No longer needed to parse `yaml` because the data is available in both `yaml` and `json` formats.

This PR also changes the text of the Download API Changelog button to be "Download Full API Changelog" :) 

One last change in this PR is to account for possibly null values within the main changelog changes array. This will only occur in the first change of the array as the APIx team is using this blank change at points to override the `changeType` for the `changeTypeBadge`. We ignore these nulls in the UI but use the data to display the correct `changeType` badge.
