### PR TITLE
DOP-4156: Redesign feedback tab button

### DIFF
--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -13,17 +13,11 @@ import useNoScroll from './hooks/useNoScroll';
 const FloatingContainer = styled.div`
   position: fixed;
   z-index: 14;
-  right: 16px;
-
-  @media ${theme.screenSize.upToLarge} {
-    top: 40%;
-  }
-
-  @media ${theme.screenSize.largeAndUp} {
-    bottom: 40px;
-  }
+  bottom: ${theme.size.large};
+  right: ${theme.size.large};
 
   @media ${theme.screenSize.upToSmall} {
+    position: fixed;
     right: 0;
     top: ${({ top }) => top};
   }
@@ -44,6 +38,7 @@ const Card = styled(LeafygreenCard)`
     height: calc(100vh - ${({ top }) => top});
     width: 100vw;
     border-radius: 0;
+    border-width: 0px;
     padding-top: 40px;
   }
 `;

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -4,6 +4,7 @@ import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
 import { theme } from '../../../../src/theme/docsTheme';
 import { useFeedbackContext } from './context';
+import { text } from './constants';
 
 const containerStyle = css`
   display: flex;
@@ -44,7 +45,7 @@ const FeedbackTab = () => {
     !feedback && (
       <div className={cx(containerStyle)} onClick={() => initializeFeedback()}>
         <Icon className={starIconStyle} glyph="Favorite" />
-        Rate this page
+        {text.feedbackButton}
       </div>
     )
   );

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -4,7 +4,7 @@ import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
 import { theme } from '../../../../src/theme/docsTheme';
 import { useFeedbackContext } from './context';
-import { text } from './constants';
+import { FEEDBACK_BUTTON_TEXT } from './constants';
 
 const containerStyle = css`
   display: flex;
@@ -45,7 +45,7 @@ const FeedbackTab = () => {
     !feedback && (
       <div className={cx(containerStyle)} onClick={() => initializeFeedback()}>
         <Icon className={starIconStyle} glyph="Favorite" />
-        {text.feedbackButton}
+        {FEEDBACK_BUTTON_TEXT}
       </div>
     )
   );

--- a/src/components/Widgets/FeedbackWidget/FeedbackTab.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackTab.js
@@ -1,60 +1,51 @@
 import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
-import LeafygreenCard from '@leafygreen-ui/card';
+import Icon from '@leafygreen-ui/icon';
 import { theme } from '../../../../src/theme/docsTheme';
 import { useFeedbackContext } from './context';
 
 const containerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 4px;
   cursor: pointer;
-  padding: 12px;
+  padding: 12px ${theme.size.default};
+  background-color: ${palette.white};
+  border: 1px solid ${palette.blue.light1};
+  border-radius: 40px;
+  box-shadow: 0px 4px 10px -4px ${palette.gray.light2};
   position: fixed;
-  user-select: none;
   z-index: 9;
-  font-weight: 500;
-  color: ${palette.green.dark2};
+  bottom: ${theme.size.large};
+  right: ${theme.size.large};
+  color: ${palette.blue.dark1};
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 20px;
 
-  // tab fixed at bottom of docs page
+  :hover {
+    box-shadow: 0px 0px 0px 3px ${palette.blue.light2};
+  }
+
   @media ${theme.screenSize.upToSmall} {
-    display: flex;
-    align-items: center;
-    font-size: 16px;
-    position: static !important;
-    width: fit-content !important;
-    margin-left: 20px;
-    margin-top: -20px;
-    margin-bottom: 20px;
-    transform: rotate(0deg) !important;
+    bottom: ${theme.size.medium};
+    right: ${theme.size.medium};
   }
+`;
 
-  @media ${theme.screenSize.smallAndUp} {
-    // tab positioned on side of page
-    @media ${theme.screenSize.upToLarge} {
-      transform: rotate(-90deg);
-      top: 50%;
-      right: -53px;
-    }
-
-    // tab positioned on bottom right of page
-    @media ${theme.screenSize.largeAndUp} {
-      bottom: -24px;
-      @media ${theme.screenSize.upTo2XLarge} {
-        right: 16px;
-      }
-      @media ${theme.screenSize['2XLargeAndUp']} {
-        right: 64px;
-      }
-    }
-  }
+const starIconStyle = css`
+  color: ${palette.blue.light1};
 `;
 
 const FeedbackTab = () => {
   const { feedback, initializeFeedback } = useFeedbackContext();
   return (
     !feedback && (
-      <LeafygreenCard className={cx(containerStyle)} onClick={() => initializeFeedback()}>
-        Share Feedback
-      </LeafygreenCard>
+      <div className={cx(containerStyle)} onClick={() => initializeFeedback()}>
+        <Icon className={starIconStyle} glyph="Favorite" />
+        Rate this page
+      </div>
     )
   );
 };

--- a/src/components/Widgets/FeedbackWidget/components/CloseButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/CloseButton.js
@@ -4,6 +4,7 @@ import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../../../theme/docsTheme';
+import { CLOSE_BUTTON_ALT_TEXT } from '../constants';
 
 const buttonStyles = css`
   position: absolute;
@@ -21,7 +22,7 @@ const buttonStyles = css`
 const CloseButton = ({ onClick, size = 'default', ...props }) => {
   return (
     <IconButton
-      aria-label="Close Feedback Form"
+      aria-label={CLOSE_BUTTON_ALT_TEXT}
       className={cx(buttonStyles)}
       onClick={onClick}
       size={size}

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -10,6 +10,7 @@ import { feedbackId } from '../FeedbackForm';
 import { isBrowser } from '../../../../utils/is-browser';
 import useNoScroll from '../hooks/useNoScroll';
 import { theme } from '../../../../theme/docsTheme';
+import { SCREENSHOT_BUTTON_TEXT, SCREENSHOT_OVERLAY_ALT_TEXT } from '../constants';
 
 const HIGHLIGHT_BORDER_SIZE = 5;
 
@@ -81,7 +82,6 @@ const ScreenshotSelect = styled(Button)`
 
 const ScreenshotButton = ({ size = 'default', ...props }) => {
   const { setScreenshotTaken } = useFeedbackContext();
-  const label = 'Take a screenshot';
   const [isScreenshotButtonClicked, setIsScreenshotButtonClicked] = useState(false);
   const [currElemState, setCurrElemState] = useState(null);
 
@@ -238,7 +238,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
             <img
               className={fwInstructionsId}
               src={withPrefix('assets/screenshotCTA.svg')}
-              alt="Screenshot"
+              alt={SCREENSHOT_OVERLAY_ALT_TEXT}
               css={instructionsPanelStyling}
               onClick={handleInstructionClick}
             />
@@ -325,7 +325,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
         leftGlyph={<img src={withPrefix('assets/screenshoticon.svg')} alt="Screenshot Button" />}
         {...props}
       >
-        {label}
+        {SCREENSHOT_BUTTON_TEXT}
       </ScreenshotSelect>
     </>
   );

--- a/src/components/Widgets/FeedbackWidget/components/ViewHeader.js
+++ b/src/components/Widgets/FeedbackWidget/components/ViewHeader.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { Body } from '@leafygreen-ui/typography';
 import { theme } from '../../../../theme/docsTheme';
+import { text } from '../constants';
 
 const TextHeader = styled(Body)`
   font-weight: 600;
@@ -15,7 +16,7 @@ const TextHeader = styled(Body)`
 
 // this should only render when in modal or mobile view
 const ViewHeader = () => {
-  return <TextHeader>How would you rate this page?</TextHeader>;
+  return <TextHeader>{text.ratingQuestion}</TextHeader>;
 };
 
 export default ViewHeader;

--- a/src/components/Widgets/FeedbackWidget/components/ViewHeader.js
+++ b/src/components/Widgets/FeedbackWidget/components/ViewHeader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { Body } from '@leafygreen-ui/typography';
 import { theme } from '../../../../theme/docsTheme';
-import { text } from '../constants';
+import { RATING_QUESTION_TEXT } from '../constants';
 
 const TextHeader = styled(Body)`
   font-weight: 600;
@@ -16,7 +16,7 @@ const TextHeader = styled(Body)`
 
 // this should only render when in modal or mobile view
 const ViewHeader = () => {
-  return <TextHeader>{text.ratingQuestion}</TextHeader>;
+  return <TextHeader>{RATING_QUESTION_TEXT}</TextHeader>;
 };
 
 export default ViewHeader;

--- a/src/components/Widgets/FeedbackWidget/constants.js
+++ b/src/components/Widgets/FeedbackWidget/constants.js
@@ -1,4 +1,3 @@
-export const text = {
-  feedbackButton: 'Rate this page',
-  ratingQuestion: 'How would you rate this page?',
-};
+export const FEEDBACK_BUTTON_TEXT = 'Rate this page';
+export const RATING_QUESTION_TEXT = 'How would you rate this page?';
+export const COMMENT_PLACEHOLDER_TEXT = 'Tell us more about your experience';

--- a/src/components/Widgets/FeedbackWidget/constants.js
+++ b/src/components/Widgets/FeedbackWidget/constants.js
@@ -1,0 +1,4 @@
+export const text = {
+  feedbackButton: 'Rate this page',
+  ratingQuestion: 'How would you rate this page?',
+};

--- a/src/components/Widgets/FeedbackWidget/constants.js
+++ b/src/components/Widgets/FeedbackWidget/constants.js
@@ -1,3 +1,32 @@
+// Stores constants that may be shared between certain Feedback Widget components and tests
+
+// ALT TEXT
+export const CLOSE_BUTTON_ALT_TEXT = 'Close Feedback Form';
+export const SCREENSHOT_OVERLAY_ALT_TEXT = 'Screenshot';
+
+// TEXT
 export const FEEDBACK_BUTTON_TEXT = 'Rate this page';
 export const RATING_QUESTION_TEXT = 'How would you rate this page?';
 export const COMMENT_PLACEHOLDER_TEXT = 'Tell us more about your experience';
+export const EMAIL_PLACEHOLDER_TEXT = 'Email Address';
+export const EMAIL_ERROR_TEXT = 'Please enter a valid email.';
+export const SCREENSHOT_BUTTON_TEXT = 'Take a screenshot';
+export const FEEDBACK_SUBMIT_BUTTON_TEXT = 'Send';
+
+export const SUBMITTED_VIEW_TEXT = {
+  HEADING: 'Thank you for your feedback!',
+  SUB_HEADING: "Your input improves MongoDB's Documentation.",
+  RESOURCES_CTA: 'Looking for more resources?',
+  SUPPORT_CTA: 'Have a support contact?',
+};
+
+export const SUBMITTED_VIEW_RESOURCE_LINKS = [
+  { text: 'MongoDB Developer Community Forums', href: 'https://www.mongodb.com/community/forums/' },
+  { text: 'MongoDB Developer Center', href: 'https://www.mongodb.com/developer/' },
+  { text: 'MongoDB University', href: 'https://learn.mongodb.com/' },
+];
+
+export const SUBMITTED_VIEW_SUPPORT_LINK = {
+  text: 'Create a Support Case',
+  href: 'https://support.mongodb.com/?_ga=2.191926057.2087449804.1701109748-1659791399.1655906873&_gac=1.114903413.1698074435.CjwKCAjws9ipBhB1EiwAccEi1AOuCPf5YadKdTucTL0245YGXrgMbNUsNrZLHXWf-WX73dnW1DOzZBoCR-QQAvD_BwE',
+};

--- a/src/components/Widgets/FeedbackWidget/index.js
+++ b/src/components/Widgets/FeedbackWidget/index.js
@@ -3,6 +3,5 @@ import useFeedbackData from './useFeedbackData';
 import FeedbackForm from './FeedbackForm';
 import FeedbackTab from './FeedbackTab';
 import FeedbackFooter from './FeedbackFooter';
-import * as constants from './constants';
 
-export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackTab, FeedbackFooter, constants };
+export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackTab, FeedbackFooter };

--- a/src/components/Widgets/FeedbackWidget/index.js
+++ b/src/components/Widgets/FeedbackWidget/index.js
@@ -3,5 +3,6 @@ import useFeedbackData from './useFeedbackData';
 import FeedbackForm from './FeedbackForm';
 import FeedbackTab from './FeedbackTab';
 import FeedbackFooter from './FeedbackFooter';
+import * as constants from './constants';
 
-export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackTab, FeedbackFooter };
+export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackTab, FeedbackFooter, constants };

--- a/src/components/Widgets/FeedbackWidget/views/CommentView.js
+++ b/src/components/Widgets/FeedbackWidget/views/CommentView.js
@@ -14,7 +14,12 @@ import useScreenSize from '../../../../hooks/useScreenSize';
 import validateEmail from '../../../../utils/validate-email';
 import StarRating from '../components/StarRating';
 import { theme } from '../../../../theme/docsTheme';
-import { COMMENT_PLACEHOLDER_TEXT } from '../constants';
+import {
+  COMMENT_PLACEHOLDER_TEXT,
+  EMAIL_ERROR_TEXT,
+  EMAIL_PLACEHOLDER_TEXT,
+  FEEDBACK_SUBMIT_BUTTON_TEXT,
+} from '../constants';
 const ScreenshotButton = Loadable(() => import('../components/ScreenshotButton'));
 
 const SubmitButton = styled(Button)`
@@ -129,16 +134,16 @@ const CommentView = () => {
         type="email"
         id="feedback-email"
         aria-labelledby="Email Text Box"
-        placeholder="Email Address"
+        placeholder={EMAIL_PLACEHOLDER_TEXT}
         value={email}
         onChange={(e) => setEmail(e.target.value)}
-        errorMessage="Please enter a valid email."
+        errorMessage={EMAIL_ERROR_TEXT}
         state={hasEmailError ? 'error' : 'none'}
         optional={true}
       />
       {!isMobile && <ScreenshotButton />}
       <SubmitButton onClick={() => handleSubmit()} type="submit">
-        {'Send'}
+        {FEEDBACK_SUBMIT_BUTTON_TEXT}
       </SubmitButton>
     </Layout>
   );

--- a/src/components/Widgets/FeedbackWidget/views/CommentView.js
+++ b/src/components/Widgets/FeedbackWidget/views/CommentView.js
@@ -14,6 +14,7 @@ import useScreenSize from '../../../../hooks/useScreenSize';
 import validateEmail from '../../../../utils/validate-email';
 import StarRating from '../components/StarRating';
 import { theme } from '../../../../theme/docsTheme';
+import { COMMENT_PLACEHOLDER_TEXT } from '../constants';
 const ScreenshotButton = Loadable(() => import('../components/ScreenshotButton'));
 
 const SubmitButton = styled(Button)`
@@ -90,7 +91,6 @@ const useValidation = (inputValue, validator) => {
 
 const CommentView = () => {
   const { submitAllFeedback, screenshotTaken, setSelectedRating } = useFeedbackContext();
-  const placeholderText = 'Tell us more about your experience';
 
   const [comment, setComment] = useState('');
   const [email, setEmail] = useState('');
@@ -120,7 +120,7 @@ const CommentView = () => {
         type="text"
         id="feedback-comment"
         aria-labelledby="Comment Text Box"
-        placeholder={placeholderText}
+        placeholder={COMMENT_PLACEHOLDER_TEXT}
         value={comment}
         onChange={(e) => setComment(e.target.value)}
         baseFontSize={13}

--- a/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
+++ b/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
@@ -7,15 +7,7 @@ import useScreenSize from '../../../../hooks/useScreenSize';
 import { Layout, Subheading } from '../components/view-components';
 import StarRating from '../components/StarRating';
 import { theme } from '../../../../theme/docsTheme';
-
-const RESOURCE_LINKS = [
-  { text: 'MongoDB Developer Community Forums', href: 'https://www.mongodb.com/community/forums/' },
-  { text: 'MongoDB Developer Center', href: 'https://www.mongodb.com/developer/' },
-  { text: 'MongoDB University', href: 'https://learn.mongodb.com/' },
-];
-
-const SUPPORT_LINK =
-  'https://support.mongodb.com/?_ga=2.191926057.2087449804.1701109748-1659791399.1655906873&_gac=1.114903413.1698074435.CjwKCAjws9ipBhB1EiwAccEi1AOuCPf5YadKdTucTL0245YGXrgMbNUsNrZLHXWf-WX73dnW1DOzZBoCR-QQAvD_BwE';
+import { SUBMITTED_VIEW_RESOURCE_LINKS, SUBMITTED_VIEW_SUPPORT_LINK, SUBMITTED_VIEW_TEXT } from '../constants';
 
 const SupportCase = styled.div`
   margin-top: ${theme.size.default};
@@ -35,12 +27,12 @@ const SubmittedView = () => {
 
   return (
     <Layout>
-      <StyledHeading>Thank you for your feedback!</StyledHeading>
+      <StyledHeading>{SUBMITTED_VIEW_TEXT.HEADING}</StyledHeading>
       <StarRating editable={false} />
-      <Subheading>Your input improves MongoDB's Documentation.</Subheading>
+      <Subheading>{SUBMITTED_VIEW_TEXT.SUB_HEADING}</Subheading>
       <Subheading>
-        <span>Looking for more resources? </span>
-        {RESOURCE_LINKS.map(({ text, href }, index) => (
+        <span>{SUBMITTED_VIEW_TEXT.RESOURCES_CTA}</span>
+        {SUBMITTED_VIEW_RESOURCE_LINKS.map(({ text, href }, index) => (
           <React.Fragment key={index}>
             <br />
             <a href={href}>{text}</a>
@@ -48,8 +40,8 @@ const SubmittedView = () => {
         ))}
         {shouldShowSupportLink && (
           <SupportCase>
-            {'Have a support contact? '}
-            <a href={SUPPORT_LINK}>Create a Support Case</a>
+            {`${SUBMITTED_VIEW_TEXT.SUPPORT_CTA} `}
+            <a href={SUBMITTED_VIEW_SUPPORT_LINK.href}>{SUBMITTED_VIEW_SUPPORT_LINK.text}</a>
           </SupportCase>
         )}
       </Subheading>

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -7,6 +7,7 @@ import {
   FeedbackForm,
   FeedbackTab,
   FeedbackFooter,
+  constants,
 } from '../../src/components/Widgets/FeedbackWidget';
 
 import { tick, mockMutationObserver, mockSegmentAnalytics, setDesktop, setMobile, setTablet } from '../utils';
@@ -16,7 +17,6 @@ import {
   clearMockStitchFunctions,
 } from '../utils/feedbackWidgetStitchFunctions';
 import Heading from '../../src/components/Heading';
-import { theme } from '../../src/theme/docsTheme';
 import {
   screenshotFunctionMocks,
   mockScreenshotFunctions,
@@ -77,20 +77,19 @@ describe('FeedbackWidget', () => {
   describe('FeedbackTab (Desktop Viewport)', () => {
     it('shows the sentiment category view when clicked', async () => {
       wrapper = await mountFormWithFeedbackState({});
-      const fwQuestion = 'How would you rate this page?';
       // Before the click, the form is hidden
-      expect(wrapper.queryAllByText(fwQuestion)).toHaveLength(0);
+      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(0);
       // Click the tab
-      userEvent.click(wrapper.getByText('Share Feedback'));
+      userEvent.click(wrapper.getByText(constants.text.feedbackButton));
 
       await tick();
       // After the click new feedback is initialized
-      expect(wrapper.queryAllByText(fwQuestion)).toHaveLength(1);
+      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(1);
     });
 
     it('is visible in the waiting view on large/desktop screens', async () => {
       wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.queryAllByText('Share Feedback')).toHaveLength(1);
+      expect(wrapper.queryAllByText(constants.text.feedbackButton)).toHaveLength(1);
     });
 
     it('is hidden outside of the waiting view on large/desktop screens', async () => {
@@ -98,35 +97,7 @@ describe('FeedbackWidget', () => {
         view: 'rating',
         comment: '',
       });
-      expect(wrapper.queryAllByText('How would you rate this page?')).toHaveLength(1);
-    });
-
-    it('is hidden on small/mobile and medium/tablet screens', async () => {
-      wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.queryAllByText('Share Feedback')).toHaveLength(1);
-      expect(wrapper.queryAllByText('Share Feedback')[0]).toHaveStyleRule('margin-left', '20px', {
-        media: `${theme.screenSize.upToSmall}`,
-      });
-    });
-  });
-
-  describe('FeedbackHeading (Mobile Viewport)', () => {
-    it('is visible on medium/tablet screens', async () => {
-      setTablet();
-      wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.queryAllByText('Share Feedback')).toHaveLength(1);
-    });
-
-    it('is visible on small/mobile screens', async () => {
-      setMobile();
-      wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.queryAllByText('Share Feedback')).toHaveLength(1);
-    });
-
-    it('is hidden on small/mobile screens when configured with page option', async () => {
-      setMobile();
-      wrapper = await mountFormWithFeedbackState({ hideHeader: true });
-      expect(wrapper.queryAllByText('Share Feedback')).toHaveLength(1);
+      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(1);
     });
   });
 
@@ -157,7 +128,7 @@ describe('FeedbackWidget', () => {
       // Click the close button
       userEvent.click(wrapper.getByLabelText('Close Feedback Form'));
       await tick();
-      expect(wrapper.queryAllByText('How would you rate this page?')).toHaveLength(0);
+      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(0);
     });
 
     describe('SentimentView', () => {

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -22,9 +22,18 @@ import {
   clearMockScreenshotFunctions,
 } from '../utils/data/feedbackWidgetScreenshotFunctions';
 import {
+  CLOSE_BUTTON_ALT_TEXT,
   COMMENT_PLACEHOLDER_TEXT,
+  EMAIL_ERROR_TEXT,
+  EMAIL_PLACEHOLDER_TEXT,
   FEEDBACK_BUTTON_TEXT,
+  FEEDBACK_SUBMIT_BUTTON_TEXT,
   RATING_QUESTION_TEXT,
+  SCREENSHOT_BUTTON_TEXT,
+  SCREENSHOT_OVERLAY_ALT_TEXT,
+  SUBMITTED_VIEW_RESOURCE_LINKS,
+  SUBMITTED_VIEW_SUPPORT_LINK,
+  SUBMITTED_VIEW_TEXT,
 } from '../../src/components/Widgets/FeedbackWidget/constants';
 import headingData from './data/Heading.test.json';
 
@@ -130,7 +139,7 @@ describe('FeedbackWidget', () => {
         view: 'rating',
       });
       // Click the close button
-      userEvent.click(wrapper.getByLabelText('Close Feedback Form'));
+      userEvent.click(wrapper.getByLabelText(CLOSE_BUTTON_ALT_TEXT));
       await tick();
       expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(0);
     });
@@ -171,7 +180,7 @@ describe('FeedbackWidget', () => {
         expect(highlightedStars).toHaveLength(expectedRating);
         expect(unselectedStar).toHaveLength(5 - expectedRating);
 
-        expect(wrapper.getByPlaceholderText('Email Address')).toBeTruthy();
+        expect(wrapper.getByPlaceholderText(EMAIL_PLACEHOLDER_TEXT)).toBeTruthy();
         expect(wrapper.getByText('Send')).toBeTruthy();
       });
 
@@ -184,13 +193,15 @@ describe('FeedbackWidget', () => {
           });
 
           // click on screenshot button; use closest() because of LG implementation of `"pointer-events": "none"`
-          userEvent.click(wrapper.getByText('Take a screenshot').closest('button'));
+          userEvent.click(wrapper.getByText(SCREENSHOT_BUTTON_TEXT).closest('button'));
           await tick();
 
           expect(screenshotFunctionMocks['addEventListener']).toHaveBeenCalled();
 
           // shows overlays
-          expect(wrapper.getByAltText('Screenshot').getElementsByClassName('overlay-instructions')).toBeTruthy();
+          expect(
+            wrapper.getByAltText(SCREENSHOT_OVERLAY_ALT_TEXT).getElementsByClassName('overlay-instructions')
+          ).toBeTruthy();
         });
 
         it('adds the screenshot attachment on send', async () => {
@@ -202,7 +213,7 @@ describe('FeedbackWidget', () => {
             screenshotTaken: true,
           });
 
-          userEvent.click(wrapper.getByText('Send').closest('button'));
+          userEvent.click(wrapper.getByText(FEEDBACK_SUBMIT_BUTTON_TEXT).closest('button'));
           await tick();
 
           expect(screenshotFunctionMocks['retrieveDataUri']).toHaveBeenCalled();
@@ -219,7 +230,7 @@ describe('FeedbackWidget', () => {
             user: { email: 'test@example.com' },
           });
           // Click the submit button
-          userEvent.click(wrapper.getByText('Send').closest('button'));
+          userEvent.click(wrapper.getByText(FEEDBACK_SUBMIT_BUTTON_TEXT).closest('button'));
           await tick();
           expect(stitchFunctionMocks['createNewFeedback']).toHaveBeenCalledTimes(1);
         });
@@ -231,25 +242,23 @@ describe('FeedbackWidget', () => {
             user: { email: 'test invalid email' },
           });
           // Type in an invalid email address
-          const emailInput = wrapper.getByPlaceholderText('Email Address');
+          const emailInput = wrapper.getByPlaceholderText(EMAIL_PLACEHOLDER_TEXT);
           userEvent.paste(emailInput, 'invalid email address');
           // Click the submit button
-          userEvent.click(wrapper.getByText('Send').closest('button'));
+          userEvent.click(wrapper.getByText(FEEDBACK_SUBMIT_BUTTON_TEXT).closest('button'));
           await tick();
-          expect(wrapper.getByText('Please enter a valid email.')).toBeTruthy();
+          expect(wrapper.getByText(EMAIL_ERROR_TEXT)).toBeTruthy();
         });
       });
     });
 
     describe('SubmittedView', () => {
       const standardViewCopy = [
-        'Thank you for your feedback!',
-        'Looking for more resources?',
-        'MongoDB Developer Community Forums',
-        'MongoDB Developer Center',
-        'MongoDB University',
+        SUBMITTED_VIEW_TEXT.HEADING,
+        SUBMITTED_VIEW_TEXT.SUB_HEADING,
+        ...SUBMITTED_VIEW_RESOURCE_LINKS.map(({ text }) => text),
       ];
-      const negativeViewCopy = ['Have a support contact?', 'Create a Support Case'];
+      const negativeViewCopy = [SUBMITTED_VIEW_TEXT.SUPPORT_CTA, SUBMITTED_VIEW_SUPPORT_LINK.text];
 
       it('shows self-serve support links for negative path', async () => {
         wrapper = await mountFormWithFeedbackState({

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -7,7 +7,6 @@ import {
   FeedbackForm,
   FeedbackTab,
   FeedbackFooter,
-  constants,
 } from '../../src/components/Widgets/FeedbackWidget';
 
 import { tick, mockMutationObserver, mockSegmentAnalytics, setDesktop, setMobile, setTablet } from '../utils';
@@ -22,6 +21,11 @@ import {
   mockScreenshotFunctions,
   clearMockScreenshotFunctions,
 } from '../utils/data/feedbackWidgetScreenshotFunctions';
+import {
+  COMMENT_PLACEHOLDER_TEXT,
+  FEEDBACK_BUTTON_TEXT,
+  RATING_QUESTION_TEXT,
+} from '../../src/components/Widgets/FeedbackWidget/constants';
 import headingData from './data/Heading.test.json';
 
 async function mountFormWithFeedbackState(feedbackState = {}, options = {}) {
@@ -78,18 +82,18 @@ describe('FeedbackWidget', () => {
     it('shows the sentiment category view when clicked', async () => {
       wrapper = await mountFormWithFeedbackState({});
       // Before the click, the form is hidden
-      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(0);
+      expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(0);
       // Click the tab
-      userEvent.click(wrapper.getByText(constants.text.feedbackButton));
+      userEvent.click(wrapper.getByText(FEEDBACK_BUTTON_TEXT));
 
       await tick();
       // After the click new feedback is initialized
-      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(1);
+      expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(1);
     });
 
     it('is visible in the waiting view on large/desktop screens', async () => {
       wrapper = await mountFormWithFeedbackState({});
-      expect(wrapper.queryAllByText(constants.text.feedbackButton)).toHaveLength(1);
+      expect(wrapper.queryAllByText(FEEDBACK_BUTTON_TEXT)).toHaveLength(1);
     });
 
     it('is hidden outside of the waiting view on large/desktop screens', async () => {
@@ -97,7 +101,7 @@ describe('FeedbackWidget', () => {
         view: 'rating',
         comment: '',
       });
-      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(1);
+      expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(1);
     });
   });
 
@@ -128,7 +132,7 @@ describe('FeedbackWidget', () => {
       // Click the close button
       userEvent.click(wrapper.getByLabelText('Close Feedback Form'));
       await tick();
-      expect(wrapper.queryAllByText(constants.text.ratingQuestion)).toHaveLength(0);
+      expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(0);
     });
 
     describe('SentimentView', () => {
@@ -148,7 +152,7 @@ describe('FeedbackWidget', () => {
         const selectedStar = stars[selectedRating - 1];
         userEvent.click(selectedStar);
         await tick();
-        expect(wrapper.getByPlaceholderText('Tell us more about your experience')).toBeTruthy();
+        expect(wrapper.getByPlaceholderText(COMMENT_PLACEHOLDER_TEXT)).toBeTruthy();
       });
     });
 

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { mockLocation } from '../utils/mock-location';
 import DocumentBody from '../../src/components/DocumentBody';
-import { constants } from '../../src/components/Widgets/FeedbackWidget';
+import { FEEDBACK_BUTTON_TEXT } from '../../src/components/Widgets/FeedbackWidget/constants';
 import mockPageContext from './data/PageContext.test.json';
 import mockSnootyMetadata from './data/SnootyMetadata.json';
 
@@ -28,7 +28,7 @@ describe('DocumentBody', () => {
       expect(languageSelector.querySelectorAll('li')).toHaveLength(2);
     }
 
-    const feedbackWidget = screen.getByText(constants.text.feedbackButton);
+    const feedbackWidget = screen.getByText(FEEDBACK_BUTTON_TEXT);
     expect(feedbackWidget).toBeVisible();
     expect(feedbackWidget).toMatchSnapshot();
 
@@ -44,7 +44,7 @@ describe('DocumentBody', () => {
     const footer = screen.queryByTestId('consistent-footer');
     expect(footer).not.toBeInTheDocument();
 
-    const feedbackWidget = screen.queryByText(constants.text.feedbackButton);
+    const feedbackWidget = screen.queryByText(FEEDBACK_BUTTON_TEXT);
     expect(feedbackWidget).not.toBeInTheDocument();
 
     const mainNav = screen.queryByRole('img', { name: 'MongoDB logo' });

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { mockLocation } from '../utils/mock-location';
 import DocumentBody from '../../src/components/DocumentBody';
+import { constants } from '../../src/components/Widgets/FeedbackWidget';
 import mockPageContext from './data/PageContext.test.json';
 import mockSnootyMetadata from './data/SnootyMetadata.json';
 
@@ -27,7 +28,7 @@ describe('DocumentBody', () => {
       expect(languageSelector.querySelectorAll('li')).toHaveLength(2);
     }
 
-    const feedbackWidget = screen.getByText('Share Feedback');
+    const feedbackWidget = screen.getByText(constants.text.feedbackButton);
     expect(feedbackWidget).toBeVisible();
     expect(feedbackWidget).toMatchSnapshot();
 
@@ -43,7 +44,7 @@ describe('DocumentBody', () => {
     const footer = screen.queryByTestId('consistent-footer');
     expect(footer).not.toBeInTheDocument();
 
-    const feedbackWidget = screen.queryByTestId('Share Feedback');
+    const feedbackWidget = screen.queryByText(constants.text.feedbackButton);
     expect(feedbackWidget).not.toBeInTheDocument();
 
     const mainNav = screen.queryByRole('img', { name: 'MongoDB logo' });

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -759,109 +759,65 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 
 exports[`DocumentBody renders the necessary elements 2`] = `
 .emotion-0 {
-  position: relative;
-  -webkit-transition: 150ms ease-in-out;
-  transition: 150ms ease-in-out;
-  transition-property: border,box-shadow;
-  border: 1px solid #E8EDEB;
-  box-shadow: 0 4px 10px -4px rgba(0,30,43,0.3);
-  background-color: white;
-  color: #1C2D38;
-  border-radius: 24px;
-  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 12px 16px;
+  background-color: #FFFFFF;
+  border: 1px solid #0498EC;
+  border-radius: 40px;
+  box-shadow: 0px 4px 10px -4px #E8EDEB;
+  position: fixed;
+  z-index: 9;
+  bottom: 32px;
+  right: 32px;
+  color: #1254B7;
+  font-weight: 600;
   font-size: 13px;
   line-height: 20px;
-  padding: 24px;
-  min-height: 68px;
-  cursor: pointer;
-  cursor: pointer;
-  padding: 12px;
-  position: fixed;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  z-index: 9;
-  font-weight: 500;
-  color: #00684A;
 }
 
-.emotion-0:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 10px -4px rgba(0,30,43,0.3);
-}
-
-.emotion-0:hover,
-.emotion-0:active {
-  border: 1px solid #E8EDEB;
-  box-shadow: 0 4px 20px -4px rgba(0,30,43,0.2);
-}
-
-.emotion-0:hover:focus,
-.emotion-0:active:focus {
-  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 20px -4px rgba(0,30,43,0.2);
+.emotion-0:hover {
+  box-shadow: 0px 0px 0px 3px #C3E7FE;
 }
 
 @media only screen and (max-width: 480px) {
   .emotion-0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    font-size: 16px;
-    position: static!important;
-    width: -webkit-fit-content!important;
-    width: -moz-fit-content!important;
-    width: fit-content!important;
-    margin-left: 20px;
-    margin-top: -20px;
-    margin-bottom: 20px;
-    -webkit-transform: rotate(0deg)!important;
-    -moz-transform: rotate(0deg)!important;
-    -ms-transform: rotate(0deg)!important;
-    transform: rotate(0deg)!important;
+    bottom: 24px;
+    right: 24px;
   }
 }
 
-@media not all and (max-width: 480px) {
-  @media only screen and (max-width: 1024px) {
-    .emotion-0 {
-      -webkit-transform: rotate(-90deg);
-      -moz-transform: rotate(-90deg);
-      -ms-transform: rotate(-90deg);
-      transform: rotate(-90deg);
-      top: 50%;
-      right: -53px;
-    }
-  }
-
-  @media not all and (max-width: 1024px) {
-    .emotion-0 {
-      bottom: -24px;
-    }
-
-    @media only screen and (max-width: 1440px) {
-      .emotion-0 {
-        right: 16px;
-      }
-    }
-
-    @media not all and (max-width: 1440px) {
-      .emotion-0 {
-        right: 64px;
-      }
-    }
-  }
+.emotion-1 {
+  color: #0498EC;
 }
 
 <div
   class="emotion-0"
 >
-  Share Feedback
+  <svg
+    aria-label="Favorite Icon"
+    class="emotion-1"
+    fill="none"
+    height="16"
+    role="img"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7.538 1.11a.5.5 0 0 1 .924 0l1.537 3.696a.5.5 0 0 0 .421.306l3.99.32a.5.5 0 0 1 .285.878l-3.04 2.604a.5.5 0 0 0-.16.496l.928 3.893a.5.5 0 0 1-.747.542L8.261 11.76a.5.5 0 0 0-.522 0l-3.415 2.086a.5.5 0 0 1-.747-.542l.928-3.893a.5.5 0 0 0-.16-.496L1.304 6.31a.5.5 0 0 1 .285-.878l3.99-.32A.5.5 0 0 0 6 4.806L7.538 1.11Z"
+      fill="currentColor"
+    />
+  </svg>
+  Rate this page
 </div>
 `;
 


### PR DESCRIPTION
### Stories/Links:

DOP-4156

### Current Behavior:

[Server docs](https://www.mongodb.com/docs/manual)

### Staging Links:

[Server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4156/index.html)

### Notes:

* Implements the redesign for the feedback tab/button.
* The button is supposed to be very similar to the style of the chatbot button, as seen in the Figma file. However, the button does not seem to be readily available to us as a variant, so I tried to get it as similar as possible for now.
* Moved some rendered text around to a constants file so that both the components and tests can share the same reference easily.