### PR TITLE
style header for search results page

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -51,6 +51,12 @@ const EmptyResultsContainer = styled('div')`
 
 const HeaderContainer = styled('div')`
   grid-area: header;
+
+  > h1:first-of-type {
+    color: ${palette.green.dark2};
+    padding-bottom: 40px;
+    margin: unset;
+  }
 `;
 
 const FiltersContainer = styled('div')`
@@ -374,7 +380,7 @@ const SearchResults = () => {
       <SearchResultsContainer>
         {/* new header for search bar */}
         <HeaderContainer>
-          <H1 style={{ color: '#00684A', paddingBottom: '40px' }}> Search Results</H1>
+          <H1> Search Results</H1>
           <SearchInput
             ref={searchBoxRef}
             value={searchField}

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -33,6 +33,12 @@ exports[`Search Results Page considers a given search filter query param and dis
   grid-area: header;
 }
 
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
+}
+
 .emotion-4 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
@@ -1178,7 +1184,6 @@ exports[`Search Results Page considers a given search filter query param and dis
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>
@@ -1635,6 +1640,12 @@ exports[`Search Results Page does not return results for a given search term wit
 
 .emotion-2 {
   grid-area: header;
+}
+
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
 }
 
 .emotion-4 {
@@ -2505,7 +2516,6 @@ exports[`Search Results Page does not return results for a given search term wit
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>
@@ -3089,6 +3099,12 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   grid-area: header;
 }
 
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
+}
+
 .emotion-4 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
@@ -3403,7 +3419,6 @@ exports[`Search Results Page renders correctly without browser 1`] = `
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>
@@ -3516,6 +3531,12 @@ exports[`Search Results Page renders loading images before returning no results 
 
 .emotion-2 {
   grid-area: header;
+}
+
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
 }
 
 .emotion-4 {
@@ -3930,7 +3951,6 @@ exports[`Search Results Page renders loading images before returning no results 
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>
@@ -4072,6 +4092,12 @@ exports[`Search Results Page renders loading images before returning nonempty re
   grid-area: header;
 }
 
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
+}
+
 .emotion-4 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
@@ -4484,7 +4510,6 @@ exports[`Search Results Page renders loading images before returning nonempty re
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>
@@ -4624,6 +4649,12 @@ exports[`Search Results Page renders results from a given search term query para
 
 .emotion-2 {
   grid-area: header;
+}
+
+.emotion-2>h1:first-of-type {
+  color: #00684A;
+  padding-bottom: 40px;
+  margin: unset;
 }
 
 .emotion-4 {
@@ -5769,7 +5800,6 @@ exports[`Search Results Page renders results from a given search term query para
     >
       <h1
         class="emotion-4"
-        style="color: rgb(0, 104, 74); padding-bottom: 40px;"
       >
          Search Results
       </h1>


### PR DESCRIPTION
Header margin is off on search page, with new landing homepage

[existing on prod](https://www.mongodb.com/docs/search/)

[preprd for new homepage](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/search/)

[changes on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/style-search-header/search/index.html)