### PR TITLE
DOP-3998: supply credentials with requests to search staging instance

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -406,7 +406,7 @@ const SearchResults = () => {
       <SearchResultsContainer showFacets={showFacets}>
         {/* new header for search bar */}
         <HeaderContainer>
-          TEST DOP-3998
+          TEST DOP-3998 via autobuilder. check build logs
           <H3 as="h1">Search Results</H3>
           <SearchInput
             ref={searchBoxRef}

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -406,7 +406,6 @@ const SearchResults = () => {
       <SearchResultsContainer showFacets={showFacets}>
         {/* new header for search bar */}
         <HeaderContainer>
-          TEST DOP-3998 via autobuilder. check build logs
           <H3 as="h1">Search Results</H3>
           <SearchInput
             ref={searchBoxRef}

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -15,7 +15,7 @@ import useScreenSize from '../../hooks/useScreenSize';
 import { theme } from '../../theme/docsTheme';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { escapeHtml } from '../../utils/escape-reserved-html-characters';
-import { searchParamsToMetaURL, searchParamsToURL } from '../../utils/search-params-to-url';
+import { searchParamsToMetaURL, searchParamsToURL, requestHeaders } from '../../utils/search-params-to-url';
 import Tag, { searchTagStyle } from '../Tag';
 import SearchContext from './SearchContext';
 import SearchFilters from './SearchFilters';
@@ -324,12 +324,12 @@ const SearchResults = () => {
     setSearchFinished(false);
 
     const fetchSearchResults = async () => {
-      const res = await fetch(searchParamsToURL(searchParams));
+      const res = await fetch(searchParamsToURL(searchParams), requestHeaders);
       return (await res.json()).results;
     };
 
     const fetchSearchMeta = async () => {
-      const res = await fetch(searchParamsToMetaURL(searchParams));
+      const res = await fetch(searchParamsToMetaURL(searchParams), requestHeaders);
       return res.json();
     };
 
@@ -359,7 +359,7 @@ const SearchResults = () => {
   // update filters only on search term change
   useEffect(() => {
     const fetchSearchMeta = async () => {
-      const res = await fetch(searchParamsToMetaURL(null, searchTerm));
+      const res = await fetch(searchParamsToMetaURL(null, searchTerm), requestHeaders);
       return res.json();
     };
 
@@ -405,6 +405,7 @@ const SearchResults = () => {
       <SearchResultsContainer showFacets={showFacets}>
         {/* new header for search bar */}
         <HeaderContainer>
+          TEST DOP-3998
           <H3 as="h1">Search Results</H3>
           <SearchInput
             ref={searchBoxRef}

--- a/src/utils/search-facet-constants.js
+++ b/src/utils/search-facet-constants.js
@@ -20,7 +20,7 @@ export const VERSION_GROUP_ID = 'version';
 // and remove its parent selection as child facet selection implies parent facet
 export const SINGLE_SELECT_FIELDS = [VERSION_GROUP_ID];
 
-export const requestHeaders = process.env['GATSBY_MARIAN_URL'].includes('staging')
+export const requestHeaders = process.env['GATSBY_MARIAN_URL']?.includes('staging')
   ? {
       credentials: 'include',
     }

--- a/src/utils/search-params-to-url.js
+++ b/src/utils/search-params-to-url.js
@@ -6,6 +6,11 @@ const TERM_PARAM = 'q';
 const PAGE_PARAM = 'page';
 const V1_SEARCH_FILTER_PARAM = 'searchProperty';
 const V2_SEARCH_FILTER_PREFIX = FACETS_KEY_PREFIX;
+export const requestHeaders = process.env['GATSBY_MARIAN_URL'].includes('staging')
+  ? {
+      credentials: 'include',
+    }
+  : {};
 
 const getFilterParams = (searchParams) => {
   const res = [];


### PR DESCRIPTION
### Stories/Links:

[DOP-3998](https://jira.mongodb.org/browse/DOP-3998)

### Current Behavior:

current preprd environment makes requests to our production search instance
https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/search/?q=mongodb
(open network tab and see requests for docs-search being made to prod instance `
https://docs-search-transport.mongodb.com/`)

### Staging Links:

[This staged change](https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/DOP-3998-2/search/?q=atlas&page=1) makes requests to `https://docs-search-transport.docs.staging.corp.mongodb.com` 
And is able to bypass CORS errors when user is already authenticated. https://docs-search-transport.docs.staging.corp.mongodb.com/v2/status can verify your authentication