### PR TITLE
DOP-4124 fixed large image overlap

### DIFF
--- a/src/components/Figure/Lightbox.js
+++ b/src/components/Figure/Lightbox.js
@@ -46,7 +46,6 @@ const LightboxWrapper = styled('div')`
   margin-top: ${theme.size.medium};
   margin-bottom: ${theme.size.medium};
   display: block;
-  max-height: 620px;
 `;
 
 const Lightbox = ({ nodeData, ...rest }) => {

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -61,7 +61,6 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
   margin-top: 24px;
   margin-bottom: 24px;
   display: block;
-  max-height: 620px;
 }
 
 .emotion-2 {

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -8,7 +8,6 @@ exports[`Lightbox renders correctly 1`] = `
   margin-top: 24px;
   margin-bottom: 24px;
   display: block;
-  max-height: 620px;
 }
 
 .emotion-2 {


### PR DESCRIPTION
### Stories/Links:

[DOP-4124](https://jira.mongodb.org/browse/DOP-4124)

### Current Behavior:

[current production behavior
](https://www.mongodb.com/docs/atlas/app-services/authentication/api-key/)

### Staging Links:

[Staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-app-services/anabella.buckvar/DOP-4124/authentication/api-key/index.html)

### Notes:
Large images have been overlapping with content, due to [this css property](https://github.com/mongodb/snooty/blob/059a676527c1c37b93789f340d3c56876e164c66/src/components/Figure/Lightbox.js#L49) that was originally added as part of [DOP-3793](https://jira.mongodb.org/browse/DOP-3793); however, that specific property is unnecessary and deleting it fixes the issue and doesn't affect the behavior requested for [DOP-3793](https://jira.mongodb.org/browse/DOP-3793)
