### PR TITLE
Adding Class Option back to Image Component

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -20,6 +20,9 @@ const Image = ({ nodeData, className }) => {
   const imgAlignment = getNestedValue(['options', 'align'], nodeData);
   const customAlign = imgAlignment ? `align-${imgAlignment}` : '';
 
+  // added to get hero image class back post-DOP-4321
+  const classOption = getNestedValue(['options', 'class'], nodeData);
+
   const defaultStyling = css`
     max-width: 100%;
     height: auto;
@@ -64,7 +67,7 @@ const Image = ({ nodeData, className }) => {
         alt={altText}
         style={userOptionStyle}
         imgClassName={cx(defaultStyling, hasBorder ? borderStyling : '')}
-        className={cx(gatsbyContainerStyle, directiveClass, customAlign, className)}
+        className={cx(gatsbyContainerStyle, directiveClass, customAlign, className, classOption)}
       />
     );
   }
@@ -77,7 +80,14 @@ const Image = ({ nodeData, className }) => {
       height={height}
       alt={altText}
       style={userOptionStyle}
-      className={cx(defaultStyling, hasBorder ? borderStyling : '', directiveClass, customAlign, className)}
+      className={cx(
+        defaultStyling,
+        hasBorder ? borderStyling : '',
+        directiveClass,
+        customAlign,
+        className,
+        classOption
+      )}
     />
   );
 };


### PR DESCRIPTION
### Stories/Links:

Vaguely related to [DOP-4342](https://jira.mongodb.org/browse/DOP-4342)

[DOP-4321](https://github.com/mongodb/snooty/commit/862eb93807c02a3a880e1a420a4892c525d932a9#diff-ffd2b22195ccbbae4128ae0f9aa63e3b223dec62b101275024fd4d21509f58e6) resulted in, for some reason or another, the `:class:` option for directives not being passed to the `<img>` tag anymore. This is a quick fix for that, as it was messing with the header on the new homepage.

### Current Behavior:

[Current behavior on draft homepage](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4300/landing/maya/main/index.html)

### Staging Links:

[Updated behavior](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4300/landing/maya/DOP-4342/)

Please ignore the "lg-ArrowRight" stuff going on!

### Notes:

### README updates

- [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- [x] This PR does not introduce changes that should be reflected in the README
