### PR TITLE
pass href to link, for it to be not undefined

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -29,6 +29,7 @@ const Button = ({
   if (uri) {
     componentProps.as = Link;
     componentProps.to = uri;
+    componentProps.href = uri;
   }
 
   return (

--- a/tests/unit/__snapshots__/Button.test.js.snap
+++ b/tests/unit/__snapshots__/Button.test.js.snap
@@ -195,7 +195,6 @@ exports[`button component renders correctly 1`] = `
     aria-disabled="false"
     class="emotion-0 lg-ui-button-0000 button emotion-1"
     href="/install/"
-    type="button"
   >
     <div
       class="emotion-2"


### PR DESCRIPTION
### Stories/Links:

Enabling buttons to have href links.
We are using a combination of <Button> and <Link> components when rendering `:button:` ReST components with :uri: options ([example here](https://github.com/mongodb/docs-landing/pull/132/files#diff-f9560dd277cc6f848625b9db1465ddf3779112495f2d1cc559ff3f91ea6d186cR180)) which is a pretty common pattern in our docs

The `href` prop was being passed to Link component as `undefined` and therefore had a null Button with no href.
The docs are not super clear, but [the example](https://www.mongodb.design/component/button/documentation/) for `as` shows them explicitly pulling out the `href` prop when passing to a NextLink

### Current Behavior:

[master branch has buttons disabled with links](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

### Staging Links:

[new homepage with changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/button-followup/index.html)