### PR TITLE
[HOTFIX] Refresh the Realm refresh token in case it's not fresh

### DIFF
--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -15,6 +15,7 @@ const loginAnonymous = async () => {
 
   // Avoid creating multiple users if one already exists
   if (app.currentUser) {
+    await app.currentUser.refreshCustomData();
     return;
   }
 


### PR DESCRIPTION
Per the instructions here: https://www.mongodb.com/docs/realm/sdk/node/users/authenticate-users/#get-a-user-access-token

### Stories/Links:

DOP-NNNN

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:
