### PR TITLE
DOP-4009: Avoid fetching TOC data for preview builds

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,8 @@
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { siteMetadata } = require('./src/utils/site-metadata');
+const { isGatsbyPreview } = require('./src/utils/is-gatsby-preview');
 
-const isPreview = process.env.GATSBY_IS_PREVIEW === `true`;
+const isPreview = isGatsbyPreview();
 const pathPrefix = !isPreview ? generatePathPrefix(siteMetadata, process.env.GATSBY_SITE) : undefined;
 
 console.log('PATH PREFIX', pathPrefix);

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -10,11 +10,8 @@ const pipeline = promisify(stream.pipeline);
 const got = require(`got`);
 const { parser } = require(`stream-json/jsonl/Parser`);
 const { sourceNodes } = require(`./other-things-to-source`);
-const { isGatsbyPreview } = require('../../src/utils/is-gatsby-preview.js');
 const { fetchClientAccessToken } = require('./utils/kanopy-auth.js');
 const { callPostBuildWebhook } = require('./utils/post-build.js');
-
-const isPreview = isGatsbyPreview;
 
 // Global variable to allow webhookBody from sourceNodes step to be passed down
 // to other Gatsby build steps that might not pass webhookBody natively.
@@ -299,12 +296,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   try {
     result.data.allPagePath.nodes.forEach((node) => {
-      let pagePath;
-      if (isPreview) {
-        pagePath = path.join(node.project, node.branch, node.page_id);
-      } else {
-        pagePath = node.page_id;
-      }
+      const pagePath = path.join(node.project, node.branch, node.page_id);
       let slug = node.page_id;
       // Slices off leading slash to ensure slug matches an entry within the toctreeOrder and renders InternalPageNav components
       if (slug !== '/' && slug[0] === '/') slug = slug.slice(1);

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -10,10 +10,11 @@ const pipeline = promisify(stream.pipeline);
 const got = require(`got`);
 const { parser } = require(`stream-json/jsonl/Parser`);
 const { sourceNodes } = require(`./other-things-to-source`);
+const { isGatsbyPreview } = require('../../src/utils/is-gatsby-preview.js');
 const { fetchClientAccessToken } = require('./utils/kanopy-auth.js');
 const { callPostBuildWebhook } = require('./utils/post-build.js');
 
-const isPreview = process.env.GATSBY_IS_PREVIEW === `true`;
+const isPreview = isGatsbyPreview;
 
 // Global variable to allow webhookBody from sourceNodes step to be passed down
 // to other Gatsby build steps that might not pass webhookBody natively.
@@ -275,9 +276,7 @@ exports.onCreateWebpackConfig = ({ stage, loaders, plugins, actions }) => {
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions;
-  const templatePath = isPreview
-    ? path.join(__dirname, `../../src/components/DocumentBodyPreview.js`)
-    : path.join(__dirname, `../../src/components/DocumentBody.js`);
+  const templatePath = path.join(__dirname, `../../src/components/DocumentBodyPreview.js`);
   const result = await graphql(`
     query {
       allPagePath {

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -8,6 +8,7 @@ import { palette } from '@leafygreen-ui/palette';
 import ArrowRightIcon from '@leafygreen-ui/icon/dist/ArrowRight';
 import { isRelativeUrl } from '../utils/is-relative-url';
 import { joinClassNames } from '../utils/join-class-names';
+import { isGatsbyPreview } from '../utils/is-gatsby-preview';
 
 /*
  * Note: This component is not suitable for internal page navigation:
@@ -79,7 +80,7 @@ const Link = ({
     // Ensure trailing slash
     to = to.replace(/\/?(\?|#|$)/, '/$1');
 
-    if (process.env.GATSBY_IS_PREVIEW === `true`) {
+    if (isGatsbyPreview) {
       // If we're in preview mode, we build the pages of each project and branch of the site within
       // its own namespace so each author can preview their own pages e.g.
       // /project1/branch1/doc-path

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -80,7 +80,7 @@ const Link = ({
     // Ensure trailing slash
     to = to.replace(/\/?(\?|#|$)/, '/$1');
 
-    if (isGatsbyPreview) {
+    if (isGatsbyPreview()) {
       // If we're in preview mode, we build the pages of each project and branch of the site within
       // its own namespace so each author can preview their own pages e.g.
       // /project1/branch1/doc-path

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -15,22 +15,22 @@ const TocContext = createContext({
 // filters all available ToC by currently selected version via VersionContext
 const TocContextProvider = ({ children, remoteMetadata }) => {
   const { activeVersions, setActiveVersions, availableVersions, showVersionDropdown } = useContext(VersionContext);
-  const { project, toctree, associated_products: associatedProducts } = useSnootyMetadata();
-  const { database, parserBranch } = useSiteMetadata();
+  const { project, branch, toctree, associated_products: associatedProducts } = useSnootyMetadata();
+  const { database } = useSiteMetadata();
   const [activeToc, setActiveToc] = useState(remoteMetadata?.toctree || toctree);
   const [isLoaded, setIsLoaded] = useState(false);
 
   const getTocMetadata = useCallback(async () => {
     // Embedded versioning is not expected to work in staging builds, so we should
     // be able to safely return the default toctree.
-    if (isGatsbyPreview) {
+    if (isGatsbyPreview()) {
       return toctree;
     }
 
     try {
       const filter = {
-        project: `${project}`,
-        branch: parserBranch,
+        project,
+        branch,
       };
       const findOptions = {
         sort: { build_id: -1 },
@@ -48,7 +48,7 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
       return remoteMetadata?.toctree || toctree;
     }
     // below dependents are server constants
-  }, [project, parserBranch, associatedProducts, showVersionDropdown, database, toctree, remoteMetadata]);
+  }, [project, branch, associatedProducts, showVersionDropdown, database, toctree, remoteMetadata]);
 
   const setInitVersion = useCallback(
     (tocNode) => {

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -21,6 +21,8 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   const getTocMetadata = useCallback(async () => {
+    // Embedded versioning is not expected to work in staging builds, so we should
+    // be able to safely return the default toctree.
     if (isGatsbyPreview) {
       return toctree;
     }

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -4,6 +4,7 @@ import { METADATA_COLLECTION } from '../build-constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { fetchDocuments } from '../utils/realm';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { isGatsbyPreview } from '../utils/is-gatsby-preview';
 import { VersionContext } from './version-context';
 
 const TocContext = createContext({
@@ -20,6 +21,10 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   const getTocMetadata = useCallback(async () => {
+    if (isGatsbyPreview) {
+      return toctree;
+    }
+
     try {
       const filter = {
         project: `${project}`,

--- a/src/utils/is-current-page.js
+++ b/src/utils/is-current-page.js
@@ -1,3 +1,5 @@
+import { isGatsbyPreview } from './is-gatsby-preview';
+
 export const isCurrentPage = (currentUrl, slug) => {
   // If we're in preview mode, we build the pages of each branch of the site within
   // its own namespace so each author can preview their own pages e.g.
@@ -8,7 +10,7 @@ export const isCurrentPage = (currentUrl, slug) => {
   // the currentUrl.
   let modifiedCurrentUrl = currentUrl;
   const firstPathSegment = currentUrl.split(`/`).slice(0, 1)[0];
-  if (process.env.GATSBY_IS_PREVIEW === `true` && firstPathSegment.startsWith(`BRANCH--`)) {
+  if (isGatsbyPreview && firstPathSegment.startsWith(`BRANCH--`)) {
     modifiedCurrentUrl = currentUrl.split(`/`).slice(1).join(`/`);
   }
   const trimSlashes = (str) => str.replace(/^\/|\/$/g, '');

--- a/src/utils/is-current-page.js
+++ b/src/utils/is-current-page.js
@@ -1,19 +1,5 @@
-import { isGatsbyPreview } from './is-gatsby-preview';
-
 export const isCurrentPage = (currentUrl, slug) => {
-  // If we're in preview mode, we build the pages of each branch of the site within
-  // its own namespace so each author can preview their own pages e.g.
-  // /BRANCH--branch1/doc-path
-  // /BRANCH--branch2/doc-path
-  //
-  // So to detect if we're on the active page, we need to remove the namespace from
-  // the currentUrl.
-  let modifiedCurrentUrl = currentUrl;
-  const firstPathSegment = currentUrl.split(`/`).slice(0, 1)[0];
-  if (isGatsbyPreview && firstPathSegment.startsWith(`BRANCH--`)) {
-    modifiedCurrentUrl = currentUrl.split(`/`).slice(1).join(`/`);
-  }
   const trimSlashes = (str) => str.replace(/^\/|\/$/g, '');
-  if (!modifiedCurrentUrl || !slug) return false;
-  return trimSlashes(modifiedCurrentUrl) === trimSlashes(slug);
+  if (!currentUrl || !slug) return false;
+  return trimSlashes(currentUrl) === trimSlashes(slug);
 };

--- a/src/utils/is-gatsby-preview.js
+++ b/src/utils/is-gatsby-preview.js
@@ -1,0 +1,6 @@
+/**
+ * Returns `true` if the build is a preview build for Gatsby Cloud.
+ */
+const isGatsbyPreview = () => process.env.GATSBY_IS_PREVIEW === 'true';
+
+module.exports = { isGatsbyPreview };

--- a/tests/context/toc-context.test.js
+++ b/tests/context/toc-context.test.js
@@ -97,6 +97,7 @@ const setMocks = () => {
   }));
 
   snootyMetadataMock.mockImplementation(() => ({
+    branch: 'master',
     toctree: sampleTocTree,
   }));
 


### PR DESCRIPTION
### Stories/Links:

DOP-4009

### Current Behavior:

[prd Gatsby Cloud site](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cloud-docs/DOCSP-32895/atlas-search/knn-beta/) - Notice how the side nav does not show the "knn beta" page

### Staging Links:

[stg Gatsby Cloud site](https://preview-mongodbrayanglerstg.gatsbyjs.io/cloud-docs/test-master/atlas-search/knn-beta/) - The side nav now shows the expected content and no longer shows the version selector for associated products (this behavior matches current staging builds).

### Notes:
Seems like the TOC is fetching data on initial load of the page, which can result in incorrect TOC data, especially if the current changes of the branch don't match up with the TOC metadata being fetched from the db.

The `parserBranch` variable, which is tied to the declared branch that the site is for, is currently used when fetching metadata. This makes sense for builds that use local manifests (like production deployments) since the site being built will only ever consist of content for one branch at a time. Although this PR does make the logic compatible with the ≥1 branches that a Gatsby Cloud site can support, I decided to also avoid the fetching logic altogether since (1) it acts as an explicit guard to ensure Embedded Versioning data will not be available in content staging builds, and (2) the fetched data should always have the same content as the latest metadata/changes of the build anyways.

This PR also cleans up and consolidates logic for `process.env.GATSBY_IS_PREVIEW === 'true'`. Some instances where this logic occurs are either not relevant given the current state of the Gatsby source plugin, or are redundant (i.e. no point in checking the env in the preview source plugin since the preview source plugin would only be used if the env is already true).