### PR TITLE
DOP-4200: Bump consistent-nav to v2.0.3-rc.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@leafygreen-ui/tooltip": "^7.1.0",
         "@leafygreen-ui/typography": "^16.5.1",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.0.3-rc.14",
+        "@mdb/consistent-nav": "^2.0.3-rc.15",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
@@ -5539,9 +5539,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.0.3-rc.14",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.14.tgz",
-      "integrity": "sha512-wqC1zR2d/HvBIif9NAMYsk5/enejHVPfzdbOQwQjWEjq2idSBzyD11yLUAOo2+eU+tzi2PjGYdQdqVn7ptxIfg==",
+      "version": "2.0.3-rc.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
+      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -28782,9 +28782,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.0.3-rc.14",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.14.tgz",
-      "integrity": "sha512-wqC1zR2d/HvBIif9NAMYsk5/enejHVPfzdbOQwQjWEjq2idSBzyD11yLUAOo2+eU+tzi2PjGYdQdqVn7ptxIfg=="
+      "version": "2.0.3-rc.15",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.15.tgz",
+      "integrity": "sha512-LJyBgPph/4oW63t6kDxOLAPjfD2CRHWGNusz2qqUs2huVqX1mp+WejYqTE9TALKVphnsD9stH7qI2jJ6d9GMMg=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@leafygreen-ui/tooltip": "^7.1.0",
     "@leafygreen-ui/typography": "^16.5.1",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.0.3-rc.14",
+    "@mdb/consistent-nav": "^2.0.3-rc.15",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
### Stories/Links:

DOP-4200

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Server docs](https://www.mongodb.com/docs/manual/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-4200/index.html)
[Server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4200/index.html)

### Notes:

* Existing consistent nav behavior between the productions sites and the staging links should be the same (consistent, if you will). The main differences should be those outlined in the Jira ticket (mostly copy and logo size changes).