### PR TITLE
DOP-4355: Extend grab area of lab drawer handle

### DIFF
--- a/src/components/Instruqt/LabDrawer.js
+++ b/src/components/Instruqt/LabDrawer.js
@@ -32,18 +32,25 @@ const handleContainerStyle = css`
   justify-content: center;
 `;
 
-const handleStyle = css`
+const handleGrabArea = css`
   position: absolute;
-  border-radius: 4px;
   cursor: ns-resize;
   top: 10px;
-  background-color: ${palette.white};
-  width: 50px;
-  height: 4px;
+
+  // Allows element to be bigger in size while maintaining visual size
+  padding: 10px 20px 20px 20px;
+  margin: -10px -20px -20px -20px;
 
   @media ${theme.screenSize.upToMedium} {
     display: none;
   }
+`;
+
+const handleStyle = css`
+  border-radius: 4px;
+  background-color: ${palette.white};
+  width: 50px;
+  height: 4px;
 `;
 
 const topContainerStyle = css`
@@ -75,11 +82,28 @@ const titleStyle = css`
   }
 `;
 
+const iframeOverlayStyle = (frameHeight, isResizing) => css`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  opacity: 0;
+  height: ${frameHeight}px;
+  width: 100%;
+  // Hide the div to allow iframe interaction
+  ${!isResizing && 'display: none;'}
+`;
+
 const CustomResizeHandle = React.forwardRef((props, ref) => {
+  // handleAxis is being filtered out to avoid prop warning for div
+  // restProps along with ref are what actually allows react-resizable to treat this as a handle
   const { handleAxis, ...restProps } = props;
   return (
     <div className={cx(handleContainerStyle)}>
-      <div className={cx(handleStyle)} ref={ref} {...restProps} />
+      {/* Allow grab area to be bigger than the actual shape of the handle */}
+      <div className={cx(handleGrabArea)} ref={ref} {...restProps}>
+        <div className={cx(handleStyle)} />
+      </div>
     </div>
   );
 });
@@ -88,6 +112,7 @@ const LabDrawer = ({ title, embedValue }) => {
   const viewportSize = useViewport();
   const { isMobile } = useScreenSize();
   const labTitle = title || 'MongoDB Interactive Lab';
+  const [isResizing, setIsResizing] = useState(false);
 
   const defaultMeasurement = 200;
   const defaultHeight = (viewportSize.height * 2) / 3 ?? defaultMeasurement;
@@ -135,6 +160,8 @@ const LabDrawer = ({ title, embedValue }) => {
       resizeHandles={['n']}
       handle={<CustomResizeHandle />}
       onResize={handleResize}
+      onResizeStart={() => setIsResizing(true)}
+      onResizeStop={() => setIsResizing(false)}
     >
       {/* Need this div with style as a wrapper to help with resizing */}
       <div style={{ width: wrapperWidth, height: height + 'px' }} data-testid="resizable-wrapper">
@@ -148,6 +175,8 @@ const LabDrawer = ({ title, embedValue }) => {
             setHeight={setHeight}
           />
         </div>
+        {/* Having an overlaying div allows dragging to not bug out when mouse crosses over into the iframe */}
+        <div className={cx(iframeOverlayStyle(frameHeight, isResizing))} />
         <InstruqtFrame title={title} embedValue={embedValue} height={frameHeight} />
       </div>
     </Resizable>,

--- a/src/components/Instruqt/LabDrawer.js
+++ b/src/components/Instruqt/LabDrawer.js
@@ -82,13 +82,12 @@ const titleStyle = css`
   }
 `;
 
-const iframeOverlayStyle = (frameHeight) => css`
+const iframeOverlayStyle = css`
   position: absolute;
   bottom: 0;
   left: 0;
   z-index: 1;
   opacity: 0;
-  height: ${frameHeight}px;
   width: 100%;
 `;
 
@@ -174,7 +173,8 @@ const LabDrawer = ({ title, embedValue }) => {
           />
         </div>
         {/* Having an overlaying div allows dragging to not bug out when mouse crosses over into the iframe */}
-        {isResizing && <div className={cx(iframeOverlayStyle(frameHeight))} />}
+        {/* Keep height separate from css style to avoid constant css updates */}
+        {isResizing && <div className={cx(iframeOverlayStyle)} style={{ height: `${frameHeight}px` }} />}
         <InstruqtFrame title={title} embedValue={embedValue} height={frameHeight} />
       </div>
     </Resizable>,

--- a/src/components/Instruqt/LabDrawer.js
+++ b/src/components/Instruqt/LabDrawer.js
@@ -82,7 +82,7 @@ const titleStyle = css`
   }
 `;
 
-const iframeOverlayStyle = (frameHeight, isResizing) => css`
+const iframeOverlayStyle = (frameHeight) => css`
   position: absolute;
   bottom: 0;
   left: 0;
@@ -90,8 +90,6 @@ const iframeOverlayStyle = (frameHeight, isResizing) => css`
   opacity: 0;
   height: ${frameHeight}px;
   width: 100%;
-  // Hide the div to allow iframe interaction
-  ${!isResizing && 'display: none;'}
 `;
 
 const CustomResizeHandle = React.forwardRef((props, ref) => {
@@ -176,7 +174,7 @@ const LabDrawer = ({ title, embedValue }) => {
           />
         </div>
         {/* Having an overlaying div allows dragging to not bug out when mouse crosses over into the iframe */}
-        <div className={cx(iframeOverlayStyle(frameHeight, isResizing))} />
+        {isResizing && <div className={cx(iframeOverlayStyle(frameHeight))} />}
         <InstruqtFrame title={title} embedValue={embedValue} height={frameHeight} />
       </div>
     </Resizable>,


### PR DESCRIPTION
### Stories/Links:

DOP-4355

### Current Behavior:

[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/main/tutorial/getting-started/index.html) - from the bug bash

### Staging Links:

[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4355/tutorial/getting-started/index.html)

### Notes:

* Main change was to wrap the lab handle to allow the grab area to extend past the actual handle div. Please let me know if the range is big enough or not!
* This PR also fixes the annoying interaction in Chrome with the iframe where resizing downwards would become wonky after the mouse starts to hover over the iframe. The change was to add a div overlay only when resizing so that the mouse would technically directly hover the div, and not the iframe itself. Unsure if this is the best way to do this or if this fixes it for everyone, so please feel free to try it out!