### PR TITLE
DOP-3983: Prevent version dropdown rendering on preview pages

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -313,9 +313,10 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         context: {
           id: node.pageNodeId,
           slug: node.page_id,
+          // Hardcode static/safe values to prevent incremental builds from rebuilding versioned preview pages
           repoBranches: {},
           associatedReposInfo: {},
-          isAssociatedProduct: {},
+          isAssociatedProduct: false,
         },
       });
     });


### PR DESCRIPTION
### Stories/Links:

DOP-3983

### Current Behavior:

[GC Staging link](https://preview-mongodbrayangler.gatsbyjs.io/node/test-page-queries/quick-start/) - the associated product version dropdown on the righthand side *sometimes* appears when switching between pages through the lefthand side nav.

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:
* This issue is happening because the value of `isAssociatedProduct` that I used was completely wrong. Firstly, it should be a boolean. Second, the empty object would be evaluated as `true` in [this check](https://github.com/mongodb/snooty/blob/38c7c6ec4f322e0e42334b4f27c7760d9dad5b86/src/templates/document.js#L47), which would allow the version dropdown to sometimes appear.
* I spent some time investigating why the dropdown would only appear sometimes, but couldn't figure out exactly why. The dropdown component itself has [a second check](https://github.com/mongodb/snooty/blob/38c7c6ec4f322e0e42334b4f27c7760d9dad5b86/src/components/AssociatedVersionSelector/index.js#L43) to determine if it should show. This check corresponds to a [client-side fetch](https://github.com/mongodb/snooty/blob/38c7c6ec4f322e0e42334b4f27c7760d9dad5b86/src/context/version-context.js#L193-L201) to double-check whether any data for that repo's associated product versions have changed since the time of static page build. Sometimes, this second check would not fire off, causing the dropdown to appear. It's unclear (to me) why it only fires sometimes, even for the same page, but I'm okay with this being a mystery for now.