### PR TITLE
Redesign bugs: target only second section of card group in landing

### DIFF
--- a/src/components/Card/CardGroup.js
+++ b/src/components/Card/CardGroup.js
@@ -90,7 +90,14 @@ const CardGroup = ({
 
   return (
     <StyledGrid
-      className={['card-group', isCompact ? 'compact' : '', isExtraCompact ? 'extra-compact' : '', className].join(' ')}
+      className={[
+        'card-group',
+        isCompact ? 'compact' : '',
+        isExtraCompact ? 'extra-compact' : '',
+        isForDrivers ? 'drivers' : '',
+        'card-group',
+        className,
+      ].join(' ')}
       columns={columns}
       noMargin={true}
       isCarousel={isCarousel}

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -44,12 +44,13 @@ const Wrapper = styled('main')`
         grid-column: 2 / -2 !important;
       }
 
-      &:not(.compact, .extra-compact) {
+      &:not(.compact, .extra-compact, .drivers) {
         p {
           font-weight: 500;
-        }
-        p:first-of-type {
-          margin-bottom: ${({ theme }) => theme.size.large};
+
+          a {
+            margin-top: ${({ theme }) => theme.size.medium};
+          }
         }
 
         @media ${({ theme }) => theme.screenSize.upToMedium} {


### PR DESCRIPTION
Targeting only the second card group in landing page by.
1) adding new className for card-group (one has [type=drivers](https://github.com/mongodb/docs-landing/pull/132/files#diff-f9560dd277cc6f848625b9db1465ddf3779112495f2d1cc559ff3f91ea6d186cR86))
2) targeting `drivers` classname from landing page stylesheet.

[staged changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/landing-cards-margins/index.html)

[vs master branch](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)