### PR TITLE
DOP-4065 frontend

### DIFF
--- a/src/components/SearchResults/Facets/FacetTags.js
+++ b/src/components/SearchResults/Facets/FacetTags.js
@@ -7,7 +7,6 @@ import { Overline } from '@leafygreen-ui/typography';
 import { theme } from '../../../theme/docsTheme';
 import Tag, { searchTagStyle } from '../../Tag';
 import SearchContext from '../SearchContext';
-import useFacets from './useFacets';
 import { initChecked } from './FacetValue';
 import { getFacetTagVariant } from './utils';
 
@@ -112,8 +111,7 @@ const ClearFacetsTag = ({ onClick }) => (
 );
 
 const FacetTags = ({ resultsCount }) => {
-  const { searchParams, clearFacets } = useContext(SearchContext);
-  const facets = useFacets();
+  const { searchParams, clearFacets, facets } = useContext(SearchContext);
   // don't have to use state since facet filters are
   // derived from URL state (search params)
   const activeFacets = useMemo(() => getActiveFacets(facets, searchParams), [facets, searchParams]);

--- a/src/components/SearchResults/Facets/FacetTags.js
+++ b/src/components/SearchResults/Facets/FacetTags.js
@@ -9,6 +9,7 @@ import Tag, { searchTagStyle } from '../../Tag';
 import SearchContext from '../SearchContext';
 import useFacets from './useFacets';
 import { initChecked } from './FacetValue';
+import { getFacetTagVariant } from './utils';
 
 // util to get all current facets, derived from search params
 const getActiveFacets = (facetOptions, searchParams) => {
@@ -97,7 +98,7 @@ const FacetTag = ({ facet: { name, key, id, facets } }) => {
   }, [facets, handleFacetChange, id, key]);
 
   return (
-    <StyledTag onClick={onClick}>
+    <StyledTag variant={getFacetTagVariant({ key, id })} onClick={onClick}>
       {name}
       <Icon glyph="X" />
     </StyledTag>

--- a/src/components/SearchResults/Facets/Facets.js
+++ b/src/components/SearchResults/Facets/Facets.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import useFacets from './useFacets';
+import React, { useContext } from 'react';
+import SearchContext from '../SearchContext';
 import FacetGroup from './FacetGroup';
 
 const Facets = () => {
-  const facets = useFacets();
+  const { facets } = useContext(SearchContext);
 
   return (
     <div data-testid="facets-container">

--- a/src/components/SearchResults/Facets/utils.js
+++ b/src/components/SearchResults/Facets/utils.js
@@ -5,7 +5,7 @@
  *
  * @returns {str} blue | green
  */
-export const getFacetTagVariant = (facet, type = 'facet-option') => {
+export const getFacetTagVariant = (facet) => {
   if (facet.key === 'target_product') {
     return 'green';
   }

--- a/src/components/SearchResults/Facets/utils.js
+++ b/src/components/SearchResults/Facets/utils.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {obj} facet - contains key and id properties as returned by /v2/status ie.
+ * https://docs-search-transport.mongodb.com/v2/status
+ *
+ * @returns {str} blue | green
+ */
+export const getFacetTagVariant = (facet, type = 'facet-option') => {
+  if (facet.key === 'target_product') {
+    return 'green';
+  }
+  return 'blue';
+};

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -60,10 +60,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
   const { search } = useLocation();
   const { filters, searchPropertyMapping } = useMarianManifests();
   const facets = useFacets();
-  const facetNamesByKeyId = constructFacetNamesByKey(facets);
-  useMemo(() => {
-    constructFacetNamesByKey(facets);
-  }, [facets]);
+  const facetNamesByKeyId = useMemo(() => constructFacetNamesByKey(facets), [facets]);
 
   const getFacetName = useCallback(
     (facet) => {

--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -143,6 +143,7 @@ const SearchResult = React.memo(
     const resultLinkRef = useRef(null);
     const category = searchPropertyMapping?.[searchProperty]?.['categoryTitle'];
     const version = searchPropertyMapping?.[searchProperty]?.['versionSelectorLabel'];
+    const validFacets = facets?.filter(getFacetName);
 
     return (
       <SearchResultLink ref={resultLinkRef} href={url} onClick={onClick} {...props}>
@@ -166,10 +167,12 @@ const SearchResult = React.memo(
               {url.includes('/api/') && <StyledTag variant="purple">{'API'}</StyledTag>}
             </StylingTagContainer>
           )}
-          {showFacets && facets?.filter(getFacetName)?.length > 0 && (
+          {showFacets && validFacets?.length > 0 && (
             <StylingTagContainer>
-              {facets.filter(getFacetName).map((facet) => (
-                <StyledTag variant={getFacetTagVariant(facet)}>{getFacetName(facet)}</StyledTag>
+              {validFacets.map((facet, idx) => (
+                <StyledTag variant={getFacetTagVariant(facet)} key={`${idx}-${facet.key}-${facet.id}`}>
+                  {getFacetName(facet)}
+                </StyledTag>
               ))}
             </StylingTagContainer>
           )}

--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -132,9 +132,10 @@ const SearchResult = React.memo(
     title,
     searchProperty,
     url,
+    facets,
     ...props
   }) => {
-    const { searchPropertyMapping, searchTerm } = useContext(SearchContext);
+    const { searchPropertyMapping, searchTerm, getFacetName } = useContext(SearchContext);
     const highlightedPreviewText = highlightSearchTerm(preview, searchTerm);
     const resultLinkRef = useRef(null);
     const category = searchPropertyMapping?.[searchProperty]?.['categoryTitle'];
@@ -159,6 +160,9 @@ const SearchResult = React.memo(
             {!!category && <StyledTag variant="green">{category}</StyledTag>}
             {!!version && <StyledTag variant="blue">{version}</StyledTag>}
             {url.includes('/api/') && <StyledTag variant="purple">{'API'}</StyledTag>}
+            {facets.filter(getFacetName).map((facet) => (
+              <StyledTag variant="blue">{getFacetName(facet)}</StyledTag>
+            ))}
           </StylingTagContainer>
           {learnMoreLink && (
             <MobileFooterContainer>

--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -166,7 +166,7 @@ const SearchResult = React.memo(
               {url.includes('/api/') && <StyledTag variant="purple">{'API'}</StyledTag>}
             </StylingTagContainer>
           )}
-          {showFacets && (
+          {showFacets && facets?.filter(getFacetName)?.length > 0 && (
             <StylingTagContainer>
               {facets.filter(getFacetName).map((facet) => (
                 <StyledTag variant={getFacetTagVariant(facet)}>{getFacetName(facet)}</StyledTag>

--- a/src/components/SearchResults/SearchResult.js
+++ b/src/components/SearchResults/SearchResult.js
@@ -5,8 +5,9 @@ import styled from '@emotion/styled';
 import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
 import { theme } from '../../theme/docsTheme';
-import Tag, { searchTagStyle } from '../Tag';
+import Tag, { searchTagStyle, tagHeightStyle } from '../Tag';
 import SearchContext from './SearchContext';
+import { getFacetTagVariant } from './Facets/utils';
 
 const LINK_COLOR = '#494747';
 // Use string for match styles due to replace/innerHTML
@@ -95,6 +96,8 @@ const StyledTag = styled(Tag)`
 const StylingTagContainer = styled('div')`
   bottom: 0;
   margin-bottom: ${theme.size.medium};
+  overflow: hidden;
+  ${tagHeightStyle};
 `;
 
 const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -135,7 +138,7 @@ const SearchResult = React.memo(
     facets,
     ...props
   }) => {
-    const { searchPropertyMapping, searchTerm, getFacetName } = useContext(SearchContext);
+    const { searchPropertyMapping, searchTerm, getFacetName, showFacets } = useContext(SearchContext);
     const highlightedPreviewText = highlightSearchTerm(preview, searchTerm);
     const resultLinkRef = useRef(null);
     const category = searchPropertyMapping?.[searchProperty]?.['categoryTitle'];
@@ -156,14 +159,20 @@ const SearchResult = React.memo(
               __html: sanitizePreviewHtml(highlightedPreviewText),
             }}
           />
-          <StylingTagContainer>
-            {!!category && <StyledTag variant="green">{category}</StyledTag>}
-            {!!version && <StyledTag variant="blue">{version}</StyledTag>}
-            {url.includes('/api/') && <StyledTag variant="purple">{'API'}</StyledTag>}
-            {facets.filter(getFacetName).map((facet) => (
-              <StyledTag variant="blue">{getFacetName(facet)}</StyledTag>
-            ))}
-          </StylingTagContainer>
+          {!showFacets && (
+            <StylingTagContainer>
+              {!!category && <StyledTag variant="green">{category}</StyledTag>}
+              {!!version && <StyledTag variant="blue">{version}</StyledTag>}
+              {url.includes('/api/') && <StyledTag variant="purple">{'API'}</StyledTag>}
+            </StylingTagContainer>
+          )}
+          {showFacets && (
+            <StylingTagContainer>
+              {facets.filter(getFacetName).map((facet) => (
+                <StyledTag variant={getFacetTagVariant(facet)}>{getFacetName(facet)}</StyledTag>
+              ))}
+            </StylingTagContainer>
+          )}
           {learnMoreLink && (
             <MobileFooterContainer>
               <LearnMoreLink href={url}>

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -460,7 +460,7 @@ const SearchResults = () => {
         {!!searchTerm && !!searchFinished && !!searchResults.length && (
           <>
             <StyledSearchResults>
-              {searchResults.map(({ title, preview, url, searchProperty }, index) => (
+              {searchResults.map(({ title, preview, url, searchProperty, facets }, index) => (
                 <StyledSearchResult
                   key={`${url}${index}`}
                   onClick={() =>
@@ -471,6 +471,7 @@ const SearchResults = () => {
                   url={url}
                   useLargeTitle
                   searchProperty={searchProperty?.[0]}
+                  facets={facets}
                 />
               ))}
               {

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -359,7 +359,7 @@ const SearchResults = () => {
   const submitNewSearch = (event) => {
     const newValue = event.target[0]?.value;
     const { page } = queryString.parse(search);
-    if (newValue === searchTerm && parseInt(page) === 1) return;
+    if (!newValue || (newValue === searchTerm && parseInt(page) === 1)) return;
 
     setSearchTerm(newValue);
   };

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -11,9 +11,13 @@ const baseStyle = css`
   padding: ${theme.size.tiny} ${theme.size.small};
 `;
 
+export const tagHeightStyle = css`
+  height: 26px;
+`;
+
 export const searchTagStyle = css`
   cursor: pointer;
-  height: 26px;
+  ${tagHeightStyle};
   padding: 4px 11px 4px 11px;
   border-radius: 12px;
   font-size: ${theme.fontSize.tiny};

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -1536,6 +1536,8 @@ exports[`Search Results Page considers a given search filter query param and dis
 .emotion-36 {
   bottom: 0;
   margin-bottom: 24px;
+  overflow: hidden;
+  height: 26px;
 }
 
 .emotion-42 {
@@ -8347,6 +8349,8 @@ exports[`Search Results Page renders results from a given search term query para
 .emotion-32 {
   bottom: 0;
   margin-bottom: 24px;
+  overflow: hidden;
+  height: 26px;
 }
 
 .emotion-35 {


### PR DESCRIPTION
### Stories/Links:

[DOP-4065](https://jira.mongodb.org/browse/DOP-4065)

### Description:
This PR utilizes new attributes returned from /search API endpoint, specifically `documents[].facets[]` Example here: https://docs-search-transport.mongodb.com/search?q=$and

Goal is the show the tagged facets on each document in the search results

### Current Behavior:
[Current behavior on prod:](https://www.mongodb.com/docs/search/?q=$or)

[Current behavior on master with feature flag on, shows no facet tags on search results](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/master/search/index.html?q=$or)

### Staging Links:
[Staged changes with feature flag = off](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/DOP-4065-frontend/search/index.html?q=$or)

[Staged changes with feature flag on](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/0b1cf03a3fa9aa82078abfb17cc6191dd32fbf39/newhomepagewhodis/landing/seung.park/DOP-4065-frontend/search/index.html?q=$or)