### PR TITLE
run dedupe and add as part of test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         node-version: '18.15'
     - name: Install
       run: npm ci --legacy-peer-deps
+    - name: Dedupe
+      run: npm dedupe
     - name: Lint
       run: npm run lint && npm run format
     - name: Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3676,22 +3676,6 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/a11y/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/a11y/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/@leafygreen-ui/badge": {
       "version": "5.0.1",
       "license": "Apache-2.0",
@@ -3764,22 +3748,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/button/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/button/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/callout": {
       "version": "5.0.1",
@@ -3879,22 +3847,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/checkbox/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/code": {
       "version": "11.0.1",
@@ -4076,14 +4028,6 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/icon-button/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/inline-definition": {
       "version": "6.0.14",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/inline-definition/-/inline-definition-6.0.14.tgz",
@@ -4111,21 +4055,12 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/inline-definition/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/lib": {
-      "version": "10.3.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-      "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
-      "license": "Apache-2.0",
+      "version": "10.4.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
       "dependencies": {
-        "@storybook/csf": "^0.0.2-next.10",
+        "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
@@ -4175,14 +4110,6 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/popover/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal": {
       "version": "5.0.3",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
@@ -4214,14 +4141,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip": {
@@ -4279,14 +4198,6 @@
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/ansi-styles": {
@@ -4359,14 +4270,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@leafygreen-ui/combobox/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.7",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.7.tgz",
@@ -4433,22 +4336,6 @@
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.10"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/form-field/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/hooks": {
@@ -4542,22 +4429,6 @@
         "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
-    "node_modules/@leafygreen-ui/input-option/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/input-option/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/@leafygreen-ui/interaction-ring": {
       "version": "3.0.0",
       "license": "Apache-2.0",
@@ -4629,22 +4500,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/logo": {
       "version": "4.0.2",
@@ -4779,22 +4634,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/menu/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/modal": {
@@ -5054,14 +4893,6 @@
         "@leafygreen-ui/leafygreen-provider": "^3.1.9"
       }
     },
-    "node_modules/@leafygreen-ui/pagination/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@leafygreen-ui/pagination/node_modules/@types/react-is": {
       "version": "18.2.4",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
@@ -5074,14 +4905,6 @@
       "version": "18.2.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/@leafygreen-ui/pagination/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/palette": {
       "version": "3.4.7",
@@ -5146,22 +4969,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/portal/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/portal/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/ripple": {
@@ -5235,9 +5042,9 @@
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/lib": {
-      "version": "10.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-      "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+      "version": "10.4.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -5322,22 +5129,6 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/search-input/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/search-input/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/@leafygreen-ui/segmented-control": {
       "version": "8.0.1",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/segmented-control/-/segmented-control-8.0.1.tgz",
@@ -5384,22 +5175,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/segmented-control/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/select": {
       "version": "7.1.2",
@@ -5586,22 +5361,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/skeleton-loader/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/table": {
       "version": "6.1.1",
@@ -5849,20 +5608,12 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/icon-button/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/lib": {
-      "version": "10.3.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-      "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
+      "version": "10.4.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
       "dependencies": {
-        "@storybook/csf": "^0.0.2-next.10",
+        "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
@@ -5874,14 +5625,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/toast/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/toggle": {
       "version": "10.0.16",
@@ -5916,22 +5659,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/toggle/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@leafygreen-ui/tokens": {
       "version": "2.2.0",
@@ -6029,22 +5756,6 @@
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
       "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-    },
-    "node_modules/@leafygreen-ui/typography/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/typography/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/@lezer/common": {
       "version": "0.15.12",
@@ -7569,10 +7280,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/csf": {
-      "version": "0.0.2-next.11",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.0.2-next.11.tgz",
-      "integrity": "sha512-xGt0YSVxZb43sKmEf1GIQD8xEbo+c+S6khDEL7Qu/pYA0gh5z3WUuhOlovnelYj/YJod+XRsfVvk23AaRfUJ4Q==",
-      "license": "MIT",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -7581,12 +7291,8 @@
       "version": "2.19.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@styled-system/background": {
@@ -8328,8 +8034,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "18.0.28",
-      "license": "MIT",
+      "version": "17.0.71",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react/-/react-17.0.71.tgz",
+      "integrity": "sha512-lfqOu9mp16nmaGRrS8deS2Taqhd5Ih0o92Te5Ws6I1py4ytHBcXLqh0YIqVsViqwVI5f+haiFM6hju814BzcmA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -8345,10 +8052,11 @@
       }
     },
     "node_modules/@types/react-is": {
-      "version": "17.0.3",
-      "license": "MIT",
+      "version": "17.0.7",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-17.0.7.tgz",
+      "integrity": "sha512-WrTEiT+c6rgq36QApoy0063uAOdltCrhF0QMXLIgYPaTvIdQhAB8hPb5oGGqX18xToElNILS9UprwU6GyINcJg==",
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/responselike": {
@@ -19809,14 +19517,6 @@
         "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
-    "node_modules/mongodb-chatbot-ui/node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/mongodb-chatbot-ui/node_modules/@types/react-is": {
       "version": "18.2.4",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
@@ -19829,14 +19529,6 @@
       "version": "18.2.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/mongodb-chatbot-ui/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -27907,19 +27599,6 @@
             "lodash": "^4.17.21",
             "prop-types": "^15.7.2"
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -27985,19 +27664,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28088,19 +27754,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28250,14 +27903,6 @@
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2"
               }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
-              }
             }
           }
         },
@@ -28281,23 +27926,15 @@
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2"
               }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
-              }
             }
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "10.3.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-          "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
+          "version": "10.4.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+          "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
           "requires": {
-            "@storybook/csf": "^0.0.2-next.10",
+            "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
             "prop-types": "^15.7.2"
           }
@@ -28337,14 +27974,6 @@
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2"
               }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
-              }
             }
           }
         },
@@ -28373,14 +28002,6 @@
                 "@storybook/csf": "^0.1.0",
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2"
-              }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
               }
             }
           }
@@ -28432,14 +28053,6 @@
                 "@leafygreen-ui/polymorphic": "^1.3.6",
                 "@leafygreen-ui/tokens": "^2.1.4"
               }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
-              }
             }
           }
         },
@@ -28485,11 +28098,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28551,19 +28159,6 @@
             "@leafygreen-ui/polymorphic": "^1.3.6",
             "@leafygreen-ui/tokens": "^2.1.4"
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28642,19 +28237,6 @@
             "@leafygreen-ui/polymorphic": "^1.3.6",
             "@leafygreen-ui/tokens": "^2.1.4"
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28716,19 +28298,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28847,19 +28416,6 @@
               }
             }
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29089,14 +28645,6 @@
             }
           }
         },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
         "@types/react-is": {
           "version": "18.2.4",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
@@ -29109,11 +28657,6 @@
           "version": "18.2.0",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29173,19 +28716,6 @@
             "lodash": "^4.17.21",
             "prop-types": "^15.7.2"
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29253,9 +28783,9 @@
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "10.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-          "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+          "version": "10.4.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+          "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -29328,19 +28858,6 @@
               }
             }
           }
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29383,19 +28900,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29561,19 +29065,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29795,23 +29286,15 @@
                 "lodash": "^4.17.21",
                 "prop-types": "^15.7.2"
               }
-            },
-            "@storybook/csf": {
-              "version": "0.1.2",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-              "requires": {
-                "type-fest": "^2.19.0"
-              }
             }
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "10.3.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-          "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
+          "version": "10.4.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+          "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
           "requires": {
-            "@storybook/csf": "^0.0.2-next.10",
+            "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
             "prop-types": "^15.7.2"
           }
@@ -29820,11 +29303,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29855,19 +29333,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -29958,19 +29423,6 @@
           "version": "4.0.8",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
           "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
-        },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -30898,9 +30350,9 @@
       "version": "3.1.0"
     },
     "@storybook/csf": {
-      "version": "0.0.2-next.11",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.0.2-next.11.tgz",
-      "integrity": "sha512-xGt0YSVxZb43sKmEf1GIQD8xEbo+c+S6khDEL7Qu/pYA0gh5z3WUuhOlovnelYj/YJod+XRsfVvk23AaRfUJ4Q==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "requires": {
         "type-fest": "^2.19.0"
       },
@@ -31472,7 +30924,9 @@
       }
     },
     "@types/react": {
-      "version": "18.0.28",
+      "version": "17.0.71",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react/-/react-17.0.71.tgz",
+      "integrity": "sha512-lfqOu9mp16nmaGRrS8deS2Taqhd5Ih0o92Te5Ws6I1py4ytHBcXLqh0YIqVsViqwVI5f+haiFM6hju814BzcmA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -31487,9 +30941,11 @@
       }
     },
     "@types/react-is": {
-      "version": "17.0.3",
+      "version": "17.0.7",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-17.0.7.tgz",
+      "integrity": "sha512-WrTEiT+c6rgq36QApoy0063uAOdltCrhF0QMXLIgYPaTvIdQhAB8hPb5oGGqX18xToElNILS9UprwU6GyINcJg==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "@types/responselike": {
@@ -38961,14 +38417,6 @@
             }
           }
         },
-        "@storybook/csf": {
-          "version": "0.1.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
-          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
         "@types/react-is": {
           "version": "18.2.4",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
@@ -38981,11 +38429,6 @@
           "version": "18.2.0",
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,14 @@
         "npm": "8.*"
       }
     },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.2.0",
       "dev": true,
@@ -228,10 +236,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "license": "MIT",
+      "version": "7.23.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -309,8 +319,9 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "license": "MIT",
+      "version": "0.3.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -568,8 +579,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "license": "MIT",
+      "version": "7.22.20",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -607,11 +619,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "license": "MIT",
+      "version": "7.23.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -1948,10 +1961,11 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/jest": {
@@ -2382,16 +2396,14 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.20.0",
-      "license": "MIT",
+      "version": "13.23.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -3060,15 +3072,10 @@
       }
     },
     "node_modules/@jest/core/node_modules/ci-info": {
-      "version": "3.8.0",
+      "version": "3.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3098,11 +3105,12 @@
       }
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -3300,12 +3308,13 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/jest-worker": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -3339,11 +3348,12 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3497,11 +3507,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.5.0",
+      "version": "29.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -3610,8 +3621,9 @@
       }
     },
     "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "license": "MIT",
+      "version": "0.3.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3634,27 +3646,27 @@
       }
     },
     "node_modules/@leafygreen-ui/a11y": {
-      "version": "1.4.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.10.tgz",
-      "integrity": "sha512-Mp3ttmutq1yDr27DXGQaqsBe4AuGyIBuBH9yQWIluIF/raTF7GLFceqa0Fa9k228FfoBis+ApASHvmS+57Gctw==",
+      "version": "1.4.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.11.tgz",
+      "integrity": "sha512-mzNMR4ci3ExdCY3Ec1kr7xH4nV02uamoohbWxcI9qSd41TFskaDAZSXO9PL9S8JosQXjpRkt0f470XvVE0kEXQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^12.0.0"
+        "@leafygreen-ui/lib": "^13.0.0"
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-      "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/lib": {
-      "version": "12.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-      "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -3665,9 +3677,9 @@
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -3719,26 +3731,26 @@
       "integrity": "sha512-qfjwhrie+mUrS2H+Qp98iQKBPoZtNpFmlGBYgg59sVOzotFvyvqwxlf/JcaNGo+v7nyOhC2XAHui0ywf9cScKw=="
     },
     "node_modules/@leafygreen-ui/button": {
-      "version": "21.0.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-21.0.6.tgz",
-      "integrity": "sha512-J9QmC29fNQG2GkQdxqR4IXyCBf3Z0A56CDRHQoPkIgrpPkAOLWH6jVbh2pMpcq/mB9LO4P9B4IH1WwdJ1XUn3w==",
+      "version": "21.0.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-21.0.11.tgz",
+      "integrity": "sha512-NJhllsXO7jAJoAou9kPIk/B8ODYUrGxr4l4TceoAwAM3cW0kZ5kys9KA+0TOmG2AxNKLcElLu+wCg3TbssFk+Q==",
       "dependencies": {
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^12.0.0",
+        "@leafygreen-ui/lib": "^13.1.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/ripple": "^1.1.12",
         "@leafygreen-ui/tokens": "^2.1.4",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.9"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/lib": {
-      "version": "12.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-      "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -3749,14 +3761,14 @@
       }
     },
     "node_modules/@leafygreen-ui/button/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/button/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -3864,14 +3876,14 @@
       }
     },
     "node_modules/@leafygreen-ui/checkbox/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/checkbox/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -3921,8 +3933,9 @@
       }
     },
     "node_modules/@leafygreen-ui/code/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -4026,45 +4039,84 @@
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.1.tgz",
-      "integrity": "sha512-P4uGzI0IBUX2g4MRY2FX6TPrMOLuh2/bOrq9TiWQgj/vhDPbAQt+62F7p3b3XL+Axywtqg6dIODNWW+WfJrXSA==",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.10.tgz",
-      "integrity": "sha512-GbMxbPLEIUVOSmzJkVJrpQAfvrKjTgjkM9TSkL06sJ0f7ghcIO6mOpoonML6BLFqOTFXuyUZ/3C0jQQDvO+Glw==",
-      "license": "Apache-2.0",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/box": "^3.1.3",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/tokens": "^2.0.3"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/box": "^3.1.8",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/icon-button/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/inline-definition": {
-      "version": "6.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/inline-definition/-/inline-definition-6.0.4.tgz",
-      "integrity": "sha512-FUBRpqrMZOh2YZNy0NotIdmryLpMN5suppcTGDM2QIrpgKBxCGJB+GJpekK/ZU5UnONeOqMH+f6o0VwN/Vpwjw==",
-      "license": "Apache-2.0",
+      "version": "6.0.14",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/inline-definition/-/inline-definition-6.0.14.tgz",
+      "integrity": "sha512-vCfSF1Lr8O4sm8f7w9rTflVyJRjF3Tyrtppr9OSfEPTDDlla+tiuSyvrMUty3xfdomc6JEGyumdozvjyU9dFsg==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.3.2",
-        "@leafygreen-ui/palette": "^4.0.3",
-        "@leafygreen-ui/tooltip": "^9.1.7"
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tooltip": "^11.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/inline-definition/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/inline-definition/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/lib": {
@@ -4082,47 +4134,159 @@
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA==",
-      "license": "Apache-2.0"
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.8.tgz",
-      "integrity": "sha512-yqcDh1hiJQSqkh376WPCV/qbm/v0OJd3NMVesTW6CrGAFjD9HJR4bUoRiT5tjTWxvWxI/gh8BhIqFgyQ7mFcJg==",
-      "license": "Apache-2.0",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+      "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/portal": "^4.1.2",
-        "@leafygreen-ui/tokens": "^2.0.3",
-        "react-transition-group": "^4.4.1"
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.1.0",
+        "@leafygreen-ui/portal": "^5.0.3",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/popover/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+      "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/portal/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip": {
-      "version": "9.1.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tooltip/-/tooltip-9.1.8.tgz",
-      "integrity": "sha512-bqLF0z4L19y253nmRoQSs4U1O7OGSCf46e1N7xBCbenlZVMLN4MSk0EQdpmDmXqMkopLOomVQAy/17guV6YULA==",
-      "license": "Apache-2.0",
+      "version": "11.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tooltip/-/tooltip-11.0.0.tgz",
+      "integrity": "sha512-dqyye58w/1uWCsoFWEVgt2rrkNOTPyk1AQN9Wc828+YObIDyBI+F6ppqDxKZtu6ztw34aEOJw3kfucE98zQk+A==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.1",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/popover": "^11.0.8",
-        "@leafygreen-ui/tokens": "^2.0.3",
-        "@leafygreen-ui/typography": "^16.3.0",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.0.1",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/popover": "^11.1.1",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/typography": "^18.0.1",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/combobox/node_modules/@leafygreen-ui/tooltip/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/combobox/node_modules/ansi-styles": {
@@ -4195,6 +4359,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@leafygreen-ui/combobox/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.7",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.7.tgz",
@@ -4202,6 +4374,81 @@
       "dependencies": {
         "@emotion/css": "^11.1.3",
         "@emotion/server": "^11.4.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/form-field/-/form-field-0.2.0.tgz",
+      "integrity": "sha512-sGpm+U+m3ErK76YciPapP9oC2GxvICKc1sMRGaAI1vMyYUbIlXEGxtLkL7Xd6HrJcC7aDRcN75MUlC2SJYQsTQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/icon": "^11.24.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/typography": "^18.0.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/palette": {
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/hooks": {
@@ -4212,9 +4459,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "11.23.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.23.0.tgz",
-      "integrity": "sha512-TaK9mlQO2K1Y4urL69FzLXMfW/hoSChlsA0WSj4IEFEyaC/bwVQTJFq9qStcRPTwf18G1rwsEQB1TlKDvlPIFA==",
+      "version": "11.25.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.25.1.tgz",
+      "integrity": "sha512-45m9INMLG2kKa8BTqP/ZGpc832w0CTO3KFK5kqwQdBouYyJogrKEQlI1Toss+JYKoBVHFYXBQc0ST8tIU4zr3w==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "lodash": "^4.17.21"
@@ -4245,44 +4492,60 @@
       }
     },
     "node_modules/@leafygreen-ui/input-option": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.5.tgz",
-      "integrity": "sha512-gU051Rr5oB6CelLziN1xpbymexEP28DsbhgN+KTXxzpOM5q4l1dNAv12UDuCSEJS/xPP0kzkBkMWT/WPOEE/uQ==",
+      "version": "1.0.13",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.13.tgz",
+      "integrity": "sha512-6J4rji1V2EHpKyqsuZPa2KVW4IHbj26Wp9VoJuFh6hz3LkNpJ5FoRxLvUGlL9wf8b+A2oK+bz5rW0FP+vs+nlw==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4",
+        "@leafygreen-ui/typography": "^18.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/lib": {
-      "version": "10.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-      "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+    },
+    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4316,8 +4579,9 @@
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -4362,14 +4626,14 @@
       }
     },
     "node_modules/@leafygreen-ui/loading-indicator/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/loading-indicator/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4408,28 +4672,41 @@
       }
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-      "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.17",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.17.tgz",
-      "integrity": "sha512-2gKZKLwGDoyhOmiYvSDRssk1OU/jSraIU4prT40lLgqZFCmA2nqDr7Hfb+W62QNvEGchoXNOXzm8KG/yrJBl2Q==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.8",
+        "@leafygreen-ui/a11y": "^1.4.11",
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/lib": {
@@ -4446,42 +4723,68 @@
       }
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.17",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.17.tgz",
-      "integrity": "sha512-8ikJSmLTsDBpXou2lNY54ZCOVRwsb6v8L6e6Fxanb/74OElrYU38iNoUdR/inW+pzdRiUQT6qx8oaqZ7EKrS0Q==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+      "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/portal": "^5.0.1",
+        "@leafygreen-ui/lib": "^13.1.0",
+        "@leafygreen-ui/portal": "^5.0.3",
         "@leafygreen-ui/tokens": "^2.2.0",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.8"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/portal": {
-      "version": "5.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.1.tgz",
-      "integrity": "sha512-SL+Kw2088aopilmzKOTfzWE4tVKyRyClr1nnOaX+xplQ+6gu22C+LDFL4cJZkkWyP8WlqAE+2s1C631W3uHbPg==",
+      "version": "5.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+      "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
       "dependencies": {
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^11.0.0"
+        "@leafygreen-ui/lib": "^13.0.0"
       },
       "peerDependencies": {
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@leafygreen-ui/menu/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@leafygreen-ui/menu/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4516,8 +4819,9 @@
       }
     },
     "node_modules/@leafygreen-ui/modal/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -4573,20 +4877,33 @@
       }
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.16",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.16.tgz",
-      "integrity": "sha512-j/y60X+At8tm1uKj2LWfppxuH3lCB1Mwa99PFhmVVD9ohNFjjqY6m5Vll7NTq10AelUimWOYk+uCzh4A96x4kQ==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.7",
-        "@leafygreen-ui/box": "^3.1.7",
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.1",
-        "@leafygreen-ui/lib": "^10.4.3",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.6"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/lib": {
@@ -4603,56 +4920,160 @@
       }
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.15",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.15.tgz",
-      "integrity": "sha512-JeQw3L5leaw0qFDz1uhuR1YPi+PB5zvvvCeHeS3llw92zGej11iJKtTVQeylacl9N4fGjFso11dZ+afZ/D2QhA==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+      "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/lib": "^10.4.3",
-        "@leafygreen-ui/portal": "^4.1.7",
-        "@leafygreen-ui/tokens": "^2.1.4",
-        "react-transition-group": "^4.4.1"
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.1.0",
+        "@leafygreen-ui/portal": "^5.0.3",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.6"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/portal": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+      "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/select": {
-      "version": "10.3.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.12.tgz",
-      "integrity": "sha512-r3WchfA1CMgz2Efd7Ccm6v8nFVF6vzAqleaEudTJ09XXtVmV9Df1v1kY/90F+GKij74OjUEOft7RgCkh0SB6/A==",
+      "version": "10.3.18",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.18.tgz",
+      "integrity": "sha512-YJkO15Clg72D5RX0V4Ea6+IozftIbHUREAb7Gs/sYFEAESIuT6u/rmhhqOBZHtWmc/yNVgcFYDPJHXWYVzYV+w==",
       "dependencies": {
-        "@leafygreen-ui/button": "^21.0.3",
+        "@leafygreen-ui/button": "^21.0.7",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^7.7.8",
-        "@leafygreen-ui/icon": "^11.22.1",
-        "@leafygreen-ui/lib": "^10.4.3",
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/icon": "^11.23.0",
+        "@leafygreen-ui/lib": "^12.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.15",
-        "@leafygreen-ui/tokens": "^2.1.4",
-        "@leafygreen-ui/typography": "^16.5.4",
-        "@types/react-is": "^17.0.0",
+        "@leafygreen-ui/popover": "^11.0.18",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/typography": "^17.0.1",
+        "@types/react-is": "^18.0.0",
         "lodash": "^4.17.21",
         "polished": "^4.1.3",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.6"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.9"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/lib": {
+      "version": "12.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
+      "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/typography": {
+      "version": "17.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-17.0.2.tgz",
+      "integrity": "sha512-wx+kk5VNMOCTenrIG2AcgAKHt9TiLhSTirZARv0J6l4VOgnO+Mkbh3sqd4mk0EOBCAFmsBR3WqwQh00JXU8Htw==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^12.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.9"
       }
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/@types/react-is": {
+      "version": "18.2.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
+      "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@leafygreen-ui/pagination/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@leafygreen-ui/pagination/node_modules/type-fest": {
       "version": "2.19.0",
@@ -4687,8 +5108,9 @@
       }
     },
     "node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -4727,9 +5149,9 @@
       }
     },
     "node_modules/@leafygreen-ui/portal/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4775,28 +5197,41 @@
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.5.tgz",
-      "integrity": "sha512-Spk36yndhplGfCdLl14RWuoDPGYfEgA6AwqbaI4T45i+A2QtDTvdSFyMUkNmDK5vzk5cWmR/SmkRS/o5T9zgMA==",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.12.tgz",
-      "integrity": "sha512-19tXprK4/jIZq19o6Y2OnPw5ifuLIhpxAJ4/gs/lIFk/4A5PZJOnZzy6ABdiMaFk/1miSjoDQ5B+lncvgAx1gA==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/box": "^3.1.4",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/tokens": "^2.1.1"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/box": "^3.1.8",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/lib": {
@@ -4813,30 +5248,84 @@
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.12.tgz",
-      "integrity": "sha512-zF8axGB+RhpoG0xgb4K/p8ydS5JAEXpwqdLrcrY9r7cAYzxX0F4mhIpYg+oyK2K5TIbgGR/fsFPbhKYsmreuMA==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+      "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.5",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/portal": "^4.1.4",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "react-transition-group": "^4.4.1"
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.1.0",
+        "@leafygreen-ui/portal": "^5.0.3",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/portal": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+      "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/lib": "^13.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/portal/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4871,21 +5360,19 @@
       }
     },
     "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.1.tgz",
-      "integrity": "sha512-P4uGzI0IBUX2g4MRY2FX6TPrMOLuh2/bOrq9TiWQgj/vhDPbAQt+62F7p3b3XL+Axywtqg6dIODNWW+WfJrXSA==",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/lib": {
-      "version": "10.3.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-      "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
-      "license": "Apache-2.0",
+      "version": "10.4.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+      "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
       "dependencies": {
-        "@storybook/csf": "^0.0.2-next.10",
+        "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
@@ -4894,10 +5381,25 @@
       }
     },
     "node_modules/@leafygreen-ui/segmented-control/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA==",
-      "license": "Apache-2.0"
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+    },
+    "node_modules/@leafygreen-ui/segmented-control/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/segmented-control/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/@leafygreen-ui/select": {
       "version": "7.1.2",
@@ -4938,8 +5440,9 @@
       }
     },
     "node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -4990,8 +5493,9 @@
       }
     },
     "node_modules/@leafygreen-ui/side-nav/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5037,19 +5541,32 @@
       }
     },
     "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@leafygreen-ui/card": {
-      "version": "10.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.4.tgz",
-      "integrity": "sha512-GiwKA+Dr/jNgUvUvn3G8A4s2AsJqYu56NvhoTjOHefowE2Y657pQdD4JWvtv1tW88VdqEt2NbGmaVc9cVs677Q==",
+      "version": "10.0.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.6.tgz",
+      "integrity": "sha512-GpBDEmJoyvJT0lqgM9K3DTIfiFLGzANdzW1SAY+5dBVfRBsKcxgLIi3OQte2uOTOd7V29atP0Zny+tM8V3vo4A==",
       "dependencies": {
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@leafygreen-ui/card/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@leafygreen-ui/lib": {
@@ -5066,14 +5583,14 @@
       }
     },
     "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/skeleton-loader/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5105,8 +5622,9 @@
       }
     },
     "node_modules/@leafygreen-ui/table/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5160,8 +5678,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5191,8 +5710,9 @@
       }
     },
     "node_modules/@leafygreen-ui/text-area/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5238,8 +5758,9 @@
       }
     },
     "node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5291,28 +5812,49 @@
       }
     },
     "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.3.tgz",
-      "integrity": "sha512-giAHwLE9ZelQemNHZCZRf5ccBG95Fvehs0Pf6EHLP1Xhpofkqbws4HIKD8OylnHxP6otP1Ciq/rHc2XJ8I0dYQ==",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.10.tgz",
-      "integrity": "sha512-GbMxbPLEIUVOSmzJkVJrpQAfvrKjTgjkM9TSkL06sJ0f7ghcIO6mOpoonML6BLFqOTFXuyUZ/3C0jQQDvO+Glw==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/box": "^3.1.3",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.13.1",
-        "@leafygreen-ui/lib": "^10.3.3",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/tokens": "^2.0.3"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/box": "^3.1.8",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.2"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/icon-button/node_modules/@leafygreen-ui/lib": {
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/icon-button/node_modules/@storybook/csf": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/lib": {
@@ -5329,9 +5871,17 @@
       }
     },
     "node_modules/@leafygreen-ui/toast/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+    },
+    "node_modules/@leafygreen-ui/toast/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/@leafygreen-ui/toggle": {
       "version": "10.0.16",
@@ -5363,14 +5913,14 @@
       }
     },
     "node_modules/@leafygreen-ui/toggle/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/toggle/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5392,9 +5942,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/tooltip": {
       "version": "7.1.3",
@@ -5415,8 +5965,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tooltip/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "7.7.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+      "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -5475,14 +6026,14 @@
       }
     },
     "node_modules/@leafygreen-ui/typography/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/typography/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5506,6 +6057,12 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
+      "optional": true
+    },
     "node_modules/@lmdb/lmdb-darwin-x64": {
       "version": "2.5.3",
       "cpu": [
@@ -5516,6 +6073,30 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
+      "optional": true
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
+      "optional": true
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
+      "optional": true
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
+      "optional": true
     },
     "node_modules/@loadable/component": {
       "version": "5.14.1",
@@ -5603,6 +6184,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
+      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "optional": true
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.0",
       "cpu": [
@@ -5613,6 +6200,30 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
+      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "optional": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
+      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "optional": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
+      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "optional": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
+      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
+      "optional": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -5690,6 +6301,12 @@
         "@parcel/core": "^2.8.3"
       }
     },
+    "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "optional": true
+    },
     "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-darwin-x64": {
       "version": "2.5.2",
       "cpu": [
@@ -5700,6 +6317,30 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "optional": true
+    },
+    "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "optional": true
+    },
+    "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "optional": true
+    },
+    "node_modules/@parcel/cache/node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "optional": true
     },
     "node_modules/@parcel/cache/node_modules/lmdb": {
       "version": "2.5.2",
@@ -5857,8 +6498,9 @@
       }
     },
     "node_modules/@parcel/core/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -6075,8 +6717,9 @@
       }
     },
     "node_modules/@parcel/node-resolver-core/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -6125,8 +6768,9 @@
       }
     },
     "node_modules/@parcel/package-manager/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -6153,16 +6797,14 @@
       }
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
-      "version": "13.20.0",
-      "license": "MIT",
+      "version": "13.23.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@parcel/packager-raw": {
@@ -6282,8 +6924,9 @@
       }
     },
     "node_modules/@parcel/transformer-js/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -6769,10 +7412,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/@types/node": {
-      "version": "14.18.36",
-      "license": "MIT"
-    },
     "node_modules/@redocly/openapi-core/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -6809,8 +7448,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6858,9 +7498,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.27.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -7031,13 +7672,10 @@
         "@emotion/memoize": "0.7.4"
       }
     },
-    "node_modules/@styled-system/should-forward-prop/node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "license": "MIT"
-    },
     "node_modules/@styled-system/should-forward-prop/node_modules/@emotion/memoize": {
-      "version": "0.7.5",
-      "license": "MIT"
+      "version": "0.7.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@styled-system/space": {
       "version": "5.1.2",
@@ -7481,8 +8119,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.0",
-      "license": "MIT"
+      "version": "0.0.51",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/facepaint": {
       "version": "1.2.2",
@@ -7527,8 +8166,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.10",
@@ -7579,11 +8219,12 @@
       }
     },
     "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "29.4.3",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7654,8 +8295,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.14.1",
-      "license": "MIT"
+      "version": "14.18.63",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -7850,8 +8492,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7975,8 +8618,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -8176,8 +8820,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "license": "MIT",
+      "version": "8.11.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8573,9 +9218,10 @@
       }
     },
     "node_modules/auto-changelog/node_modules/node-fetch": {
-      "version": "2.6.9",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8592,9 +9238,10 @@
       }
     },
     "node_modules/auto-changelog/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9190,8 +9837,9 @@
       }
     },
     "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.1",
-      "license": "MIT",
+      "version": "3.6.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9356,23 +10004,14 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "license": "MIT",
+      "version": "4.22.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -9499,8 +10138,9 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
-      "license": "MIT",
+      "version": "7.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -9569,18 +10209,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001457",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ],
-      "license": "CC-BY-4.0"
+      "version": "1.0.30001566",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -9854,8 +10485,9 @@
       }
     },
     "node_modules/clipboardy/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -10056,9 +10688,10 @@
       "license": "MIT"
     },
     "node_modules/colorette": {
-      "version": "2.0.19",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.20",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -10276,14 +10909,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.28.0",
-      "license": "MIT",
+      "version": "3.34.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/core-js-compat/-/core-js-compat-3.34.0.tgz",
+      "integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
       "dependencies": {
-        "browserslist": "^4.21.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
+        "browserslist": "^4.22.2"
       }
     },
     "node_modules/core-js-pure": {
@@ -10467,8 +11097,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -11239,8 +11870,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.311",
-      "license": "ISC"
+      "version": "1.4.607",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.4.607.tgz",
+      "integrity": "sha512-YUlnPwE6eYxzwBnFmawA8LiLRfm70R2aJRIUv0n03uHt/cUzzYACOogmvk8M2+hVzt/kB80KJXx7d5f5JofPvQ=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -11325,12 +11957,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/engine.io-client/node_modules/xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/engine.io-parser": {
@@ -11973,18 +12599,16 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "license": "MIT",
+      "version": "2.0.0-next.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -12183,16 +12807,14 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.20.0",
-      "license": "MIT",
+      "version": "13.23.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -12224,8 +12846,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13032,8 +13655,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13136,8 +13760,9 @@
       "license": "ISC"
     },
     "node_modules/fs-extra": {
-      "version": "11.1.0",
-      "license": "MIT",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -13167,8 +13792,9 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "license": "MIT"
+      "version": "1.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -13494,8 +14120,9 @@
       }
     },
     "node_modules/gatsby-cli/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13512,8 +14139,9 @@
       }
     },
     "node_modules/gatsby-cli/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13861,8 +14489,9 @@
       }
     },
     "node_modules/gatsby-telemetry/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13966,8 +14595,9 @@
       }
     },
     "node_modules/gatsby/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13984,8 +14614,9 @@
       }
     },
     "node_modules/gatsby/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14442,6 +15073,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -14728,8 +15370,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "license": "MIT",
+      "version": "5.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "engines": {
         "node": ">= 4"
       }
@@ -15084,13 +15727,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "license": "MIT",
+      "version": "2.13.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/is-date-object": {
@@ -15701,11 +16342,12 @@
       }
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -15859,9 +16501,10 @@
       }
     },
     "node_modules/jest-cli/node_modules/yargs": {
-      "version": "17.7.1",
+      "version": "17.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -15957,15 +16600,10 @@
       }
     },
     "node_modules/jest-config/node_modules/ci-info": {
-      "version": "3.8.0",
+      "version": "3.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -15995,11 +16633,12 @@
       }
     },
     "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16102,11 +16741,12 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16221,11 +16861,12 @@
       }
     },
     "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16343,12 +16984,13 @@
       }
     },
     "node_modules/jest-haste-map/node_modules/jest-worker": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -16394,11 +17036,12 @@
       }
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16479,11 +17122,12 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16591,11 +17235,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16852,12 +17497,13 @@
       }
     },
     "node_modules/jest-runner/node_modules/jest-worker": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -17101,11 +17747,12 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -17130,9 +17777,10 @@
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17160,11 +17808,12 @@
       "license": "ISC"
     },
     "node_modules/jest-util": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -17205,15 +17854,10 @@
       }
     },
     "node_modules/jest-util/node_modules/ci-info": {
-      "version": "3.8.0",
+      "version": "3.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -17334,11 +17978,12 @@
       }
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -17651,8 +18296,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "license": "MIT",
+      "version": "4.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -18645,9 +19291,9 @@
       "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
     },
     "node_modules/micromark/node_modules/@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "version": "4.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -18876,66 +19522,82 @@
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/badge": {
-      "version": "8.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-8.0.12.tgz",
-      "integrity": "sha512-qhpsnhZa8q1j7thmeek43XLjrXW5kghFiYRLd4STK810jahr3l5OBsHQpIG5n4Rg4xYB7ZK0/MsDmA+guO+QmQ==",
+      "version": "8.0.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-8.0.15.tgz",
+      "integrity": "sha512-oraJpLtZ4nXJNmKp71/wzYsk+djf8fXNNgDKo1srpN0lZXlEYfHG1qAaHpYGA60QIP4iQuRU4OkShGfruPACww==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/banner": {
-      "version": "7.0.13",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/banner/-/banner-7.0.13.tgz",
-      "integrity": "sha512-krAqzH/3yIRicdYjXoDnSgZ4+2dxgFuW1C9gsWkZhZ+nU7ko7Cijz0ZSd9FNUlJBA4ozFOoacdqe9fGn9K77Ig==",
+      "version": "7.0.18",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/banner/-/banner-7.0.18.tgz",
+      "integrity": "sha512-EdH40+L6hrq3y1pPayIHawtQXUp9rzZtziDHlKeuUg2AgsSwfQ3WF48H2IP1ADF9I3npHpwMPsO3wGktEMG8lA==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/icon-button": "^15.0.17",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/icon": "^11.25.1",
+        "@leafygreen-ui/icon-button": "^15.0.19",
+        "@leafygreen-ui/lib": "^13.1.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4",
-        "@leafygreen-ui/typography": "^16.5.5"
+        "@leafygreen-ui/typography": "^18.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/banner/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/card": {
-      "version": "10.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.4.tgz",
-      "integrity": "sha512-GiwKA+Dr/jNgUvUvn3G8A4s2AsJqYu56NvhoTjOHefowE2Y657pQdD4JWvtv1tW88VdqEt2NbGmaVc9cVs677Q==",
+      "version": "10.0.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.6.tgz",
+      "integrity": "sha512-GpBDEmJoyvJT0lqgM9K3DTIfiFLGzANdzW1SAY+5dBVfRBsKcxgLIi3OQte2uOTOd7V29atP0Zny+tM8V3vo4A==",
       "dependencies": {
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/code": {
-      "version": "14.2.14",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-14.2.14.tgz",
-      "integrity": "sha512-OChQiccLQcYKa8WhhtXiLpKxA7HiniGdCSaYV468+J+gc4O/FPSD0j5RwlMkVaRHYsvPYUfEv23nmQwfgVTK2Q==",
+      "version": "14.2.18",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-14.2.18.tgz",
+      "integrity": "sha512-vtAEzURQ/Or8G9vBjsjN4aCWoysHr/Ny/3ewEcLRpz66vkC0kplArdnmG5dVSmklzImU4jKa+QOeM74l3DTHUQ==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.9",
-        "@leafygreen-ui/button": "^21.0.5",
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/button": "^21.0.11",
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/icon-button": "^15.0.17",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/icon": "^11.25.1",
+        "@leafygreen-ui/icon-button": "^15.0.19",
+        "@leafygreen-ui/lib": "^13.1.0",
         "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/select": "^10.3.14",
+        "@leafygreen-ui/select": "^11.0.1",
         "@leafygreen-ui/tokens": "^2.2.0",
         "@types/facepaint": "^1.2.1",
         "@types/highlight.js": "^10.1.0",
@@ -18947,47 +19609,47 @@
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.8"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-      "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+      "version": "8.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+      "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.17",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.17.tgz",
-      "integrity": "sha512-2gKZKLwGDoyhOmiYvSDRssk1OU/jSraIU4prT40lLgqZFCmA2nqDr7Hfb+W62QNvEGchoXNOXzm8KG/yrJBl2Q==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.8",
+        "@leafygreen-ui/a11y": "^1.4.11",
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/icon": "^11.22.2",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.7"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.8.tgz",
-      "integrity": "sha512-Krz+ImnEtb8FmowYKV/VSZOKGKsLSJoNxVVCsv4ZPpCzKFfa+q34Z35Y3rwF1FqY/WoOFFkBWKhqv9L0pmgxNA==",
+      "version": "3.1.10",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.10.tgz",
+      "integrity": "sha512-ZPrC9rQVCvyRQU76snv7h/DhDrarVlvbokV8r9ylanfnjFZwm02RliRVYiGiJHkz3LYrdmpJ2384z9juRFQDaQ==",
       "dependencies": {
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^11.0.0"
+        "@leafygreen-ui/lib": "^13.0.0"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/lib": {
-      "version": "11.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-      "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
+      "version": "13.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+      "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -19041,90 +19703,124 @@
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.7",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-      "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.17",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.17.tgz",
-      "integrity": "sha512-8ikJSmLTsDBpXou2lNY54ZCOVRwsb6v8L6e6Fxanb/74OElrYU38iNoUdR/inW+pzdRiUQT6qx8oaqZ7EKrS0Q==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+      "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^11.0.0",
-        "@leafygreen-ui/portal": "^5.0.1",
+        "@leafygreen-ui/lib": "^13.1.0",
+        "@leafygreen-ui/portal": "^5.0.3",
         "@leafygreen-ui/tokens": "^2.2.0",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.8"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/popover/node_modules/@leafygreen-ui/portal": {
-      "version": "5.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.1.tgz",
-      "integrity": "sha512-SL+Kw2088aopilmzKOTfzWE4tVKyRyClr1nnOaX+xplQ+6gu22C+LDFL4cJZkkWyP8WlqAE+2s1C631W3uHbPg==",
+      "version": "5.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+      "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
       "dependencies": {
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^11.0.0"
+        "@leafygreen-ui/lib": "^13.0.0"
       },
       "peerDependencies": {
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/select": {
-      "version": "10.3.14",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.14.tgz",
-      "integrity": "sha512-kmWhh4WVPc7vxzaMNntxO1ytpWEB+HzPxl+uPA0zfg3WIZbeIzQZTR6X134L9Jco0kuyT1mndmXtYjPI9lCWSA==",
+      "version": "11.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-11.1.1.tgz",
+      "integrity": "sha512-aH0RNrIF3EU+5ChHJxVVjzlmFGkYRTq9DTRqm9eWgWcZIT3+ggIJCOwBNMr/8rD72NhyXm+RD8Gp2wwk8XJJrg==",
       "dependencies": {
-        "@leafygreen-ui/button": "^21.0.5",
+        "@leafygreen-ui/button": "^21.0.10",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/hooks": "^8.0.1",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/input-option": "^1.0.13",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/popover": "^11.0.17",
+        "@leafygreen-ui/popover": "^11.1.1",
         "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^16.5.5",
+        "@leafygreen-ui/typography": "^18.0.1",
         "@types/react-is": "^18.0.0",
         "lodash": "^4.17.21",
         "polished": "^4.1.3",
         "react-is": "^18.0.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.8"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/select/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/text-input": {
-      "version": "12.1.20",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/text-input/-/text-input-12.1.20.tgz",
-      "integrity": "sha512-ENw5x8zs17rfH08aHAtealhmRQJsEfYAhL17NuqWMrgfHIobQBz+UZ0vwOp2VNs0gyntcpfKMbHLD/P4SQLouw==",
+      "version": "12.1.24",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/text-input/-/text-input-12.1.24.tgz",
+      "integrity": "sha512-IE7Ukw3brzBkPqaSAQNsjaYrj5AHsZO4T1VMPME/06ESWk0YUukPlc3vRH9F72LkPkrOetf8TzmfRglGs3wShQ==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/form-field": "^0.2.0",
         "@leafygreen-ui/hooks": "^8.0.0",
         "@leafygreen-ui/icon": "^11.23.0",
-        "@leafygreen-ui/lib": "^11.0.0",
+        "@leafygreen-ui/lib": "^13.0.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/tokens": "^2.2.0",
-        "@leafygreen-ui/typography": "^16.5.5"
+        "@leafygreen-ui/typography": "^18.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.8"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+      }
+    },
+    "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/text-input/node_modules/@leafygreen-ui/typography": {
+      "version": "18.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+      "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.25.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
     },
     "node_modules/mongodb-chatbot-ui/node_modules/@types/react-is": {
-      "version": "18.2.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.1.tgz",
-      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
+      "version": "18.2.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
+      "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -19289,8 +19985,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -19389,8 +20086,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "license": "MIT"
+      "version": "2.0.14",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -19533,8 +20231,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yargs": {
-      "version": "17.7.1",
-      "license": "MIT",
+      "version": "17.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -19757,15 +20456,16 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "license": "MIT",
+      "version": "0.9.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -19877,13 +20577,11 @@
       }
     },
     "node_modules/package-json/node_modules/@sindresorhus/is": {
-      "version": "5.3.0",
-      "license": "MIT",
+      "version": "5.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "engines": {
         "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/package-json/node_modules/@szmarczak/http-timer": {
@@ -19904,13 +20602,14 @@
       }
     },
     "node_modules/package-json/node_modules/cacheable-request": {
-      "version": "10.2.8",
-      "license": "MIT",
+      "version": "10.2.14",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dependencies": {
-        "@types/http-cache-semantics": "^4.0.1",
+        "@types/http-cache-semantics": "^4.0.2",
         "get-stream": "^6.0.1",
         "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.2",
+        "keyv": "^4.5.3",
         "mimic-response": "^4.0.0",
         "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
@@ -19930,13 +20629,14 @@
       }
     },
     "node_modules/package-json/node_modules/got": {
-      "version": "12.5.3",
-      "license": "MIT",
+      "version": "12.6.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.1",
+        "cacheable-request": "^10.2.8",
         "decompress-response": "^6.0.0",
         "form-data-encoder": "^2.1.2",
         "get-stream": "^6.0.1",
@@ -19947,14 +20647,12 @@
       },
       "engines": {
         "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/package-json/node_modules/http2-wrapper": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -20024,8 +20722,9 @@
       }
     },
     "node_modules/package-json/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -20127,14 +20826,12 @@
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "4.4.0",
+      "version": "4.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -20189,8 +20886,9 @@
       }
     },
     "node_modules/password-prompt/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -20575,8 +21273,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -20952,8 +21651,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
       }
@@ -21115,8 +21815,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "license": "MIT",
+      "version": "2.3.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -21627,13 +22328,15 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.3.0",
-      "license": "MIT",
+      "version": "4.4.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -21654,8 +22357,9 @@
       }
     },
     "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-      "version": "3.6.1",
-      "license": "MIT",
+      "version": "3.6.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -21694,8 +22398,9 @@
       "license": "MIT"
     },
     "node_modules/realm-web/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -21800,14 +22505,11 @@
       }
     },
     "node_modules/redoc/node_modules/style-loader": {
-      "version": "3.3.1",
-      "license": "MIT",
+      "version": "3.3.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/style-loader/-/style-loader-3.3.3.tgz",
+      "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
       "engines": {
         "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
@@ -22027,18 +22729,16 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "license": "MIT",
+      "version": "1.22.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
@@ -22152,9 +22852,10 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
+      "version": "7.8.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -22246,42 +22947,32 @@
       }
     },
     "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
+        "domhandler": "^5.0.3"
       }
     },
     "node_modules/sanitize-html/node_modules/entities": {
-      "version": "4.4.0",
-      "license": "BSD-2-Clause",
+      "version": "4.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
+      "version": "8.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/sax": {
@@ -22307,8 +22998,9 @@
       }
     },
     "node_modules/schema-utils": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "3.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -22316,10 +23008,6 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
@@ -22345,8 +23033,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -22484,8 +23173,9 @@
       }
     },
     "node_modules/sharp/node_modules/detect-libc": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
       }
@@ -22505,8 +23195,9 @@
       "license": "MIT"
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22735,8 +23426,9 @@
       "license": "MIT"
     },
     "node_modules/slugify": {
-      "version": "1.6.5",
-      "license": "MIT",
+      "version": "1.6.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -22950,8 +23642,9 @@
       }
     },
     "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "3.6.1",
-      "license": "MIT",
+      "version": "3.6.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -23353,8 +24046,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -23401,8 +24095,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yargs": {
-      "version": "17.7.1",
-      "license": "MIT",
+      "version": "17.7.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -23527,8 +24222,9 @@
       }
     },
     "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.1",
-      "license": "MIT",
+      "version": "3.6.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -24123,8 +24819,9 @@
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -24157,24 +24854,15 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "license": "MIT",
+      "version": "1.0.13",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -24522,10 +25210,6 @@
       "version": "0.5.0",
       "license": "MIT"
     },
-    "node_modules/webpack/node_modules/@types/estree": {
-      "version": "0.0.51",
-      "license": "MIT"
-    },
     "node_modules/webpack/node_modules/webpack-sources": {
       "version": "3.2.3",
       "license": "MIT",
@@ -24653,6 +25337,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24720,9 +25405,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.1",
+      "version": "8.14.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -24760,8 +25446,9 @@
       "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.0",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -24798,8 +25485,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.2.1",
-      "license": "ISC",
+      "version": "2.3.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
       }
@@ -24913,6 +25601,11 @@
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
+    },
     "@adobe/css-tools": {
       "version": "4.2.0",
       "dev": true
@@ -24980,9 +25673,12 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.18.6",
+      "version": "7.23.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       }
     },
     "@babel/compat-data": {
@@ -25031,7 +25727,9 @@
       },
       "dependencies": {
         "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
+          "version": "0.3.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -25192,7 +25890,9 @@
       "version": "7.19.4"
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.19.1"
+      "version": "7.22.20",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.21.0"
@@ -25215,10 +25915,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.18.6",
+      "version": "7.23.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -25993,9 +26695,11 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/jest": {
@@ -26280,7 +26984,9 @@
           }
         },
         "globals": {
-          "version": "13.20.0",
+          "version": "13.23.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+          "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -26782,7 +27488,9 @@
           }
         },
         "ci-info": {
-          "version": "3.8.0",
+          "version": "3.9.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
           "dev": true
         },
         "color-convert": {
@@ -26801,10 +27509,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -26936,11 +27646,13 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.5.0",
+            "jest-util": "^29.7.0",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },
@@ -26964,10 +27676,12 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "requires": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       }
     },
     "@jest/source-map": {
@@ -27072,10 +27786,12 @@
       }
     },
     "@jest/types": {
-      "version": "29.5.0",
+      "version": "29.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -27143,7 +27859,9 @@
       },
       "dependencies": {
         "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
+          "version": "0.3.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -27163,27 +27881,27 @@
       }
     },
     "@leafygreen-ui/a11y": {
-      "version": "1.4.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.10.tgz",
-      "integrity": "sha512-Mp3ttmutq1yDr27DXGQaqsBe4AuGyIBuBH9yQWIluIF/raTF7GLFceqa0Fa9k228FfoBis+ApASHvmS+57Gctw==",
+      "version": "1.4.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.11.tgz",
+      "integrity": "sha512-mzNMR4ci3ExdCY3Ec1kr7xH4nV02uamoohbWxcI9qSd41TFskaDAZSXO9PL9S8JosQXjpRkt0f470XvVE0kEXQ==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/hooks": "^8.0.0",
-        "@leafygreen-ui/lib": "^12.0.0"
+        "@leafygreen-ui/lib": "^13.0.0"
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "8.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-          "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+          "version": "8.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+          "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "12.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-          "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+          "version": "13.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+          "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -27191,9 +27909,9 @@
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27240,13 +27958,13 @@
       "integrity": "sha512-qfjwhrie+mUrS2H+Qp98iQKBPoZtNpFmlGBYgg59sVOzotFvyvqwxlf/JcaNGo+v7nyOhC2XAHui0ywf9cScKw=="
     },
     "@leafygreen-ui/button": {
-      "version": "21.0.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-21.0.6.tgz",
-      "integrity": "sha512-J9QmC29fNQG2GkQdxqR4IXyCBf3Z0A56CDRHQoPkIgrpPkAOLWH6jVbh2pMpcq/mB9LO4P9B4IH1WwdJ1XUn3w==",
+      "version": "21.0.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/button/-/button-21.0.11.tgz",
+      "integrity": "sha512-NJhllsXO7jAJoAou9kPIk/B8ODYUrGxr4l4TceoAwAM3cW0kZ5kys9KA+0TOmG2AxNKLcElLu+wCg3TbssFk+Q==",
       "requires": {
         "@leafygreen-ui/box": "^3.1.8",
         "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^12.0.0",
+        "@leafygreen-ui/lib": "^13.1.0",
         "@leafygreen-ui/palette": "^4.0.7",
         "@leafygreen-ui/ripple": "^1.1.12",
         "@leafygreen-ui/tokens": "^2.1.4",
@@ -27254,9 +27972,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "12.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
-          "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+          "version": "13.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+          "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -27264,14 +27982,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27367,14 +28085,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27415,7 +28133,9 @@
           }
         },
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -27500,36 +28220,76 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.7.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.1.tgz",
-          "integrity": "sha512-P4uGzI0IBUX2g4MRY2FX6TPrMOLuh2/bOrq9TiWQgj/vhDPbAQt+62F7p3b3XL+Axywtqg6dIODNWW+WfJrXSA==",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.10",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.10.tgz",
-          "integrity": "sha512-GbMxbPLEIUVOSmzJkVJrpQAfvrKjTgjkM9TSkL06sJ0f7ghcIO6mOpoonML6BLFqOTFXuyUZ/3C0jQQDvO+Glw==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.2",
-            "@leafygreen-ui/box": "^3.1.3",
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/icon": "^11.13.1",
-            "@leafygreen-ui/lib": "^10.3.3",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/tokens": "^2.0.3"
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/box": "^3.1.8",
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.22.2",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/tokens": "^2.1.4"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
           }
         },
         "@leafygreen-ui/inline-definition": {
-          "version": "6.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/inline-definition/-/inline-definition-6.0.4.tgz",
-          "integrity": "sha512-FUBRpqrMZOh2YZNy0NotIdmryLpMN5suppcTGDM2QIrpgKBxCGJB+GJpekK/ZU5UnONeOqMH+f6o0VwN/Vpwjw==",
+          "version": "6.0.14",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/inline-definition/-/inline-definition-6.0.14.tgz",
+          "integrity": "sha512-vCfSF1Lr8O4sm8f7w9rTflVyJRjF3Tyrtppr9OSfEPTDDlla+tiuSyvrMUty3xfdomc6JEGyumdozvjyU9dFsg==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/lib": "^10.3.2",
-            "@leafygreen-ui/palette": "^4.0.3",
-            "@leafygreen-ui/tooltip": "^9.1.7"
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/tooltip": "^11.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -27543,38 +28303,144 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.8",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.8.tgz",
-          "integrity": "sha512-yqcDh1hiJQSqkh376WPCV/qbm/v0OJd3NMVesTW6CrGAFjD9HJR4bUoRiT5tjTWxvWxI/gh8BhIqFgyQ7mFcJg==",
+          "version": "11.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+          "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/hooks": "^7.7.1",
-            "@leafygreen-ui/lib": "^10.3.3",
-            "@leafygreen-ui/portal": "^4.1.2",
-            "@leafygreen-ui/tokens": "^2.0.3",
-            "react-transition-group": "^4.4.1"
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.1.0",
+            "@leafygreen-ui/portal": "^5.0.3",
+            "@leafygreen-ui/tokens": "^2.2.0",
+            "react-transition-group": "^4.4.5"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
+          }
+        },
+        "@leafygreen-ui/portal": {
+          "version": "5.0.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+          "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+          "requires": {
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
           }
         },
         "@leafygreen-ui/tooltip": {
-          "version": "9.1.8",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tooltip/-/tooltip-9.1.8.tgz",
-          "integrity": "sha512-bqLF0z4L19y253nmRoQSs4U1O7OGSCf46e1N7xBCbenlZVMLN4MSk0EQdpmDmXqMkopLOomVQAy/17guV6YULA==",
+          "version": "11.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tooltip/-/tooltip-11.0.0.tgz",
+          "integrity": "sha512-dqyye58w/1uWCsoFWEVgt2rrkNOTPyk1AQN9Wc828+YObIDyBI+F6ppqDxKZtu6ztw34aEOJw3kfucE98zQk+A==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/hooks": "^7.7.1",
-            "@leafygreen-ui/icon": "^11.13.1",
-            "@leafygreen-ui/lib": "^10.3.3",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/popover": "^11.0.8",
-            "@leafygreen-ui/tokens": "^2.0.3",
-            "@leafygreen-ui/typography": "^16.3.0",
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/hooks": "^8.0.1",
+            "@leafygreen-ui/icon": "^11.25.0",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/popover": "^11.1.1",
+            "@leafygreen-ui/tokens": "^2.2.0",
+            "@leafygreen-ui/typography": "^18.0.1",
             "lodash": "^4.17.21",
             "polished": "^4.2.2"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@leafygreen-ui/typography": {
+              "version": "18.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+              "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^4.0.7",
+                "@leafygreen-ui/icon": "^11.25.0",
+                "@leafygreen-ui/lib": "^13.0.0",
+                "@leafygreen-ui/palette": "^4.0.7",
+                "@leafygreen-ui/polymorphic": "^1.3.6",
+                "@leafygreen-ui/tokens": "^2.1.4"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
           }
         },
         "ansi-styles": {
@@ -27619,6 +28485,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -27631,6 +28502,71 @@
         "@emotion/server": "^11.4.0"
       }
     },
+    "@leafygreen-ui/form-field": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/form-field/-/form-field-0.2.0.tgz",
+      "integrity": "sha512-sGpm+U+m3ErK76YciPapP9oC2GxvICKc1sMRGaAI1vMyYUbIlXEGxtLkL7Xd6HrJcC7aDRcN75MUlC2SJYQsTQ==",
+      "requires": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.0.0",
+        "@leafygreen-ui/icon": "^11.24.0",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.2.0",
+        "@leafygreen-ui/typography": "^18.0.0"
+      },
+      "dependencies": {
+        "@leafygreen-ui/hooks": {
+          "version": "8.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+          "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "13.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+          "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+          "requires": {
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+        },
+        "@leafygreen-ui/typography": {
+          "version": "18.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+          "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.25.0",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/polymorphic": "^1.3.6",
+            "@leafygreen-ui/tokens": "^2.1.4"
+          }
+        },
+        "@storybook/csf": {
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "@leafygreen-ui/hooks": {
       "version": "6.0.1",
       "requires": {
@@ -27638,9 +28574,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "11.23.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.23.0.tgz",
-      "integrity": "sha512-TaK9mlQO2K1Y4urL69FzLXMfW/hoSChlsA0WSj4IEFEyaC/bwVQTJFq9qStcRPTwf18G1rwsEQB1TlKDvlPIFA==",
+      "version": "11.25.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.25.1.tgz",
+      "integrity": "sha512-45m9INMLG2kKa8BTqP/ZGpc832w0CTO3KFK5kqwQdBouYyJogrKEQlI1Toss+JYKoBVHFYXBQc0ST8tIU4zr3w==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "lodash": "^4.17.21"
@@ -27666,23 +28602,23 @@
       }
     },
     "@leafygreen-ui/input-option": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.5.tgz",
-      "integrity": "sha512-gU051Rr5oB6CelLziN1xpbymexEP28DsbhgN+KTXxzpOM5q4l1dNAv12UDuCSEJS/xPP0kzkBkMWT/WPOEE/uQ==",
+      "version": "1.0.13",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.13.tgz",
+      "integrity": "sha512-6J4rji1V2EHpKyqsuZPa2KVW4IHbj26Wp9VoJuFh6hz3LkNpJ5FoRxLvUGlL9wf8b+A2oK+bz5rW0FP+vs+nlw==",
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.1.4",
+        "@leafygreen-ui/typography": "^18.0.0"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "10.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-          "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+          "version": "13.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+          "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -27690,14 +28626,27 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+        },
+        "@leafygreen-ui/typography": {
+          "version": "18.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+          "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.25.0",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/polymorphic": "^1.3.6",
+            "@leafygreen-ui/tokens": "^2.1.4"
+          }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27725,7 +28674,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -27762,14 +28713,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27803,25 +28754,37 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "8.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-          "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+          "version": "8.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+          "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.17",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.17.tgz",
-          "integrity": "sha512-2gKZKLwGDoyhOmiYvSDRssk1OU/jSraIU4prT40lLgqZFCmA2nqDr7Hfb+W62QNvEGchoXNOXzm8KG/yrJBl2Q==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.8",
+            "@leafygreen-ui/a11y": "^1.4.11",
             "@leafygreen-ui/box": "^3.1.8",
             "@leafygreen-ui/emotion": "^4.0.7",
             "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -27835,36 +28798,60 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.17",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.17.tgz",
-          "integrity": "sha512-8ikJSmLTsDBpXou2lNY54ZCOVRwsb6v8L6e6Fxanb/74OElrYU38iNoUdR/inW+pzdRiUQT6qx8oaqZ7EKrS0Q==",
+          "version": "11.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+          "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
             "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/portal": "^5.0.1",
+            "@leafygreen-ui/lib": "^13.1.0",
+            "@leafygreen-ui/portal": "^5.0.3",
             "@leafygreen-ui/tokens": "^2.2.0",
             "react-transition-group": "^4.4.5"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/portal": {
-          "version": "5.0.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.1.tgz",
-          "integrity": "sha512-SL+Kw2088aopilmzKOTfzWE4tVKyRyClr1nnOaX+xplQ+6gu22C+LDFL4cJZkkWyP8WlqAE+2s1C631W3uHbPg==",
+          "version": "5.0.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+          "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
           "requires": {
             "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/lib": "^11.0.0"
+            "@leafygreen-ui/lib": "^13.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -27894,7 +28881,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -27945,17 +28934,29 @@
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.16",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.16.tgz",
-          "integrity": "sha512-j/y60X+At8tm1uKj2LWfppxuH3lCB1Mwa99PFhmVVD9ohNFjjqY6m5Vll7NTq10AelUimWOYk+uCzh4A96x4kQ==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.7",
-            "@leafygreen-ui/box": "^3.1.7",
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/box": "^3.1.8",
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.1",
-            "@leafygreen-ui/lib": "^10.4.3",
+            "@leafygreen-ui/icon": "^11.22.2",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -27969,50 +28970,145 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.15",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.15.tgz",
-          "integrity": "sha512-JeQw3L5leaw0qFDz1uhuR1YPi+PB5zvvvCeHeS3llw92zGej11iJKtTVQeylacl9N4fGjFso11dZ+afZ/D2QhA==",
+          "version": "11.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+          "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/hooks": "^7.7.8",
-            "@leafygreen-ui/lib": "^10.4.3",
-            "@leafygreen-ui/portal": "^4.1.7",
-            "@leafygreen-ui/tokens": "^2.1.4",
-            "react-transition-group": "^4.4.1"
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.1.0",
+            "@leafygreen-ui/portal": "^5.0.3",
+            "@leafygreen-ui/tokens": "^2.2.0",
+            "react-transition-group": "^4.4.5"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
+          }
+        },
+        "@leafygreen-ui/portal": {
+          "version": "5.0.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+          "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+          "requires": {
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/select": {
-          "version": "10.3.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.12.tgz",
-          "integrity": "sha512-r3WchfA1CMgz2Efd7Ccm6v8nFVF6vzAqleaEudTJ09XXtVmV9Df1v1kY/90F+GKij74OjUEOft7RgCkh0SB6/A==",
+          "version": "10.3.18",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.18.tgz",
+          "integrity": "sha512-YJkO15Clg72D5RX0V4Ea6+IozftIbHUREAb7Gs/sYFEAESIuT6u/rmhhqOBZHtWmc/yNVgcFYDPJHXWYVzYV+w==",
           "requires": {
-            "@leafygreen-ui/button": "^21.0.3",
+            "@leafygreen-ui/button": "^21.0.7",
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/hooks": "^7.7.8",
-            "@leafygreen-ui/icon": "^11.22.1",
-            "@leafygreen-ui/lib": "^10.4.3",
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/icon": "^11.23.0",
+            "@leafygreen-ui/lib": "^12.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/popover": "^11.0.15",
-            "@leafygreen-ui/tokens": "^2.1.4",
-            "@leafygreen-ui/typography": "^16.5.4",
-            "@types/react-is": "^17.0.0",
+            "@leafygreen-ui/popover": "^11.0.18",
+            "@leafygreen-ui/tokens": "^2.2.0",
+            "@leafygreen-ui/typography": "^17.0.1",
+            "@types/react-is": "^18.0.0",
             "lodash": "^4.17.21",
             "polished": "^4.1.3",
-            "react-is": "^17.0.1"
+            "react-is": "^18.0.1"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "12.0.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-12.0.0.tgz",
+              "integrity": "sha512-nhaxi4oBesnizxO0YK7XwcmiLL9U5QuN7lkZdWGDdmoJgNNL+aRju4W5vmZc7vcazSHfr3gAL+NFAGaAuopyRA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@leafygreen-ui/typography": {
+              "version": "17.0.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-17.0.2.tgz",
+              "integrity": "sha512-wx+kk5VNMOCTenrIG2AcgAKHt9TiLhSTirZARv0J6l4VOgnO+Mkbh3sqd4mk0EOBCAFmsBR3WqwQh00JXU8Htw==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^4.0.7",
+                "@leafygreen-ui/icon": "^11.22.2",
+                "@leafygreen-ui/lib": "^12.0.0",
+                "@leafygreen-ui/palette": "^4.0.7",
+                "@leafygreen-ui/polymorphic": "^1.3.6",
+                "@leafygreen-ui/tokens": "^2.1.4"
+              }
+            }
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
+        },
+        "@types/react-is": {
+          "version": "18.2.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
+          "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "type-fest": {
           "version": "2.19.0",
@@ -28042,7 +29138,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28077,9 +29175,9 @@
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28121,25 +29219,37 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.7.5",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.5.tgz",
-          "integrity": "sha512-Spk36yndhplGfCdLl14RWuoDPGYfEgA6AwqbaI4T45i+A2QtDTvdSFyMUkNmDK5vzk5cWmR/SmkRS/o5T9zgMA==",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.12.tgz",
-          "integrity": "sha512-19tXprK4/jIZq19o6Y2OnPw5ifuLIhpxAJ4/gs/lIFk/4A5PZJOnZzy6ABdiMaFk/1miSjoDQ5B+lncvgAx1gA==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.2",
-            "@leafygreen-ui/box": "^3.1.4",
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/icon": "^11.17.0",
-            "@leafygreen-ui/lib": "^10.4.0",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/tokens": "^2.1.1"
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/box": "^3.1.8",
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.22.2",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/tokens": "^2.1.4"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -28153,27 +29263,76 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.12.tgz",
-          "integrity": "sha512-zF8axGB+RhpoG0xgb4K/p8ydS5JAEXpwqdLrcrY9r7cAYzxX0F4mhIpYg+oyK2K5TIbgGR/fsFPbhKYsmreuMA==",
+          "version": "11.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+          "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/hooks": "^7.7.5",
-            "@leafygreen-ui/lib": "^10.4.0",
-            "@leafygreen-ui/portal": "^4.1.4",
-            "@leafygreen-ui/tokens": "^2.1.1",
-            "react-transition-group": "^4.4.1"
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.1.0",
+            "@leafygreen-ui/portal": "^5.0.3",
+            "@leafygreen-ui/tokens": "^2.2.0",
+            "react-transition-group": "^4.4.5"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
+          }
+        },
+        "@leafygreen-ui/portal": {
+          "version": "5.0.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+          "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
+          "requires": {
+            "@leafygreen-ui/hooks": "^8.0.0",
+            "@leafygreen-ui/lib": "^13.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/hooks": {
+              "version": "8.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+              "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
+              "requires": {
+                "lodash": "^4.17.21"
+              }
+            },
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28203,27 +29362,40 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.7.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.1.tgz",
-          "integrity": "sha512-P4uGzI0IBUX2g4MRY2FX6TPrMOLuh2/bOrq9TiWQgj/vhDPbAQt+62F7p3b3XL+Axywtqg6dIODNWW+WfJrXSA==",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "10.3.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.3.3.tgz",
-          "integrity": "sha512-n+L4u9TnwXgZlzGniEJ4QdKzeXlFU54AgTjb6a2k4nHLBL6eQgRwrHCL4Dviv6ARFHH0tfLWMqBguMOY33Cw2w==",
+          "version": "10.4.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.3.tgz",
+          "integrity": "sha512-p5BtXHeQsvLnnrN0eunPFZeaMtW9z7Mbvm2WOS9lvnAySj8xZp5Vn9Y3XjyYLbPhpGVBhhOAJFP3YMxbP9DKgg==",
           "requires": {
-            "@storybook/csf": "^0.0.2-next.10",
+            "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
             "prop-types": "^15.7.2"
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+        },
+        "@storybook/csf": {
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28259,7 +29431,9 @@
           }
         },
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28305,7 +29479,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28347,16 +29523,28 @@
       },
       "dependencies": {
         "@leafygreen-ui/card": {
-          "version": "10.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.4.tgz",
-          "integrity": "sha512-GiwKA+Dr/jNgUvUvn3G8A4s2AsJqYu56NvhoTjOHefowE2Y657pQdD4JWvtv1tW88VdqEt2NbGmaVc9cVs677Q==",
+          "version": "10.0.6",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.6.tgz",
+          "integrity": "sha512-GpBDEmJoyvJT0lqgM9K3DTIfiFLGzANdzW1SAY+5dBVfRBsKcxgLIi3OQte2uOTOd7V29atP0Zny+tM8V3vo4A==",
           "requires": {
             "@leafygreen-ui/box": "^3.1.8",
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4",
             "polished": "^4.2.2"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -28370,14 +29558,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28404,7 +29592,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28453,7 +29643,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28480,7 +29672,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28521,7 +29715,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28569,25 +29765,45 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.7.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.3.tgz",
-          "integrity": "sha512-giAHwLE9ZelQemNHZCZRf5ccBG95Fvehs0Pf6EHLP1Xhpofkqbws4HIKD8OylnHxP6otP1Ciq/rHc2XJ8I0dYQ==",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.10",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.10.tgz",
-          "integrity": "sha512-GbMxbPLEIUVOSmzJkVJrpQAfvrKjTgjkM9TSkL06sJ0f7ghcIO6mOpoonML6BLFqOTFXuyUZ/3C0jQQDvO+Glw==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.2",
-            "@leafygreen-ui/box": "^3.1.3",
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/icon": "^11.13.1",
-            "@leafygreen-ui/lib": "^10.3.3",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/tokens": "^2.0.3"
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/box": "^3.1.8",
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.22.2",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/tokens": "^2.1.4"
+          },
+          "dependencies": {
+            "@leafygreen-ui/lib": {
+              "version": "13.1.0",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+              "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
+              "requires": {
+                "@storybook/csf": "^0.1.0",
+                "lodash": "^4.17.21",
+                "prop-types": "^15.7.2"
+              }
+            },
+            "@storybook/csf": {
+              "version": "0.1.2",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+              "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+              "requires": {
+                "type-fest": "^2.19.0"
+              }
+            }
           }
         },
         "@leafygreen-ui/lib": {
@@ -28601,9 +29817,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -28631,14 +29852,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28659,9 +29880,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         }
       }
     },
@@ -28680,7 +29901,9 @@
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "7.7.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.8.tgz",
+          "integrity": "sha512-8n0GjAxIxXN1e7XcZ2bobdI56XCqbtH3AZTbWTgQdILnTdxuA/9+yif1zIP4L8shoUbcosuMwU5HRu4UnX9n1g==",
           "requires": {
             "lodash": "^4.17.21"
           }
@@ -28732,14 +29955,14 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28760,8 +29983,38 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
+      "optional": true
+    },
     "@lmdb/lmdb-darwin-x64": {
       "version": "2.5.3",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "optional": true
     },
     "@loadable/component": {
@@ -28817,8 +30070,38 @@
         "json5": "^2.2.1"
       }
     },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
+      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "optional": true
+    },
     "@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.0",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
+      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
+      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
+      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
+      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
       "optional": true
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -28864,8 +30147,38 @@
         "lmdb": "2.5.2"
       },
       "dependencies": {
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+          "optional": true
+        },
         "@lmdb/lmdb-darwin-x64": {
           "version": "2.5.2",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
           "optional": true
         },
         "lmdb": {
@@ -28967,7 +30280,9 @@
           "version": "7.0.0"
         },
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -29074,7 +30389,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -29102,7 +30419,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -29119,7 +30438,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.20.0",
+          "version": "13.23.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+          "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -29183,7 +30504,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -29470,9 +30793,6 @@
         "yaml-ast-parser": "0.0.43"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.18.36"
-        },
         "argparse": {
           "version": "2.0.1"
         },
@@ -29498,7 +30818,9 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -29531,7 +30853,9 @@
       "version": "2.0.0"
     },
     "@sinclair/typebox": {
-      "version": "0.25.24",
+      "version": "0.27.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -29657,15 +30981,12 @@
           "version": "0.8.8",
           "requires": {
             "@emotion/memoize": "0.7.4"
-          },
-          "dependencies": {
-            "@emotion/memoize": {
-              "version": "0.7.4"
-            }
           }
         },
         "@emotion/memoize": {
-          "version": "0.7.5"
+          "version": "0.7.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
         }
       }
     },
@@ -29973,7 +31294,9 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.0"
+      "version": "0.0.51",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/facepaint": {
       "version": "1.2.2",
@@ -30014,7 +31337,9 @@
       }
     },
     "@types/http-cache-semantics": {
-      "version": "4.0.1"
+      "version": "4.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "@types/http-proxy": {
       "version": "1.17.10",
@@ -30053,10 +31378,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.4.3",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -30117,7 +31444,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.14.1"
+      "version": "14.18.63",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -30268,7 +31597,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -30327,7 +31658,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -30485,7 +31818,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.2"
+      "version": "8.11.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -30714,14 +32049,18 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "dev": true,
           "requires": {
             "whatwg-url": "^5.0.0"
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -31101,7 +32440,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.1",
+          "version": "3.6.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -31210,12 +32551,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.5",
+      "version": "4.22.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "requires": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "bser": {
@@ -31286,7 +32629,9 @@
       "version": "5.0.4"
     },
     "cacheable-request": {
-      "version": "7.0.2",
+      "version": "7.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -31333,7 +32678,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001457"
+      "version": "1.0.30001566",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -31515,7 +32862,9 @@
           "version": "2.0.1"
         },
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -31652,7 +33001,9 @@
       "version": "2.9.3"
     },
     "colorette": {
-      "version": "2.0.19",
+      "version": "2.0.20",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "combined-stream": {
@@ -31808,9 +33159,11 @@
       "version": "3.28.0"
     },
     "core-js-compat": {
-      "version": "3.28.0",
+      "version": "3.34.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/core-js-compat/-/core-js-compat-3.34.0.tgz",
+      "integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
       "requires": {
-        "browserslist": "^4.21.5"
+        "browserslist": "^4.22.2"
       }
     },
     "core-js-pure": {
@@ -31921,7 +33274,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -32413,7 +33768,9 @@
       "version": "1.1.1"
     },
     "electron-to-chromium": {
-      "version": "1.4.311"
+      "version": "1.4.607",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.4.607.tgz",
+      "integrity": "sha512-YUlnPwE6eYxzwBnFmawA8LiLRfm70R2aJRIUv0n03uHt/cUzzYACOogmvk8M2+hVzt/kB80KJXx7d5f5JofPvQ=="
     },
     "emittery": {
       "version": "0.13.1",
@@ -32469,9 +33826,6 @@
       "dependencies": {
         "ws": {
           "version": "8.2.3"
-        },
-        "xmlhttprequest-ssl": {
-          "version": "2.0.0"
         }
       }
     },
@@ -32818,7 +34172,9 @@
           "version": "2.1.0"
         },
         "globals": {
-          "version": "13.20.0",
+          "version": "13.23.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/globals/-/globals-13.23.0.tgz",
+          "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -32839,7 +34195,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -32978,9 +34336,11 @@
           "version": "5.3.0"
         },
         "resolve": {
-          "version": "2.0.0-next.4",
+          "version": "2.0.0-next.5",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/resolve/-/resolve-2.0.0-next.5.tgz",
+          "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
           "requires": {
-            "is-core-module": "^2.9.0",
+            "is-core-module": "^2.13.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -33543,7 +34903,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -33600,7 +34962,9 @@
       "version": "1.0.0"
     },
     "fs-extra": {
-      "version": "11.1.0",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -33618,7 +34982,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -33837,13 +35203,17 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -33950,13 +35320,17 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -34173,7 +35547,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -34436,6 +35812,14 @@
         }
       }
     },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
     "hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -34614,7 +35998,9 @@
       "version": "1.2.1"
     },
     "ignore": {
-      "version": "5.2.4"
+      "version": "5.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
     },
     "image-size": {
       "version": "1.0.2",
@@ -34823,9 +36209,11 @@
       }
     },
     "is-core-module": {
-      "version": "2.11.0",
+      "version": "2.13.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "is-date-object": {
@@ -35178,10 +36566,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35274,7 +36664,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.7.1",
+          "version": "17.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -35336,7 +36728,9 @@
           }
         },
         "ci-info": {
-          "version": "3.8.0",
+          "version": "3.9.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
           "dev": true
         },
         "color-convert": {
@@ -35355,10 +36749,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35423,10 +36819,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35499,10 +36897,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35579,11 +36979,13 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.5.0",
+            "jest-util": "^29.7.0",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           }
@@ -35610,10 +37012,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -35665,10 +37069,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35738,10 +37144,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -35906,11 +37314,13 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.5.0",
+            "jest-util": "^29.7.0",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },
@@ -36079,10 +37489,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -36098,7 +37510,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -36118,10 +37532,12 @@
       }
     },
     "jest-util": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -36145,7 +37561,9 @@
           }
         },
         "ci-info": {
-          "version": "3.8.0",
+          "version": "3.9.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ci-info/-/ci-info-3.9.0.tgz",
+          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
           "dev": true
         },
         "color-convert": {
@@ -36219,10 +37637,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -36432,7 +37852,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.2",
+      "version": "4.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -36979,9 +38401,9 @@
       },
       "dependencies": {
         "@types/debug": {
-          "version": "4.1.8",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/debug/-/debug-4.1.8.tgz",
-          "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+          "version": "4.1.12",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/debug/-/debug-4.1.12.tgz",
+          "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
           "requires": {
             "@types/ms": "*"
           }
@@ -37287,57 +38709,72 @@
       },
       "dependencies": {
         "@leafygreen-ui/badge": {
-          "version": "8.0.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-8.0.12.tgz",
-          "integrity": "sha512-qhpsnhZa8q1j7thmeek43XLjrXW5kghFiYRLd4STK810jahr3l5OBsHQpIG5n4Rg4xYB7ZK0/MsDmA+guO+QmQ==",
+          "version": "8.0.15",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/badge/-/badge-8.0.15.tgz",
+          "integrity": "sha512-oraJpLtZ4nXJNmKp71/wzYsk+djf8fXNNgDKo1srpN0lZXlEYfHG1qAaHpYGA60QIP4iQuRU4OkShGfruPACww==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4"
           }
         },
         "@leafygreen-ui/banner": {
-          "version": "7.0.13",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/banner/-/banner-7.0.13.tgz",
-          "integrity": "sha512-krAqzH/3yIRicdYjXoDnSgZ4+2dxgFuW1C9gsWkZhZ+nU7ko7Cijz0ZSd9FNUlJBA4ozFOoacdqe9fGn9K77Ig==",
+          "version": "7.0.18",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/banner/-/banner-7.0.18.tgz",
+          "integrity": "sha512-EdH40+L6hrq3y1pPayIHawtQXUp9rzZtziDHlKeuUg2AgsSwfQ3WF48H2IP1ADF9I3npHpwMPsO3wGktEMG8lA==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/icon-button": "^15.0.17",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/icon": "^11.25.1",
+            "@leafygreen-ui/icon-button": "^15.0.19",
+            "@leafygreen-ui/lib": "^13.1.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4",
-            "@leafygreen-ui/typography": "^16.5.5"
+            "@leafygreen-ui/typography": "^18.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/typography": {
+              "version": "18.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+              "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^4.0.7",
+                "@leafygreen-ui/icon": "^11.25.0",
+                "@leafygreen-ui/lib": "^13.0.0",
+                "@leafygreen-ui/palette": "^4.0.7",
+                "@leafygreen-ui/polymorphic": "^1.3.6",
+                "@leafygreen-ui/tokens": "^2.1.4"
+              }
+            }
           }
         },
         "@leafygreen-ui/card": {
-          "version": "10.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.4.tgz",
-          "integrity": "sha512-GiwKA+Dr/jNgUvUvn3G8A4s2AsJqYu56NvhoTjOHefowE2Y657pQdD4JWvtv1tW88VdqEt2NbGmaVc9cVs677Q==",
+          "version": "10.0.6",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/card/-/card-10.0.6.tgz",
+          "integrity": "sha512-GpBDEmJoyvJT0lqgM9K3DTIfiFLGzANdzW1SAY+5dBVfRBsKcxgLIi3OQte2uOTOd7V29atP0Zny+tM8V3vo4A==",
           "requires": {
             "@leafygreen-ui/box": "^3.1.8",
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4",
             "polished": "^4.2.2"
           }
         },
         "@leafygreen-ui/code": {
-          "version": "14.2.14",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-14.2.14.tgz",
-          "integrity": "sha512-OChQiccLQcYKa8WhhtXiLpKxA7HiniGdCSaYV468+J+gc4O/FPSD0j5RwlMkVaRHYsvPYUfEv23nmQwfgVTK2Q==",
+          "version": "14.2.18",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/code/-/code-14.2.18.tgz",
+          "integrity": "sha512-vtAEzURQ/Or8G9vBjsjN4aCWoysHr/Ny/3ewEcLRpz66vkC0kplArdnmG5dVSmklzImU4jKa+QOeM74l3DTHUQ==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.9",
-            "@leafygreen-ui/button": "^21.0.5",
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/button": "^21.0.11",
             "@leafygreen-ui/emotion": "^4.0.7",
             "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/icon": "^11.23.0",
-            "@leafygreen-ui/icon-button": "^15.0.17",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/icon": "^11.25.1",
+            "@leafygreen-ui/icon-button": "^15.0.19",
+            "@leafygreen-ui/lib": "^13.1.0",
             "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/select": "^10.3.14",
+            "@leafygreen-ui/select": "^11.0.1",
             "@leafygreen-ui/tokens": "^2.2.0",
             "@types/facepaint": "^1.2.1",
             "@types/highlight.js": "^10.1.0",
@@ -37350,40 +38787,40 @@
           }
         },
         "@leafygreen-ui/hooks": {
-          "version": "8.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.0.tgz",
-          "integrity": "sha512-SpcjqRlPsRW5DsfqGdjf11N0f3JJw+bl5dOlp43Biz0RuJHJtt0h8b0D5Ig5dCn0jBDNiGNazG2lshX+btd9iA==",
+          "version": "8.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.0.1.tgz",
+          "integrity": "sha512-n++2Qdtv0UsJoSSCtrDU0Qlcq0JvSy+fzvvexDphqbchoC47DtgFqVfftq8UcmkvkkJOkTASrIZesV45rVJAiQ==",
           "requires": {
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.17",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.17.tgz",
-          "integrity": "sha512-2gKZKLwGDoyhOmiYvSDRssk1OU/jSraIU4prT40lLgqZFCmA2nqDr7Hfb+W62QNvEGchoXNOXzm8KG/yrJBl2Q==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.8",
+            "@leafygreen-ui/a11y": "^1.4.11",
             "@leafygreen-ui/box": "^3.1.8",
             "@leafygreen-ui/emotion": "^4.0.7",
             "@leafygreen-ui/icon": "^11.22.2",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.1.4"
           }
         },
         "@leafygreen-ui/leafygreen-provider": {
-          "version": "3.1.8",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.8.tgz",
-          "integrity": "sha512-Krz+ImnEtb8FmowYKV/VSZOKGKsLSJoNxVVCsv4ZPpCzKFfa+q34Z35Y3rwF1FqY/WoOFFkBWKhqv9L0pmgxNA==",
+          "version": "3.1.10",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.10.tgz",
+          "integrity": "sha512-ZPrC9rQVCvyRQU76snv7h/DhDrarVlvbokV8r9ylanfnjFZwm02RliRVYiGiJHkz3LYrdmpJ2384z9juRFQDaQ==",
           "requires": {
             "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/lib": "^11.0.0"
+            "@leafygreen-ui/lib": "^13.0.0"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "11.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-11.0.0.tgz",
-          "integrity": "sha512-sHkY/MOwRQDc9qAR1awreW0dP+6ELueJJd4JCJmi6XYbdL0wDotFwsWfCwkL+N6cFbE1e+xBQtFLB6T1+58+iQ==",
+          "version": "13.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.1.0.tgz",
+          "integrity": "sha512-YDq/IYwhcIWYg8A81Uo2J/a+0VP9Pfbn2heUGfytLY9gYcrpMYL7kClAHwZzg8iS4iOaIexGcaUFu0I3OYFxyA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -37430,80 +38867,112 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.7",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.7.tgz",
-          "integrity": "sha512-rBeAk4Tk3t9pYqXYKqVZfma/MH1SBtt02BxAL6TpJb8wQ+i5zap6o1Gnb3nF9LAG7sA0+OHfr1B5uSvr63GGqw=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.17",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.17.tgz",
-          "integrity": "sha512-8ikJSmLTsDBpXou2lNY54ZCOVRwsb6v8L6e6Fxanb/74OElrYU38iNoUdR/inW+pzdRiUQT6qx8oaqZ7EKrS0Q==",
+          "version": "11.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.2.0.tgz",
+          "integrity": "sha512-wGN1yQL7p1+eD4Aivu6Gg7UexdlUceSVAVMPBj3mWXUexcQjT5bRk+S7eR/x7R079Sn1Es2voEQSiO+hur39Gw==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
             "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/lib": "^11.0.0",
-            "@leafygreen-ui/portal": "^5.0.1",
+            "@leafygreen-ui/lib": "^13.1.0",
+            "@leafygreen-ui/portal": "^5.0.3",
             "@leafygreen-ui/tokens": "^2.2.0",
             "react-transition-group": "^4.4.5"
           },
           "dependencies": {
             "@leafygreen-ui/portal": {
-              "version": "5.0.1",
-              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.1.tgz",
-              "integrity": "sha512-SL+Kw2088aopilmzKOTfzWE4tVKyRyClr1nnOaX+xplQ+6gu22C+LDFL4cJZkkWyP8WlqAE+2s1C631W3uHbPg==",
+              "version": "5.0.3",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.0.3.tgz",
+              "integrity": "sha512-vwoZHtdrMzR5uBsfxAvl1kdB/xtQwtfpRTuCqC5Q3X+DsLg9JReDl+5dsGMegwDwkqwzsndYVGpq0BcFuDITXQ==",
               "requires": {
                 "@leafygreen-ui/hooks": "^8.0.0",
-                "@leafygreen-ui/lib": "^11.0.0"
+                "@leafygreen-ui/lib": "^13.0.0"
               }
             }
           }
         },
         "@leafygreen-ui/select": {
-          "version": "10.3.14",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-10.3.14.tgz",
-          "integrity": "sha512-kmWhh4WVPc7vxzaMNntxO1ytpWEB+HzPxl+uPA0zfg3WIZbeIzQZTR6X134L9Jco0kuyT1mndmXtYjPI9lCWSA==",
+          "version": "11.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/select/-/select-11.1.1.tgz",
+          "integrity": "sha512-aH0RNrIF3EU+5ChHJxVVjzlmFGkYRTq9DTRqm9eWgWcZIT3+ggIJCOwBNMr/8rD72NhyXm+RD8Gp2wwk8XJJrg==",
           "requires": {
-            "@leafygreen-ui/button": "^21.0.5",
+            "@leafygreen-ui/button": "^21.0.10",
             "@leafygreen-ui/emotion": "^4.0.7",
-            "@leafygreen-ui/hooks": "^8.0.0",
-            "@leafygreen-ui/icon": "^11.23.0",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/hooks": "^8.0.1",
+            "@leafygreen-ui/icon": "^11.25.0",
+            "@leafygreen-ui/input-option": "^1.0.13",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
-            "@leafygreen-ui/popover": "^11.0.17",
+            "@leafygreen-ui/popover": "^11.1.1",
             "@leafygreen-ui/tokens": "^2.2.0",
-            "@leafygreen-ui/typography": "^16.5.5",
+            "@leafygreen-ui/typography": "^18.0.1",
             "@types/react-is": "^18.0.0",
             "lodash": "^4.17.21",
             "polished": "^4.1.3",
             "react-is": "^18.0.1"
+          },
+          "dependencies": {
+            "@leafygreen-ui/typography": {
+              "version": "18.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+              "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^4.0.7",
+                "@leafygreen-ui/icon": "^11.25.0",
+                "@leafygreen-ui/lib": "^13.0.0",
+                "@leafygreen-ui/palette": "^4.0.7",
+                "@leafygreen-ui/polymorphic": "^1.3.6",
+                "@leafygreen-ui/tokens": "^2.1.4"
+              }
+            }
           }
         },
         "@leafygreen-ui/text-input": {
-          "version": "12.1.20",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/text-input/-/text-input-12.1.20.tgz",
-          "integrity": "sha512-ENw5x8zs17rfH08aHAtealhmRQJsEfYAhL17NuqWMrgfHIobQBz+UZ0vwOp2VNs0gyntcpfKMbHLD/P4SQLouw==",
+          "version": "12.1.24",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/text-input/-/text-input-12.1.24.tgz",
+          "integrity": "sha512-IE7Ukw3brzBkPqaSAQNsjaYrj5AHsZO4T1VMPME/06ESWk0YUukPlc3vRH9F72LkPkrOetf8TzmfRglGs3wShQ==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/form-field": "^0.2.0",
             "@leafygreen-ui/hooks": "^8.0.0",
             "@leafygreen-ui/icon": "^11.23.0",
-            "@leafygreen-ui/lib": "^11.0.0",
+            "@leafygreen-ui/lib": "^13.0.0",
             "@leafygreen-ui/palette": "^4.0.7",
             "@leafygreen-ui/tokens": "^2.2.0",
-            "@leafygreen-ui/typography": "^16.5.5"
+            "@leafygreen-ui/typography": "^18.0.0"
+          },
+          "dependencies": {
+            "@leafygreen-ui/typography": {
+              "version": "18.0.1",
+              "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.0.1.tgz",
+              "integrity": "sha512-XPTya1YVmpiGInxrD//aF0uCvhpnGPKDTkkZKD0Mk+bPP3qXaXtP8YwdrGnMLEJsuRG3ipmOrA5/YXcNQDeQkQ==",
+              "requires": {
+                "@leafygreen-ui/emotion": "^4.0.7",
+                "@leafygreen-ui/icon": "^11.25.0",
+                "@leafygreen-ui/lib": "^13.0.0",
+                "@leafygreen-ui/palette": "^4.0.7",
+                "@leafygreen-ui/polymorphic": "^1.3.6",
+                "@leafygreen-ui/tokens": "^2.1.4"
+              }
+            }
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.2.tgz",
+          "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
         },
         "@types/react-is": {
-          "version": "18.2.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.1.tgz",
-          "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
+          "version": "18.2.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-is/-/react-is-18.2.4.tgz",
+          "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
           "requires": {
             "@types/react": "*"
           }
@@ -37619,7 +39088,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -37684,7 +39155,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.10"
+      "version": "2.0.14",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "normalize-path": {
       "version": "3.0.0"
@@ -37765,7 +39238,9 @@
           "version": "1.10.2"
         },
         "yargs": {
-          "version": "17.7.1",
+          "version": "17.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -37897,14 +39372,16 @@
       "version": "0.14.7"
     },
     "optionator": {
-      "version": "0.9.1",
+      "version": "0.9.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       }
     },
     "ordered-binary": {
@@ -37962,7 +39439,9 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "5.3.0"
+          "version": "5.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@sindresorhus/is/-/is-5.6.0.tgz",
+          "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g=="
         },
         "@szmarczak/http-timer": {
           "version": "5.0.1",
@@ -37974,12 +39453,14 @@
           "version": "7.0.0"
         },
         "cacheable-request": {
-          "version": "10.2.8",
+          "version": "10.2.14",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/cacheable-request/-/cacheable-request-10.2.14.tgz",
+          "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
           "requires": {
-            "@types/http-cache-semantics": "^4.0.1",
+            "@types/http-cache-semantics": "^4.0.2",
             "get-stream": "^6.0.1",
             "http-cache-semantics": "^4.1.1",
-            "keyv": "^4.5.2",
+            "keyv": "^4.5.3",
             "mimic-response": "^4.0.0",
             "normalize-url": "^8.0.0",
             "responselike": "^3.0.0"
@@ -37989,12 +39470,14 @@
           "version": "6.0.1"
         },
         "got": {
-          "version": "12.5.3",
+          "version": "12.6.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/got/-/got-12.6.1.tgz",
+          "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
           "requires": {
             "@sindresorhus/is": "^5.2.0",
             "@szmarczak/http-timer": "^5.0.1",
             "cacheable-lookup": "^7.0.0",
-            "cacheable-request": "^10.2.1",
+            "cacheable-request": "^10.2.8",
             "decompress-response": "^6.0.0",
             "form-data-encoder": "^2.1.2",
             "get-stream": "^6.0.1",
@@ -38005,7 +39488,9 @@
           }
         },
         "http2-wrapper": {
-          "version": "2.2.0",
+          "version": "2.2.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+          "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
           "requires": {
             "quick-lru": "^5.1.1",
             "resolve-alpn": "^1.2.0"
@@ -38036,7 +39521,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -38103,7 +39590,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "4.4.0",
+          "version": "4.5.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
           "dev": true
         }
       }
@@ -38142,7 +39631,9 @@
           "version": "2.0.1"
         },
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -38344,7 +39835,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -38535,7 +40028,9 @@
       },
       "dependencies": {
         "detect-libc": {
-          "version": "2.0.1"
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
         }
       }
     },
@@ -38648,7 +40143,9 @@
       }
     },
     "punycode": {
-      "version": "2.3.0"
+      "version": "2.3.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "pure-rand": {
       "version": "6.0.1",
@@ -38954,12 +40451,15 @@
       }
     },
     "readable-stream": {
-      "version": "4.3.0",
+      "version": "4.4.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       }
     },
     "readable-web-to-node-stream": {
@@ -38969,7 +40469,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.1",
+          "version": "3.6.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -38999,7 +40501,9 @@
           "version": "5.3.0"
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "optional": true,
           "requires": {
             "whatwg-url": "^5.0.0"
@@ -39068,7 +40572,9 @@
           "version": "1.4.7"
         },
         "style-loader": {
-          "version": "3.3.1"
+          "version": "3.3.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/style-loader/-/style-loader-3.3.3.tgz",
+          "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw=="
         }
       }
     },
@@ -39216,9 +40722,11 @@
       "version": "1.0.0"
     },
     "resolve": {
-      "version": "1.22.1",
+      "version": "1.22.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -39277,7 +40785,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.0",
+      "version": "7.8.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -39334,23 +40844,29 @@
           }
         },
         "domutils": {
-          "version": "3.0.1",
+          "version": "3.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
+            "domhandler": "^5.0.3"
           }
         },
         "entities": {
-          "version": "4.4.0"
+          "version": "4.5.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "htmlparser2": {
-          "version": "8.0.1",
+          "version": "8.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
           "requires": {
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
+            "domhandler": "^5.0.3",
             "domutils": "^3.0.1",
-            "entities": "^4.3.0"
+            "entities": "^4.4.0"
           }
         }
       }
@@ -39372,7 +40888,9 @@
       }
     },
     "schema-utils": {
-      "version": "3.1.1",
+      "version": "3.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "requires": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -39397,7 +40915,9 @@
       "version": "1.1.2"
     },
     "semver": {
-      "version": "6.3.0"
+      "version": "6.3.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -39498,7 +41018,9 @@
       },
       "dependencies": {
         "detect-libc": {
-          "version": "2.0.1"
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -39510,7 +41032,9 @@
           "version": "5.1.0"
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -39654,7 +41178,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.5"
+      "version": "1.6.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw=="
     },
     "snake-case": {
       "version": "3.0.4",
@@ -39796,7 +41322,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.1",
+          "version": "3.6.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -40058,7 +41586,9 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.9",
+          "version": "2.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -40083,7 +41613,9 @@
           "version": "1.10.2"
         },
         "yargs": {
-          "version": "17.7.1",
+          "version": "17.7.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -40170,7 +41702,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.1",
+          "version": "3.6.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -40571,7 +42105,9 @@
       }
     },
     "universalify": {
-      "version": "2.0.0"
+      "version": "2.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "unixify": {
       "version": "1.0.0",
@@ -40591,7 +42127,9 @@
       "version": "1.0.0"
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.0.13",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -40788,9 +42326,6 @@
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
-        "@types/estree": {
-          "version": "0.0.51"
-        },
         "webpack-sources": {
           "version": "3.2.3"
         }
@@ -40914,7 +42449,8 @@
       "version": "2.0.0"
     },
     "word-wrap": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -40958,7 +42494,9 @@
       }
     },
     "ws": {
-      "version": "8.12.1",
+      "version": "8.14.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "dev": true
     },
     "xdg-basedir": {
@@ -40973,8 +42511,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     },
     "xmlserializer": {
       "version": "0.6.1"
@@ -40995,7 +42534,9 @@
       "version": "3.1.1"
     },
     "yaml": {
-      "version": "2.2.1"
+      "version": "2.3.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA=="
     },
     "yaml-ast-parser": {
       "version": "0.0.43"

--- a/tests/unit/__snapshots__/Button.test.js.snap
+++ b/tests/unit/__snapshots__/Button.test.js.snap
@@ -122,7 +122,7 @@ exports[`button component renders correctly 1`] = `
   outline: none;
 }
 
-.emotion-1:active,
+.emotion-1:active[aria-disabled='false'],
 .emotion-1:focus,
 .emotion-1:hover {
   -webkit-text-decoration: none;
@@ -134,7 +134,7 @@ exports[`button component renders correctly 1`] = `
 }
 
 .emotion-1:hover[aria-disabled='false'],
-.emotion-1:active {
+.emotion-1:active[aria-disabled='false'] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
@@ -174,8 +174,11 @@ exports[`button component renders correctly 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -307,7 +307,7 @@ exports[`CodeIO renders correctly 1`] = `
   outline: none;
 }
 
-.emotion-16:active,
+.emotion-16:active[aria-disabled='false'],
 .emotion-16:focus,
 .emotion-16:hover {
   -webkit-text-decoration: none;
@@ -319,7 +319,7 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 .emotion-16:hover[aria-disabled='false'],
-.emotion-16:active {
+.emotion-16:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -353,8 +353,11 @@ exports[`CodeIO renders correctly 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -120,7 +120,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   outline: none;
 }
 
-.emotion-8:active,
+.emotion-8:active[aria-disabled='false'],
 .emotion-8:focus,
 .emotion-8:hover {
   -webkit-text-decoration: none;
@@ -132,7 +132,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-8:hover[aria-disabled='false'],
-.emotion-8:active {
+.emotion-8:active[aria-disabled='false'] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
@@ -190,8 +190,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -609,7 +612,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   outline: none;
 }
 
-.emotion-9:active,
+.emotion-9:active[aria-disabled='false'],
 .emotion-9:focus,
 .emotion-9:hover {
   -webkit-text-decoration: none;
@@ -621,7 +624,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
 }
 
 .emotion-9:hover[aria-disabled='false'],
-.emotion-9:active {
+.emotion-9:active[aria-disabled='false'] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
@@ -657,8 +660,11 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -1024,7 +1030,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   outline: none;
 }
 
-.emotion-9:active,
+.emotion-9:active[aria-disabled='false'],
 .emotion-9:focus,
 .emotion-9:hover {
   -webkit-text-decoration: none;
@@ -1036,7 +1042,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
 }
 
 .emotion-9:hover[aria-disabled='false'],
-.emotion-9:active {
+.emotion-9:active[aria-disabled='false'] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
@@ -1072,8 +1078,11 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;

--- a/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
+++ b/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
@@ -137,7 +137,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   outline: none;
 }
 
-.emotion-8:active,
+.emotion-8:active[aria-disabled='false'],
 .emotion-8:focus,
 .emotion-8:hover {
   -webkit-text-decoration: none;
@@ -149,7 +149,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
 }
 
 .emotion-8:hover[aria-disabled='false'],
-.emotion-8:active {
+.emotion-8:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -187,8 +187,11 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -967,15 +970,15 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
             <label
               class="emotion-37"
               for="combobox-input-1"
-              id="combobox-label-1"
+              id="combobox-label-2"
             >
               Select Resource
             </label>
           </div>
           <div
-            aria-controls="combobox-menu-1"
+            aria-controls="combobox-menu-3"
             aria-expanded="false"
-            aria-owns="combobox-menu-1"
+            aria-owns="combobox-menu-3"
             class="emotion-38"
             role="combobox"
             tabindex="-1"
@@ -985,9 +988,9 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
             >
               <input
                 aria-autocomplete="list"
-                aria-controls="combobox-menu-1"
+                aria-controls="combobox-menu-3"
                 aria-label="Select Resource"
-                aria-labelledby="combobox-label-1"
+                aria-labelledby="combobox-label-2"
                 autocomplete="off"
                 class="emotion-40"
                 id="combobox-input-1"

--- a/tests/unit/__snapshots__/QuizWidget.test.js.snap
+++ b/tests/unit/__snapshots__/QuizWidget.test.js.snap
@@ -150,7 +150,7 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   outline: none;
 }
 
-.emotion-21:active,
+.emotion-21:active[aria-disabled='false'],
 .emotion-21:focus,
 .emotion-21:hover {
   -webkit-text-decoration: none;
@@ -162,7 +162,7 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
 }
 
 .emotion-21:hover[aria-disabled='false'],
-.emotion-21:active {
+.emotion-21:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -200,8 +200,11 @@ exports[`quiz widget snapshots renders quiz widget correctly 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -866,7 +866,7 @@ exports[`Search Results Page considers a given search filter query param and dis
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -1071,7 +1071,7 @@ exports[`Search Results Page considers a given search filter query param and dis
   outline: none;
 }
 
-.emotion-21:active,
+.emotion-21:active[aria-disabled='false'],
 .emotion-21:focus,
 .emotion-21:hover {
   -webkit-text-decoration: none;
@@ -1083,7 +1083,7 @@ exports[`Search Results Page considers a given search filter query param and dis
 }
 
 .emotion-21:hover[aria-disabled='false'],
-.emotion-21:active {
+.emotion-21:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -1117,8 +1117,11 @@ exports[`Search Results Page considers a given search filter query param and dis
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -1334,7 +1337,7 @@ exports[`Search Results Page considers a given search filter query param and dis
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   cursor: not-allowed;
   color: #C1C7C6;
   background-color: rgba(255, 255, 255, 0);
@@ -2112,8 +2115,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-66"
             >
               <button
-                aria-controls="select-81-menu"
-                aria-describedby="select-81-description"
+                aria-controls="select-17-menu"
+                aria-describedby="select-17-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -2121,7 +2124,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 class="emotion-67"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-82"
+                id="select-18"
                 type="button"
                 value="Realm"
               >
@@ -2169,8 +2172,8 @@ exports[`Search Results Page considers a given search filter query param and dis
               class="emotion-66"
             >
               <button
-                aria-controls="select-83-menu"
-                aria-describedby="select-83-description"
+                aria-controls="select-19-menu"
+                aria-describedby="select-19-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -2179,7 +2182,7 @@ exports[`Search Results Page considers a given search filter query param and dis
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-84"
+                id="select-20"
                 type="button"
                 value="Latest"
               >
@@ -2493,7 +2496,7 @@ exports[`Search Results Page does not return results for a given search term wit
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -2649,7 +2652,7 @@ exports[`Search Results Page does not return results for a given search term wit
   outline: none;
 }
 
-.emotion-16:active,
+.emotion-16:active[aria-disabled='false'],
 .emotion-16:focus,
 .emotion-16:hover {
   -webkit-text-decoration: none;
@@ -2661,7 +2664,7 @@ exports[`Search Results Page does not return results for a given search term wit
 }
 
 .emotion-16:hover[aria-disabled='false'],
-.emotion-16:active {
+.emotion-16:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -2695,8 +2698,11 @@ exports[`Search Results Page does not return results for a given search term wit
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -3576,8 +3582,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-40"
             >
               <button
-                aria-controls="select-109-menu"
-                aria-describedby="select-109-description"
+                aria-controls="select-21-menu"
+                aria-describedby="select-21-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -3585,7 +3591,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 class="emotion-41"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-110"
+                id="select-22"
                 type="button"
                 value=""
               >
@@ -3633,8 +3639,8 @@ exports[`Search Results Page does not return results for a given search term wit
               class="emotion-40"
             >
               <button
-                aria-controls="select-111-menu"
-                aria-describedby="select-111-description"
+                aria-controls="select-23-menu"
+                aria-describedby="select-23-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -3643,7 +3649,7 @@ exports[`Search Results Page does not return results for a given search term wit
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-112"
+                id="select-24"
                 type="button"
                 value=""
               >
@@ -3991,7 +3997,7 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   outline: none;
 }
 
-.emotion-11:active,
+.emotion-11:active[aria-disabled='false'],
 .emotion-11:focus,
 .emotion-11:hover {
   -webkit-text-decoration: none;
@@ -4003,7 +4009,7 @@ exports[`Search Results Page renders correctly without browser 1`] = `
 }
 
 .emotion-11:hover[aria-disabled='false'],
-.emotion-11:active {
+.emotion-11:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -4037,8 +4043,11 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -4380,7 +4389,7 @@ exports[`Search Results Page renders loading images before returning no results 
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -4536,7 +4545,7 @@ exports[`Search Results Page renders loading images before returning no results 
   outline: none;
 }
 
-.emotion-16:active,
+.emotion-16:active[aria-disabled='false'],
 .emotion-16:focus,
 .emotion-16:hover {
   -webkit-text-decoration: none;
@@ -4548,7 +4557,7 @@ exports[`Search Results Page renders loading images before returning no results 
 }
 
 .emotion-16:hover[aria-disabled='false'],
-.emotion-16:active {
+.emotion-16:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -4582,8 +4591,11 @@ exports[`Search Results Page renders loading images before returning no results 
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -5673,8 +5685,8 @@ exports[`Search Results Page renders loading images before returning no results 
               class="emotion-53"
             >
               <button
-                aria-controls="select-17-menu"
-                aria-describedby="select-17-description"
+                aria-controls="select-5-menu"
+                aria-describedby="select-5-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -5682,7 +5694,7 @@ exports[`Search Results Page renders loading images before returning no results 
                 class="emotion-54"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-18"
+                id="select-6"
                 type="button"
                 value=""
               >
@@ -5730,8 +5742,8 @@ exports[`Search Results Page renders loading images before returning no results 
               class="emotion-53"
             >
               <button
-                aria-controls="select-19-menu"
-                aria-describedby="select-19-description"
+                aria-controls="select-7-menu"
+                aria-describedby="select-7-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -5740,7 +5752,7 @@ exports[`Search Results Page renders loading images before returning no results 
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-20"
+                id="select-8"
                 type="button"
                 value=""
               >
@@ -6054,7 +6066,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -6210,7 +6222,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
   outline: none;
 }
 
-.emotion-16:active,
+.emotion-16:active[aria-disabled='false'],
 .emotion-16:focus,
 .emotion-16:hover {
   -webkit-text-decoration: none;
@@ -6222,7 +6234,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
 }
 
 .emotion-16:hover[aria-disabled='false'],
-.emotion-16:active {
+.emotion-16:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -6256,8 +6268,11 @@ exports[`Search Results Page renders loading images before returning nonempty re
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -7728,7 +7743,7 @@ exports[`Search Results Page renders results from a given search term query para
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -7884,7 +7899,7 @@ exports[`Search Results Page renders results from a given search term query para
   outline: none;
 }
 
-.emotion-16:active,
+.emotion-16:active[aria-disabled='false'],
 .emotion-16:focus,
 .emotion-16:hover {
   -webkit-text-decoration: none;
@@ -7896,7 +7911,7 @@ exports[`Search Results Page renders results from a given search term query para
 }
 
 .emotion-16:hover[aria-disabled='false'],
-.emotion-16:active {
+.emotion-16:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -7930,8 +7945,11 @@ exports[`Search Results Page renders results from a given search term query para
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;
@@ -8191,7 +8209,7 @@ exports[`Search Results Page renders results from a given search term query para
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   cursor: not-allowed;
   color: #C1C7C6;
   background-color: rgba(255, 255, 255, 0);
@@ -8941,8 +8959,8 @@ exports[`Search Results Page renders results from a given search term query para
               class="emotion-61"
             >
               <button
-                aria-controls="select-57-menu"
-                aria-describedby="select-57-description"
+                aria-controls="select-13-menu"
+                aria-describedby="select-13-description"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -8950,7 +8968,7 @@ exports[`Search Results Page renders results from a given search term query para
                 class="emotion-62"
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
-                id="select-58"
+                id="select-14"
                 type="button"
                 value=""
               >
@@ -8998,8 +9016,8 @@ exports[`Search Results Page renders results from a given search term query para
               class="emotion-61"
             >
               <button
-                aria-controls="select-59-menu"
-                aria-describedby="select-59-description"
+                aria-controls="select-15-menu"
+                aria-describedby="select-15-description"
                 aria-disabled="true"
                 aria-expanded="false"
                 aria-invalid="false"
@@ -9008,7 +9026,7 @@ exports[`Search Results Page renders results from a given search term query para
                 data-leafygreen-ui="button"
                 data-testid="lg-select"
                 disabled=""
-                id="select-60"
+                id="select-16"
                 type="button"
                 value=""
               >

--- a/tests/unit/__snapshots__/Video.test.js.snap
+++ b/tests/unit/__snapshots__/Video.test.js.snap
@@ -82,7 +82,7 @@ exports[`Wistia video renders correctly 1`] = `
   outline: none;
 }
 
-.emotion-4:active,
+.emotion-4:active[aria-disabled='false'],
 .emotion-4:focus,
 .emotion-4:hover {
   -webkit-text-decoration: none;
@@ -94,7 +94,7 @@ exports[`Wistia video renders correctly 1`] = `
 }
 
 .emotion-4:hover[aria-disabled='false'],
-.emotion-4:active {
+.emotion-4:active[aria-disabled='false'] {
   color: #001E2B;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px #E8EDEB;
@@ -144,8 +144,11 @@ exports[`Wistia video renders correctly 1`] = `
   align-items: center;
   height: 100%;
   width: 100%;
-  pointer-events: none;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 0;
   -webkit-transition: all 150 ease-in-out;
   transition: all 150 ease-in-out;


### PR DESCRIPTION
### Stories/Links:

DOP-4167

### Current Behavior:

[docs landing on master branch pre deduping](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/master/index.html)

### Staging Links:

[staged changes on homepage after running dedupe. see network requests for size of js chunk
](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4167/index.html)

### Notes:

- seems like this has actually increased our node modules directory size, and the bundled js chunk has slightly increased in size ~1.4% :

```
➜  snooty git:(DOP-4167) npm ci --legacy-peer-deps
➜  snooty git:(DOP-4167) du -hs node_modules
980M	node_modules
➜  snooty git:(DOP-4167) npm run build:clean
➜  snooty git:(DOP-4167) du -hs public 
140M	public
```
![Screenshot 2023-12-07 at 4 36 00 PM](https://github.com/mongodb/snooty/assets/13054820/009ea164-1814-449e-acee-967f5b16055e)


here are the outputs of running an `npm dedupe` post `npm ci --legacy-peerdeps`:
```
➜  snooty git:(master) rm -rf node_modules 
➜  snooty git:(DOP-4167) npm ci --legacy-peer-deps
➜  snooty git:(DOP-4167) npm dedupe
➜  snooty git:(DOP-4167) ✗ du -hs node_modules 
1.0G	node_modules
➜  snooty git:(DOP-4167) ✗ npm run build:clean
➜  snooty git:(DOP-4167) ✗ du -hs public
140M	public
```

![image](https://github.com/mongodb/snooty/assets/13054820/902ce640-a50f-4819-965f-7081303199ea)

