### PR TITLE
DOP-4051: Fix Undefined Icon Warning in Frontend

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -39,7 +39,7 @@ const Button = ({
       size={size}
       darkMode={darkMode}
       variant={variant}
-      rightGlyph={<Icon glyph={rightGlyph} />}
+      rightGlyph={rightGlyph ? <Icon glyph={rightGlyph} /> : null}
       {...componentProps}
     >
       {argument.map((child, i) => (


### PR DESCRIPTION
### Stories/Links:

[DOP-4051](https://jira.mongodb.org/browse/DOP-4051)

### Current Behavior:
An error for "undefined" glyphs appears during the frontend build stage because the `Button` component expected a rightGlyph.

### Staging Links:

[staging
](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/anabella.buckvar/DOP-4051/index.html)
### Notes:
