### PR TITLE
DOP-4132 Snooty overlapping tabs bug

### DIFF
--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -29,7 +29,7 @@ const defaultTabsStyling = css`
     align-items: center;
   }
 
-  @media ${theme.screenSize.upToXLarge} {
+  @media ${theme.screenSize.upTo2XLarge} {
     ${TAB_BUTTON_SELECTOR} {
       overflow: initial;
       max-width: initial;


### PR DESCRIPTION
### Stories/Links:

[DOP-4132](https://jira.mongodb.org/browse/DOP-4132)

### Current Behavior:

Currently, on the production [docs manual homepage](https://www.mongodb.com/docs/manual/), a row of horizontal tabs overlap when the screen size reaches a width of 1200px, the xLarge breakpoint

### Staging Links:

[docs manual homepage staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/anabella.buckvar/DOP-4132/index.html)

### Notes:
