### PR TITLE
:bulb: DOP-4098 updates comment to reflect pulling from docset instead of repo_branches

### DIFF
--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -77,7 +77,7 @@ const DeprecatedVersionSelector = ({ metadata: { deprecated_versions: deprecated
   const updateVersion = useCallback(({ value }) => setVersion(value), []);
   const buttonDisabled = !(product && version);
 
-  // Fetch repos_branches for `displayName` and url
+  // Fetch docsets for url and combine `displayName` from oldGenToReposMap method
   useEffect(() => {
     if (reposDatabase) {
       fetchDocsets(reposDatabase).then((resp) => {


### PR DESCRIPTION
### Stories/Links:

DOP-4098

### Current Behavior:

N/A

### Staging Links:

N/A

### Notes:

Part of me searching through all DOP codebases to ensure we are not pulling in `prefix`, `bucket`, and `URL` from `repo_branches`, I stumbled across an outdated comment, and this PR updates that to reflect that `URL` now comes from `docsets` collection. 
