### PR TITLE
DOP-3918: OpenAPIChangelog responsive to env

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -75,12 +75,14 @@ const createRemoteMetadataNode = async ({ createNode, createNodeId, createConten
   }
 };
 
-const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog';
+// const atlasAdminChangelogS3Prefix = 'https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog';
+const atlasAdminDevChangelogS3Prefix = 'https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog';
 
 const fetchChangelogData = async (runId, versions) => {
   try {
     /* Using metadata runId, fetch OpenAPI Changelog full change list */
-    const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/changelog.json`);
+    // const changelogResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/changelog.json`);
+    const changelogResp = await fetch(`${atlasAdminDevChangelogS3Prefix}/${runId}/changelog.json`);
     const changelog = await changelogResp.json();
 
     /* Aggregate all Resources in changelog for frontend filter */
@@ -93,7 +95,8 @@ const fetchChangelogData = async (runId, versions) => {
     /* Fetch most recent Resource Versions' diff */
     const mostRecentResourceVersions = versions.slice(-2);
     const mostRecentDiffLabel = mostRecentResourceVersions.join('_');
-    const mostRecentDiffResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/${mostRecentDiffLabel}.json`);
+    // const mostRecentDiffResp = await fetch(`${atlasAdminChangelogS3Prefix}/${runId}/${mostRecentDiffLabel}.json`);
+    const mostRecentDiffResp = await fetch(`${atlasAdminDevChangelogS3Prefix}/${runId}/${mostRecentDiffLabel}.json`);
     const mostRecentDiffData = await mostRecentDiffResp.json();
 
     return {
@@ -114,7 +117,8 @@ const fetchChangelogData = async (runId, versions) => {
 const createOpenAPIChangelogNode = async ({ createNode, createNodeId, createContentDigest }) => {
   try {
     /* Fetch OpenAPI Changelog metadata */
-    const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/prod.json`);
+    // const indexResp = await fetch(`${atlasAdminChangelogS3Prefix}/prod.json`);
+    const indexResp = await fetch(`${atlasAdminDevChangelogS3Prefix}/dev.json`);
     const index = await indexResp.json();
 
     const { runId, versions } = index;

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -8,6 +8,7 @@ import Button from '@leafygreen-ui/button';
 import { Toast, ToastProvider, Variant } from '@leafygreen-ui/toast';
 import { theme } from '../../theme/docsTheme';
 import useChangelogData from '../../utils/use-changelog-data';
+import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import FiltersPanel from './components/FiltersPanel';
 import ChangeList from './components/ChangeList';
 import { useFetchDiff } from './utils/useFetchDiff';
@@ -69,6 +70,7 @@ const StyledLoadingSkeleton = styled.div`
 `;
 
 const OpenAPIChangelog = () => {
+  const { snootyEnv } = useSiteMetadata();
   const { index = {}, changelog = [], changelogResourcesList = [] } = useChangelogData();
   const resourceVersions = index.versions?.length ? index.versions.slice().reverse() : [];
   const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId), [index]);
@@ -80,7 +82,7 @@ const OpenAPIChangelog = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [toastOpen, setToastOpen] = useState(false);
 
-  const [diff] = useFetchDiff(resourceVersionOne, resourceVersionTwo, setIsLoading, setToastOpen);
+  const [diff] = useFetchDiff(resourceVersionOne, resourceVersionTwo, setIsLoading, setToastOpen, snootyEnv);
   const [diffResourcesList, setDiffResourcesList] = useState(getDiffResourcesList(diff));
 
   const [filteredDiff, setFilteredDiff] = useState(diff);

--- a/src/components/OpenAPIChangelog/OpenAPIChangelog.js
+++ b/src/components/OpenAPIChangelog/OpenAPIChangelog.js
@@ -73,7 +73,7 @@ const OpenAPIChangelog = () => {
   const { snootyEnv } = useSiteMetadata();
   const { index = {}, changelog = [], changelogResourcesList = [] } = useChangelogData();
   const resourceVersions = index.versions?.length ? index.versions.slice().reverse() : [];
-  const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId), [index]);
+  const downloadChangelogUrl = useMemo(() => getDownloadChangelogUrl(index.runId, snootyEnv), [index, snootyEnv]);
 
   const [versionMode, setVersionMode] = useState(ALL_VERSIONS);
   const [selectedResources, setSelectedResources] = useState([]);

--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -3,9 +3,11 @@ import { Variant } from '@leafygreen-ui/badge';
 export const ALL_VERSIONS = 'ALL_VERSIONS';
 export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 
-export const getDownloadChangelogUrl = (runId) =>
-  // `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
-  `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+export const getDownloadChangelogUrl = (runId, snootyEnv) => {
+  return snootyEnv === 'production'
+    ? `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`
+    : `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+};
 
 export const changeTypeBadges = {
   release: {

--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -4,7 +4,8 @@ export const ALL_VERSIONS = 'ALL_VERSIONS';
 export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 
 export const getDownloadChangelogUrl = (runId) =>
-  `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+  // `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
+  `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
 
 export const changeTypeBadges = {
   release: {

--- a/src/components/OpenAPIChangelog/utils/useFetchDiff.js
+++ b/src/components/OpenAPIChangelog/utils/useFetchDiff.js
@@ -3,7 +3,7 @@ import { fetchOADiff } from '../../../utils/realm';
 import useChangelogData from '../../../utils/use-changelog-data';
 import { getDiffRequestFormat } from './getDiffRequestFormat';
 
-export const useFetchDiff = (resourceVersionOne, resourceVersionTwo, setIsLoading, setToastOpen) => {
+export const useFetchDiff = (resourceVersionOne, resourceVersionTwo, setIsLoading, setToastOpen, snootyEnv) => {
   const { index = {}, mostRecentDiff = {} } = useChangelogData();
   const [diff, setDiff] = useState([]);
 
@@ -18,7 +18,7 @@ export const useFetchDiff = (resourceVersionOne, resourceVersionTwo, setIsLoadin
       setIsLoading(false);
     } else {
       setIsLoading(true);
-      fetchOADiff(index.runId, fromAndToDiffLabel)
+      fetchOADiff(index.runId, fromAndToDiffLabel, snootyEnv)
         .then((response) => {
           setDiff(response);
           setIsLoading(false);
@@ -30,7 +30,7 @@ export const useFetchDiff = (resourceVersionOne, resourceVersionTwo, setIsLoadin
           setTimeout(() => setToastOpen(false), 5000);
         });
     }
-  }, [resourceVersionOne, resourceVersionTwo, index, mostRecentDiff, setIsLoading, setToastOpen]);
+  }, [resourceVersionOne, resourceVersionTwo, index, mostRecentDiff, setIsLoading, setToastOpen, snootyEnv]);
 
   return [diff, setDiff];
 };

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -55,6 +55,6 @@ export const fetchDocuments = async (database, collectionName, query, projection
   return fetchData('fetchDocuments', database, collectionName, query, projections, options);
 };
 
-export const fetchOADiff = async (runId, diffString) => {
-  return fetchData('fetchOADiff', runId, diffString);
+export const fetchOADiff = async (runId, diffString, snootyEnv) => {
+  return fetchData('fetchOADiff', runId, diffString, snootyEnv);
 };

--- a/tests/unit/OpenAPIChangelog.test.js
+++ b/tests/unit/OpenAPIChangelog.test.js
@@ -49,6 +49,7 @@ useStaticQuery.mockImplementation(() => ({
       project: '',
       snootyBranch: '',
       user: '',
+      snootyEnv: 'production',
     },
   },
   allChangelogData: {
@@ -68,9 +69,11 @@ describe('OpenAPIChangelog tests', () => {
   let mockFetchOADiff;
 
   beforeEach(() => {
-    mockFetchOADiff = jest.spyOn(realm, 'fetchOADiff').mockImplementation(async (runId, fromAndToDiffString) => {
-      return mockDiff;
-    });
+    mockFetchOADiff = jest
+      .spyOn(realm, 'fetchOADiff')
+      .mockImplementation(async (runId, fromAndToDiffString, snootyEnv) => {
+        return mockDiff;
+      });
   });
 
   afterAll(() => {


### PR DESCRIPTION
### Stories/Links:

DOP-3918

### Current Behavior:

[Prod](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog/)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/changelog/cloud-docs/matt.meigs/DOP-3918-changelog-env/reference/api-changelog/index.html)

### Notes:

Dev and Staging builds will now use the dev data from the APIx team. This will enable them to view their changes before pushing to prod. 