### PR TITLE
add slug to locale switcher

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -117,10 +117,11 @@ const DocumentBody = (props) => {
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
 
+  const slugForUrl = slug === '/' ? '' : slug; // handle the index's path
   const onSelectLocale = (locale) => {
     const localeHrefMap = {
-      'zh-cn': 'https://mongodbcom-cdn.staging.corp.mongodb.com/zh-cn/docs-qa/',
-      'en-us': 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/',
+      'zh-cn': `https://mongodbcom-cdn.staging.corp.mongodb.com/zh-cn/docs-qa/${slugForUrl}`,
+      'en-us': `https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/${slugForUrl}`,
     };
 
     if (isBrowser) {

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -117,7 +117,7 @@ const DocumentBody = (props) => {
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
 
-  const slugForUrl = slug === '/' ? '' : slug; // handle the index's path
+  const slugForUrl = slug === '/' ? '' : slug; // handle the `/` path
   const onSelectLocale = (locale) => {
     const localeHrefMap = {
       'zh-cn': `https://mongodbcom-cdn.staging.corp.mongodb.com/zh-cn/docs-qa/${slugForUrl}`,


### PR DESCRIPTION
### Stories/Links:

We want the locale flipper to flip you to the same page as you're on.

### Current Behavior:

It points to the equivalent of www.mongodb.com/docs/

### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/allison/smartlingslug/tools-and-connectors/index.html

### Notes:
