### PR TITLE
DOP-4178: Prevent infinite new anon users for Snooty App Service

### DIFF
--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -13,6 +13,11 @@ const loginAnonymous = async () => {
     return loginDefer;
   }
 
+  // Avoid creating multiple users if one already exists
+  if (app.currentUser) {
+    return;
+  }
+
   loginDefer = new Promise(async (res, rej) => {
     try {
       const credentials = Realm.Credentials.anonymous();


### PR DESCRIPTION
### Stories/Links:

DOP-4178

### Current Behavior:

[Server docs](https://www.mongodb.com/docs/manual/)

### Staging Links:

[Server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4178/index.html)

### Notes:

* To verify that the change no longer infinitely creates new users, feel free to clear local storage and refresh the page. The number of users for the Snooty App Service should be 1. Realm should handle refresh tokens and caching anonymous user so that it doesn't result in a new user every time. Compare this behavior with current behavior on production, where new users are added to local storage upon every refresh.