### PR TITLE
DOP-4207: check if image exists before calling

### DIFF
--- a/src/context/image-context.js
+++ b/src/context/image-context.js
@@ -15,7 +15,9 @@ export default ImageContext;
 const ImageContextProvider = ({ images, children }) => {
   const imageByPath = {};
   for (const image of images) {
-    imageByPath[image.relativePath] = getImage(image);
+    if (image?.relativePath) {
+      imageByPath[image.relativePath] = getImage(image);
+    }
   }
   return <ImageContext.Provider value={{ imageByPath }}>{children} </ImageContext.Provider>;
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4207

### Notes:
- Minor fix to check for null images. Was getting a build error `  WebpackError: TypeError: Cannot read properties of null (reading 'relativePath')` on cloud-docs /billing page.
- Verified this works as intended with webp images as in this [staging link ](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/mmeigs-move-ako/cloud-docs/seung.park/DOP-4207-safeguard-null-images/billing/index.html)