### PR TITLE
DOP-3996: Allow writer's staging to use staging Chatbot server url

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -6,7 +6,7 @@ import { theme } from '../theme/docsTheme';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 const CHATBOT_SERVER_BASE_URL =
-  process.env.SNOOTY_ENV === 'production' || process.env.SNOOTY_ENV === 'dotcomprd'
+  process.env.SNOOTY_ENV === 'dotcomprd'
     ? 'https://knowledge.mongodb.com/api/v1'
     : 'https://knowledge.staging.corp.mongodb.com/api/v1';
 


### PR DESCRIPTION
### Stories/Links:

Clean up of 
DOP-3996

### Notes:

As Raymund pointed out [here](https://github.com/mongodb/snooty/pull/880#discussion_r1319143056), the SNOOTY_ENV value of "production" is used for writer's staging. Docs writer's staging should use the staging Chatbot server url for visibility in testing. 