### PR TITLE
DOP-3890: Call post-build webhook

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -57,7 +57,6 @@ const APIBase = process.env.API_BASE || `https://snooty-data-api.mongodb.com`;
 
 exports.sourceNodes = async ({ actions, createNodeId, reporter, createContentDigest, cache, webhookBody }) => {
   console.log({ webhookBody });
-  console.log(webhookBody);
   let hasOpenAPIChangelog = false;
   const { createNode } = actions;
 
@@ -317,4 +316,8 @@ exports.createPages = async ({ actions, graphql }) => {
       },
     });
   });
+};
+
+exports.onPostBuild = async ({ webhookBody }) => {
+  console.log({ onPostBuildWebhookBody: webhookBody });
 };

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -244,6 +244,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     }
   `);
 
+  if (result.errors) {
+    await callPostBuildWebhook(currentWebhookBody, 'failed');
+    reporter.panic('There was an error in the graphql query', result.errors);
+  }
+
   if (!repoBranches) {
     try {
       const repoInfo = await db.stitchInterface.fetchRepoBranches();

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -329,11 +329,5 @@ exports.createPages = async ({ actions, graphql }) => {
 
 exports.onPostBuild = async (nodeOptions, pluginOptions) => {
   console.log('onPostBuild!!!');
-  console.log(
-    JSON.stringify({
-      nodeOptions,
-      pluginOptions,
-    })
-  );
   await callPostBuildWebhook(currentWebhookBody, 'success');
 };

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -327,6 +327,13 @@ exports.createPages = async ({ actions, graphql }) => {
   });
 };
 
-exports.onPostBuild = async () => {
-  callPostBuildWebhook(currentWebhookBody, 'success');
+exports.onPostBuild = async (nodeOptions, pluginOptions) => {
+  console.log('onPostBuild!!!');
+  console.log(
+    JSON.stringify({
+      nodeOptions,
+      pluginOptions,
+    })
+  );
+  await callPostBuildWebhook(currentWebhookBody, 'success');
 };

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -327,7 +327,11 @@ exports.createPages = async ({ actions, graphql }) => {
   });
 };
 
-exports.onPostBuild = async (nodeOptions, pluginOptions) => {
+exports.onPostBootstrap = () => {
+  console.log('onPostBootstrap!!!');
+};
+
+exports.onPostBuild = async () => {
   console.log('onPostBuild!!!');
   await callPostBuildWebhook(currentWebhookBody, 'success');
 };

--- a/plugins/gatsby-source-snooty-preview/utils/post-build.js
+++ b/plugins/gatsby-source-snooty-preview/utils/post-build.js
@@ -10,10 +10,10 @@ const constructSnootyHeader = (payloadString) =>
 
 /**
  * Calls the post-build webhook to let the Autobuilder know that the Gatsby Cloud
- * build is complete.
+ * build is finished.
  * @param {object} webhookBody - The webhook body passed to the source plugin to
  * initiate the preview build.
- * @param {string} status - The status of the build, typically "success" or "failed".
+ * @param {string} status - The status of the build, typically "completed" or "failed".
  * This value should coincide with the Autobuilder's job statuses.
  */
 const callPostBuildWebhook = async (webhookBody, status) => {
@@ -21,6 +21,12 @@ const callPostBuildWebhook = async (webhookBody, status) => {
   // that was not called by the preview webhook
   if (!webhookBody || !Object.keys(webhookBody).length) {
     console.log('No webhookBody found. This build will not call the post-build webhook.');
+    return;
+  }
+
+  const supportedStatuses = ['completed', 'failed'];
+  if (!supportedStatuses.includes(status)) {
+    console.log(`Post-build webhook call does not support status "${status}".`);
     return;
   }
 

--- a/plugins/gatsby-source-snooty-preview/utils/post-build.js
+++ b/plugins/gatsby-source-snooty-preview/utils/post-build.js
@@ -1,0 +1,49 @@
+const crypto = require('crypto');
+
+/**
+ * Constructs a signature using the payload and Snooty's secret. The signature
+ * can be used to help webhooks be more confident that the caller is Snooty.
+ * @param {string} payloadString
+ */
+const constructSnootyHeader = (payloadString) =>
+  crypto.createHmac('sha256', process.env.SNOOTY_SECRET).update(payloadString).digest('hex');
+
+/**
+ * Calls the post-build webhook to let the Autobuilder know that the Gatsby Cloud
+ * build is complete.
+ * @param {object} webhookBody - The webhook body passed to the source plugin to
+ * initiate the preview build.
+ * @param {string} status - The status of the build, typically "success" or "failed".
+ * This value should coincide with the Autobuilder's job statuses.
+ */
+const callPostBuildWebhook = async (webhookBody, status) => {
+  // Webhook body could be empty if the Gatsby Cloud site is doing a fresh build
+  // that was not called by the preview webhook
+  if (!webhookBody || !Object.keys(webhookBody).length) {
+    console.log('No webhookBody found. This build will not call the post-build webhook.');
+    return;
+  }
+
+  const payload = {
+    ...webhookBody,
+    status,
+  };
+  const body = JSON.stringify(payload);
+  const headers = {
+    'x-snooty-signature': constructSnootyHeader(body),
+  };
+
+  console.log('Calling post-build webhook.');
+  const res = await fetch(process.env.AUTOBUILDER_POST_BUILD_WEBHOOK, { method: 'POST', body, headers });
+  // Calling the webhook from this function should assume we are fulfilling the requirements of the call.
+  // Any error thrown here is definitely unexpected.
+  if (!res.ok) {
+    const errMessage = await res.text();
+    throw new Error(
+      `There was an issue calling the Autobuilder post-build webhook. Please have the DOP team check CloudWatch logs. ${errMessage}`
+    );
+  }
+  console.log('Post-build webhook was successfully called!');
+};
+
+module.exports = { callPostBuildWebhook };

--- a/plugins/gatsby-source-snooty-preview/utils/post-build.js
+++ b/plugins/gatsby-source-snooty-preview/utils/post-build.js
@@ -39,7 +39,7 @@ const callPostBuildWebhook = async (webhookBody, status) => {
     'x-snooty-signature': constructSnootyHeader(body),
   };
 
-  console.log('Calling post-build webhook.');
+  console.log(`Calling post-build webhook with status "${status}".`);
   const res = await fetch(process.env.AUTOBUILDER_POST_BUILD_WEBHOOK, { method: 'POST', body, headers });
   // Calling the webhook from this function should assume we are fulfilling the requirements of the call.
   // Any error thrown here is definitely unexpected.


### PR DESCRIPTION
### Stories/Links:

DOP-3890

### Notes:

* [Build log](https://www.gatsbyjs.com/dashboard/083213ad-92d8-4d3f-af78-848bb8100c91/sites/51bd00fd-eaf5-4965-8493-f52ac88723c6/builds/e1a5f0ed-118c-4b04-82ee-dfaab63dec11/details?returnTo=%2Fdashboard%2F083213ad-92d8-4d3f-af78-848bb8100c91%2Fsites%2F51bd00fd-eaf5-4965-8493-f52ac88723c6%2FcmsPreview#rawLogs) where webhook was called (see "Post-build webhook was successfully called!" log message). The job ID present in the webhook body `64ca88c35de6a8485ac4de7c` was also successfully called.
* I tried to cover major/obvious points of failure by calling the webhook when those may potentially occur. This might not necessarily be exhaustive and we may need to add more calls in the future as needed.