### PR TITLE
DOP-4144: add default page logic to be 1

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -384,7 +384,7 @@ const SearchResults = () => {
 
   const onPageClick = useCallback(
     async (isForward) => {
-      const currentPage = parseInt(searchParams.get('page'));
+      const currentPage = parseInt(searchParams.get('page')) || 1;
       const newPage = isForward ? currentPage + 1 : currentPage - 1;
       if (newPage < 1) {
         return;


### PR DESCRIPTION
### Stories/Links:

DOP-4144

### Current Behavior:

[docs search on prod with no page in URL query param does not allow next page](https://www.mongodb.com/docs/search/?q=%24elemAt)

### Staging Links:

[staged changes with no page URL in query param (still allows to navigate to next page)](https://docs-mongodbcom-staging.corp.mongodb.com/cc800abda5dfe62f645022423a560d547c3705c3/newhomepagewhodis/landing/seung.park/DOP-4144/search/?q=mongodb)

### Notes:
- staged changes is making requests to stage search server. must be okta verified at https://docs-search-transport.docs.staging.corp.mongodb.com/v2/status