### PR TITLE
DOP-4041: Changelog download button broken

### DIFF
--- a/src/components/OpenAPIChangelog/utils/constants.js
+++ b/src/components/OpenAPIChangelog/utils/constants.js
@@ -4,7 +4,7 @@ export const ALL_VERSIONS = 'ALL_VERSIONS';
 export const COMPARE_VERSIONS = 'COMPARE_VERSIONS';
 
 export const getDownloadChangelogUrl = (runId, snootyEnv) => {
-  return snootyEnv === 'production'
+  return snootyEnv === 'production' || snootyEnv === 'dotcomprd'
     ? `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`
     : `https://mongodb-mms-build-server.s3.amazonaws.com/openapi/changelog/${runId}/changelog.json`;
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4041

### Notes:

Currently on prod, the OpenAPIChangelog download button does not work correctly. It is referencing the staging S3 bucket with a production runId. This adds a check for the 'dotcomprd' snooty env value.