### PR TITLE
DOP-4081: version dropdown for facet filters

### DIFF
--- a/src/components/SearchResults/Facets/FacetGroup.js
+++ b/src/components/SearchResults/Facets/FacetGroup.js
@@ -1,13 +1,18 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState, useContext } from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
-import { Body } from '@leafygreen-ui/typography';
-import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
-import FacetValue from './FacetValue';
+import { palette } from '@leafygreen-ui/palette';
+import { Body } from '@leafygreen-ui/typography';
+import Select from '../../Select';
+import SearchContext from '../SearchContext';
+import { theme } from '../../../theme/docsTheme';
+import FacetValue, { initChecked } from './FacetValue';
 
 // Facet options with the following ids will truncate the initial number of items shown
 const TRUNCATE_OPTIONS = ['programming_language', 'sub_product'];
 const TRUNCATE_AMOUNT = 5;
+
+export const VERSION_GROUP_ID = 'version';
 
 const optionStyle = (isNested) => css`
   ${isNested
@@ -39,6 +44,71 @@ const showMoreGlyphStyle = css`
   color: ${palette.gray.dark2};
 `;
 
+// TODO: move to new file
+
+const selectStyle = css`
+  font-size: ${theme.fontSize.small};
+  line-height: 20px;
+  margin-bottom: 8px;
+  padding-left: 22px;
+
+  button {
+    height: 22px;
+  }
+`;
+
+const FacetVersionGroup = ({ facetOption: { name, id, options } }) => {
+  // create select options from options
+  const selectOptions = useMemo(
+    () => options.map((option) => ({ text: option.name, value: option.id, key: option.key })),
+    [options]
+  );
+  const { handleFacetChange, searchParams } = useContext(SearchContext);
+
+  const [value, setValue] = useState(
+    () => selectOptions.find(({ key, value }) => initChecked(searchParams, key, value))?.value || selectOptions[0].value
+  );
+
+  const optionsById = useMemo(
+    () =>
+      options.reduce((map, option) => {
+        map[option.id] = option;
+        return map;
+      }, {}),
+    [options]
+  );
+
+  const onChange = useCallback(
+    (newOption) => {
+      const selectedOption = optionsById[newOption.value];
+      const oldSelection = optionsById[value];
+      const facetsToUpdate = [];
+
+      // update to unselect current selection
+      facetsToUpdate.push({
+        key: oldSelection.key,
+        id: oldSelection.id,
+        checked: false,
+      });
+
+      // update to select new selection
+      facetsToUpdate.push({
+        key: selectedOption.key,
+        id: selectedOption.id,
+        checked: true,
+      });
+
+      setValue(selectedOption.id);
+      handleFacetChange(facetsToUpdate);
+    },
+    [handleFacetChange, optionsById, value]
+  );
+
+  return <Select className={cx(selectStyle)} value={value} choices={selectOptions} onChange={onChange}></Select>;
+};
+
+// END TODO: move to new file
+
 // Representative of a "facet-option" from search server response
 const FacetGroup = ({ facetOption: { name, id, options }, isNested = false, numSelectedChildren }) => {
   const shouldTruncate = options.length >= TRUNCATE_AMOUNT && TRUNCATE_OPTIONS.includes(id);
@@ -58,6 +128,10 @@ const FacetGroup = ({ facetOption: { name, id, options }, isNested = false, numS
   const handleExpansionClick = useCallback(() => {
     setTruncated((prev) => !prev);
   }, []);
+
+  if (id === VERSION_GROUP_ID) {
+    return <FacetVersionGroup facetOption={{ name, id, options }} />;
+  }
 
   return (
     <div className={cx(optionStyle(isNested))}>

--- a/src/components/SearchResults/Facets/FacetGroup.js
+++ b/src/components/SearchResults/Facets/FacetGroup.js
@@ -3,14 +3,13 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
+import { VERSION_GROUP_ID } from '../../../utils/search-facet-constants';
 import FacetVersionGroup from './FacetVersionGroup';
 import FacetValue from './FacetValue';
 
 // Facet options with the following ids will truncate the initial number of items shown
 const TRUNCATE_OPTIONS = ['programming_language', 'sub_product'];
 const TRUNCATE_AMOUNT = 5;
-
-export const VERSION_GROUP_ID = 'version';
 
 const optionStyle = (isNested) => css`
   ${isNested

--- a/src/components/SearchResults/Facets/FacetGroup.js
+++ b/src/components/SearchResults/Facets/FacetGroup.js
@@ -1,12 +1,10 @@
-import React, { useCallback, useMemo, useState, useContext } from 'react';
+import React, { useCallback, useState } from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
 import { Body } from '@leafygreen-ui/typography';
-import Select from '../../Select';
-import SearchContext from '../SearchContext';
-import { theme } from '../../../theme/docsTheme';
-import FacetValue, { initChecked } from './FacetValue';
+import FacetVersionGroup from './FacetVersionGroup';
+import FacetValue from './FacetValue';
 
 // Facet options with the following ids will truncate the initial number of items shown
 const TRUNCATE_OPTIONS = ['programming_language', 'sub_product'];
@@ -43,71 +41,6 @@ const showMoreStyle = css`
 const showMoreGlyphStyle = css`
   color: ${palette.gray.dark2};
 `;
-
-// TODO: move to new file
-
-const selectStyle = css`
-  font-size: ${theme.fontSize.small};
-  line-height: 20px;
-  margin-bottom: 8px;
-  padding-left: 22px;
-
-  button {
-    height: 22px;
-  }
-`;
-
-const FacetVersionGroup = ({ facetOption: { name, id, options } }) => {
-  // create select options from options
-  const selectOptions = useMemo(
-    () => options.map((option) => ({ text: option.name, value: option.id, key: option.key })),
-    [options]
-  );
-  const { handleFacetChange, searchParams } = useContext(SearchContext);
-
-  const [value, setValue] = useState(
-    () => selectOptions.find(({ key, value }) => initChecked(searchParams, key, value))?.value || selectOptions[0].value
-  );
-
-  const optionsById = useMemo(
-    () =>
-      options.reduce((map, option) => {
-        map[option.id] = option;
-        return map;
-      }, {}),
-    [options]
-  );
-
-  const onChange = useCallback(
-    (newOption) => {
-      const selectedOption = optionsById[newOption.value];
-      const oldSelection = optionsById[value];
-      const facetsToUpdate = [];
-
-      // update to unselect current selection
-      facetsToUpdate.push({
-        key: oldSelection.key,
-        id: oldSelection.id,
-        checked: false,
-      });
-
-      // update to select new selection
-      facetsToUpdate.push({
-        key: selectedOption.key,
-        id: selectedOption.id,
-        checked: true,
-      });
-
-      setValue(selectedOption.id);
-      handleFacetChange(facetsToUpdate);
-    },
-    [handleFacetChange, optionsById, value]
-  );
-
-  return <Select className={cx(selectStyle)} value={value} choices={selectOptions} onChange={onChange}></Select>;
-};
-
-// END TODO: move to new file
 
 // Representative of a "facet-option" from search server response
 const FacetGroup = ({ facetOption: { name, id, options }, isNested = false, numSelectedChildren }) => {

--- a/src/components/SearchResults/Facets/FacetValue.js
+++ b/src/components/SearchResults/Facets/FacetValue.js
@@ -129,7 +129,7 @@ const FacetValue = ({
         facetsToUpdate.push({
           key: preferredVersion.key,
           id: preferredVersion.id,
-          checked: true,
+          checked: checked,
         });
       }
       facetsToUpdate.push({ key, id, checked });

--- a/src/components/SearchResults/Facets/FacetValue.js
+++ b/src/components/SearchResults/Facets/FacetValue.js
@@ -2,8 +2,9 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import Checkbox from '@leafygreen-ui/checkbox';
 import { palette } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
-import SearchContext, { FACETS_KEY_PREFIX, FACETS_LEVEL_KEY } from '../SearchContext';
-import FacetGroup, { VERSION_GROUP_ID } from './FacetGroup';
+import { FACETS_KEY_PREFIX, FACETS_LEVEL_KEY, VERSION_GROUP_ID } from '../../../utils/search-facet-constants';
+import SearchContext from '../SearchContext';
+import FacetGroup from './FacetGroup';
 
 const checkboxStyle = css`
   // Target the label/text
@@ -32,7 +33,9 @@ const onlyButtonStyle = css`
   margin-left: 8px;
 `;
 
-export const initChecked = (searchParams, key, id) => searchParams.getAll(FACETS_KEY_PREFIX + key).includes(id);
+export const initChecked = (searchParams, key, id) => {
+  return searchParams.getAll(FACETS_KEY_PREFIX + key).includes(id);
+};
 
 /**
  * Check if the key + value of a query param are actual subfacets.

--- a/src/components/SearchResults/Facets/FacetVersionGroup.js
+++ b/src/components/SearchResults/Facets/FacetVersionGroup.js
@@ -1,0 +1,77 @@
+import React, { useCallback, useMemo, useState, useContext } from 'react';
+import { css, cx } from '@leafygreen-ui/emotion';
+import Select from '../../Select';
+import SearchContext from '../SearchContext';
+import { theme } from '../../../theme/docsTheme';
+import { initChecked } from './FacetValue';
+
+const selectStyle = css`
+  font-size: ${theme.fontSize.small};
+  line-height: 20px;
+  margin-bottom: 8px;
+  padding-left: 22px;
+
+  button {
+    height: 22px;
+  }
+`;
+
+const FacetVersionGroup = ({ facetOption: { options } }) => {
+  // create select options from options
+  const selectOptions = useMemo(
+    () => options.map((option) => ({ text: option.name, value: option.id, key: option.key })),
+    [options]
+  );
+  const { handleFacetChange, searchParams } = useContext(SearchContext);
+
+  const [value, setValue] = useState(
+    () => selectOptions.find(({ key, value }) => initChecked(searchParams, key, value))?.value || selectOptions[0].value
+  );
+
+  const optionsById = useMemo(
+    () =>
+      options.reduce((map, option) => {
+        map[option.id] = option;
+        return map;
+      }, {}),
+    [options]
+  );
+
+  const onChange = useCallback(
+    (newOption) => {
+      const selectedOption = optionsById[newOption.value];
+      const oldSelection = optionsById[value];
+      const facetsToUpdate = [];
+
+      // update to unselect current selection
+      facetsToUpdate.push({
+        key: oldSelection.key,
+        id: oldSelection.id,
+        checked: false,
+      });
+
+      // update to select new selection
+      facetsToUpdate.push({
+        key: selectedOption.key,
+        id: selectedOption.id,
+        checked: true,
+      });
+
+      setValue(selectedOption.id);
+      handleFacetChange(facetsToUpdate);
+    },
+    [handleFacetChange, optionsById, value]
+  );
+
+  return (
+    <Select
+      className={cx(selectStyle)}
+      value={value}
+      choices={selectOptions}
+      onChange={onChange}
+      data-testid={'facets-version-group'}
+    ></Select>
+  );
+};
+
+export default FacetVersionGroup;

--- a/src/components/SearchResults/Facets/useFacets.js
+++ b/src/components/SearchResults/Facets/useFacets.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { assertTrailingSlash } from '../../../utils/assert-trailing-slash';
-import { MARIAN_URL } from '../../../constants';
+// import { assertTrailingSlash } from '../../../utils/assert-trailing-slash';
+import { statusV2 } from '../../../../tests/unit/data/SearchResults.test.json';
+// import { MARIAN_URL } from '../../../constants';
 
 const useFacets = () => {
   const [facets, setFacets] = useState([]);
@@ -8,13 +9,16 @@ const useFacets = () => {
   // Fetch facets
   useEffect(() => {
     const fetchFacets = async () => {
-      try {
-        const result = await fetch(assertTrailingSlash(MARIAN_URL) + 'v2/status');
-        const jsonResult = await result.json();
-        setFacets(jsonResult);
-      } catch (err) {
-        console.error(`Failed to fetch facets: ${err}`);
-      }
+      // DOP-4081
+      // TODO: remove after testing version facets
+      setFacets(statusV2);
+      // try {
+      //   const result = await fetch(assertTrailingSlash(MARIAN_URL) + 'v2/status');
+      //   const jsonResult = await result.json();
+      //   setFacets(jsonResult);
+      // } catch (err) {
+      //   console.error(`Failed to fetch facets: ${err}`);
+      // }
     };
     fetchFacets();
   }, []);

--- a/src/components/SearchResults/Facets/useFacets.js
+++ b/src/components/SearchResults/Facets/useFacets.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-// import { assertTrailingSlash } from '../../../utils/assert-trailing-slash';
-import { statusV2 } from '../../../../tests/unit/data/SearchResults.test.json';
-// import { MARIAN_URL } from '../../../constants';
+import { assertTrailingSlash } from '../../../utils/assert-trailing-slash';
+import { MARIAN_URL } from '../../../constants';
 
 const useFacets = () => {
   const [facets, setFacets] = useState([]);
@@ -9,16 +8,13 @@ const useFacets = () => {
   // Fetch facets
   useEffect(() => {
     const fetchFacets = async () => {
-      // DOP-4081
-      // TODO: remove after testing version facets
-      setFacets(statusV2);
-      // try {
-      //   const result = await fetch(assertTrailingSlash(MARIAN_URL) + 'v2/status');
-      //   const jsonResult = await result.json();
-      //   setFacets(jsonResult);
-      // } catch (err) {
-      //   console.error(`Failed to fetch facets: ${err}`);
-      // }
+      try {
+        const result = await fetch(assertTrailingSlash(MARIAN_URL) + 'v2/status');
+        const jsonResult = await result.json();
+        setFacets(jsonResult);
+      } catch (err) {
+        console.error(`Failed to fetch facets: ${err}`);
+      }
     };
     fetchFacets();
   }, []);

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -70,7 +70,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
   );
   // get vars from URL
   // state management for Search is within URL.
-  const [searchParams, setSearchParams] = useState(new URLSearchParams(search));
+  const [searchParams, setSearchParams] = useState(() => new URLSearchParams(search));
   const page = parseInt(searchParams.get('page') || 1);
   const searchTerm = searchParams.get('q');
   const searchFilter = searchParams.get('searchProperty');

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -2,10 +2,8 @@ import { createContext, useCallback, useMemo, useState } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { navigate } from 'gatsby';
 import { useMarianManifests } from '../../hooks/use-marian-manifests';
+import { FACETS_LEVEL_KEY, FACETS_KEY_PREFIX } from '../../utils/search-facet-constants';
 import useFacets from './Facets/useFacets';
-
-export const FACETS_KEY_PREFIX = 'facets.';
-export const FACETS_LEVEL_KEY = '>';
 
 const combineKeyAndId = (facet) => `${facet.key}${FACETS_LEVEL_KEY}${facet.id}`;
 

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -16,8 +16,6 @@ import { theme } from '../../theme/docsTheme';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { escapeHtml } from '../../utils/escape-reserved-html-characters';
 import { searchParamsToMetaURL, searchParamsToURL } from '../../utils/search-params-to-url';
-// TODO: remove after testing
-import { statusV2 } from '../../../tests/unit/data/SearchResults.test.json';
 import Tag, { searchTagStyle } from '../Tag';
 import SearchContext from './SearchContext';
 import SearchFilters from './SearchFilters';
@@ -367,9 +365,7 @@ const SearchResults = () => {
 
     fetchSearchMeta()
       .then((res) => {
-        // setSearchResultFacets(res?.facets);
-        // TODO: remove testing DOP-4081
-        setSearchResultFacets(statusV2);
+        setSearchResultFacets(res?.facets);
       })
       .catch((e) => {
         console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);
@@ -503,7 +499,6 @@ const SearchResults = () => {
                     onForwardArrowClick={onPageClick.bind(null, true)}
                     onBackArrowClick={onPageClick.bind(null, false)}
                     shouldDisableBackArrow={parseInt(new URLSearchParams(search).get('page')) === 1}
-                    // TODO: should disable if at max count from meta query
                     shouldDisableForwardArrow={searchResults?.length && searchResults.length < 10}
                   ></Pagination>
                 </>

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -351,9 +351,6 @@ const SearchResults = () => {
     fetchSearchMeta()
       .then((res) => {
         setSearchCount(res?.count);
-        // setSearchResultFacets(res?.facets);
-        // TODO: remove testing DOP-4081
-        setSearchResultFacets(statusV2);
       })
       .catch((e) => {
         console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);
@@ -370,7 +367,9 @@ const SearchResults = () => {
 
     fetchSearchMeta()
       .then((res) => {
-        setSearchResultFacets(res?.facets);
+        // setSearchResultFacets(res?.facets);
+        // TODO: remove testing DOP-4081
+        setSearchResultFacets(statusV2);
       })
       .catch((e) => {
         console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -16,6 +16,8 @@ import { theme } from '../../theme/docsTheme';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { escapeHtml } from '../../utils/escape-reserved-html-characters';
 import { searchParamsToMetaURL, searchParamsToURL } from '../../utils/search-params-to-url';
+// TODO: remove after testing
+import { statusV2 } from '../../../tests/unit/data/SearchResults.test.json';
 import Tag, { searchTagStyle } from '../Tag';
 import SearchContext from './SearchContext';
 import SearchFilters from './SearchFilters';
@@ -350,7 +352,9 @@ const SearchResults = () => {
     fetchSearchMeta()
       .then((res) => {
         setSearchCount(res?.count);
-        setSearchResultFacets(res?.facets);
+        // setSearchResultFacets(res?.facets);
+        // TODO: remove testing DOP-4081
+        setSearchResultFacets(statusV2);
       })
       .catch((e) => {
         console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);

--- a/src/utils/search-facet-constants.js
+++ b/src/utils/search-facet-constants.js
@@ -1,0 +1,21 @@
+/**
+ * Util file for keeping constants related to search server
+ * Store query parameter names and response names here
+ *
+ */
+
+// query param keys
+export const TERM_PARAM = 'q';
+export const PAGE_PARAM = 'page';
+export const V1_SEARCH_FILTER_PARAM = 'searchProperty';
+
+// facet param keys
+// ie. facets.target_product>atlas>sub_product=atlas-cli
+// translates to (target_products = atlas, target_products.atlas.sub_product = atlas-cli)
+export const FACETS_KEY_PREFIX = 'facets.';
+export const FACETS_LEVEL_KEY = '>';
+
+export const VERSION_GROUP_ID = 'version';
+// single select fields will be dropdown in UI,
+// and remove its parent selection as child facet selection implies parent facet
+export const SINGLE_SELECT_FIELDS = [VERSION_GROUP_ID];

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -6,6 +6,7 @@ const TERM_PARAM = 'q';
 const PAGE_PARAM = 'page';
 const V1_SEARCH_FILTER_PARAM = 'searchProperty';
 const V2_SEARCH_FILTER_PREFIX = FACETS_KEY_PREFIX;
+const SINGLE_SELECT_FIELDS = ['version'];
 
 const getFilterParams = (searchParams) => {
   const res = [];
@@ -36,6 +37,12 @@ function removeParentSelections(searchParams) {
     if (parts.length <= 1) {
       continue;
     }
+
+    // if not within fields that you can only select one value
+    if (SINGLE_SELECT_FIELDS.indexOf(parts[parts.length - 1]) === -1) {
+      continue;
+    }
+
     const parentKey = parts.slice(0, parts.length - 2).join(FACETS_LEVEL_KEY);
     const parentValue = parts[parts.length - 2];
     newSearchParams.delete(parentKey, parentValue);
@@ -72,7 +79,7 @@ export const searchParamsToURL = (searchParams) => {
  * @param {string} [searchTerm]
  */
 export const searchParamsToMetaURL = (searchParams, searchTerm) => {
-  const modifiedSearchParams = removeParentSelections(searchParams);
+  const modifiedSearchParams = searchParams ? removeParentSelections(searchParams) : new URLSearchParams();
   const queryString = searchTerm || modifiedSearchParams.get(TERM_PARAM);
 
   let queryParams = `?q=${queryString}`;

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -1,17 +1,18 @@
 import { MARIAN_URL } from '../constants';
-import { FACETS_KEY_PREFIX, FACETS_LEVEL_KEY } from '../components/SearchResults/SearchContext';
 import { assertTrailingSlash } from './assert-trailing-slash';
-
-const TERM_PARAM = 'q';
-const PAGE_PARAM = 'page';
-const V1_SEARCH_FILTER_PARAM = 'searchProperty';
-const V2_SEARCH_FILTER_PREFIX = FACETS_KEY_PREFIX;
-const SINGLE_SELECT_FIELDS = ['version'];
+import {
+  TERM_PARAM,
+  PAGE_PARAM,
+  V1_SEARCH_FILTER_PARAM,
+  FACETS_KEY_PREFIX,
+  FACETS_LEVEL_KEY,
+  SINGLE_SELECT_FIELDS,
+} from './search-facet-constants';
 
 const getFilterParams = (searchParams) => {
   const res = [];
   searchParams.forEach((value, key) => {
-    if (key.startsWith(V2_SEARCH_FILTER_PREFIX)) {
+    if (key.startsWith(FACETS_KEY_PREFIX)) {
       res.push(`${key}=${value}`);
     }
   });

--- a/tests/unit/data/SearchResults.test.json
+++ b/tests/unit/data/SearchResults.test.json
@@ -132,7 +132,42 @@
           "name": "Community Kubernetes Operator",
           "facets": []
         },
-        { "type": "facet-value", "id": "compass", "key": "target_product", "name": "Compass", "facets": [] },
+        { "type": "facet-value", "id": "compass", "key": "target_product", "name": "Compass", "facets": [ {
+          "type": "facet-option",
+          "id": "version",
+          "key": "target_product>compass>version",
+          "name": "Version",
+          "options": [
+            {
+              "type": "facet-value",
+              "id": "v7.0",
+              "key": "target_product>compass>sub_product",
+              "name": "v7.0 (current)",
+              "facets": []
+            },
+            {
+              "type": "facet-value",
+              "id": "v6.0",
+              "key": "target_product>compass>sub_product",
+              "name": "v6.0",
+              "facets": []
+            },
+            {
+              "type": "facet-value",
+              "id": "v5.0",
+              "key": "target_product>compass>sub_product",
+              "name": "v5.0",
+              "facets": []
+            },
+            {
+              "type": "facet-value",
+              "id": "v4.4",
+              "key": "target_product>compass>sub_product",
+              "name": "v4.4",
+              "facets": []
+            }
+          ]
+        }] },
         {
           "type": "facet-value",
           "id": "database-tools",

--- a/tests/unit/data/SearchResults.test.json
+++ b/tests/unit/data/SearchResults.test.json
@@ -141,28 +141,28 @@
             {
               "type": "facet-value",
               "id": "v7.0",
-              "key": "target_product>compass>sub_product",
+              "key": "target_product>compass>version",
               "name": "v7.0 (current)",
               "facets": []
             },
             {
               "type": "facet-value",
               "id": "v6.0",
-              "key": "target_product>compass>sub_product",
+              "key": "target_product>compass>version",
               "name": "v6.0",
               "facets": []
             },
             {
               "type": "facet-value",
               "id": "v5.0",
-              "key": "target_product>compass>sub_product",
+              "key": "target_product>compass>version",
               "name": "v5.0",
               "facets": []
             },
             {
               "type": "facet-value",
               "id": "v4.4",
-              "key": "target_product>compass>sub_product",
+              "key": "target_product>compass>version",
               "name": "v4.4",
               "facets": []
             }
@@ -314,28 +314,28 @@
                 {
                   "type": "facet-value",
                   "id": "v7.0",
-                  "key": "target_product>docs>sub_product",
+                  "key": "target_product>docs>version",
                   "name": "v7.0 (current)",
                   "facets": []
                 },
                 {
                   "type": "facet-value",
                   "id": "v6.0",
-                  "key": "target_product>docs>sub_product",
+                  "key": "target_product>docs>version",
                   "name": "v6.0",
                   "facets": []
                 },
                 {
                   "type": "facet-value",
                   "id": "v5.0",
-                  "key": "target_product>docs>sub_product",
+                  "key": "target_product>docs>version",
                   "name": "v5.0",
                   "facets": []
                 },
                 {
                   "type": "facet-value",
                   "id": "v4.4",
-                  "key": "target_product>docs>sub_product",
+                  "key": "target_product>docs>version",
                   "name": "v4.4",
                   "facets": []
                 }

--- a/tests/unit/data/SearchResults.test.json
+++ b/tests/unit/data/SearchResults.test.json
@@ -264,7 +264,49 @@
           "name": "Relational Migrator",
           "facets": []
         },
-        { "type": "facet-value", "id": "docs", "key": "target_product", "name": "Server", "facets": [] },
+        { 
+          "type": "facet-value", 
+          "id": "docs", 
+          "key": "target_product", 
+          "name": "Server", 
+          "facets": [
+            {
+              "type": "facet-option",
+              "id": "version",
+              "key": "target_product>docs>version",
+              "name": "Version",
+              "options": [
+                {
+                  "type": "facet-value",
+                  "id": "v7.0",
+                  "key": "target_product>docs>sub_product",
+                  "name": "v7.0 (current)",
+                  "facets": []
+                },
+                {
+                  "type": "facet-value",
+                  "id": "v6.0",
+                  "key": "target_product>docs>sub_product",
+                  "name": "v6.0",
+                  "facets": []
+                },
+                {
+                  "type": "facet-value",
+                  "id": "v5.0",
+                  "key": "target_product>docs>sub_product",
+                  "name": "v5.0",
+                  "facets": []
+                },
+                {
+                  "type": "facet-value",
+                  "id": "v4.4",
+                  "key": "target_product>docs>sub_product",
+                  "name": "v4.4",
+                  "facets": []
+                }
+              ]
+            }
+          ]},
         {
           "type": "facet-value",
           "id": "spark-connector",

--- a/tests/unit/utils/mock-marian-fetch.js
+++ b/tests/unit/utils/mock-marian-fetch.js
@@ -46,7 +46,7 @@ export const mockMarianFetch = (url) => {
       });
     case 'v2/status':
       return allowJsonPromise(statusV2);
-    case 'v2/search/meta?q=test&facets.genre=tutorial&facets.target_product>atlas>sub_product=atlas-cli&combineFilters=true':
+    case 'v2/search/meta?q=test&facets.genre=tutorial&facets.target_product>atlas>sub_product=atlas-cli':
       return allowJsonPromise({
         count: 99,
         facets: statusV2,


### PR DESCRIPTION
### Stories/Links:

DOP-4081

### Staging Links:

[regression check for existing search with feature flag off `GATSBY_FEATURE_FACETED_SEARCH=false`](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/DOP-4081/search/?q=compass&page=1&searchProperty=atlas-master)

[staging link with test data used ](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/bf468afd223919483e1a071ee959d062620fafb7/newhomepagewhodis/landing/seung.park/DOP-4081/search/index.html?q=%24and&page=1&facets.target_product%3Edocs%3Esub_product=v7.0&facets.target_product=docs)

### Notes:
- This is using test data, as `versions` is not available as facet options yet.
- When a version is selected, parent facet selections are pruned when sending the API request to /search and v2/search/meta since 
- When a parent facet selection is deselected, the version is also deselected from UI and from API requests