### PR TITLE
DOP-4083: Prevent page creation when missing metadata

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -220,7 +220,9 @@ exports.createPages = async ({ actions, createNodeId, getNode, graphql, reporter
       if (!getNode(metadataNodeId)) {
         // Take into account the possibility of having new page data available in the API
         // right before the query is made, but with no metadata yet
-        console.warn(`Skipping node creation for page "${node.page_id}". No metadata node "${metadataNodeId}" found.`);
+        console.warn(
+          `Skipping node creation for page "${node.page_id}", in project "${node.project}" on branch "${node.branch}. No metadata node "${metadataNodeId}" found.`
+        );
         return;
       }
 

--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -218,8 +218,8 @@ exports.createPages = async ({ actions, createNodeId, getNode, graphql, reporter
 
       const metadataNodeId = createSnootyMetadataId({ createNodeId, branch: node.branch, project: node.project });
       if (!getNode(metadataNodeId)) {
-        // Take into account the possibility of having new page data available in the API
-        // right before the query is made, but with no metadata yet
+        // Take into account the possibility of having new page data available through the API,
+        // but no metadata yet due to async uploads
         console.warn(
           `Skipping node creation for page "${node.page_id}", in project "${node.project}" on branch "${node.branch}. No metadata node "${metadataNodeId}" found.`
         );

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -97,16 +97,8 @@ const handlePage = (
     return;
   }
 
-  const metadataNodeId = createSnootyMetadataId({ createNodeId, branch, project });
-  // if (!getNode(metadataNodeId)) {
-  //   // Take into account the possibility of having new page data available in the API
-  //   // right before the query is made, but with no metadata yet
-  //   console.warn(`Skipping node creation for page "${page.page_id}". No metadata node "${metadataNodeId}" found.`);
-  //   return;
-  // }
-
   page.page_id = page_id;
-  page.metadata = metadataNodeId;
+  page.metadata = createSnootyMetadataId({ createNodeId, branch, project });
   page.id = pageNodeId;
   page.internal = {
     type: 'Page',

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -97,8 +97,14 @@ const handlePage = (
     return;
   }
 
+  const metadataNodeId = createSnootyMetadataId({ createNodeId, branch, project });
+  if (!getNode(metadataNodeId)) {
+    console.warn(`Skipping node creation for page "${raw_page_id}". No metadata node "${metadataNodeId}" found.`);
+    return;
+  }
+
   page.page_id = page_id;
-  page.metadata = createSnootyMetadataId({ createNodeId, branch, project });
+  page.metadata = metadataNodeId;
   page.id = pageNodeId;
   page.internal = {
     type: 'Page',

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -99,7 +99,9 @@ const handlePage = (
 
   const metadataNodeId = createSnootyMetadataId({ createNodeId, branch, project });
   if (!getNode(metadataNodeId)) {
-    console.warn(`Skipping node creation for page "${raw_page_id}". No metadata node "${metadataNodeId}" found.`);
+    // Take into account the possibility of having new page data available in the API
+    // right before the query is made, but with no metadata yet
+    console.warn(`Skipping node creation for page "${page.page_id}". No metadata node "${metadataNodeId}" found.`);
     return;
   }
 

--- a/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
+++ b/plugins/gatsby-source-snooty-preview/utils/data-consumer.js
@@ -98,12 +98,12 @@ const handlePage = (
   }
 
   const metadataNodeId = createSnootyMetadataId({ createNodeId, branch, project });
-  if (!getNode(metadataNodeId)) {
-    // Take into account the possibility of having new page data available in the API
-    // right before the query is made, but with no metadata yet
-    console.warn(`Skipping node creation for page "${page.page_id}". No metadata node "${metadataNodeId}" found.`);
-    return;
-  }
+  // if (!getNode(metadataNodeId)) {
+  //   // Take into account the possibility of having new page data available in the API
+  //   // right before the query is made, but with no metadata yet
+  //   console.warn(`Skipping node creation for page "${page.page_id}". No metadata node "${metadataNodeId}" found.`);
+  //   return;
+  // }
 
   page.page_id = page_id;
   page.metadata = metadataNodeId;
@@ -185,4 +185,4 @@ const consumeData = async (
   }
 };
 
-module.exports = { consumeData, KEY_LAST_FETCHED, KEY_LAST_CLIENT_ACCESS_TOKEN };
+module.exports = { consumeData, createSnootyMetadataId, KEY_LAST_FETCHED, KEY_LAST_CLIENT_ACCESS_TOKEN };


### PR DESCRIPTION
### Stories/Links:

DOP-4083

### Current Behavior:

[Gatsby Cloud build log](https://www.gatsbyjs.com/dashboard/083213ad-92d8-4d3f-af78-848bb8100c91/sites/415d6555-c510-4289-a4f2-8593e1b97ee7/builds/67082c47-acad-4a49-af5a-1fa7a57a4e22/details?returnTo=%2Fdashboard%2F083213ad-92d8-4d3f-af78-848bb8100c91%2Fsites%2F415d6555-c510-4289-a4f2-8593e1b97ee7%2FcmsPreview#rawLogs) - ambiguously missing metadata. This results in the page rendering the error described in the Jira ticket, which may be confusing for users.

Example render of page with missing metadata:

![image](https://github.com/mongodb/snooty/assets/27821750/c246f5bc-25a3-4f51-97be-75e60e3795b0)

Context on why metadata could be missing: this issue can crop up whenever someone is doing parallel builds that span across different branches at the same time. There's a chance for the first build to run a Gatsby Cloud build, which could potentially pull in data from different builds occurring at the same time, since the source plugin currently tries to pull in as much new data as possible based on timestamp. There's a non-zero chance for new pages to be queried, but the metadata document associated with the new pages could have been uploaded afterwards. DOP-4096 sheds some light on why the timestamps can become out of order for parallel builds. This ticket should be done to help minimize/fix the potential root cause of the problem.

### Staging Links:

[Gatsby build log](https://www.gatsbyjs.com/dashboard/083213ad-92d8-4d3f-af78-848bb8100c91/sites/415d6555-c510-4289-a4f2-8593e1b97ee7/builds/06afd8b6-bb24-4361-93ef-c23b4aa8b719/details?returnTo=%2Fdashboard%2F083213ad-92d8-4d3f-af78-848bb8100c91%2Fsites%2F415d6555-c510-4289-a4f2-8593e1b97ee7%2FcmsPreview#rawLogs) - shows warnings of missing metadata to make the issue clearer for DOP to see the issue
[Gatsby build site](https://build-06afd8b6-bb24-4361-93ef-c23b4aa8b719.gatsbyjs.io/docs/DOP-4083-2/) - the page should be a regular 404 page, instead of showing the random error

### Notes:

* This PR is not meant to be a solution for preventing missing metadata nodes when building pages. The purpose of this PR is to (1) increase the visibility of missing metadata in the GC build logs, and (2) avoid rendering the error page, which may be confusing for the docs team. I've made the logs warnings for now since the source plugin should still attempt to create pages for the correct data that it possesses at the time, but happy to change accordingly.