### PR TITLE
DOP-4053: Update Headers to use correct "as" headings

### DIFF
--- a/src/components/Landing/MoreWays/index.js
+++ b/src/components/Landing/MoreWays/index.js
@@ -44,7 +44,9 @@ export const MoreWays = ({ nodeData: { children, options, argument }, ...rest })
         <Video nodeData={{ argument: [{ refuri: options.video_url }] }} />
       </VideoItem>
       <DescriptionItem>
-        <Subtitle className={cx(headerStyles)}>{argument[0]?.value}</Subtitle>
+        <Subtitle as="h3" className={cx(headerStyles)}>
+          {argument[0]?.value}
+        </Subtitle>
         {children.map((child, i) => (
           <ComponentFactory nodeData={child} key={i} {...rest} showLinkArrow={true} hideExternalIcon={true} />
         ))}

--- a/src/components/LandingIntro/index.js
+++ b/src/components/LandingIntro/index.js
@@ -64,7 +64,7 @@ const headerStyling = css`
 const LandingIntro = ({ nodeData: { children, argument } }) => (
   <FlexboxContainer>
     <DescriptionContainer>
-      <H3 className={cx(headerStyling)}>
+      <H3 as="h2" className={cx(headerStyling)}>
         {argument.map((child, i) => (
           <ComponentFactory nodeData={child} key={i} />
         ))}

--- a/src/components/SectionHeader.js
+++ b/src/components/SectionHeader.js
@@ -4,7 +4,11 @@ import { cx } from '@leafygreen-ui/emotion';
 import { H3 } from '@leafygreen-ui/typography';
 
 const SectionHeader = ({ children, customStyles }) => {
-  return <H3 className={cx(customStyles)}>{children}</H3>;
+  return (
+    <H3 as="h2" className={cx(customStyles)}>
+      {children}
+    </H3>
+  );
 };
 
 SectionHeader.prototype = {


### PR DESCRIPTION
### Stories/Links:

[DOP-4053](https://jira.mongodb.org/browse/DOP-4053)

### Current Behavior:

The new homepage hardcoded some of the headings in the components using the relevant LG components per the design, but didn't include the as props so that the headings render as the correct h-type in the DOM. 

[Prod Homepage](https://www.mongodb.com/docs/)

### Staging Links:
[homepage staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/anabella.buckvar/DOP-4053/)
