### PR TITLE
assert trailing slash on canonicals

### DIFF
--- a/src/hooks/use-canonical-url.js
+++ b/src/hooks/use-canonical-url.js
@@ -1,3 +1,4 @@
+import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 import { useSiteMetadata } from './use-site-metadata';
 import { usePathPrefix } from './use-path-prefix';
 
@@ -51,5 +52,6 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
     }
   }
 
+  canonical = assertTrailingSlash(canonical);
   return canonical;
 };

--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -29,13 +29,13 @@ describe('Head', () => {
     beforeEach(() => {
       mockStaticQuery({}, mockEOLSnootyMetadata);
     });
-    it('renders the canonical tag structured from the Head component', () => {
+    it('renders the canonical tag structured from the Head component with trailing slash', () => {
       render(<Head pageContext={mockHeadPageContext} />);
       const { siteUrl } = useSiteMetadata();
       const urlSlug = 'stable';
       const siteBasePrefix = mockHeadPageContext.repoBranches.siteBasePrefix;
 
-      const currentVersion = `${siteUrl}/${siteBasePrefix}/${urlSlug}`;
+      const currentVersion = `${siteUrl}/${siteBasePrefix}/${urlSlug}/`;
 
       const canonicalTag = screen.getByTestId('canonical');
       expect(canonicalTag).toBeInTheDocument();


### PR DESCRIPTION
### Stories/Links:

DOP-3935

### Current Behavior:

[Prod page without trailing slash in canonical](https://www.mongodb.com/docs/manual/reference/connection-string/)

### Staging Links:

[Staging page with trailing slash in canonical](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/matt.meigs/DOP-3935-canonical-slash/reference/connection-string/index.html)

### Notes:

Recent changes to the behavior of building canonicals has resulted in great coverage, however it also introduced an unintended regression in not assuring a trailing a slash in our canonical links. This PR remedies that.