### PR TITLE
DOP-3893: Fix tests for plugin compatibility

### DIFF
--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -4,18 +4,21 @@ import { Head } from '../../src/components/DocumentBody';
 import mockStaticQuery from '../utils/mockStaticQuery';
 import { useSiteMetadata } from '../../src/hooks/use-site-metadata';
 import { usePathPrefix } from '../../src/hooks/use-path-prefix';
+import useSnootyMetadata from '../../src/utils/use-snooty-metadata';
 import mockCompleteEOLPageContext from './data/CompleteEOLPageContext.json';
 import mockEOLSnootyMetadata from './data/EOLSnootyMetadata.json';
 import mockHeadPageContext from './data/HeadPageContext.test.json';
 
+jest.mock(`../../src/utils/use-snooty-metadata`, () => jest.fn());
+
 describe('Head', () => {
   describe("Canonical for completely EOL'd", () => {
     beforeEach(() => {
-      mockStaticQuery({}, mockEOLSnootyMetadata);
+      mockStaticQuery({});
+      useSnootyMetadata.mockImplementation(() => mockEOLSnootyMetadata);
     });
     it('renders the canonical tag from the snooty.toml', () => {
       render(<Head pageContext={mockCompleteEOLPageContext} />);
-
       const _canonical = mockEOLSnootyMetadata.canonical;
       const canonicalTag = screen.getByTestId('canonical');
       expect(canonicalTag).toBeInTheDocument();
@@ -48,7 +51,7 @@ describe('Head', () => {
   describe("Canonical for non-EoL'd", () => {
     beforeEach(() => {
       const modMockEOLSnootyMetadataToBeNotEOL = { ...mockEOLSnootyMetadata, eol: false };
-      mockStaticQuery({}, modMockEOLSnootyMetadataToBeNotEOL);
+      useSnootyMetadata.mockImplementation(() => modMockEOLSnootyMetadataToBeNotEOL);
     });
 
     it('renders the canonical tag that points to itself', () => {
@@ -69,7 +72,7 @@ describe('Head', () => {
 
   describe('Canonical when pulled from directive', () => {
     beforeEach(() => {
-      mockStaticQuery({}, mockEOLSnootyMetadata);
+      useSnootyMetadata.mockImplementation(() => mockEOLSnootyMetadata);
     });
 
     const metaCanonical = {

--- a/tests/unit/IA.test.js
+++ b/tests/unit/IA.test.js
@@ -1,17 +1,25 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+// Keep mockLocation on top to ensure mock is applied
+import { mockLocation } from '../utils/mock-location';
 import IA from '../../src/components/Sidenav/IA';
-import mockStaticQuery from '../utils/mockStaticQuery';
+import useSnootyMetadata from '../../src/utils/use-snooty-metadata';
 import sampleData from './data/IA.test.json';
 
+jest.mock(`../../src/utils/use-snooty-metadata`, () => jest.fn());
+
+beforeAll(() => {
+  mockLocation(null, `/`);
+});
+
 it('renders a simple page IA correctly', () => {
-  mockStaticQuery({}, {});
+  useSnootyMetadata.mockImplementation(() => ({}));
   const tree = render(<IA ia={sampleData.pageIA} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
 
 it('renders a page IA with IA linked data', () => {
-  mockStaticQuery({}, sampleData.iaTreeMetadata);
+  useSnootyMetadata.mockImplementation(() => sampleData.iaTreeMetadata);
   const mockIAData = [...sampleData.pageIA];
   // Programmatically add an ID for linked data, in case sample data order changes.
   for (const mockData of mockIAData) {

--- a/tests/utils/mockStaticQuery.js
+++ b/tests/utils/mockStaticQuery.js
@@ -1,13 +1,10 @@
 import * as Gatsby from 'gatsby';
 
 const useStaticQuery = jest.spyOn(Gatsby, 'useStaticQuery');
-const mockStaticQuery = (mockSiteMetadata = {}, mockSnootyMetadata = {}) => {
+const mockStaticQuery = (mockSiteMetadata = {}) => {
   useStaticQuery.mockImplementation(() => ({
     site: {
       siteMetadata: mockSiteMetadata,
-    },
-    allSnootyMetadata: {
-      nodes: [{ metadata: mockSnootyMetadata }],
     },
   }));
 };


### PR DESCRIPTION
### Stories/Links:

DOP-3893

### Notes:

* This PR fixes tests that broke after merging the `master` to the `gatsby-cloud-rc` branch.
* Seems like no other tests are currently broken thanks to Michal! (The GH action to run the tests do not work for the current base branch, but this can be confirmed by running `npm run test` locally)