### PR TITLE
DOP-4207: use Gatsby image to lazy load images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,11 @@ const pathPrefix = !isPreview ? generatePathPrefix(siteMetadata) : undefined;
 console.log('PATH PREFIX', pathPrefix);
 
 // Specifies which plugins to use depending on build environment
-const plugins = ['gatsby-plugin-emotion', isPreview ? 'gatsby-source-snooty-preview' : 'gatsby-source-snooty-prod'];
+const plugins = [
+  'gatsby-plugin-image',
+  'gatsby-plugin-emotion',
+  isPreview ? 'gatsby-source-snooty-preview' : 'gatsby-source-snooty-prod',
+];
 
 // PRODUCTION DEPLOYMENTS --
 // If not a preview build, use the layout that includes the

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "gatsby": "^5.0.0",
         "gatsby-plugin-emotion": "^8.0.0",
         "gatsby-plugin-google-tagmanager": "^5.0.0",
+        "gatsby-plugin-image": "^3.13.0",
         "gatsby-plugin-layout": "^4.7.0",
         "gatsby-plugin-sitemap": "^6.0.0",
         "hex-rgb": "^5.0.0",
@@ -7735,13 +7736,6 @@
       "version": "0.16.2",
       "license": "MIT"
     },
-    "node_modules/@types/sharp": {
-      "version": "0.31.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "dev": true,
@@ -8691,6 +8685,11 @@
         "deep-equal": "^2.0.5"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+    },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
       "license": "MIT",
@@ -8951,12 +8950,13 @@
       }
     },
     "node_modules/babel-plugin-remove-graphql-queries": {
-      "version": "5.7.0",
-      "license": "MIT",
+      "version": "5.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.13.0.tgz",
+      "integrity": "sha512-ZqrQUsnkOuEEjofPXSDfBbDY0CYEQEieofyaBIg/apQop+eQCmMphWPMd7/57MLMZi1Dnq1yw1FfSWO50LmhjA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.7.0"
+        "gatsby-core-utils": "^4.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9696,7 +9696,8 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -10009,7 +10010,8 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -10031,7 +10033,8 @@
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -10039,7 +10042,8 @@
     },
     "node_modules/color/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -10049,7 +10053,8 @@
     },
     "node_modules/color/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -12421,7 +12426,8 @@
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "engines": {
         "node": ">=6"
       }
@@ -12579,6 +12585,11 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -13129,15 +13140,17 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-exists-cached": {
       "version": "1.0.0",
       "license": "ISC"
     },
     "node_modules/fs-extra": {
-      "version": "11.1.0",
-      "license": "MIT",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -13555,16 +13568,17 @@
       "license": "ISC"
     },
     "node_modules/gatsby-core-utils": {
-      "version": "4.7.0",
-      "license": "MIT",
+      "version": "4.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-core-utils/-/gatsby-core-utils-4.13.0.tgz",
+      "integrity": "sha512-+oJJsADfcEnzpQpof+L5qtP4iSeMaEPn1QSjXENlg/go9Pi/4eqb+Nn3y3q8bC/zy4hMWFWrPdMJmdW581uNvA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
         "configstore": "^5.0.1",
-        "fastq": "^1.13.0",
-        "file-type": "^16.5.3",
-        "fs-extra": "^11.1.0",
-        "got": "^11.8.5",
+        "fastq": "^1.15.0",
+        "file-type": "^16.5.4",
+        "fs-extra": "^11.1.1",
+        "got": "^11.8.6",
         "hash-wasm": "^4.9.0",
         "import-from": "^4.0.0",
         "lmdb": "2.5.3",
@@ -13703,6 +13717,51 @@
         "react-dom": "^18.0.0 || ^0.0.0"
       }
     },
+    "node_modules/gatsby-plugin-image": {
+      "version": "3.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-plugin-image/-/gatsby-plugin-image-3.13.0.tgz",
+      "integrity": "sha512-l5aEZbl81lTJUzchL03CzbjOADmbSKUMcBP+TO4j5Mu//K286ilfNUa97QD6VeaWeLEBMCK2tACc+8wmgYmxvQ==",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^5.13.0",
+        "camelcase": "^6.3.0",
+        "chokidar": "^3.5.3",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.0",
+        "gatsby-plugin-utils": "^4.13.0",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.3",
+        "gatsby": "^5.0.0-next",
+        "gatsby-plugin-sharp": "^5.0.0-next",
+        "gatsby-source-filesystem": "^5.0.0-next",
+        "react": "^18.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^0.0.0"
+      },
+      "peerDependenciesMeta": {
+        "gatsby-plugin-sharp": {
+          "optional": true
+        },
+        "gatsby-source-filesystem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gatsby-plugin-layout": {
       "version": "4.7.0",
       "license": "MIT",
@@ -13778,17 +13837,18 @@
       }
     },
     "node_modules/gatsby-plugin-utils": {
-      "version": "4.7.0",
-      "license": "MIT",
+      "version": "4.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-plugin-utils/-/gatsby-plugin-utils-4.13.0.tgz",
+      "integrity": "sha512-3qwhM6mUYjorRiD0D0cgmCHcKwroG2d4PlfErnapHJpM/ISGfdBBOfRhPyk2N0u3dbGeb3KQq5gImCCS73bvxg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "fastq": "^1.13.0",
-        "fs-extra": "^11.1.0",
-        "gatsby-core-utils": "^4.7.0",
-        "gatsby-sharp": "^1.7.0",
+        "fastq": "^1.15.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.0",
+        "gatsby-sharp": "^1.13.0",
         "graphql-compose": "^9.0.10",
         "import-from": "^4.0.0",
-        "joi": "^17.7.0",
+        "joi": "^17.9.2",
         "mime": "^3.0.0"
       },
       "engines": {
@@ -13828,11 +13888,11 @@
       }
     },
     "node_modules/gatsby-sharp": {
-      "version": "1.7.0",
-      "license": "MIT",
+      "version": "1.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-sharp/-/gatsby-sharp-1.13.0.tgz",
+      "integrity": "sha512-DviUtgm7tatSd1Hm54o/orHimOcyXBO9OJkSfzEchPFClvOza+2Qe/lqZShio0gFDxmG0Jgn0XCLzG7uH5VyJQ==",
       "dependencies": {
-        "@types/sharp": "^0.31.1",
-        "sharp": "^0.31.3"
+        "sharp": "^0.32.6"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -14109,7 +14169,8 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -17485,8 +17546,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.8.3",
-      "license": "BSD-3-Clause",
+      "version": "17.11.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -18764,7 +18826,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mobx": {
       "version": "6.8.0",
@@ -19240,7 +19303,8 @@
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -19278,8 +19342,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.33.0",
-      "license": "MIT",
+      "version": "3.52.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -19289,7 +19354,8 @@
     },
     "node_modules/node-abi/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19298,8 +19364,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -19312,7 +19379,8 @@
     },
     "node_modules/node-abi/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
@@ -19698,6 +19766,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/objectFitPolyfill": {
+      "version": "2.3.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
+      "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -20938,7 +21011,8 @@
     },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -20961,10 +21035,50 @@
       }
     },
     "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prelude-ls": {
@@ -21209,6 +21323,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -22472,36 +22591,36 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.31.3",
+      "version": "0.32.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^5.0.0",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.5.4",
         "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
+        "tar-fs": "^3.0.4",
         "tunnel-agent": "^0.6.0"
       },
       "engines": {
         "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/sharp/node_modules/detect-libc": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/sharp/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22510,12 +22629,14 @@
       }
     },
     "node_modules/sharp/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22528,7 +22649,8 @@
     },
     "node_modules/sharp/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -22618,39 +22740,13 @@
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -22659,14 +22755,16 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
-      "license": "MIT",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
-      "license": "MIT"
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -22987,6 +23085,15 @@
       "version": "1.1.0",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.15.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -23512,39 +23619,23 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dependencies": {
-        "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
       }
     },
     "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "3.1.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/terser": {
@@ -23883,7 +23974,8 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "license": "Apache-2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -30194,12 +30286,6 @@
     "@types/scheduler": {
       "version": "0.16.2"
     },
-    "@types/sharp": {
-      "version": "0.31.1",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "dev": true
@@ -30787,6 +30873,11 @@
         "deep-equal": "^2.0.5"
       }
     },
+    "b4a": {
+      "version": "1.6.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+    },
     "babel-eslint": {
       "version": "10.1.0",
       "requires": {
@@ -30958,11 +31049,13 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "5.7.0",
+      "version": "5.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.13.0.tgz",
+      "integrity": "sha512-ZqrQUsnkOuEEjofPXSDfBbDY0CYEQEieofyaBIg/apQop+eQCmMphWPMd7/57MLMZi1Dnq1yw1FfSWO50LmhjA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.7.0"
+        "gatsby-core-utils": "^4.13.0"
       }
     },
     "babel-plugin-styled-components": {
@@ -31428,7 +31521,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.3"
@@ -31625,6 +31720,8 @@
     },
     "color": {
       "version": "4.2.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "requires": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -31632,12 +31729,16 @@
       "dependencies": {
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },
@@ -31652,6 +31753,8 @@
     },
     "color-string": {
       "version": "1.9.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -33149,7 +33252,9 @@
       "dev": true
     },
     "expand-template": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "expect": {
       "version": "29.5.0",
@@ -33275,6 +33380,11 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3"
+    },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -33603,13 +33713,17 @@
       "version": "0.5.2"
     },
     "fs-constants": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-exists-cached": {
       "version": "1.0.0"
     },
     "fs-extra": {
-      "version": "11.1.0",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -33995,15 +34109,17 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "4.7.0",
+      "version": "4.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-core-utils/-/gatsby-core-utils-4.13.0.tgz",
+      "integrity": "sha512-+oJJsADfcEnzpQpof+L5qtP4iSeMaEPn1QSjXENlg/go9Pi/4eqb+Nn3y3q8bC/zy4hMWFWrPdMJmdW581uNvA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
         "configstore": "^5.0.1",
-        "fastq": "^1.13.0",
-        "file-type": "^16.5.3",
-        "fs-extra": "^11.1.0",
-        "got": "^11.8.5",
+        "fastq": "^1.15.0",
+        "file-type": "^16.5.4",
+        "fs-extra": "^11.1.1",
+        "got": "^11.8.6",
         "hash-wasm": "^4.9.0",
         "import-from": "^4.0.0",
         "lmdb": "2.5.3",
@@ -34089,6 +34205,34 @@
         "web-vitals": "^1.1.2"
       }
     },
+    "gatsby-plugin-image": {
+      "version": "3.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-plugin-image/-/gatsby-plugin-image-3.13.0.tgz",
+      "integrity": "sha512-l5aEZbl81lTJUzchL03CzbjOADmbSKUMcBP+TO4j5Mu//K286ilfNUa97QD6VeaWeLEBMCK2tACc+8wmgYmxvQ==",
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^5.13.0",
+        "camelcase": "^6.3.0",
+        "chokidar": "^3.5.3",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.0",
+        "gatsby-plugin-utils": "^4.13.0",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+        }
+      }
+    },
     "gatsby-plugin-layout": {
       "version": "4.7.0",
       "requires": {
@@ -34134,16 +34278,18 @@
       }
     },
     "gatsby-plugin-utils": {
-      "version": "4.7.0",
+      "version": "4.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-plugin-utils/-/gatsby-plugin-utils-4.13.0.tgz",
+      "integrity": "sha512-3qwhM6mUYjorRiD0D0cgmCHcKwroG2d4PlfErnapHJpM/ISGfdBBOfRhPyk2N0u3dbGeb3KQq5gImCCS73bvxg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "fastq": "^1.13.0",
-        "fs-extra": "^11.1.0",
-        "gatsby-core-utils": "^4.7.0",
-        "gatsby-sharp": "^1.7.0",
+        "fastq": "^1.15.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.0",
+        "gatsby-sharp": "^1.13.0",
         "graphql-compose": "^9.0.10",
         "import-from": "^4.0.0",
-        "joi": "^17.7.0",
+        "joi": "^17.9.2",
         "mime": "^3.0.0"
       }
     },
@@ -34158,10 +34304,11 @@
       "version": "2.7.0"
     },
     "gatsby-sharp": {
-      "version": "1.7.0",
+      "version": "1.13.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/gatsby-sharp/-/gatsby-sharp-1.13.0.tgz",
+      "integrity": "sha512-DviUtgm7tatSd1Hm54o/orHimOcyXBO9OJkSfzEchPFClvOza+2Qe/lqZShio0gFDxmG0Jgn0XCLzG7uH5VyJQ==",
       "requires": {
-        "@types/sharp": "^0.31.1",
-        "sharp": "^0.31.3"
+        "sharp": "^0.32.6"
       }
     },
     "gatsby-telemetry": {
@@ -34257,7 +34404,9 @@
       }
     },
     "github-from-package": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -36328,7 +36477,9 @@
       }
     },
     "joi": {
-      "version": "17.8.3",
+      "version": "17.11.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -37240,7 +37391,9 @@
       }
     },
     "mkdirp-classic": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mobx": {
       "version": "6.8.0"
@@ -37593,7 +37746,9 @@
       "version": "3.3.4"
     },
     "napi-build-utils": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "natural-compare": {
       "version": "1.4.0"
@@ -37621,25 +37776,33 @@
       "version": "2.1.1"
     },
     "node-abi": {
-      "version": "3.33.0",
+      "version": "3.52.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -37871,6 +38034,11 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
+    },
+    "objectFitPolyfill": {
+      "version": "2.3.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
+      "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
     },
     "on-finished": {
       "version": "2.4.1",
@@ -38533,6 +38701,8 @@
     },
     "prebuild-install": {
       "version": "7.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -38549,7 +38719,42 @@
       },
       "dependencies": {
         "detect-libc": {
-          "version": "2.0.1"
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tar-fs": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-fs/-/tar-fs-2.1.1.tgz",
+          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "mkdirp-classic": "^0.5.2",
+            "pump": "^3.0.0",
+            "tar-stream": "^2.1.4"
+          }
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
         }
       }
     },
@@ -38698,6 +38903,11 @@
     },
     "queue-microtask": {
       "version": "1.2.3"
+    },
+    "queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "quick-lru": {
       "version": "5.1.1"
@@ -39499,38 +39709,50 @@
       "version": "1.1.0"
     },
     "sharp": {
-      "version": "0.31.3",
+      "version": "0.32.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "requires": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^5.0.0",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.5.4",
         "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
+        "tar-fs": "^3.0.4",
         "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
         "detect-libc": {
-          "version": "2.0.1"
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.0.2.tgz",
+          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "node-addon-api": {
-          "version": "5.1.0"
+          "version": "6.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/node-addon-api/-/node-addon-api-6.1.0.tgz",
+          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.5.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -39597,10 +39819,14 @@
       "version": "1.0.0"
     },
     "simple-concat": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
       "version": "4.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -39609,12 +39835,16 @@
     },
     "simple-swizzle": {
       "version": "0.2.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "requires": {
         "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
-          "version": "0.3.2"
+          "version": "0.3.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -39834,6 +40064,15 @@
     },
     "streamsearch": {
       "version": "1.1.0"
+    },
+    "streamx": {
+      "version": "2.15.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "requires": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
     },
     "strict-uri-encode": {
       "version": "2.0.0"
@@ -40165,32 +40404,23 @@
       "version": "2.2.1"
     },
     "tar-fs": {
-      "version": "2.1.1",
+      "version": "3.0.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "requires": {
-        "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
       }
     },
     "tar-stream": {
-      "version": "2.2.0",
+      "version": "3.1.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
       "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.1",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "terser": {
@@ -40418,6 +40648,8 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "gatsby": "^5.0.0",
     "gatsby-plugin-emotion": "^8.0.0",
     "gatsby-plugin-google-tagmanager": "^5.0.0",
+    "gatsby-plugin-image": "^3.13.0",
     "gatsby-plugin-layout": "^4.7.0",
     "gatsby-plugin-sitemap": "^6.0.0",
     "hex-rgb": "^5.0.0",

--- a/src/components/Figure/Lightbox.js
+++ b/src/components/Figure/Lightbox.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@leafygreen-ui/modal';
 import styled from '@emotion/styled';
@@ -51,16 +51,19 @@ const LightboxWrapper = styled('div')`
 const Lightbox = ({ nodeData, ...rest }) => {
   const [open, setOpen] = useState(false);
   const figureWidth = nodeData.options?.figwidth || 'auto';
+  const openModal = useCallback(() => {
+    setOpen(!open);
+  }, [open]);
   return (
     <React.Fragment>
       <LightboxWrapper figwidth={figureWidth}>
-        <div onClick={() => setOpen((curr) => !curr)} role="button" tabIndex="-1">
+        <div onClick={openModal} role="button" tabIndex="-1">
           <Image nodeData={nodeData} />
           <LightboxCaption>{CAPTION_TEXT}</LightboxCaption>
         </div>
         <CaptionLegend {...rest} nodeData={nodeData} />
       </LightboxWrapper>
-      <StyledModal size="medium" open={open} setOpen={setOpen}>
+      <StyledModal size="medium" open={open} setOpen={openModal}>
         <Image nodeData={nodeData} />
       </StyledModal>
     </React.Fragment>

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -10,22 +10,12 @@ import CaptionLegend from './CaptionLegend';
 export default class Figure extends Component {
   constructor(props) {
     super(props);
+    const figWidth = parseInt(getNestedValue(['nodeData', 'options', 'figwidth'], props), 10);
+    const imgWidth = parseInt(getNestedValue(['nodeData', 'options', 'width'], props), 10);
     this.state = {
-      isLightboxSize: false,
+      isLightboxSize: !figWidth || figWidth / imgWidth < 0.9,
     };
   }
-
-  imgShouldHaveLightbox = (img) => {
-    const naturalArea = img.naturalWidth * img.naturalHeight;
-    const clientArea = img.clientWidth * img.clientHeight;
-    return clientArea < naturalArea * 0.9;
-  };
-
-  handleImageLoaded = (imgRef) => {
-    this.setState({
-      isLightboxSize: this.imgShouldHaveLightbox(imgRef),
-    });
-  };
 
   render() {
     const { nodeData, ...rest } = this.props;
@@ -44,7 +34,7 @@ export default class Figure extends Component {
         `}
         style={{ width: getNestedValue(['options', 'figwidth'], nodeData) || 'auto' }}
       >
-        <Image nodeData={nodeData} handleImageLoaded={this.handleImageLoaded} />
+        <Image nodeData={nodeData} />
         <CaptionLegend {...rest} nodeData={nodeData} />
       </div>
     );

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,8 +7,7 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { getGatsbyImage } from '../utils/get-gatsby-image';
 
 const Image = ({ nodeData, handleImageLoaded, className, ...props }) => {
-  // const scale = getNestedValue(['options', 'scale'], nodeData);
-  // TODO: add scale to aspect ratio
+  const scale = getNestedValue(['options', 'scale'], nodeData);
   const height = getNestedValue(['options', 'height'], nodeData);
   const width = getNestedValue(['options', 'width'], nodeData);
 
@@ -35,6 +34,9 @@ const Image = ({ nodeData, handleImageLoaded, className, ...props }) => {
   if (height) {
     imageOptions['height'] = height;
   }
+  if (scale) {
+    imageOptions['scale'] = parseInt(scale, 10) / 100;
+  }
   const imageData = getGatsbyImage(imageOptions);
 
   return (
@@ -46,7 +48,7 @@ const Image = ({ nodeData, handleImageLoaded, className, ...props }) => {
         ${hasBorder ? borderStyling : ''}
         max-width: 100%;
       `)}
-      objectFit={'scale-down'}
+      objectFit={'contain'}
     />
   );
 };

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -100,7 +100,8 @@ const Wrapper = styled('main')`
       `}
     }
 
-    > img {
+    > img,
+    > .gatsby-image-wrapper {
       display: block;
       grid-column: 2;
       margin-top: auto;

--- a/src/utils/get-gatsby-image.js
+++ b/src/utils/get-gatsby-image.js
@@ -1,21 +1,27 @@
 import { withPrefix } from 'gatsby';
 import { getImageData } from 'gatsby-plugin-image';
 
-const DEFAULT_OPTIONS = {
-  layout: 'fullWidth',
-  aspectRatio: 16 / 9,
-};
-
 function urlBuilder({ baseUrl }) {
   return baseUrl;
 }
 
-export const getGatsbyImage = ({ imageUrl, ...props }) => {
-  return getImageData({
+export const getGatsbyImage = ({ imageUrl, width, height, scale }) => {
+  const options = {
     baseUrl: withPrefix(imageUrl),
     urlBuilder,
     formats: ['auto'],
-    ...DEFAULT_OPTIONS,
-    ...props,
-  });
+  };
+
+  const imgScale = scale ?? 1;
+
+  // width and image are required
+  // but will safely fallback to 16/9 aspect if not
+  if (width && height) {
+    options.width = width * imgScale;
+    options.height = height * imgScale;
+  } else {
+    options.layout = 'fullWidth';
+    options.aspectRatio = 16 / 9;
+  }
+  return getImageData(options);
 };

--- a/src/utils/get-gatsby-image.js
+++ b/src/utils/get-gatsby-image.js
@@ -1,0 +1,21 @@
+import { withPrefix } from 'gatsby';
+import { getImageData } from 'gatsby-plugin-image';
+
+const DEFAULT_OPTIONS = {
+  layout: 'fullWidth',
+  aspectRatio: 16 / 9,
+};
+
+function urlBuilder({ baseUrl }) {
+  return baseUrl;
+}
+
+export const getGatsbyImage = ({ imageUrl, ...props }) => {
+  return getImageData({
+    baseUrl: withPrefix(imageUrl),
+    urlBuilder,
+    formats: ['auto'],
+    ...DEFAULT_OPTIONS,
+    ...props,
+  });
+};

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -19,11 +19,39 @@ exports[`renders border correctly when specified as an option 1`] = `
     class="figure emotion-0"
     style="width: 700px;"
   >
-    <img
-      alt="/images/firstcluster.png"
-      class="   emotion-1"
-      src="/images/firstcluster.png"
-    />
+    <div
+      class="gatsby-image-wrapper   "
+      data-gatsby-image-wrapper=""
+      style="position: relative; overflow: hidden;"
+    >
+      <div
+        aria-hidden="true"
+        style="padding-top: 56.25%;"
+      />
+      <div
+        aria-hidden="true"
+        data-placeholder-image=""
+        style="height: 100%; left: 0px; position: absolute; top: 0px; width: 100%;"
+      />
+      <img
+        alt="/images/firstcluster.png"
+        class="emotion-1"
+        data-gatsby-image-ssr=""
+        data-main-image=""
+        data-src="/images/firstcluster.png"
+        data-srcset="/images/firstcluster.png 320w,/images/firstcluster.png 654w,/images/firstcluster.png 768w,/images/firstcluster.png 1024w,/images/firstcluster.png 1366w,/images/firstcluster.png 1600w,/images/firstcluster.png 1920w,/images/firstcluster.png 2048w,/images/firstcluster.png 2560w,/images/firstcluster.png 3440w,/images/firstcluster.png 3840w,/images/firstcluster.png 4096w"
+        decoding="async"
+        loading="lazy"
+        sizes="100vw"
+        style="height: 100%; left: 0px; position: absolute; top: 0px; transform: translateZ(0); transition: opacity 250ms linear; width: 100%; will-change: opacity; object-fit: contain; opacity: 0;"
+      />
+      <noscript />
+      <script
+        type="module"
+      >
+        const t="undefined"!=typeof HTMLImageElement&&"loading"in HTMLImageElement.prototype;if(t){const t=document.querySelectorAll("img[data-main-image]");for(let e of t){e.dataset.src&&(e.setAttribute("src",e.dataset.src),e.removeAttribute("data-src")),e.dataset.srcset&&(e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset"));const t=e.parentNode.querySelectorAll("source[data-srcset]");for(let e of t)e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset");e.complete&&(e.style.opacity=1,e.parentNode.parentNode.querySelector("[data-placeholder-image]").style.opacity=0)}}
+      </script>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -44,11 +72,39 @@ exports[`renders correctly 1`] = `
     class="figure emotion-0"
     style="width: 700px;"
   >
-    <img
-      alt="/images/firstcluster.png"
-      class="   emotion-1"
-      src="/images/firstcluster.png"
-    />
+    <div
+      class="gatsby-image-wrapper   "
+      data-gatsby-image-wrapper=""
+      style="position: relative; overflow: hidden;"
+    >
+      <div
+        aria-hidden="true"
+        style="padding-top: 56.25%;"
+      />
+      <div
+        aria-hidden="true"
+        data-placeholder-image=""
+        style="height: 100%; left: 0px; position: absolute; top: 0px; width: 100%;"
+      />
+      <img
+        alt="/images/firstcluster.png"
+        class="emotion-1"
+        data-gatsby-image-ssr=""
+        data-main-image=""
+        data-src="/images/firstcluster.png"
+        data-srcset="/images/firstcluster.png 320w,/images/firstcluster.png 654w,/images/firstcluster.png 768w,/images/firstcluster.png 1024w,/images/firstcluster.png 1366w,/images/firstcluster.png 1600w,/images/firstcluster.png 1920w,/images/firstcluster.png 2048w,/images/firstcluster.png 2560w,/images/firstcluster.png 3440w,/images/firstcluster.png 3840w,/images/firstcluster.png 4096w"
+        decoding="async"
+        loading="lazy"
+        sizes="100vw"
+        style="height: 100%; left: 0px; position: absolute; top: 0px; transform: translateZ(0); transition: opacity 250ms linear; width: 100%; will-change: opacity; object-fit: contain; opacity: 0;"
+      />
+      <noscript />
+      <script
+        type="module"
+      >
+        const t="undefined"!=typeof HTMLImageElement&&"loading"in HTMLImageElement.prototype;if(t){const t=document.querySelectorAll("img[data-main-image]");for(let e of t){e.dataset.src&&(e.setAttribute("src",e.dataset.src),e.removeAttribute("data-src")),e.dataset.srcset&&(e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset"));const t=e.parentNode.querySelectorAll("source[data-srcset]");for(let e of t)e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset");e.complete&&(e.style.opacity=1,e.parentNode.parentNode.querySelector("[data-placeholder-image]").style.opacity=0)}}
+      </script>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -83,11 +139,39 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
       role="button"
       tabindex="-1"
     >
-      <img
-        alt="/images/firstcluster.png"
-        class="   emotion-2"
-        src="/images/firstcluster.png"
-      />
+      <div
+        class="gatsby-image-wrapper   "
+        data-gatsby-image-wrapper=""
+        style="position: relative; overflow: hidden;"
+      >
+        <div
+          aria-hidden="true"
+          style="padding-top: 56.25%;"
+        />
+        <div
+          aria-hidden="true"
+          data-placeholder-image=""
+          style="height: 100%; left: 0px; position: absolute; top: 0px; width: 100%;"
+        />
+        <img
+          alt="/images/firstcluster.png"
+          class="emotion-2"
+          data-gatsby-image-ssr=""
+          data-main-image=""
+          data-src="/images/firstcluster.png"
+          data-srcset="/images/firstcluster.png 320w,/images/firstcluster.png 654w,/images/firstcluster.png 768w,/images/firstcluster.png 1024w,/images/firstcluster.png 1366w,/images/firstcluster.png 1600w,/images/firstcluster.png 1920w,/images/firstcluster.png 2048w,/images/firstcluster.png 2560w,/images/firstcluster.png 3440w,/images/firstcluster.png 3840w,/images/firstcluster.png 4096w"
+          decoding="async"
+          loading="lazy"
+          sizes="100vw"
+          style="height: 100%; left: 0px; position: absolute; top: 0px; transform: translateZ(0); transition: opacity 250ms linear; width: 100%; will-change: opacity; object-fit: contain; opacity: 0;"
+        />
+        <noscript />
+        <script
+          type="module"
+        >
+          const t="undefined"!=typeof HTMLImageElement&&"loading"in HTMLImageElement.prototype;if(t){const t=document.querySelectorAll("img[data-main-image]");for(let e of t){e.dataset.src&&(e.setAttribute("src",e.dataset.src),e.removeAttribute("data-src")),e.dataset.srcset&&(e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset"));const t=e.parentNode.querySelectorAll("source[data-srcset]");for(let e of t)e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset");e.complete&&(e.style.opacity=1,e.parentNode.parentNode.querySelector("[data-placeholder-image]").style.opacity=0)}}
+        </script>
+      </div>
       <div
         class="emotion-3 emotion-4"
       >

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -30,11 +30,39 @@ exports[`Lightbox renders correctly 1`] = `
       role="button"
       tabindex="-1"
     >
-      <img
-        alt="/images/firstcluster.png"
-        class="   emotion-2"
-        src="/images/firstcluster.png"
-      />
+      <div
+        class="gatsby-image-wrapper   "
+        data-gatsby-image-wrapper=""
+        style="position: relative; overflow: hidden;"
+      >
+        <div
+          aria-hidden="true"
+          style="padding-top: 56.25%;"
+        />
+        <div
+          aria-hidden="true"
+          data-placeholder-image=""
+          style="height: 100%; left: 0px; position: absolute; top: 0px; width: 100%;"
+        />
+        <img
+          alt="/images/firstcluster.png"
+          class="emotion-2"
+          data-gatsby-image-ssr=""
+          data-main-image=""
+          data-src="/images/firstcluster.png"
+          data-srcset="/images/firstcluster.png 320w,/images/firstcluster.png 654w,/images/firstcluster.png 768w,/images/firstcluster.png 1024w,/images/firstcluster.png 1366w,/images/firstcluster.png 1600w,/images/firstcluster.png 1920w,/images/firstcluster.png 2048w,/images/firstcluster.png 2560w,/images/firstcluster.png 3440w,/images/firstcluster.png 3840w,/images/firstcluster.png 4096w"
+          decoding="async"
+          loading="lazy"
+          sizes="100vw"
+          style="height: 100%; left: 0px; position: absolute; top: 0px; transform: translateZ(0); transition: opacity 250ms linear; width: 100%; will-change: opacity; object-fit: contain; opacity: 0;"
+        />
+        <noscript />
+        <script
+          type="module"
+        >
+          const t="undefined"!=typeof HTMLImageElement&&"loading"in HTMLImageElement.prototype;if(t){const t=document.querySelectorAll("img[data-main-image]");for(let e of t){e.dataset.src&&(e.setAttribute("src",e.dataset.src),e.removeAttribute("data-src")),e.dataset.srcset&&(e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset"));const t=e.parentNode.querySelectorAll("source[data-srcset]");for(let e of t)e.setAttribute("srcset",e.dataset.srcset),e.removeAttribute("data-srcset");e.complete&&(e.style.opacity=1,e.parentNode.parentNode.querySelector("[data-placeholder-image]").style.opacity=0)}}
+        </script>
+      </div>
       <div
         class="emotion-3 emotion-4"
       >


### PR DESCRIPTION
### Stories/Links:

DOP-4207

This PR aims to utilize [gatsby plugin image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/) to lazy load images from the same source (/public/images directory of snooty [built during gatsby build phase](https://github.com/mongodb/snooty/blob/master/plugins/gatsby-source-snooty-prod/gatsby-node.js#L152)).

Using the [prereq parser changes](https://github.com/mongodb/snooty-parser/pull/547) to append the `width` and `height` properties to images, we will use gatsby image to provide a dimension that will preserve the correct space for lazy loaded images to prevent layout shifts.

### Current Behavior:

https://www.mongodb.com/docs/manual/

examples of images:
https://www.mongodb.com/docs/manual/core/csfle/reference/encryption-components/
https://www.mongodb.com/docs/manual/reference/write-concern/write-lifecycle/


### Staging Links:

[docs server on master branch (using parser master branch)](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/seung.park/master/)
[staged changes on branch (using parser prereq branch)](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/seung.park/DOP-4207/) *note. the hero image off center is due to existing feature styling, not a change from this branch

examples of staged changes with images:
[example of image without dimensions provided by parser](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/seung.park/DOP-4207/core/csfle/reference/encryption-components/)
https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/seung.park/DOP-4207/reference/write-concern/write-lifecycle/

[figure with lightbox](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/seung.park/DOP-4207/core/causal-consistency-read-write-concerns/)
