### PR TITLE
:recycle: DOP-4358 pull out some functions into its own utils to be reused, along with creating a currentUserCleanup function

### DIFF
--- a/src/components/Widgets/FeedbackWidget/realm.js
+++ b/src/components/Widgets/FeedbackWidget/realm.js
@@ -1,36 +1,17 @@
 import React from 'react';
 import * as Realm from 'realm-web';
 import { isBrowser } from '../../../utils/is-browser';
+import { removeAllUsersFromLocalStorage } from '../../../utils/realm-user-management';
 
 const APP_ID = 'feedbackwidgetv3-dgcsv';
 export const app = isBrowser ? Realm.App.getApp(APP_ID) : { auth: {} };
-
-/**
- * @param {object} storage
- * @returns The prefix for the storage key used by Realm for localStorage access
- */
-function parseStorageKey(storage) {
-  if (!storage.keyPart) {
-    return '';
-  }
-  const prefix = parseStorageKey(storage.storage);
-  return prefix + storage.keyPart + ':';
-}
 
 /**
  * Deletes localStorage data for all users
  */
 function deleteLocalStorageData() {
   const { allUsers } = app;
-  // The accessToken and refreshToken are automatically removed if invalid, but not the following keys
-  const keysToDelete = ['profile', 'providerType'];
-
-  Object.values(allUsers).forEach((user) => {
-    const storageKeyPrefix = parseStorageKey(user.storage);
-    keysToDelete.forEach((key) => {
-      localStorage.removeItem(storageKeyPrefix + key);
-    });
-  });
+  removeAllUsersFromLocalStorage(allUsers);
 }
 
 // User Authentication & Management

--- a/src/utils/realm-user-management.js
+++ b/src/utils/realm-user-management.js
@@ -1,0 +1,43 @@
+/**
+ * @param {object} storage
+ * @returns The prefix for the storage key used by Realm for localStorage access
+ */
+const parseStorageKey = (storage) => {
+  if (!storage.keyPart) {
+    return '';
+  }
+  const prefix = parseStorageKey(storage.storage);
+  return prefix + storage.keyPart + ':';
+};
+
+export const removeAllUsersFromLocalStorage = (allUsers) => {
+  // The accessToken and refreshToken are automatically removed if invalid, but not the following keys
+  const keysToDelete = ['profile', 'providerType'];
+
+  Object.values(allUsers).forEach((user) => {
+    const storageKeyPrefix = parseStorageKey(user.storage);
+    keysToDelete.forEach((key) => {
+      localStorage.removeItem(storageKeyPrefix + key);
+    });
+  });
+};
+
+export const ensureCurrentUserSingleton = (app) => {
+  if (app.currentUser) {
+    return;
+  }
+};
+
+export const currentUsersCleanup = (app, maxUsersAllowed = 10) => {
+  const { allUsers } = app;
+
+  const allUsersSize = Object.keys(allUsers).length;
+
+  if (allUsersSize >= maxUsersAllowed) {
+    // Delete local storage for the app, removing all logged in users creds
+    // local store will restore new values on page navigation or refresh
+    if (typeof window !== 'undefined') {
+      removeAllUsersFromLocalStorage(allUsers);
+    }
+  }
+};

--- a/src/utils/realm.js
+++ b/src/utils/realm.js
@@ -1,5 +1,6 @@
 import * as Realm from 'realm-web';
 import { SNOOTY_REALM_APP_ID } from '../build-constants';
+import { ensureCurrentUserSingleton, currentUsersCleanup } from './realm-user-management';
 
 const app = new Realm.App({ id: SNOOTY_REALM_APP_ID });
 
@@ -13,10 +14,12 @@ const loginAnonymous = async () => {
     return loginDefer;
   }
 
+  // Only clears local store if there are more than or equal to
+  // 10 users in storage.
+  currentUsersCleanup(app);
+
   // Avoid creating multiple users if one already exists
-  if (app.currentUser) {
-    return;
-  }
+  ensureCurrentUserSingleton(app);
 
   loginDefer = new Promise(async (res, rej) => {
     try {


### PR DESCRIPTION
### Stories/Links:

DOP-4358

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

This logic focuses on the following 

- Pulls out localStorage removal logic into its own utils method, so it can be reused in other places. 
- Defined and implemented a `cleanUsersCleanup` method for browsers that contain more than 10 realm users in their `localStorage`. 

There is no staging link provided in this PR, as it wouldn't provide much value for testing.
