### PR TITLE
DOP-4333: Limit search fetches to SearchResults component

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -6,7 +6,6 @@ import { SidenavMobileMenuDropdown } from '../Sidenav';
 import SiteBanner from '../Banner/SiteBanner';
 import { isBrowser } from '../../utils/is-browser';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
-import { useMarianManifests } from '../../hooks/use-marian-manifests';
 import { theme } from '../../theme/docsTheme';
 
 const CHATBOT_ENABLED = process.env['GATSBY_SHOW_CHATBOT'] === 'true';
@@ -21,8 +20,7 @@ const StyledHeaderContainer = styled.header(
 );
 
 const Header = ({ sidenav, eol, template }) => {
-  const { project, branch } = useSnootyMetadata();
-  const { searchPropertyMapping } = useMarianManifests();
+  const { project } = useSnootyMetadata();
 
   let searchProperty;
 
@@ -33,34 +31,11 @@ const Header = ({ sidenav, eol, template }) => {
   const shouldSearchRealm = project === 'realm' || searchProperty === 'realm-master';
   const unifiedNavProperty = shouldSearchRealm ? 'REALM' : 'DOCS';
 
-  const searchParams = [];
-
-  let searchManifestName = project;
-
-  /**
-   * The searchPropertyMapping object will contain a new property
-   * called "projectToSearchMap". This map contains a mapping from
-   * the project name to the true search manifest name in cases where the
-   * project name is NOT the search manifest name.
-   */
-
-  if (searchPropertyMapping.projectToSearchMap && project in searchPropertyMapping.projectToSearchMap) {
-    searchManifestName = searchPropertyMapping.projectToSearchMap[project];
-  }
-
-  const projectManifest = `${searchManifestName}-${branch}`;
-
-  if (projectManifest in searchPropertyMapping) {
-    searchParams.push({ param: 'docsProperty', value: projectManifest });
-  }
-
   return (
     <StyledHeaderContainer template={template}>
       <SiteBanner />
       <>
-        {!eol && (
-          <UnifiedNav fullWidth="true" position="relative" property={{ name: unifiedNavProperty, searchParams }} />
-        )}
+        {!eol && <UnifiedNav fullWidth="true" position="relative" property={{ name: unifiedNavProperty }} />}
         {sidenav && <SidenavMobileMenuDropdown />}
       </>
     </StyledHeaderContainer>

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -7,10 +7,6 @@ import { HeaderContextProvider } from './Header/header-context';
 import { SidenavContextProvider } from './Sidenav';
 import { TabProvider } from './Tabs/tab-context';
 import { ContentsProvider } from './Contents/contents-context';
-import { SearchContextProvider } from './SearchResults/SearchContext';
-
-// Check for feature flag here to make it easier to pass down for testing purposes
-const SHOW_FACETS = process.env.GATSBY_FEATURE_FACETED_SEARCH === 'true';
 
 const RootProvider = ({ children, headingNodes, selectors, slug, repoBranches, remoteMetadata, project }) => {
   let providers = (
@@ -19,9 +15,7 @@ const RootProvider = ({ children, headingNodes, selectors, slug, repoBranches, r
         <HeaderContextProvider>
           <VersionContextProvider repoBranches={repoBranches} slug={slug}>
             <TocContextProvider remoteMetadata={remoteMetadata}>
-              <SidenavContextProvider>
-                <SearchContextProvider showFacets={SHOW_FACETS}>{children}</SearchContextProvider>
-              </SidenavContextProvider>
+              <SidenavContextProvider>{children}</SidenavContextProvider>
             </TocContextProvider>
           </VersionContextProvider>
         </HeaderContextProvider>

--- a/src/components/SearchResults/SearchWrapper.js
+++ b/src/components/SearchResults/SearchWrapper.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SearchContextProvider } from './SearchContext';
+import SearchResults from './SearchResults';
+
+// Check for feature flag here to make it easier to pass down for testing purposes
+const SHOW_FACETS = process.env.GATSBY_FEATURE_FACETED_SEARCH === 'true';
+
+// Wraps the main SearchResults component with a context provider to limit scope of data
+const SearchWrapper = () => {
+  return (
+    <SearchContextProvider showFacets={SHOW_FACETS}>
+      <SearchResults />
+    </SearchContextProvider>
+  );
+};
+
+export default SearchWrapper;

--- a/src/components/SearchResults/index.js
+++ b/src/components/SearchResults/index.js
@@ -1,3 +1,3 @@
-import SearchResults from './SearchResults';
+import SearchWrapper from './SearchWrapper';
 
-export default SearchResults;
+export default SearchWrapper;

--- a/tests/unit/SearchResults.test.js
+++ b/tests/unit/SearchResults.test.js
@@ -7,7 +7,7 @@ import { act } from 'react-dom/test-utils';
 // Importing all specifically to use jest spyOn, mockImplementation for mocking
 import { mockLocation } from '../utils/mock-location';
 import { tick, setMobile } from '../utils';
-import SearchResults from '../../src/components/SearchResults';
+import SearchResults from '../../src/components/SearchResults/SearchResults';
 import { SearchContextProvider } from '../../src/components/SearchResults/SearchContext';
 import mockStaticQuery from '../utils/mockStaticQuery';
 import * as RealmUtil from '../../src/utils/realm';


### PR DESCRIPTION
### Stories/Links:

DOP-4333

### Current Behavior:

Open the network tab of the browser's dev tools, filter by "search-transport" and you should see requests for them, even on pages that aren't the search page. The search page is expected to have them.

[Server prod](https://www.mongodb.com/docs/manual/)
[Landing prod](https://www.mongodb.com/docs/) - homepage
[Landing prod](https://www.mongodb.com/docs/search?q=test) - search
[Landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/facets-enabled/master/landing/raymund.rodriguez/main/index.html?q=test) - search (facets enabled)

### Staging Links:

Open the network tab of the browser's dev tools, filter by "search-transport" and you should see requests for them only on the search pages, and no requests on non-search pages. Ideally, this PR does not change the search page's current behavior.

[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4333/index.html)
[Landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/facets-disabled/master/landing/raymund.rodriguez/DOP-4333/index.html?q=test) - homepage
[Landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/facets-disabled/master/landing/raymund.rodriguez/DOP-4333/search/index.html?q=test) - search (no facets)
[Landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/facets-enabled/master/landing/raymund.rodriguez/DOP-4333/search/index.html?q=test) - search (with facets)

### Notes:

* Main change is that a new `SearchWrapper` component was created to wrap `SearchResults` so that we can move the `SearchContextProvider` away from `RootProvider`. This will allow the existing `SearchResults` component to pull in search data from context without any major refactoring.
* Also removed the fetch request for search data from the `Header` component. This was once used for contextual search across different docs sites, but since this functionality was removed from DOP-4105, it should be safe to remove now without any negative regression. We should consider re-adding if contextual search needs to be re-enabled.