### PR TITLE
hotfix: Use hook for snootyenv

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -5,11 +5,7 @@ import styled from '@emotion/styled';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme';
 import 'react-loading-skeleton/dist/skeleton.css';
-
-const CHATBOT_SERVER_BASE_URL =
-  process.env.SNOOTY_ENV === 'dotcomprd'
-    ? 'https://knowledge.mongodb.com/api/v1'
-    : 'https://knowledge.staging.corp.mongodb.com/api/v1';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 const SKELETON_BORDER_RADIUS = '12px';
 
@@ -75,6 +71,13 @@ const StyledChatBotUiContainer = styled.div`
 const LazyChatbot = lazy(() => import('mongodb-chatbot-ui'));
 
 const ChatbotUi = ({ template }) => {
+  const { snootyEnv } = useSiteMetadata();
+
+  const CHATBOT_SERVER_BASE_URL =
+    snootyEnv === 'production' || snootyEnv === 'dotcomprd'
+      ? 'https://knowledge.mongodb.com/api/v1'
+      : 'https://knowledge.staging.corp.mongodb.com/api/v1';
+
   return (
     <StyledChatBotUiContainer data-testid="chatbot-ui" template={template}>
       {/* We wrapped this in a Suspense. We can use this opportunity to render a loading state if we decided we want that */}


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

updates the chatbot component to pull `snootyEnv` from the `site-metadata` hook and not the raw PROCESS.ENV - gatsby can only fetch GATSBY_ prefixed env vars at client side render time
