### PR TITLE
Dop 4004 deprecated v docsets

### DIFF
--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -6,9 +6,8 @@ import Button from '@leafygreen-ui/button';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { isBrowser } from '../utils/is-browser';
 import { theme } from '../theme/docsTheme';
-import { fetchDocuments } from '../utils/realm';
+import { fetchDocsets } from '../utils/realm';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { BRANCHES_COLLECTION } from '../build-constants';
 import Select from './Select';
 
 const SELECT_WIDTH = '336px';
@@ -81,7 +80,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
   // Fetch repos_branches for `displayName` and url
   useEffect(() => {
     if (reposDatabase) {
-      fetchDocuments(reposDatabase, BRANCHES_COLLECTION).then((resp) => {
+      fetchDocsets(reposDatabase).then((resp) => {
         const reposBranchesMap = keyBy(resp, 'project');
         const reposBranchesMapWithOldGen = addOldGenToReposMap(reposBranchesMap);
         setReposMap(reposBranchesMapWithOldGen);

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -61,6 +61,10 @@ export const fetchDocuments = async (database, collectionName, query, projection
   return callAuthenticatedFunction('fetchDocuments', database, collectionName, query, projections, options);
 };
 
+export const fetchDocsets = async (database) => {
+  return callAuthenticatedFunction('fetchDocsets', database);
+};
+
 export const fetchOADiff = async (runId, diffString, snootyEnv) => {
   return callAuthenticatedFunction('fetchOADiff', runId, diffString, snootyEnv);
 };

--- a/tests/unit/DeprecatedVersionSelector.test.js
+++ b/tests/unit/DeprecatedVersionSelector.test.js
@@ -56,7 +56,7 @@ describe('DeprecatedVersionSelector when rendered', () => {
   let wrapper, mockFetchDocuments;
 
   beforeEach(() => {
-    mockFetchDocuments = jest.spyOn(realm, 'fetchDocuments').mockImplementation(async (dbName, collectionName) => {
+    mockFetchDocuments = jest.spyOn(realm, 'fetchDocsets').mockImplementation(async (dbName) => {
       return mockedReposBranches;
     });
   });


### PR DESCRIPTION
### Stories/Links:

DOP-4004

### Current Behavior:

[Current](https://www.mongodb.com/docs/legacy/) 

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/matt.meigs/DOP-4004-deprecated-v-docsets/legacy/index.html)  (embarrassingly, should have re-parsed with master. Pls ignore the "Oui, monsieur" :) )

### Notes:

The two links above should work identically. 

This stand as a POC and first implementation of migrating a request from solely querying `repos_branches` to using `docsets` as the source of truth.

[Here](https://realm.mongodb.com/groups/5bad1d3d96e82129f16c5df3/apps/5d41ef5e2de84772fc7c2de2/functions/6500a370c65dceebe0717295) is the new Atlas App Services function.