### PR TITLE
DOP-4327: Remove references to publishedBranches from frontend

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -141,7 +141,6 @@ const DocumentBody = (props) => {
           location={location}
           pageOptions={page?.options}
           pageTitle={pageTitle}
-          publishedBranches={getNestedValue(['publishedBranches'], metadata)}
           slug={slug}
           isInPresentationMode={isInPresentationMode}
           template={template}

--- a/src/components/DocumentBodyPreview.js
+++ b/src/components/DocumentBodyPreview.js
@@ -97,7 +97,6 @@ const DocumentBody = (props) => {
         // prod plugin for consistency
         template,
         page: data?.page?.ast,
-        publishedBranches: getNestedValue(['publishedBranches'], metadata),
         ...props.pageContext,
       }}
       metadata={metadata}
@@ -108,7 +107,6 @@ const DocumentBody = (props) => {
           location={location}
           pageOptions={page?.options}
           pageTitle={pageTitle}
-          publishedBranches={getNestedValue(['publishedBranches'], metadata)}
           slug={slug}
           template={template}
           isInPresentationMode={isInPresentationMode}

--- a/src/components/Widgets/FeedbackWidget/useFeedbackData.js
+++ b/src/components/Widgets/FeedbackWidget/useFeedbackData.js
@@ -1,13 +1,12 @@
 import useSnootyMetadata from '../../../utils/use-snooty-metadata';
 
-export default function useFeedbackData({ slug, title, url, publishedBranches }) {
+export default function useFeedbackData({ slug, title, url }) {
   const { project } = useSnootyMetadata();
   const feedback_data = {
     slug,
     url,
     title,
     docs_property: project,
-    docs_version: publishedBranches ? publishedBranches.version.published : null,
   };
   return feedback_data;
 }

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -36,7 +36,7 @@ const WidgetsContainer = styled.div`
   }
 `;
 
-const Widgets = ({ children, pageOptions, pageTitle, publishedBranches, slug, isInPresentationMode, template }) => {
+const Widgets = ({ children, pageOptions, pageTitle, slug, isInPresentationMode, template }) => {
   const { isOpen } = useContext(InstruqtContext);
   const url = isBrowser ? window.location.href : null;
   const hideFeedbackHeader = pageOptions.hidefeedback === 'header';
@@ -44,7 +44,6 @@ const Widgets = ({ children, pageOptions, pageTitle, publishedBranches, slug, is
     slug,
     url,
     title: pageTitle || 'Home',
-    publishedBranches,
   });
 
   // DOP-4025: hide feedback tab on homepage
@@ -73,7 +72,6 @@ Widgets.propTypes = {
     hideFeedback: PropTypes.string,
   }),
   pageTitle: PropTypes.string.isRequired,
-  publishedBranches: PropTypes.object,
   slug: PropTypes.string.isRequired,
   isInPresentationMode: PropTypes.bool,
 };

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -85,7 +85,7 @@ const GlobalGrid = styled('div')`
 
 const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBranches, template } }) => {
   const { sidenav } = getTemplate(template);
-  const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol, project } = useSnootyMetadata();
+  const { chapters, guides, slugToTitle, title, toctree, eol, project } = useSnootyMetadata();
   const remoteMetadata = useRemoteMetadata();
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
@@ -115,7 +115,6 @@ const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBran
               guides={guides}
               page={page.ast}
               pageTitle={pageTitle}
-              publishedBranches={publishedBranches}
               repoBranches={repoBranches}
               siteTitle={title}
               slug={slug}
@@ -141,7 +140,6 @@ DefaultLayout.propTypes = {
     page: PropTypes.shape({
       options: PropTypes.object,
     }).isRequired,
-    publishedBranches: PropTypes.object,
     slug: PropTypes.string,
     template: PropTypes.string,
   }).isRequired,

--- a/src/layouts/preview-layout.js
+++ b/src/layouts/preview-layout.js
@@ -139,7 +139,7 @@ const DefaultLayout = ({
   metadata,
 }) => {
   const { sidenav } = getTemplate(template);
-  const { chapters, guides, publishedBranches, slugToTitle, title, toctree, eol } = metadata;
+  const { chapters, guides, slugToTitle, title, toctree, eol } = metadata;
 
   const pageTitle = React.useMemo(() => page?.options?.title || slugToTitle?.[slug === '/' ? 'index' : slug], [slug]); // eslint-disable-line react-hooks/exhaustive-deps
   useDelightedSurvey(slug, metadata.project);
@@ -164,7 +164,6 @@ const DefaultLayout = ({
                 guides={guides}
                 page={page}
                 pageTitle={pageTitle}
-                publishedBranches={publishedBranches}
                 repoBranches={repoBranches}
                 siteTitle={title}
                 slug={slug}
@@ -188,7 +187,6 @@ DefaultLayout.propTypes = {
     page: PropTypes.shape({
       options: PropTypes.object,
     }).isRequired,
-    publishedBranches: PropTypes.object,
     slug: PropTypes.string,
     template: PropTypes.string,
   }).isRequired,

--- a/tests/unit/useFeedbackData.test.js
+++ b/tests/unit/useFeedbackData.test.js
@@ -49,24 +49,5 @@ describe('useFeedbackData', () => {
     expect(wrapper.getByText('https://docs.mongodb.com/test')).toBeTruthy();
     expect(wrapper.getByText('Test Page Please Ignore')).toBeTruthy();
     expect(wrapper.getByText('testproject')).toBeTruthy();
-    expect(wrapper.queryByText('4.2')).toEqual(null);
-  });
-
-  it('returns the current docs version, if applicable', () => {
-    const wrapper = render(
-      <Test
-        data={{
-          slug: '/test',
-          title: 'Test Page Please Ignore',
-          url: 'https://docs.mongodb.com/test',
-          publishedBranches: {
-            version: {
-              published: '4.2',
-            },
-          },
-        }}
-      />
-    );
-    expect(wrapper.getByText('4.2')).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Stories/Links:

[DOP-4327](https://jira.mongodb.org/browse/DOP-4327)

This PR should not result in any meaningful changes, it is just removing the deprecated data structure `publishedBranches` which used to list out active and published branches/versions of a docs repo but has has long been deprecated in favor of repos_branches. The frontend still referenced it and passed it down as a prop to the feedback widget, but it was not actually being used.

### Staging Links:

[Staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/anabella.buckvar/DOP-4327/)

### Notes:
