### PR TITLE
DOP-4089: Facet combination behaviors. Count different category as AND selections, same category as OR

### DIFF
--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -83,7 +83,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
 
   // navigate changes and store state in URL
   const onSearchChange = ({ searchTerm, searchFilter, page }) => {
-    const newSearch = new URLSearchParams();
+    const newSearch = new URLSearchParams(search);
     if (searchTerm) {
       newSearch.set('q', searchTerm);
     }
@@ -140,7 +140,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         filters,
         page,
         setPage: (p) => {
-          onSearchChange({ page: p });
+          onSearchChange({ searchTerm: new URLSearchParams(search).get('q'), page: p });
         },
         searchTerm,
         setSearchTerm: (q, p = 1) => {
@@ -148,7 +148,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         },
         searchFilter,
         setSearchFilter: (searchProperty) => {
-          onSearchChange({ searchFilter: searchProperty });
+          onSearchChange({ searchTerm: new URLSearchParams(search).get('q'), searchFilter: searchProperty });
         },
         searchPropertyMapping,
         selectedCategory,

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -140,7 +140,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         filters,
         page,
         setPage: (p) => {
-          onSearchChange({ searchTerm: new URLSearchParams(search).get('q'), page: p });
+          onSearchChange({ searchTerm: searchTerm, page: p });
         },
         searchTerm,
         setSearchTerm: (q, p = 1) => {
@@ -148,7 +148,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
         },
         searchFilter,
         setSearchFilter: (searchProperty) => {
-          onSearchChange({ searchTerm: new URLSearchParams(search).get('q'), searchFilter: searchProperty });
+          onSearchChange({ searchTerm: searchTerm, searchFilter: searchProperty });
         },
         searchPropertyMapping,
         selectedCategory,

--- a/src/components/SearchResults/SearchContext.js
+++ b/src/components/SearchResults/SearchContext.js
@@ -83,7 +83,7 @@ const SearchContextProvider = ({ children, showFacets = false }) => {
 
   // navigate changes and store state in URL
   const onSearchChange = ({ searchTerm, searchFilter, page }) => {
-    const newSearch = new URLSearchParams(search);
+    const newSearch = new URLSearchParams();
     if (searchTerm) {
       newSearch.set('q', searchTerm);
     }

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -319,7 +319,6 @@ const SearchResults = () => {
   useEffect(() => {
     if (!searchParams.get('q')) {
       setSearchResults([]);
-      setSearchCount(0);
       return;
     }
     setSearchFinished(false);
@@ -346,18 +345,33 @@ const SearchResults = () => {
         setSearchFinished(true);
       });
 
-    // fetch search meta (count and filters)
+    // fetch search meta (count)
     fetchSearchMeta()
       .then((res) => {
         setSearchCount(res?.count);
-        setSearchResultFacets(res?.facets);
       })
       .catch((e) => {
         console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);
         setSearchCount();
-        setSearchResultFacets([]);
       });
   }, [searchParams]);
+
+  // update filters only on search term change
+  useEffect(() => {
+    const fetchSearchMeta = async () => {
+      const res = await fetch(searchParamsToMetaURL(null, searchTerm));
+      return res.json();
+    };
+
+    fetchSearchMeta()
+      .then((res) => {
+        setSearchResultFacets(res?.facets);
+      })
+      .catch((e) => {
+        console.error(`Error while fetching search meta: ${JSON.stringify(e)}`);
+        setSearchResultFacets([]);
+      });
+  }, [searchTerm]);
 
   const submitNewSearch = (event) => {
     const newValue = event.target[0]?.value;

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -31,7 +31,7 @@ export const searchParamsToURL = (searchParams) => {
   const filters = getFilterParams(searchParams);
 
   const queryParams = `?q=${searchTerm}&page=${page}${searchProperty ? `&searchProperty=${searchProperty}` : ''}${
-    filters.length ? `&${filters}&combineFilters=true` : ''
+    filters.length ? `&${filters}` : ''
   }`;
   return `${assertTrailingSlash(MARIAN_URL)}search${queryParams}`;
 };
@@ -41,16 +41,18 @@ export const searchParamsToURL = (searchParams) => {
  * Extracts query params from search params and appends to new request URL as string
  * Route is used to return meta data for search params
  *
- * @param {URLSearchParams} searchParams
+ * @param {URLSearchParams} [searchParams]
+ * @param {string} [searchTerm]
  */
-export const searchParamsToMetaURL = (searchParams) => {
-  const searchTerm = searchParams.get(TERM_PARAM);
-  const searchProperty = searchParams.get(V1_SEARCH_FILTER_PARAM);
-  const filters = getFilterParams(searchParams);
+export const searchParamsToMetaURL = (searchParams, searchTerm) => {
+  const queryString = searchTerm || searchParams.get(TERM_PARAM);
 
-  const queryParams = `?q=${searchTerm}${searchProperty ? `&searchProperty=${searchProperty}` : ''}${
-    filters.length ? `&${filters}&combineFilters=true` : ''
-  }`;
+  let queryParams = `?q=${queryString}`;
+  if (searchParams) {
+    const searchProperty = searchParams.get(V1_SEARCH_FILTER_PARAM);
+    const filters = getFilterParams(searchParams);
+    queryParams += `${searchProperty ? `&searchProperty=${searchProperty}` : ''}${filters.length ? `&${filters}` : ''}`;
+  }
   const META_PATH = `v2/search/meta`;
   return `${assertTrailingSlash(MARIAN_URL)}${META_PATH}${queryParams}`;
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4089

This PR is the front end portion of responsive facets.
Behavior is as outlined:
- Facet list is derived from the `search term` only. (selecting a facet does not change facet list)
- Count is updated when `search term` or `facet selections` are changed
- Facet selections of the same category should count as OR selections
- Facet selections of two different categories should count as AND selections

### Current Behavior:

[current search](https://www.mongodb.com/docs/search/?q=%24and)

### Staging Links:

[regression check for old search behavior. should behave same as above current behavior](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/newhomepagewhodis/landing/seung.park/DOP-4089/search/index.html?q=%24and)

**no staging link for changes. see steps to test below**

### Notes:

Steps to test:
- requires local search transport server as the prod search server has not been deployed with [search transport server PR](https://github.com/mongodb/docs-search-transport/pull/84)
- change env file to have var `GATSBY_MARIAN_URL=http://localhost:8080/`