### PR TITLE
DOP-4017

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -86,7 +86,7 @@ const DocumentBody = (props) => {
   const lookup = slug === '/' ? 'index' : slug;
   const pageTitle = getPlaintext(getNestedValue(['slugToTitle', lookup], metadata)) || 'MongoDB Documentation';
 
-  const { Template } = getTemplate(template);
+  const { Template, useChatbot } = getTemplate(template);
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
 
@@ -101,7 +101,7 @@ const DocumentBody = (props) => {
         isInPresentationMode={isInPresentationMode}
       >
         <FootnoteContext.Provider value={{ footnotes }}>
-          <Template {...props}>
+          <Template {...props} useChatbot={useChatbot}>
             {pageNodes.map((child, index) => (
               <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
             ))}

--- a/src/components/DocumentBodyPreview.js
+++ b/src/components/DocumentBodyPreview.js
@@ -78,7 +78,7 @@ const DocumentBody = (props) => {
   const lookup = slug === '/' ? 'index' : slug;
   const pageTitle = getPlaintext(getNestedValue(['slugToTitle', lookup], metadata)) || 'MongoDB Documentation';
   const siteTitle = getNestedValue(['title'], metadata) || '';
-  const { Template } = getTemplate(template);
+  const { Template, useChatbot } = getTemplate(template);
 
   return (
     <>
@@ -91,7 +91,7 @@ const DocumentBody = (props) => {
         slug={slug}
       >
         <FootnoteContext.Provider value={{ footnotes }}>
-          <Template {...props}>
+          <Template {...props} useChatbot={useChatbot}>
             {pageNodes.map((child, index) => (
               <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
             ))}

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -48,13 +48,13 @@ const Wrapper = styled('main')`
 `;
 
 // The Landing template exclusively represents mongodb.com/docs. All other landings use the ProductLanding template
-const Landing = ({ children, pageContext }) => {
+const Landing = ({ children, pageContext, useChatbot }) => {
   const { fontSize, screenSize, size } = useTheme();
   return (
     <>
       <div>
         <Wrapper>
-          {SHOW_CHATBOT && <ChatbotUi template={pageContext?.template} />}
+          {SHOW_CHATBOT && useChatbot && <ChatbotUi template={pageContext?.template} />}
           {children}
         </Wrapper>
       </div>
@@ -189,6 +189,7 @@ Landing.propTypes = {
   pageContext: PropTypes.shape({
     page: PropTypes.object.isRequired,
   }).isRequired,
+  useChatbot: PropTypes.bool,
 };
 
 export default Landing;

--- a/src/utils/get-template.js
+++ b/src/utils/get-template.js
@@ -13,6 +13,7 @@ import {
 const getTemplate = (templateName) => {
   let template;
   let sidenav;
+  let useChatbot = false;
   switch (templateName) {
     case 'blank':
       template = Blank;
@@ -31,6 +32,7 @@ const getTemplate = (templateName) => {
     case 'landing':
       template = Landing;
       sidenav = true;
+      useChatbot = true;
       break;
     case 'openapi':
       template = OpenAPITemplate;
@@ -43,6 +45,10 @@ const getTemplate = (templateName) => {
       template = ProductLanding;
       sidenav = true;
       break;
+    case 'search':
+      template = Landing;
+      sidenav = true;
+      break;
     // Default template and guide template share very similar layouts
     default:
       template = Document;
@@ -50,7 +56,7 @@ const getTemplate = (templateName) => {
       break;
   }
 
-  return { Template: template, sidenav };
+  return { Template: template, sidenav, useChatbot };
 };
 
 export { getTemplate };


### PR DESCRIPTION
### Stories/Links:

DOP-4017

This PR allows for `search` template option, re-using `landing` template with an option to show/hide the chatbot.

### Current Behavior:

[current behavior for search (with chatbot flag turned on)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/new-homepage-test-run-1/landing/seung.park/new-homepage-test-run-1/search/)

### Staging Links:

[search page using `search` template option](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4017/landing/seung.park/DOP-4017/search/?q=test&page=1)

### Notes:
- this is done with [docs-landing](https://github.com/mongodb/docs-landing/pull/134) search.txt set to `:template: search`