### PR TITLE
DOP-3982: Fix internal navigation in Gatsby plugin

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -307,6 +307,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         pagePath = node.page_id;
       }
       let slug = node.page_id;
+      // Slices off leading slash to ensure slug matches an entry within the toctreeOrder and renders InternalPageNav components
       if (slug !== '/' && slug[0] === '/') slug = slug.slice(1);
 
       createPage({

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -306,13 +306,15 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       } else {
         pagePath = node.page_id;
       }
+      let slug = node.page_id;
+      if (slug !== '/' && slug[0] === '/') slug = slug.slice(1);
 
       createPage({
         path: pagePath,
         component: templatePath,
         context: {
           id: node.pageNodeId,
-          slug: node.page_id,
+          slug,
           repoBranches: {},
           associatedReposInfo: {},
           isAssociatedProduct: {},

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -35,20 +35,9 @@ const titleSpanStyling = css`
 `;
 
 const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
-  const slugWithoutSlash = slug[0] === '/' ? slug.slice(1) : slug;
-  const slugIndex = toctreeOrder.indexOf(slugWithoutSlash);
+  const slugIndex = toctreeOrder.indexOf(slug);
   const prevSlug = slugIndex > 0 ? toctreeOrder[slugIndex - 1] : null;
   const nextSlug = slugIndex < toctreeOrder.length - 1 ? toctreeOrder[slugIndex + 1] : null;
-
-  console.log(slug);
-  console.log('slugIndex ', slugIndex);
-  console.log('prev next ', prevSlug, nextSlug);
-
-  if (slug.includes('organizations')) {
-    console.log(toctreeOrder);
-    const filtered = toctreeOrder.filter((el) => el.includes('organizations'));
-    console.log(filtered);
-  }
 
   return (
     <div css={tableContainerStyling}>

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -35,9 +35,21 @@ const titleSpanStyling = css`
 `;
 
 const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
-  const slugIndex = toctreeOrder.indexOf(slug);
+  const slugWithoutSlash = slug[0] === '/' ? slug.slice(1) : slug;
+  const slugIndex = toctreeOrder.indexOf(slugWithoutSlash);
   const prevSlug = slugIndex > 0 ? toctreeOrder[slugIndex - 1] : null;
   const nextSlug = slugIndex < toctreeOrder.length - 1 ? toctreeOrder[slugIndex + 1] : null;
+
+  console.log(slug);
+  console.log('slugIndex ', slugIndex);
+  console.log('prev next ', prevSlug, nextSlug);
+
+  if (slug.includes('organizations')) {
+    console.log(toctreeOrder);
+    const filtered = toctreeOrder.filter((el) => el.includes('organizations'));
+    console.log(filtered);
+  }
+
   return (
     <div css={tableContainerStyling}>
       {prevSlug && (

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -38,7 +38,6 @@ const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
   const slugIndex = toctreeOrder.indexOf(slug);
   const prevSlug = slugIndex > 0 ? toctreeOrder[slugIndex - 1] : null;
   const nextSlug = slugIndex < toctreeOrder.length - 1 ? toctreeOrder[slugIndex + 1] : null;
-
   return (
     <div css={tableContainerStyling}>
       {prevSlug && (


### PR DESCRIPTION
### Stories/Links:

DOP-3982

### Notes:

Currently each page's internal nav (back and forward) buttons are just a forward button to go back to "What is MongoDB Atlas?" example: https://preview-mongodbmmeigs.gatsbyjs.io/cloud-docs/matt-build/cloud-providers-regions/

This was caused by the slug passed to each page having a forward slash prepended which does not match the toctree mappings. 