### PR TITLE
DOP-4025 follow up

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -41,7 +41,7 @@ const Heading = ({ sectionDepth, nodeData, page, ...rest }) => {
   const asHeading = sectionDepth >= 1 && sectionDepth <= 6 ? `h${sectionDepth}` : 'h6';
   const isPageTitle = sectionDepth === 1;
   const { isMobile, isTabletOrMobile } = useScreenSize();
-  const hidefeedbackheader = page?.options?.hidefeedback === 'header';
+  const hidefeedbackheader = page?.options?.hidefeedback === 'header' || page?.options?.hidefeedback === 'page';
   const { selectors } = useContext(TabContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
   const shouldShowMobileHeader = !!(isPageTitle && isTabletOrMobile && (hasSelectors || !hidefeedbackheader));

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -15,14 +15,11 @@ const Widgets = ({ children, pageOptions, pageTitle, publishedBranches, slug, is
 
   // DOP-4025: hide feedback tab on homepage
   const hideFeedback = pageOptions.hidefeedback === 'page';
-  if (hideFeedback) {
-    return <>{children}</>;
-  }
 
   return (
     <FeedbackProvider page={feedbackData} hideHeader={hideFeedbackHeader}>
       {children}
-      {!isInPresentationMode && (
+      {!isInPresentationMode && !hideFeedback && (
         <>
           <FeedbackTab />
           <FeedbackForm />


### PR DESCRIPTION
### Stories/Links:

DOP-4025

### Current Behavior:

Follow up to [previous PR](https://github.com/mongodb/snooty/pull/902)

[FeedbackHeading](https://github.com/mongodb/snooty/blob/master/src/components/Heading.js#L57) on mobile was calling Feedback context values with no provider being initiated:

```
index.modern.mjs:1 Uncaught Error: You must nest useFeedbackContext() inside of a FeedbackProvider.
    at useFeedbackContext (context.js:102:1)
    at FeedbackHeading (FeedbackHeading.js:6:1)
    at renderWithHooks (react-dom.development.js:16305:1)
    at mountIndeterminateComponent (react-dom.development.js:20074:1)
    at beginWork (react-dom.development.js:21587:1)
    at beginWork$1 (react-dom.development.js:27426:1)
    at performUnitOfWork (react-dom.development.js:26557:1)
    at workLoopSync (react-dom.development.js:26466:1)
    at renderRootSync (react-dom.development.js:26434:1)
    at recoverFromConcurrentError (react-dom.development.js:25850:1)
```

Resolved to just hiding the tab and form when `hidefeedback` page options is set to `page`