### PR TITLE
DOP-4054: Update Uni and Community left sidenav links on landing to subfolder versions

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -161,8 +161,8 @@ const StyledChapterNumberLabel = styled(ChapterNumberLabel)`
 
 const additionalLinks = [
   { glyph: 'Support', title: 'Contact Support', url: 'https://support.mongodb.com/welcome' },
-  { glyph: 'Person', title: 'Join our community', url: 'https://community.mongodb.com/' },
-  { glyph: 'University', title: 'Register for Courses', url: 'https://university.mongodb.com/' },
+  { glyph: 'Person', title: 'Join our community', url: 'https://www.mongodb.com/community/' },
+  { glyph: 'University', title: 'Register for Courses', url: 'https://learn.mongodb.com/' },
 ];
 
 const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, slug, eol }) => {


### PR DESCRIPTION
### Stories/Links:

[DOP-4054](https://jira.mongodb.org/browse/DOP-4054)

### Current Behavior:
[prod homepage](https://www.mongodb.com/docs/)

### Staging Links:

[staging homepage](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/anabella.buckvar/DOP-4054/index.html)
