### PR TITLE
DOP-4264: allow sibling associated products' ToC to be visible

### DIFF
--- a/plugins/gatsby-source-snooty-preview/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-preview/gatsby-node.js
@@ -55,6 +55,10 @@ exports.createSchemaCustomization = async ({ actions }) => {
       slug: String
       images: [File] @link(by: "relativePath", from: "pageAssets")
     }
+
+    type AssociatedProduct implements Node @dontInfer {
+      productName: String
+    }
   `;
   createTypes(typeDefs);
 };

--- a/plugins/utils/docsets.js
+++ b/plugins/utils/docsets.js
@@ -13,6 +13,7 @@ const createDocsetNodes = async ({ db, createNode, createNodeId, createContentDi
       prefix: docset.prefix,
       project: docset.project,
       url: docset.url,
+      branches: docset.branches,
     });
   });
 };

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -29,6 +29,9 @@ const Image = ({ nodeData, className }) => {
     border: 0.5px solid ${palette.gray.light1};
     border-radius: 4px;
   `;
+  const gatsbyContainerStyle = css`
+    height: max-content;
+  `;
 
   const { imageByPath } = useContext(ImageContext);
   const image = imageByPath[removeLeadingSlash(imgSrc)];
@@ -61,7 +64,7 @@ const Image = ({ nodeData, className }) => {
         alt={altText}
         style={userOptionStyle}
         imgClassName={cx(defaultStyling, hasBorder ? borderStyling : '')}
-        className={cx(directiveClass, customAlign, className)}
+        className={cx(gatsbyContainerStyle, directiveClass, customAlign, className)}
       />
     );
   }

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -12,27 +12,12 @@ import { SearchContextProvider } from './SearchResults/SearchContext';
 // Check for feature flag here to make it easier to pass down for testing purposes
 const SHOW_FACETS = process.env.GATSBY_FEATURE_FACETED_SEARCH === 'true';
 
-const RootProvider = ({
-  children,
-  headingNodes,
-  selectors,
-  slug,
-  repoBranches,
-  associatedReposInfo,
-  isAssociatedProduct,
-  remoteMetadata,
-  project,
-}) => {
+const RootProvider = ({ children, headingNodes, selectors, slug, repoBranches, remoteMetadata, project }) => {
   let providers = (
     <TabProvider selectors={selectors}>
       <ContentsProvider headingNodes={headingNodes}>
         <HeaderContextProvider>
-          <VersionContextProvider
-            repoBranches={repoBranches}
-            slug={slug}
-            associatedReposInfo={associatedReposInfo}
-            isAssociatedProduct={isAssociatedProduct}
-          >
+          <VersionContextProvider repoBranches={repoBranches} slug={slug}>
             <TocContextProvider remoteMetadata={remoteMetadata}>
               <SidenavContextProvider>
                 <SearchContextProvider showFacets={SHOW_FACETS}>{children}</SearchContextProvider>

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useCallback } from 'react';
 import { METADATA_COLLECTION } from '../build-constants';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { fetchDocuments } from '../utils/realm';
+import { fetchDocument } from '../utils/realm';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
 import { isGatsbyPreview } from '../utils/is-gatsby-preview';
 import { VersionContext } from './version-context';
@@ -39,16 +39,15 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
       if (associatedProducts?.length || showVersionDropdown) {
         filter['is_merged_toc'] = true;
       }
-      const db = database;
-      const metadata = await fetchDocuments(db, METADATA_COLLECTION, filter, undefined, findOptions);
-      return metadata[0]?.toctree ?? toctree;
+      const metadata = await fetchDocument(database, METADATA_COLLECTION, filter, { toctree: 1 }, findOptions);
+      return metadata?.toctree ?? toctree;
     } catch (e) {
       // fallback to toctree from build time
       console.error(e);
       return remoteMetadata?.toctree || toctree;
     }
     // below dependents are server constants
-  }, [project, branch, associatedProducts, showVersionDropdown, database, toctree, remoteMetadata]);
+  }, [toctree, project, branch, associatedProducts?.length, showVersionDropdown, database, remoteMetadata?.toctree]);
 
   const setInitVersion = useCallback(
     (tocNode) => {

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -76,7 +76,9 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
   // initial effect is to fetch metadata
   // should only run once on init
   useEffect(() => {
+    console.log(79);
     if (!Object.keys(activeVersions).length || isLoaded) {
+      console.log('returning early');
       return;
     }
     getTocMetadata().then((tocTreeResponse) => {

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -76,9 +76,7 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
   // initial effect is to fetch metadata
   // should only run once on init
   useEffect(() => {
-    console.log(79);
     if (!Object.keys(activeVersions).length || isLoaded) {
-      console.log('returning early');
       return;
     }
     getTocMetadata().then((tocTreeResponse) => {

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -1,12 +1,14 @@
 import React, { createContext, useReducer, useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { navigate } from '@gatsbyjs/reach-router';
 import { METADATA_COLLECTION } from '../build-constants';
+import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useCurrentUrlSlug } from '../hooks/use-current-url-slug';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { fetchDocset, fetchDocuments } from '../utils/realm';
 import { getUrl } from '../utils/url-utils';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { useAllDocsets } from '../hooks/useAllDocsets';
 
 // <-------------- begin helper functions -------------->
 const STORAGE_KEY = 'activeVersions';
@@ -60,7 +62,7 @@ const getBranches = async (metadata, repoBranches, associatedReposInfo, associat
     for (let associatedProduct of associatedProducts) {
       promises.push(
         fetchDocset(metadata.reposDatabase, {
-          project: associatedProduct.name,
+          project: associatedProduct,
         })
       );
     }
@@ -139,12 +141,28 @@ const VersionContext = createContext({
   setAvailableVersions: () => {},
   showVersionDropdown: false,
   showEol: false,
+  isAssociatedProduct: false,
   onVersionSelect: () => {},
 });
 
-const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociatedProduct, slug, children }) => {
+const VersionContextProvider = ({ repoBranches, slug, children }) => {
   const siteMetadata = useSiteMetadata();
-  const { associated_products: associatedProducts, project } = useSnootyMetadata();
+  const associatedProductNames = useAllAssociatedProducts();
+  const docsets = useAllDocsets();
+  const { project } = useSnootyMetadata();
+  const associatedReposInfo = useMemo(
+    () =>
+      associatedProductNames.reduce((res, productName) => {
+        res[productName] = docsets.find((docset) => docset.project === productName);
+        return res;
+      }, {}),
+    [associatedProductNames, docsets]
+  );
+
+  const isAssociatedProduct = useMemo(
+    () => associatedProductNames.includes(project),
+    [associatedProductNames, project]
+  );
   const metadata = useMemo(() => {
     return {
       ...siteMetadata,
@@ -176,12 +194,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
 
   // on init, fetch versions from realm app services
   useEffect(() => {
-    const allAssociatedProducts = (associatedProducts || []).concat(
-      Object.keys(associatedReposInfo || {}).map((repo) => ({
-        name: repo,
-      }))
-    );
-    getBranches(metadata, repoBranches, associatedReposInfo, allAssociatedProducts).then(
+    getBranches(metadata, repoBranches, associatedReposInfo, associatedProductNames).then(
       ({ versions, groups, hasEolBranches }) => {
         if (!mountRef.current) {
           return;
@@ -278,6 +291,7 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
         availableGroups,
         showVersionDropdown,
         onVersionSelect,
+        isAssociatedProduct,
         showEol,
       }}
     >

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -176,7 +176,12 @@ const VersionContextProvider = ({ repoBranches, associatedReposInfo, isAssociate
 
   // on init, fetch versions from realm app services
   useEffect(() => {
-    getBranches(metadata, repoBranches, associatedReposInfo, associatedProducts || []).then(
+    const allAssociatedProducts = (associatedProducts || []).concat(
+      Object.keys(associatedReposInfo || {}).map((repo) => ({
+        name: repo,
+      }))
+    );
+    getBranches(metadata, repoBranches, associatedReposInfo, allAssociatedProducts).then(
       ({ versions, groups, hasEolBranches }) => {
         if (!mountRef.current) {
           return;

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -1,6 +1,7 @@
 import React, { createContext, useReducer, useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { navigate } from '@gatsbyjs/reach-router';
 import { METADATA_COLLECTION } from '../build-constants';
+import { useAllDocsets } from '../hooks/useAllDocsets';
 import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useCurrentUrlSlug } from '../hooks/use-current-url-slug';
@@ -8,7 +9,6 @@ import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { fetchDocset, fetchDocuments } from '../utils/realm';
 import { getUrl } from '../utils/url-utils';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
-import { useAllDocsets } from '../hooks/useAllDocsets';
 
 // <-------------- begin helper functions -------------->
 const STORAGE_KEY = 'activeVersions';

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -6,7 +6,7 @@ import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useCurrentUrlSlug } from '../hooks/use-current-url-slug';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
-import { fetchDocset, fetchDocuments } from '../utils/realm';
+import { fetchDocset, fetchDocument } from '../utils/realm';
 import { getUrl } from '../utils/url-utils';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
 
@@ -124,8 +124,8 @@ const getUmbrellaProject = async (project, dbName) => {
     const query = {
       'associated_products.name': project,
     };
-    const umbrellaProjects = fetchDocuments(dbName, METADATA_COLLECTION, query);
-    return umbrellaProjects;
+    const umbrellaProject = await fetchDocument(dbName, METADATA_COLLECTION, query);
+    return umbrellaProject;
   } catch (e) {
     console.error(e);
   }
@@ -212,11 +212,11 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
 
   const [showVersionDropdown, setShowVersionDropdown] = useState(isAssociatedProduct);
   useEffect(() => {
-    getUmbrellaProject(metadata.project, metadata.database).then((metadataList) => {
+    getUmbrellaProject(metadata.project, metadata.database).then((umbrellaMetadata) => {
       if (!mountRef.current) {
         return;
       }
-      setShowVersionDropdown(metadataList.length > 0);
+      setShowVersionDropdown(!!umbrellaMetadata);
     });
   }, [metadata.project, metadata.database]);
 

--- a/src/hooks/useAllDocsets.js
+++ b/src/hooks/useAllDocsets.js
@@ -23,6 +23,12 @@ export const useAllDocsets = () => {
               stg
               regression
             }
+            branches {
+              gitBranchName
+              active
+              urlSlug
+              urlAliases
+            }
           }
         }
       }

--- a/src/hooks/useAssociatedProducts.js
+++ b/src/hooks/useAssociatedProducts.js
@@ -1,0 +1,17 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+// Return an array of MongoDB products
+export const useAllAssociatedProducts = () => {
+  const { allAssociatedProduct } = useStaticQuery(
+    graphql`
+      query AllAssociatedProducts {
+        allAssociatedProduct {
+          nodes {
+            productName
+          }
+        }
+      }
+    `
+  );
+  return allAssociatedProduct.nodes.map((ap) => ap.productName);
+};

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -25,12 +25,19 @@ class RealmInterface {
     return this.realmClient.callFunction('fetchDocuments', DB, collection, buildFilter);
   }
 
-  async getMetadata(buildFilter, findOptions) {
-    return this.realmClient.callFunction('fetchDocument', DB, METADATA_COLLECTION, buildFilter, undefined, findOptions);
+  async getMetadata(buildFilter, projectionOptions, findOptions) {
+    return this.realmClient.callFunction(
+      'fetchDocumentSorted',
+      DB,
+      METADATA_COLLECTION,
+      buildFilter,
+      projectionOptions,
+      findOptions
+    );
   }
 
   async fetchDocument(database, collectionName, query) {
-    return this.realmClient.callFunction('fetchDocument', database, collectionName, query);
+    return this.realmClient.callFunction('fetchDocumentSorted', database, collectionName, query);
   }
 
   async fetchDocset(matchConditions = { project: siteMetadata.project }) {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -83,10 +83,7 @@ const GlobalGrid = styled('div')`
   overflow: clip;
 `;
 
-const DefaultLayout = ({
-  children,
-  pageContext: { page, slug, repoBranches, template, associatedReposInfo, isAssociatedProduct },
-}) => {
+const DefaultLayout = ({ children, pageContext: { page, slug, repoBranches, template } }) => {
   const { sidenav } = getTemplate(template);
   const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol, project } = useSnootyMetadata();
   const remoteMetadata = useRemoteMetadata();
@@ -102,10 +99,8 @@ const DefaultLayout = ({
       <RootProvider
         slug={slug}
         repoBranches={repoBranches}
-        associatedReposInfo={associatedReposInfo}
         headingNodes={page?.options?.headings}
         selectors={page?.options?.selectors}
-        isAssociatedProduct={isAssociatedProduct}
         remoteMetadata={remoteMetadata}
         project={project}
       >

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -59,7 +59,7 @@ export const fetchOASFile = async (apiName, database) => {
 };
 
 export const fetchDocument = async (database, collectionName, query, projections) => {
-  return callAuthenticatedFunction('fetchDocument', database, collectionName, query, projections);
+  return callAuthenticatedFunction('fetchDocumentSorted', database, collectionName, query, projections);
 };
 
 export const fetchDocset = async (database, matchConditions) => {

--- a/tests/context/toc-context.test.js
+++ b/tests/context/toc-context.test.js
@@ -11,7 +11,7 @@ import { TocContext, TocContextProvider } from '../../src/context/toc-context';
 // <------------------ START test data mocks ------------------>
 const siteMetadataMock = jest.spyOn(siteMetadata, 'useSiteMetadata');
 const snootyMetadataMock = jest.spyOn(snootyMetadata, 'default');
-const realmMock = jest.spyOn(realm, 'fetchDocuments');
+const realmMock = jest.spyOn(realm, 'fetchDocument');
 const project = 'cloud-docs';
 
 let sampleTocTree, responseTree, mockedResponse;
@@ -80,11 +80,9 @@ const setResponse = () => {
     },
   });
 
-  mockedResponse = [
-    {
-      toctree: responseTree,
-    },
-  ];
+  mockedResponse = {
+    toctree: responseTree,
+  };
 };
 
 const setMocks = () => {

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -85,11 +85,7 @@ const mockedAssociatedRepoInfo = {
 
 const setProjectAndAssociatedProducts = () => {
   uesSiteMetadataMock.mockImplementation(() => ({
-    site: {
-      siteMetadata: {
-        parserBranch: 'master',
-      },
-    },
+    parserBranch: 'master',
   }));
   snootyMetadataMock.mockImplementation(() => ({
     project,
@@ -163,12 +159,8 @@ const mountConsumer = () => {
 const mountAtlasCliConsumer = (eol) => {
   const project = 'atlas-cli';
   uesSiteMetadataMock.mockImplementationOnce(() => ({
-    site: {
-      siteMetadata: {
-        project: project,
-        parserBranch: eol ? 'v1.0' : 'master',
-      },
-    },
+    project: project,
+    parserBranch: eol ? 'v1.0' : 'master',
   }));
 
   snootyMetadataMock.mockImplementationOnce(() => {
@@ -179,7 +171,7 @@ const mountAtlasCliConsumer = (eol) => {
   });
 
   return render(
-    <VersionContextProvider repoBranches={cloudDocsRepoBranches}>
+    <VersionContextProvider repoBranches={mockedAssociatedRepoInfo['atlas-cli']}>
       test consumer below
       <TestConsumer />
     </VersionContextProvider>
@@ -318,6 +310,7 @@ describe('Version Context', () => {
     await act(async () => {
       wrapper = mountAtlasCliConsumer(true);
     });
+    wrapper.debug();
     for (let branch of mockedAssociatedRepoInfo['atlas-cli'].branches) {
       expect(await wrapper.findByText(getKey(project, branch.gitBranchName))).toBeTruthy();
     }

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -234,9 +234,9 @@ describe('Version Context', () => {
       };
     });
   });
-  mockFetchDocuments = jest.spyOn(realm, 'fetchDocuments').mockImplementation(async (dbName, collectionName, query) => {
+  mockFetchDocuments = jest.spyOn(realm, 'fetchDocument').mockImplementation(async (dbName, collectionName, query) => {
     if (query && query['associated_products'] === 'docs-atlas-cli') {
-      return [{}]; // spoofing data for "at least one parent association"
+      return {}; // spoofing data for "at least one parent association"
     }
     return [];
   });

--- a/tests/context/version-context.test.js
+++ b/tests/context/version-context.test.js
@@ -1,71 +1,20 @@
 import React, { useContext } from 'react';
-import * as Gatsby from 'gatsby';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { VersionContextProvider, VersionContext, STORAGE_KEY } from '../../src/context/version-context';
+import * as siteMetadata from '../../src/hooks/use-site-metadata';
+import * as snootyMetadata from '../../src/utils/use-snooty-metadata';
+import * as useAssociatedProducts from '../../src/hooks/useAssociatedProducts';
+import * as useAllDocsets from '../../src/hooks/useAllDocsets';
 import * as browserStorage from '../../src/utils/browser-storage';
 import * as realm from '../../src/utils/realm';
-import * as snootyMetadata from '../../src/utils/use-snooty-metadata';
 
 const snootyMetadataMock = jest.spyOn(snootyMetadata, 'default');
-const useStaticQuery = jest.spyOn(Gatsby, 'useStaticQuery');
+const uesSiteMetadataMock = jest.spyOn(siteMetadata, 'useSiteMetadata');
+const useAssociatedProductsMock = jest.spyOn(useAssociatedProducts, 'useAllAssociatedProducts');
+const useAllDocsetsMock = jest.spyOn(useAllDocsets, 'useAllDocsets');
 const project = 'cloud-docs';
-const setProjectAndAssociatedProducts = () => {
-  useStaticQuery.mockImplementation(() => ({
-    site: {
-      siteMetadata: {
-        parserBranch: 'master',
-      },
-    },
-  }));
-  snootyMetadataMock.mockImplementation(() => ({
-    project,
-    associated_products: [
-      {
-        name: 'atlas-cli',
-        versions: ['v1.1', 'v1.2', 'master'],
-      },
-    ],
-  }));
-};
-
-const getKey = (project, branchName) => `${project}-${branchName}`;
-
-const TestConsumer = () => {
-  const { activeVersions, setActiveVersions, availableVersions } = useContext(VersionContext);
-
-  const handleClick = (project, version) => {
-    const value = {};
-    value[project] = version;
-    setActiveVersions(value);
-  };
-
-  const versionElms = [];
-  for (let project in availableVersions) {
-    for (let branch of availableVersions[project]) {
-      versionElms.push(
-        <div
-          onClick={() => {
-            handleClick(project, branch.gitBranchName);
-          }}
-          key={getKey(project, branch.gitBranchName)}
-          id={getKey(project, branch.gitBranchName)}
-        >
-          {getKey(project, branch.gitBranchName)}
-        </div>
-      );
-    }
-  }
-  return (
-    <>
-      <h1>active versions:</h1>
-      <div id="active-versions">{JSON.stringify(activeVersions)}</div>
-      <h1>availableVersions:</h1>
-      <div id="available-versions">{versionElms}</div>
-    </>
-  );
-};
 
 const cloudDocsRepoBranches = {
   branches: [
@@ -134,10 +83,77 @@ const mockedAssociatedRepoInfo = {
   },
 };
 
+const setProjectAndAssociatedProducts = () => {
+  uesSiteMetadataMock.mockImplementation(() => ({
+    site: {
+      siteMetadata: {
+        parserBranch: 'master',
+      },
+    },
+  }));
+  snootyMetadataMock.mockImplementation(() => ({
+    project,
+    associated_products: [
+      {
+        name: 'atlas-cli',
+        versions: ['v1.1', 'v1.2', 'master'],
+      },
+    ],
+  }));
+  useAssociatedProductsMock.mockImplementation(() => ['atlas-cli']);
+  useAllDocsetsMock.mockImplementation(() => [
+    {
+      project: 'cloud-docs',
+      branches: cloudDocsRepoBranches.branches,
+    },
+    {
+      project: 'atlas-cli',
+      branches: mockedAssociatedRepoInfo['atlas-cli']['branches'],
+    },
+  ]);
+};
+
+const getKey = (project, branchName) => `${project}-${branchName}`;
+
+const TestConsumer = () => {
+  const { activeVersions, setActiveVersions, availableVersions } = useContext(VersionContext);
+
+  const handleClick = (project, version) => {
+    const value = {};
+    value[project] = version;
+    setActiveVersions(value);
+  };
+
+  const versionElms = [];
+  for (let project in availableVersions) {
+    for (let branch of availableVersions[project]) {
+      versionElms.push(
+        <div
+          onClick={() => {
+            handleClick(project, branch.gitBranchName);
+          }}
+          key={getKey(project, branch.gitBranchName)}
+          id={getKey(project, branch.gitBranchName)}
+        >
+          {getKey(project, branch.gitBranchName)}
+        </div>
+      );
+    }
+  }
+  return (
+    <>
+      <h1>active versions:</h1>
+      <div id="active-versions">{JSON.stringify(activeVersions)}</div>
+      <h1>availableVersions:</h1>
+      <div id="available-versions">{versionElms}</div>
+    </>
+  );
+};
+
 const mountConsumer = () => {
   setProjectAndAssociatedProducts();
   return render(
-    <VersionContextProvider repoBranches={cloudDocsRepoBranches} associatedReposInfo={mockedAssociatedRepoInfo}>
+    <VersionContextProvider repoBranches={cloudDocsRepoBranches}>
       test consumer below
       <TestConsumer />
     </VersionContextProvider>
@@ -146,7 +162,7 @@ const mountConsumer = () => {
 
 const mountAtlasCliConsumer = (eol) => {
   const project = 'atlas-cli';
-  useStaticQuery.mockImplementationOnce(() => ({
+  uesSiteMetadataMock.mockImplementationOnce(() => ({
     site: {
       siteMetadata: {
         project: project,
@@ -163,7 +179,7 @@ const mountAtlasCliConsumer = (eol) => {
   });
 
   return render(
-    <VersionContextProvider repoBranches={cloudDocsRepoBranches} associatedReposInfo={mockedAssociatedRepoInfo}>
+    <VersionContextProvider repoBranches={cloudDocsRepoBranches}>
       test consumer below
       <TestConsumer />
     </VersionContextProvider>

--- a/tests/unit/VersionDropdown.test.js
+++ b/tests/unit/VersionDropdown.test.js
@@ -45,6 +45,12 @@ const fetchDocuments = () => {
   });
 };
 
+const fetchDocument = () => {
+  return jest.spyOn(realm, 'fetchDocument').mockImplementation(async () => {
+    return {};
+  });
+};
+
 const fetchDocset = () => {
   return jest.spyOn(realm, 'fetchDocset').mockImplementation(async (database, matchConditions) => {
     switch (matchConditions.project) {
@@ -211,14 +217,16 @@ describe('VersionDropdown', () => {
 
   describe('Component', () => {
     jest.useFakeTimers();
-    let mockFetchDocuments, mockedFetchDocset;
+    let mockFetchDocuments, mockedFetchDocset, mockFetchDocument;
 
     beforeEach(async () => {
+      mockFetchDocument = fetchDocument();
       mockFetchDocuments = fetchDocuments();
       mockedFetchDocset = fetchDocset();
     });
 
     afterAll(async () => {
+      mockFetchDocument.mockClear();
       mockFetchDocuments.mockClear();
       mockedFetchDocset.mockClear();
     });

--- a/tests/unit/VersionDropdown.test.js
+++ b/tests/unit/VersionDropdown.test.js
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import * as realm from '../../src/utils/realm';
 import { generatePrefix } from '../../src/components/VersionDropdown/utils';
 import VersionDropdown from '../../src/components/VersionDropdown';
+import * as useAssociatedProducts from '../../src/hooks/useAssociatedProducts';
+import * as useAllDocsets from '../../src/hooks/useAllDocsets';
 import mockData from '../unit/data/VersionDropdown.test.json';
 import { VersionContextProvider } from '../../src/context/version-context';
 import { tick } from '../utils';
@@ -19,6 +21,20 @@ jest.mock('../../src/utils/use-snooty-metadata', () => {
 jest.mock('@gatsbyjs/reach-router', () => ({
   navigate: jest.fn(),
 }));
+
+const useAssociatedProductsMock = jest.spyOn(useAssociatedProducts, 'useAllAssociatedProducts');
+const useAllDocsetsMock = jest.spyOn(useAllDocsets, 'useAllDocsets');
+useAssociatedProductsMock.mockImplementation(() => ['atlas-cli']);
+useAllDocsetsMock.mockImplementation(() => [
+  {
+    project: 'cloud-docs',
+    branches: [],
+  },
+  {
+    project: 'atlas-cli',
+    branches: [],
+  },
+]);
 
 const fetchDocuments = () => {
   return jest.spyOn(realm, 'fetchDocuments').mockImplementation(async (dbName, collectionName, query) => {
@@ -121,7 +137,7 @@ const queryElementWithin = (versionDropdown, role) => within(versionDropdown).qu
 
 const mountConsumer = () => {
   return render(
-    <VersionContextProvider repoBranches={docsNodeRepoBranches} slug={'/'} isAssociatedProduct={true}>
+    <VersionContextProvider repoBranches={docsNodeRepoBranches} slug={'/'}>
       <VersionDropdown eol={mockData.eol} slug={mockData.slug} repoBranches={docsNodeRepoBranches} />
     </VersionContextProvider>
   );


### PR DESCRIPTION
### Stories/Links:

DOP-4264

### Current Behavior:

This behavior is not in prod / stage yet, as we reverted back the doc content changes

### Staging Links:
[cloud docs with atlas cli and operator ToC's embedded
](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/mmeigs-move-ako/cloud-docs/seung.park/DOP-4264-frontend/index.html)[docs-atlas-cli with atlas cli and operator ToC's embedded into cloud docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-cli/seung.park/DOP-4264-frontend/index.html)
[docs-atlas-operator with atlas cli and operator ToC's embedded into cloud docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-operator/seung.park/DOP-4264-frontend/)

### Notes:
- The first initial front end bug was that we were not getting any sibling associated information (only checking if current project was used as an associated_product in an umbrella project, or if the current project has any associated_products). Updated this so that we should be able to pull any sibling products that are associated via a single umbrella product.
- The second bug was that we were not getting the most recent metadata at build time, so [added a new realm function](https://realm.mongodb.com/groups/5bad1d3d96e82129f16c5df3/apps/5d41ef5e2de84772fc7c2de2/functions/65a98f0ea36bd623a2b35921) `fetchDocumentSorted` to enable sort specifications.
- Made some changes on how we pass associated products' repo information down. Previously, it was passed down as a page context, but this has been updated to use the Gatsby createNode API during build time, to use long with a graphql query.
- **prereq:** This is in parity with the [persistence module PR](https://github.com/mongodb/docs-worker-pool/pull/966) that fixes the URL vs slug bug described in [ticket comment.](https://jira.mongodb.org/browse/DOP-4264?focusedCommentId=6023765&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6023765) 
- All the data is stored in snooty_dev collections, but referencing pool_test collections for branches