### PR TITLE
DOP-3690: remove selectedFacets as a state. read from url params

### DIFF
--- a/src/components/SearchResults/Facets/FacetValue.js
+++ b/src/components/SearchResults/Facets/FacetValue.js
@@ -15,12 +15,14 @@ const checkboxStyle = css`
   }
 `;
 
+const initChecked = (searchParams, key, id) => searchParams.getAll(`facets.${key}`).includes(id);
+
 const FacetValue = ({ facetValue: { name, facets, key, id } }) => {
-  const { handleFacetChange, selectedFacets } = useContext(SearchContext);
+  const { handleFacetChange, searchParams } = useContext(SearchContext);
   // Differentiate between facets with the same id found under different facet options
   const fullFacetId = `${key}>${id}`;
   // Decide on initial state based on selected facets deduced from query params
-  const [isChecked, setIsChecked] = useState(() => !!selectedFacets.find((facet) => facet.fullFacetId === fullFacetId));
+  const [isChecked, setIsChecked] = useState(() => initChecked(searchParams, key, id));
 
   const onChangeHandler = useCallback(
     ({ target }) => {

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -85,11 +85,11 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         navigate(`?${newSearch.toString()}`);
       };
 
+      const newFacet = { fullFacetId, key, id };
       if (checked) {
-        const newFacet = { fullFacetId, key, id };
         updateFacetSearchParams([newFacet], 'add');
       } else {
-        const facetsToRemove = [];
+        const facetsToRemove = [newFacet];
         // Remove facet from array, including any sub-facet with same relationship
         updateFacetSearchParams(facetsToRemove, 'remove');
       }

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -14,42 +14,15 @@ const SearchContext = createContext({
   searchTerm: '',
   selectedVersion: null,
   selectedCategory: null,
-  selectedFacets: [],
   setSearchFilter: null,
   setSelectedVersion: () => {},
   setSelectedCategory: () => {},
   setShowMobileFilters: () => {},
-  setSelectedFacets: () => {},
   handleFacetChange: () => {},
   shouldAutofocus: false,
   showFacets: false,
+  searchParams: {},
 });
-
-/**
- * Get facets from query params on initial load
- * @param {URLSearchParams} searchParams
- */
-const getSelectedFacetParams = (searchParams) => {
-  const selectedFacets = [];
-  // Use set to avoid duplicate keys for facet options
-  const keySet = new Set(searchParams.keys());
-
-  for (const key of keySet) {
-    if (!key.startsWith(FACETS_KEY_PREFIX)) {
-      continue;
-    }
-
-    // Reconstruct facet object
-    const strippedKey = key.split(FACETS_KEY_PREFIX)[1];
-    const facetIds = searchParams.getAll(key);
-    facetIds.forEach((id) => {
-      const fullFacetId = `${strippedKey}>${id}`;
-      selectedFacets.push({ fullFacetId, key: strippedKey, id });
-    });
-  }
-
-  return selectedFacets;
-};
 
 const SearchContextProvider = ({ children, showFacets = false }) => {
   const { search } = useLocation();
@@ -68,7 +41,6 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
   const [showMobileFilters, setShowMobileFilters] = useState(false);
 
   // Facets are applied on toggle, in the format facet-option>facet-value
-  const [selectedFacets, setSelectedFacets] = useState(() => getSelectedFacetParams(searchParams));
 
   // navigate changes and store state in URL
   const onSearchChange = ({ searchTerm, searchFilter, page }) => {
@@ -115,20 +87,10 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
 
       if (checked) {
         const newFacet = { fullFacetId, key, id };
-        setSelectedFacets((prev) => [...prev, newFacet]);
         updateFacetSearchParams([newFacet], 'add');
       } else {
         const facetsToRemove = [];
         // Remove facet from array, including any sub-facet with same relationship
-        setSelectedFacets((prev) =>
-          prev.filter((facet) => {
-            const shouldKeep = !facet.fullFacetId.includes(fullFacetId);
-            if (!shouldKeep) {
-              facetsToRemove.push(facet);
-            }
-            return shouldKeep;
-          })
-        );
         updateFacetSearchParams(facetsToRemove, 'remove');
       }
     },
@@ -156,11 +118,11 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         setSelectedCategory,
         selectedVersion,
         setSelectedVersion,
-        selectedFacets,
         handleFacetChange,
         showMobileFilters,
         setShowMobileFilters,
         showFacets,
+        searchParams,
       }}
     >
       {children}


### PR DESCRIPTION
small change to remove selectedFacets as a state, and read from url query params

behavior should be the same (FacetValues can be selected to append new url search params)

from notes:

```
- option 4: 
- expose search params from context
- iterate over all options to show pills (that are in the exposed search params from context) <- not done in this PR
- in facet value component (check if search params has this facet.key) to make it checked
  - also, facet value component, check if all childrens' keys are selected (to make it full check vs half check) <- not done in this PR
```