### PR TITLE
DOP-4090: add transperfect script to head

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -17,6 +17,14 @@ export const onRenderBody = ({ setHeadComponents }) => {
     />,
     // Optimizely
     <script key="optimizely" src="https://cdn.optimizely.com/js/20988630008.js" />,
+    // Transperfect
+    <script
+      key="transperfect"
+      referrerpolicy="no-referrer-when-downgrade"
+      type="text/javascript"
+      src="https://www.onelink-edge.com/moxie.min.js"
+      data-oljs="P3FF1-D8F7-16C3-610C"
+    />,
     // Delighted
     <script
       key="delighted"

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -122,7 +122,7 @@ const DocumentBody = (props) => {
   const onSelectLocale = (locale) => {
     const localeHrefMap = {
       'zh-cn': `https://mongodbcom-cdn.staging.corp.mongodb.com/zh-cn${slugForUrl}/`,
-      'en-us': `https://mongodbcom-cdn.website.staging.corp.mongodb.com${slugForUrl}/`,
+      'en-us': `https://mongodbcom-cdn.staging.corp.mongodb.com${slugForUrl}/`,
     };
 
     if (isBrowser) {


### PR DESCRIPTION
### Stories/Links:

DOP-4090

### Current Behavior:
… it doesn't have the script

### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/allison/DOP-4090-tp/index.html (inspect to confirm script is there, screenshot below)

<img width="1051" alt="Screenshot 2023-10-16 at 12 07 54 PM" src="https://github.com/mongodb/snooty/assets/1724699/dc5177ca-dcb1-4c49-9395-16c2f8da887e">

