### PR TITLE
DOP-3846: Remove instruqt fullscreen and feature flag

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -48,7 +48,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
   const { selectors } = useContext(TabContext);
   const { hasDrawer, isOpen, setIsOpen } = useContext(InstruqtContext);
   const hasSelectors = selectors && Object.keys(selectors).length > 0;
-  const shouldShowLabButton = process.env.GATSBY_FEATURE_LAB_DRAWER === 'true' && isPageTitle && hasDrawer;
+  const shouldShowLabButton = isPageTitle && hasDrawer;
   const shouldShowMobileHeader = !!(isPageTitle && isTabletOrMobile && hasSelectors);
 
   return (

--- a/src/components/Instruqt/InstruqtFrame.js
+++ b/src/components/Instruqt/InstruqtFrame.js
@@ -1,11 +1,11 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 
 const iframeStyle = css`
   border: none;
 `;
 
-const InstruqtFrame = forwardRef(({ title, height, embedValue }, ref) => {
+const InstruqtFrame = ({ title, height, embedValue }) => {
   const labTitle = title || 'MongoDB Interactive Lab';
   const frameTitle = `Instruqt - ${labTitle}`;
   // Allow frameHeight to be 0 when drawer is closed to avoid iframe overflowing
@@ -14,7 +14,6 @@ const InstruqtFrame = forwardRef(({ title, height, embedValue }, ref) => {
 
   return (
     <iframe
-      ref={ref}
       className={cx(iframeStyle)}
       allowFullScreen
       sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"
@@ -24,6 +23,6 @@ const InstruqtFrame = forwardRef(({ title, height, embedValue }, ref) => {
       src={frameSrc}
     />
   );
-});
+};
 
 export default InstruqtFrame;

--- a/src/components/Instruqt/index.js
+++ b/src/components/Instruqt/index.js
@@ -6,7 +6,8 @@ import { InstruqtContext } from './instruqt-context';
 const Instruqt = ({ nodeData }) => {
   const embedValue = nodeData?.argument[0]?.value;
   const title = nodeData?.options?.title;
-  const { isOpen, hasDrawer } = useContext(InstruqtContext);
+  const isDrawer = nodeData?.options?.drawer;
+  const { isOpen } = useContext(InstruqtContext);
 
   if (!embedValue) {
     return null;
@@ -14,7 +15,7 @@ const Instruqt = ({ nodeData }) => {
 
   return (
     <>
-      {hasDrawer ? (
+      {isDrawer ? (
         isOpen && (
           <>
             <LabDrawer embedValue={embedValue} title={title} />

--- a/src/components/Instruqt/index.js
+++ b/src/components/Instruqt/index.js
@@ -1,44 +1,12 @@
-import React, { useCallback, useRef, useContext } from 'react';
-import { css } from '@emotion/react';
-import IconButton from '@leafygreen-ui/icon-button';
-import Icon from '@leafygreen-ui/icon';
-import { theme } from '../../theme/docsTheme';
+import React, { useContext } from 'react';
 import LabDrawer from './LabDrawer';
 import InstruqtFrame from './InstruqtFrame';
 import { InstruqtContext } from './instruqt-context';
 
-const controlsStyle = css`
-  width: 100%;
-  height: 48px;
-  background-color: rgb(28, 38, 57);
-  margin-top: -10px;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding: 0 1rem;
-  margin-bottom: ${theme.size.default};
-`;
-
 const Instruqt = ({ nodeData }) => {
   const embedValue = nodeData?.argument[0]?.value;
   const title = nodeData?.options?.title;
-  const iframeRef = useRef(null);
   const { isOpen, hasDrawer } = useContext(InstruqtContext);
-
-  const onFullScreen = useCallback(() => {
-    if (iframeRef) {
-      const element = iframeRef.current;
-      if (element.requestFullscreen) {
-        element.requestFullscreen();
-      } else if (element.msRequestFullscreen) {
-        element.msRequestFullscreen();
-      } else if (element.mozRequestFullScreen) {
-        element.mozRequestFullScreen();
-      } else if (element.webkitRequestFullscreen) {
-        element.webkitRequestFullscreen();
-      }
-    }
-  }, [iframeRef]);
 
   if (!embedValue) {
     return null;
@@ -46,21 +14,14 @@ const Instruqt = ({ nodeData }) => {
 
   return (
     <>
-      {process.env.GATSBY_FEATURE_LAB_DRAWER === 'true' && hasDrawer ? (
+      {hasDrawer ? (
         isOpen && (
           <>
             <LabDrawer embedValue={embedValue} title={title} />
           </>
         )
       ) : (
-        <>
-          <InstruqtFrame title={title} embedValue={embedValue} ref={iframeRef} />
-          <div css={controlsStyle}>
-            <IconButton aria-label="Full Screen" onClick={onFullScreen}>
-              <Icon glyph="FullScreenEnter" />
-            </IconButton>
-          </div>
-        </>
+        <InstruqtFrame title={title} embedValue={embedValue} />
       )}
     </>
   );

--- a/tests/unit/Instruqt.test.js
+++ b/tests/unit/Instruqt.test.js
@@ -50,7 +50,7 @@ describe('Instruqt', () => {
     };
 
     it('renders in a drawer', () => {
-      const wrapper = renderComponent(mockData.example, hasLabDrawer);
+      const wrapper = renderComponent(mockData.exampleDrawer, hasLabDrawer);
       openLabDrawer(wrapper);
 
       // Ensure everything exists
@@ -61,7 +61,7 @@ describe('Instruqt', () => {
     });
 
     it('can be minimized and brought back to starting height', () => {
-      const wrapper = renderComponent(mockData.example, hasLabDrawer);
+      const wrapper = renderComponent(mockData.exampleDrawer, hasLabDrawer);
       openLabDrawer(wrapper);
       const drawerContainer = wrapper.getByTestId('resizable-wrapper');
       // Label text based on aria labels for LG Icons
@@ -80,7 +80,7 @@ describe('Instruqt', () => {
     });
 
     it('can set height to maximum', () => {
-      const wrapper = renderComponent(mockData.example, hasLabDrawer);
+      const wrapper = renderComponent(mockData.exampleDrawer, hasLabDrawer);
       openLabDrawer(wrapper);
       const drawerContainer = wrapper.getByTestId('resizable-wrapper');
       const fullscreenEnterButton = wrapper.getByLabelText('Full Screen Enter Icon');
@@ -98,13 +98,29 @@ describe('Instruqt', () => {
     });
 
     it('can be closed', () => {
-      const wrapper = renderComponent(mockData.example, hasLabDrawer);
+      const wrapper = renderComponent(mockData.exampleDrawer, hasLabDrawer);
       openLabDrawer(wrapper);
       const xButton = wrapper.getByLabelText('X Icon');
       expect(wrapper.queryByTestId('resizable-wrapper')).toBeTruthy();
 
       userEvent.click(xButton);
       expect(wrapper.queryByTestId('resizable-wrapper')).toBeFalsy();
+    });
+
+    // This would most likely be a content edge case, but testing here to ensure graceful handling
+    it('renders both a drawer and embedded content', () => {
+      const wrapper = render(
+        <InstruqtProvider hasLabDrawer={hasLabDrawer}>
+          <Heading sectionDepth={1} nodeData={mockTitleHeading} />
+          <Instruqt nodeData={mockData.exampleDrawer} />
+          <Instruqt nodeData={mockData.example} />
+        </InstruqtProvider>
+      );
+      openLabDrawer(wrapper);
+      const drawerContainers = wrapper.queryAllByTestId('resizable-wrapper');
+      // Ensure there's only 1 drawer, but 2 Instruqt frames
+      expect(drawerContainers).toHaveLength(1);
+      expect(wrapper.queryAllByTitle('Instruqt', { exact: false })).toHaveLength(2);
     });
   });
 });

--- a/tests/unit/Instruqt.test.js
+++ b/tests/unit/Instruqt.test.js
@@ -26,10 +26,6 @@ const renderComponent = (nodeData, hasLabDrawer = false) => {
 };
 
 describe('Instruqt', () => {
-  beforeEach(() => {
-    process.env.GATSBY_FEATURE_LAB_DRAWER = false;
-  });
-
   it('renders null when directive argument does not exist', () => {
     const wrapper = renderComponent(mockData.noArgument);
     expect(wrapper.queryByTitle('Instruqt', { exact: false })).toBeFalsy();
@@ -44,10 +40,6 @@ describe('Instruqt', () => {
     const hasLabDrawer = true;
     jest.useFakeTimers();
     const defaultWindowHeight = global.window.innerHeight;
-
-    beforeEach(() => {
-      process.env.GATSBY_FEATURE_LAB_DRAWER = 'true';
-    });
 
     const openLabDrawer = (wrapper) => {
       const expectedButtonText = 'Open Interactive Tutorial';

--- a/tests/unit/data/Instruqt.test.json
+++ b/tests/unit/data/Instruqt.test.json
@@ -17,5 +17,20 @@
         "value": "/mongodb-docs/tracks/getting-started-with-mongodb?token=em_j_d_wUT93QTFvgsZ"
       }
     ]
+  },
+  "exampleDrawer": {
+    "type": "directive",
+    "children": [],
+    "domain": "mongodb",
+    "name": "instruqt",
+    "argument": [
+      {
+        "type": "text",
+        "value": "/mongodb-docs/tracks/getting-started-with-mongodb?token=em_j_d_wUT93QTFvgsZ"
+      }
+    ],
+    "options": {
+      "drawer": true
+    }
   }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-3846

### Current Behavior:

[Server prod](https://www.mongodb.com/docs/manual/tutorial/getting-started/)
[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4284/tutorial/getting-started/index.html)

### Staging Links:

[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-3846/tutorial/getting-started/index.html) - drawer
[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-3846/reference/method/db.collection.find/index.html#try-it-yourself) - no drawer

### Notes:

* Main change is to remove the fullscreen functionality from the existing Instruqt component. This component was originally added as part of the original implementation of the Instruqt iframe, but is no longer needed since the iframe natively supports fullscreen now.
* Bonus changes:
  * Removed the feature flag for Instruqt drawers. The recent changes to this component have been pretty stable and removing this now avoids us from needing to perform additional feature flag configuration on the Autobuilder. Risk in removing should be low since the content team is required to use a `drawer` option to render the labs as drawers.
  * Changed lab drawers to have them render based on their directive's option instead of the context. This makes the source of truth closer to the directive itself, and prevents any potential issues if someone were to use both a drawer and an embedded lab on the same page (unlikely, but this minimizes any unintentional rendering).