### PR TITLE
DOP-4063: Reorganize data consumption for preview plugin

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -116,7 +116,9 @@ exports.sourceNodes = async ({
       }
     };
 
-    // Handle data consumed by the Snooty Data API based on data type
+    // Since there's a lot of data incoming from the Snooty Data API, we stream
+    // the data in chunks and parse them as they come instead of fetching everything
+    // as a single JSON response
     const decode = parser();
     decode.on('data', async (_entry) => {
       // Un-nest data

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -2,16 +2,13 @@ const { getDataStore } = require('gatsby/dist/datastore');
 const path = require('path');
 const stream = require('stream');
 const { promisify } = require('util');
-const fs = require('fs').promises;
-const { transformBreadcrumbs } = require('../../src/utils/setup/transform-breadcrumbs.js');
 const pipeline = promisify(stream.pipeline);
 const got = require(`got`);
 const { parser } = require(`stream-json/jsonl/Parser`);
-const { saveStaticFiles } = require('../../src/utils/setup/save-asset-files');
-const { getNestedValue } = require('../../src/utils/get-nested-value');
 const { sourceNodes } = require(`./other-things-to-source`);
 const { fetchClientAccessToken } = require('./utils/kanopy-auth.js');
 const { callPostBuildWebhook } = require('./utils/post-build.js');
+const { consumeData, KEY_LAST_FETCHED, KEY_LAST_CLIENT_ACCESS_TOKEN } = require('./utils/data-consumer.js');
 
 // Global variable to allow webhookBody from sourceNodes step to be passed down
 // to other Gatsby build steps that might not pass webhookBody natively.
@@ -52,19 +49,8 @@ exports.createSchemaCustomization = async ({ actions }) => {
   createTypes(typeDefs);
 };
 
-const saveFile = async (file, data) => {
-  await fs.mkdir(path.join('public', path.dirname(file)), {
-    recursive: true,
-  });
-  await fs.writeFile(path.join('public', file), data, 'binary');
-};
-
 const APIBase = process.env.API_BASE || `https://snooty-data-api.mongodb.com`;
 const GATSBY_CLOUD_SITE_USER = process.env.GATSBY_CLOUD_SITE_USER;
-
-function createSnootyMetadataId({ branch, project, createNodeId }) {
-  return createNodeId(`metadata-${branch}-${project}`);
-}
 
 let isFirstRun = true;
 exports.sourceNodes = async ({
@@ -80,12 +66,11 @@ exports.sourceNodes = async ({
   console.log({ webhookBody });
   currentWebhookBody = webhookBody;
   let hasOpenAPIChangelog = false;
-  const { createNode, deleteNode, touchNode } = actions;
+  const { createNode, touchNode } = actions;
 
-  let pageCount = 0;
   const fileWritePromises = [];
-  const lastFetched = (await cache.get(`lastFetched`)) || 0;
-  const lastClientAccessToken = await cache.get('lastClientAccessToken');
+  const lastFetched = (await cache.get(KEY_LAST_FETCHED)) || 0;
+  const lastClientAccessToken = await cache.get(KEY_LAST_CLIENT_ACCESS_TOKEN);
   console.log({ lastFetched });
 
   if (isFirstRun && lastFetched) {
@@ -120,100 +105,32 @@ exports.sourceNodes = async ({
     }
     const httpStream = got.stream(url, { headers });
 
-    const decode = parser();
-    decode.on(`data`, async (_entry) => {
-      const entry = _entry.value;
-      const shouldDeleteContentNode = entry.data?.deleted;
-
-      if (entry.type === `timestamp`) {
-        cache.set(`lastFetched`, entry.data);
-        cache.set('lastClientAccessToken', clientAccessToken);
-      } else if (entry.type === `asset`) {
-        entry.data.filenames.forEach((filePath) => {
-          fileWritePromises.push(saveFile(filePath, Buffer.from(entry.data.assetData, `base64`)));
-        });
-      } else if (entry.type === `metadata`) {
-        // Create metadata node.
-        const { _id, build_id, created_at, static_files: staticFiles, ...metadataMinusStatic } = entry.data;
-        const { parentPaths, slugToTitle, branch, project } = metadataMinusStatic;
-        const nodeId = createSnootyMetadataId({ createNodeId, branch, project });
-
-        if (shouldDeleteContentNode) {
-          deleteNode(getNode(nodeId));
-        } else {
-          if (parentPaths) {
-            transformBreadcrumbs(parentPaths, slugToTitle);
-          }
-
-          // Save files in the static_files field of metadata document, including intersphinx inventories.
-          if (staticFiles) {
-            await saveStaticFiles(staticFiles);
-          }
-
-          createNode({
-            children: [],
-            id: nodeId,
-            internal: {
-              contentDigest: createContentDigest(metadataMinusStatic),
-              type: 'SnootyMetadata',
-            },
-            branch,
-            project,
-            parent: null,
-            metadata: metadataMinusStatic,
-          });
-        }
-      } else if (entry.type === `page`) {
-        if (entry.data?.ast?.options?.template === 'changelog') hasOpenAPIChangelog = true;
-        pageCount += 1;
-        const { source, ...page } = entry.data;
-
-        const filename = getNestedValue(['filename'], page) || '';
-        // The old gatsby sourceNodes has this code — I'm not sure it actually
-        // is a concern (I couldn't find any page documents that didn't end in .txt)
-        // but Chesterton's Fence and all.
-        if (filename.endsWith('.txt')) {
-          const branch = page.page_id.split(`/`)[2];
-          const raw_page_id = page.page_id.split(`/`).slice(3).join(`/`);
-          const page_id = raw_page_id === `index` ? `/` : `/${raw_page_id}`;
-          const project = page.page_id.split(`/`)[0];
-
-          const pageNodeId = createNodeId(page_id + project + branch);
-          const pagePathNodeId = pageNodeId + `/path`;
-
-          if (shouldDeleteContentNode) {
-            deleteNode(getNode(pageNodeId));
-            deleteNode(getNode(pagePathNodeId));
-          } else {
-            page.page_id = page_id;
-            page.metadata = createSnootyMetadataId({ createNodeId, branch, project });
-            page.id = pageNodeId;
-            page.internal = {
-              type: `Page`,
-              contentDigest: createContentDigest(page),
-            };
-
-            const pagePathNode = {
-              id: pagePathNodeId,
-              page_id,
-              branch,
-              project,
-              pageNodeId: page.id,
-              internal: {
-                type: `PagePath`,
-                contentDigest: page.internal.contentDigest,
-              },
-            };
-
-            createNode(page);
-            createNode(pagePathNode);
-
-            if (pageCount % 1000 === 0) {
-              console.log({ pageCount, page_id, id: page.id });
-            }
-          }
-        }
+    let pageCount = 0;
+    // Callback function to be ran after a valid page has been found and handled.
+    // Tracks and updates information that spans across several data entries
+    const onHandlePage = (pageTemplate, pageId, pageNodeId) => {
+      if (pageTemplate === 'changelog') hasOpenAPIChangelog = true;
+      pageCount += 1;
+      if (pageCount % 1000 === 0) {
+        console.log({ pageCount, page_id: pageId, id: pageNodeId });
       }
+    };
+
+    // Handle data consumed by the Snooty Data API based on data type
+    const decode = parser();
+    decode.on('data', async (_entry) => {
+      // Un-nest data
+      const entry = _entry.value;
+      await consumeData(entry, {
+        actions,
+        cache,
+        clientAccessToken,
+        createContentDigest,
+        createNodeId,
+        fileWritePromises,
+        getNode,
+        onHandlePage,
+      });
     });
 
     console.time(`source updates`);

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -1,0 +1,173 @@
+const { transformBreadcrumbs } = require('../../../src/utils/setup/transform-breadcrumbs.js');
+const { saveStaticFiles, saveFile } = require('../../../src/utils/setup/save-asset-files');
+const { getNestedValue } = require('../../../src/utils/get-nested-value');
+
+const KEY_LAST_FETCHED = 'lastFetched';
+const KEY_LAST_CLIENT_ACCESS_TOKEN = 'lastClientAccessToken';
+
+function createSnootyMetadataId({ branch, project, createNodeId }) {
+  return createNodeId(`metadata-${branch}-${project}`);
+}
+
+// Syncs the plugin with timestamp of data being returned from the API.
+const handleTimestamp = (data, { cache, clientAccessToken }) => {
+  cache.set(KEY_LAST_FETCHED, data);
+  cache.set(KEY_LAST_CLIENT_ACCESS_TOKEN, clientAccessToken);
+};
+
+const handleAsset = (data, { fileWritePromises }) => {
+  const { filenames, assetData } = data;
+
+  // Incorrect asset format should not be acceptable
+  if (!filenames || !filenames.length) {
+    throw new Error('No filenames found for asset');
+  }
+  if (!assetData) {
+    throw new Error('Missing asset data');
+  }
+
+  filenames.forEach((filePath) => {
+    // These promises will be resolved once all data is consumed
+    fileWritePromises.push(saveFile(filePath, Buffer.from(assetData, 'base64')));
+  });
+};
+
+const handleMetadata = async (
+  data,
+  { createContentDigest, createNode, createNodeId, deleteNode, getNode, shouldDeleteContentNode }
+) => {
+  const { _id, build_id, created_at, static_files: staticFiles, ...metadataMinusStatic } = data;
+  const { parentPaths, slugToTitle, branch, project } = metadataMinusStatic;
+  const nodeId = createSnootyMetadataId({ createNodeId, branch, project });
+
+  if (shouldDeleteContentNode) {
+    deleteNode(getNode(nodeId));
+    return;
+  }
+
+  if (parentPaths) {
+    transformBreadcrumbs(parentPaths, slugToTitle);
+  }
+
+  // Save files in the static_files field of metadata document, including intersphinx inventories.
+  if (staticFiles) {
+    await saveStaticFiles(staticFiles);
+  }
+
+  createNode({
+    children: [],
+    id: nodeId,
+    internal: {
+      contentDigest: createContentDigest(metadataMinusStatic),
+      type: 'SnootyMetadata',
+    },
+    branch,
+    project,
+    parent: null,
+    metadata: metadataMinusStatic,
+  });
+};
+
+const handlePage = (
+  data,
+  { createContentDigest, createNode, createNodeId, deleteNode, getNode, onHandlePage, shouldDeleteContentNode }
+) => {
+  // Strip source string, in case it exists. We don't need the raw source of the AST
+  const { source, ...page } = data;
+
+  const filename = getNestedValue(['filename'], page) || '';
+  // There can be ASTs for included .rst files as well. We should skip these, in case
+  // we encounter them
+  if (!filename.endsWith('.txt')) {
+    console.warn(`Found an AST that is not for a page: ${filename}`);
+    return;
+  }
+
+  const branch = page.page_id.split('/')[2];
+  const raw_page_id = page.page_id.split('/').slice(3).join('/');
+  const page_id = raw_page_id === 'index' ? '/' : `/${raw_page_id}`;
+  const project = page.page_id.split('/')[0];
+
+  const pageNodeId = createNodeId(page_id + project + branch);
+  const pagePathNodeId = pageNodeId + '/path';
+
+  if (shouldDeleteContentNode) {
+    deleteNode(getNode(pageNodeId));
+    deleteNode(getNode(pagePathNodeId));
+    return;
+  }
+
+  page.page_id = page_id;
+  page.metadata = createSnootyMetadataId({ createNodeId, branch, project });
+  page.id = pageNodeId;
+  page.internal = {
+    type: 'Page',
+    contentDigest: createContentDigest(page),
+  };
+
+  const pagePathNode = {
+    id: pagePathNodeId,
+    page_id,
+    branch,
+    project,
+    pageNodeId: page.id,
+    internal: {
+      type: 'PagePath',
+      contentDigest: page.internal.contentDigest,
+    },
+  };
+
+  createNode(page);
+  createNode(pagePathNode);
+
+  const pageTemplate = data.ast?.options?.template;
+  onHandlePage(pageTemplate, page_id, pageNodeId);
+};
+
+const consumeData = async (
+  entry,
+  { actions, cache, createNodeId, createContentDigest, getNode, fileWritePromises, clientAccessToken, onHandlePage }
+) => {
+  const { type, data } = entry;
+
+  // Shape and format should be consistent across all data
+  if (!type) {
+    throw new Error('Data entry is missing data type');
+  }
+  if (!data) {
+    throw new Error('Data entry is missing data');
+  }
+
+  const shouldDeleteContentNode = data.deleted;
+  const { createNode, deleteNode } = actions;
+
+  if (entry.type === 'timestamp') {
+    handleTimestamp(data, { cache, clientAccessToken });
+  } else if (entry.type === 'asset') {
+    handleAsset(data, { fileWritePromises });
+  } else if (entry.type === 'metadata') {
+    await handleMetadata(data, {
+      createContentDigest,
+      createNode,
+      createNodeId,
+      deleteNode,
+      getNode,
+      shouldDeleteContentNode,
+    });
+  } else if (entry.type === 'page') {
+    handlePage(data, {
+      createContentDigest,
+      createNode,
+      createNodeId,
+      deleteNode,
+      getNode,
+      onHandlePage,
+      shouldDeleteContentNode,
+    });
+  } else {
+    // Shouldn't affect current builds
+    console.warn(`Unexpected data type: ${entry.type}`);
+  }
+};
+
+module.exports = { consumeData, KEY_LAST_FETCHED, KEY_LAST_CLIENT_ACCESS_TOKEN };

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -148,11 +148,11 @@ const consumeData = async (
   const shouldDeleteContentNode = data.deleted;
   const { createNode, deleteNode } = actions;
 
-  if (entry.type === 'timestamp') {
+  if (type === 'timestamp') {
     handleTimestamp(data, { cache, clientAccessToken });
-  } else if (entry.type === 'asset') {
+  } else if (type === 'asset') {
     handleAsset(data, { fileWritePromises });
-  } else if (entry.type === 'metadata') {
+  } else if (type === 'metadata') {
     await handleMetadata(data, {
       createContentDigest,
       createNode,
@@ -161,7 +161,7 @@ const consumeData = async (
       getNode,
       shouldDeleteContentNode,
     });
-  } else if (entry.type === 'page') {
+  } else if (type === 'page') {
     handlePage(data, {
       createContentDigest,
       createNode,
@@ -173,7 +173,7 @@ const consumeData = async (
     });
   } else {
     // Shouldn't affect current builds
-    console.warn(`Unexpected data type: ${entry.type}`);
+    console.warn(`Unexpected data type: ${type}`);
   }
 };
 

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -78,7 +78,7 @@ const handlePage = (
   const filename = getNestedValue(['filename'], page) || '';
   // There can be ASTs for included .rst files as well. We should skip these, in case
   // we encounter them
-  if (!filename.endsWith('.txt')) {
+  if (!filename || !filename.endsWith('.txt')) {
     console.warn(`Found an AST that is not for a page: ${filename}`);
     return;
   }
@@ -124,6 +124,13 @@ const handlePage = (
   onHandlePage(pageTemplate, page_id, pageNodeId);
 };
 
+/**
+ * Handles incoming data accordingly based on its data type. Notably, this handles
+ * converting build data from the Snooty Data API into nodes and assets that the
+ * Gatsby site will need to render pages.
+ * @param {*} entry - A single data entry obtained from the Snooty Data API
+ * @param {*} options - Gatsby functions and other utilities to be used by handlers
+ */
 const consumeData = async (
   entry,
   { actions, cache, createNodeId, createContentDigest, getNode, fileWritePromises, clientAccessToken, onHandlePage }

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -37,4 +37,4 @@ const saveStaticFiles = async (staticFiles) => {
   );
 };
 
-module.exports = { saveAssetFiles, saveStaticFiles };
+module.exports = { saveAssetFiles, saveStaticFiles, saveFile };


### PR DESCRIPTION
### Stories/Links:

DOP-4063

### Staging Links:

This change is strictly for the Gatsby Cloud preview plugin, but not changes should be made. A successful refactoring means that the staging links build with correct side navs (for metadata), pages (for pages), and images (for assets).

[cloud-docs](https://preview-mongodbrayangler.gatsbyjs.io/cloud-docs/gc-test-img/)
[docs](https://preview-mongodbrayangler.gatsbyjs.io/docs/DOP-4063-test/)

### Notes:

* The bulk of this PR is just reorganizing the way data was being consumed from the Snooty Data API so that it was less nested, and easier to maintain. There should be no functional changes other than some additional proactive error handling for incorrect data formats to help improve completeness.