### PR TITLE
:white_check_mark: DOP-4302 handles test with lazy loading a component

### DIFF
--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -45,25 +45,19 @@ describe('DocumentBody', () => {
       expect(languageSelector.querySelectorAll('li')).toHaveLength(4);
     }
 
-    await waitFor(
-      () => {
-        const feedbackWidget = screen.getByText(FEEDBACK_BUTTON_TEXT);
-        expect(feedbackWidget).toBeVisible();
-        expect(feedbackWidget).toMatchSnapshot();
+    const feedbackWidget = await screen.getByText(FEEDBACK_BUTTON_TEXT);
+    expect(feedbackWidget).toBeVisible();
+    expect(feedbackWidget).toMatchSnapshot();
 
-        const chatbotWidget = screen.getByText(CHATBOT_WIDGET_TEXT);
-        /* NOT to be visible for now, with display:none */
-        expect(chatbotWidget).not.toBeVisible();
-        expect(chatbotWidget).toMatchSnapshot();
-      },
-      { timeout: 8000 }
-    );
+    const chatbotWidget = screen.getByText(CHATBOT_WIDGET_TEXT);
+    /* NOT to be visible for now, with display:none */
+    expect(chatbotWidget).not.toBeVisible();
+    expect(chatbotWidget).toMatchSnapshot();
 
     const mainNav = screen.getByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).toBeVisible();
     expect(mainNav).toMatchSnapshot();
-    /* Give more time for lazy-loaded components to be found */
-  }, 12000);
+  });
 
   it('does not render the following elements, footer, feedback widget, navigation', async () => {
     mockLocation('?presentation=true');

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -45,18 +45,23 @@ describe('DocumentBody', () => {
       expect(languageSelector.querySelectorAll('li')).toHaveLength(4);
     }
 
-    const feedbackWidget = await screen.getByText(FEEDBACK_BUTTON_TEXT);
-    expect(feedbackWidget).toBeVisible();
-    expect(feedbackWidget).toMatchSnapshot();
-
-    const chatbotWidget = screen.getByText(CHATBOT_WIDGET_TEXT);
-    /* NOT to be visible for now, with display:none */
-    expect(chatbotWidget).not.toBeVisible();
-    expect(chatbotWidget).toMatchSnapshot();
-
     const mainNav = screen.getByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).toBeVisible();
     expect(mainNav).toMatchSnapshot();
+
+    return waitFor(
+      () => {
+        const feedbackWidget = screen.getByText(FEEDBACK_BUTTON_TEXT);
+        expect(feedbackWidget).toBeVisible();
+        expect(feedbackWidget).toMatchSnapshot();
+
+        const chatbotWidget = screen.getByText(CHATBOT_WIDGET_TEXT);
+        /* NOT to be visible for now, with display:none */
+        expect(chatbotWidget).not.toBeVisible();
+        expect(chatbotWidget).toMatchSnapshot();
+      },
+      { timeout: 8000 }
+    );
   });
 
   it('does not render the following elements, footer, feedback widget, navigation', async () => {

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -773,6 +773,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 
 exports[`DocumentBody renders the necessary elements 2`] = `
 .emotion-0 {
+  width: 100%;
+  min-width: 100px;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+<img
+  alt="MongoDB logo"
+  class="emotion-0"
+  src="https://webimages.mongodb.com/_com_assets/cms/kuyj3d95v5vbmm2f4-horizontal_white.svg?auto=format%252Ccompress"
+/>
+`;
+
+exports[`DocumentBody renders the necessary elements 3`] = `
+.emotion-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -832,23 +847,8 @@ exports[`DocumentBody renders the necessary elements 2`] = `
 </button>
 `;
 
-exports[`DocumentBody renders the necessary elements 3`] = `
+exports[`DocumentBody renders the necessary elements 4`] = `
 <b>
   Ask MongoDB AI
 </b>
-`;
-
-exports[`DocumentBody renders the necessary elements 4`] = `
-.emotion-0 {
-  width: 100%;
-  min-width: 100px;
-  font-size: 14px;
-  line-height: 18px;
-}
-
-<img
-  alt="MongoDB logo"
-  class="emotion-0"
-  src="https://webimages.mongodb.com/_com_assets/cms/kuyj3d95v5vbmm2f4-horizontal_white.svg?auto=format%252Ccompress"
-/>
 `;


### PR DESCRIPTION
### Stories/Links:

DOP-4302

### Current Behavior:

[Flaky test](https://github.com/mongodb/snooty/actions/runs/7805040018/job/21288329645)

### Staging Links:

[Passing test](https://github.com/mongodb/snooty/actions/runs/7820424159)

### Notes:

It seems according to Jest's [test](https://jestjs.io/docs/api#testname-fn-timeout) method documentation, there is a way of making a test wait for the promise to resolve before letting the test complete. 

In our case, the solution is to return the promise from the `waitFor` async function from RTL.  Since this test now waits for the promise to resolve, we can remove the optional timeout.
