### PR TITLE
Homepage redesign: more ways mobile video

### DIFF
--- a/src/components/Landing/MoreWays/index.js
+++ b/src/components/Landing/MoreWays/index.js
@@ -11,7 +11,7 @@ const StyledContainer = styled('div')`
   flex-direction: row;
   justify-content: center;
   grid-column-start: 2;
-  grid-column-end: 14;
+  grid-column-end: -2;
   max-width: 1440px;
   column-gap: 2rem;
   @media ${theme.screenSize.upToLarge} {

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -57,6 +57,11 @@ const Wrapper = styled('main')`
           margin-left: 42px;
           margin-right: 42px;
         }
+
+        @media ${({ theme }) => theme.screenSize.upToSmall} {
+          margin-left: ${({ theme }) => theme.size.medium};
+          margin-right: ${({ theme }) => theme.size.medium};
+        }
       }
     }
   }


### PR DESCRIPTION
Minor change to use negative column for `grid-column-end`

[mobile view of video and card group on mobile:](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

[change on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/cd384df47f04f518017bd11b4c2877e19c4df008/newhomepagewhodis/landing/seung.park/moreways-mobile-video/index.html)