### PR TITLE
DOP-3825: bump top nav to 1.2.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@leafygreen-ui/tooltip": "^7.1.0",
         "@leafygreen-ui/typography": "^16.5.1",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "1.2.38",
+        "@mdb/consistent-nav": "1.2.39",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "adm-zip": "^0.5.9",
@@ -4719,9 +4719,9 @@
       "license": "MIT"
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "1.2.38",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.38.tgz",
-      "integrity": "sha512-0YmuZKxoW7q4T1eiV/FZhD/8NHsB+7VzYC5O6HdGyT/L6NcUl1Gc6n4Gord5v530og9ekYGpb2bTkN9DQRcJcA==",
+      "version": "1.2.39",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.39.tgz",
+      "integrity": "sha512-YTRRsNF3Vf42rw3ESYp5RUgFUZehO23M1ujHB1KKvndHS5pp9mXobZfz9rTroL0rKgJprT+9E6dQOqs6+yK5JA==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -26593,9 +26593,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "1.2.38",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.38.tgz",
-      "integrity": "sha512-0YmuZKxoW7q4T1eiV/FZhD/8NHsB+7VzYC5O6HdGyT/L6NcUl1Gc6n4Gord5v530og9ekYGpb2bTkN9DQRcJcA=="
+      "version": "1.2.39",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-1.2.39.tgz",
+      "integrity": "sha512-YTRRsNF3Vf42rw3ESYp5RUgFUZehO23M1ujHB1KKvndHS5pp9mXobZfz9rTroL0rKgJprT+9E6dQOqs6+yK5JA=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@leafygreen-ui/tooltip": "^7.1.0",
     "@leafygreen-ui/typography": "^16.5.1",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "1.2.38",
+    "@mdb/consistent-nav": "1.2.39",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
### Stories/Links:

DOP-3825

### Current Behavior:

There isn't Vector Search in the top nav.

### Staging Links:

Now there is: https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/allison/master/

