### PR TITLE
DOP-3765: Prep npmrc for Gatsby Cloud installations

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,7 @@
 registry=https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/
+@mdb:registry=https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/
 //artifactory.corp.mongodb.com/artifactory/api/npm/npm/:_auth=${NPM_BASE_64_AUTH}
 _email=${NPM_EMAIL}
 _always-auth=true
+# Ensures npm doesn't throw error about conflicting versions of React for LG components
+legacy-peer-deps=true


### PR DESCRIPTION
### Stories/Links:

DOP-3765

### Current Behavior:

[Server docs](https://www.mongodb.com/docs/manual/) - prod

### Staging Links:

[Server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymundrodriguez/DOP-3765/index.html) - no change expected; built using clean install with updated `.npmrc` file

### Notes:

* `.npmrc` has been updated with new fields needed to allow Gatsby Cloud to install dependencies as needed.
   * A registry was added for `@mdb` packages since GC was having trouble setting the registry. I kept our existing default registry as-is to avoid any breaking changes since our `package-lock.json` already sources everything from Artifactory.
   * `legacy-peer-deps` was added as a default flag because GC may automatically install GC-specific dependencies when building a site. This will force GC to install using `--legacy-peer-deps` to avoid installation errors.
* The purpose of this PR is to update Snooty to allow the Gatsby Cloud to install frontend dependencies, as needed. Source plugin work will be tackled separately.