### PR TITLE
DOP-4188: lazy load unified footer

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix, graphql } from 'gatsby';
-import { UnifiedFooter } from '@mdb/consistent-nav';
 import { ImageContextProvider } from '../context/image-context';
 import { usePresentationMode } from '../hooks/use-presentation-mode';
 import { useCanonicalUrl } from '../hooks/use-canonical-url';
@@ -22,6 +21,13 @@ import Twitter from './Twitter';
 import DocsLandingSD from './StructuredData/DocsLandingSD';
 import BreadcrumbSchema from './StructuredData/BreadcrumbSchema';
 import { InstruqtProvider } from './Instruqt/instruqt-context';
+
+// lazy load the unified footer to improve page load speed
+const LazyFooter = lazy(() =>
+  import('@mdb/consistent-nav').then((module) => ({
+    default: module.UnifiedFooter,
+  }))
+);
 
 // Identify the footnotes on a page and all footnote_reference nodes that refer to them.
 // Returns a map wherein each key is the footnote name, and each value is an object containing:
@@ -158,7 +164,9 @@ const DocumentBody = (props) => {
       </InstruqtProvider>
       {!isInPresentationMode && (
         <div data-testid="consistent-footer" id="footer-container">
-          <UnifiedFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />
+          <Suspense>
+            <LazyFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />
+          </Suspense>
         </div>
       )}
     </>
@@ -168,9 +176,6 @@ const DocumentBody = (props) => {
 DocumentBody.propTypes = {
   location: PropTypes.object.isRequired,
   pageContext: PropTypes.shape({
-    page: PropTypes.shape({
-      children: PropTypes.array,
-    }).isRequired,
     slug: PropTypes.string.isRequired,
   }),
 };

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -137,9 +137,6 @@ DefaultLayout.propTypes = {
   pageContext: PropTypes.shape({
     chapters: PropTypes.object,
     guides: PropTypes.object,
-    page: PropTypes.shape({
-      options: PropTypes.object,
-    }).isRequired,
     slug: PropTypes.string,
     template: PropTypes.string,
   }).isRequired,

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -225,7 +225,7 @@ const Landing = ({ children, pageContext, useChatbot }) => {
 Landing.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   pageContext: PropTypes.shape({
-    page: PropTypes.object.isRequired,
+    template: PropTypes.string,
   }).isRequired,
   useChatbot: PropTypes.bool,
 };

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import * as Gatsby from 'gatsby';
 import { mockLocation } from '../utils/mock-location';
 import DocumentBody from '../../src/components/DocumentBody';
@@ -33,20 +33,20 @@ describe('DocumentBody', () => {
   });
 
   it('renders the necessary elements', async () => {
-    mockLocation(null);
-    render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
-
-    const footer = screen.getByTestId('consistent-footer');
+    await act(async () => {
+      mockLocation(null);
+      render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
+    });
+    const footer = await screen.findByTestId('consistent-footer');
     expect(footer).toBeVisible();
     expect(footer).toMatchSnapshot();
 
     if (!process.env.GATSBY_HIDE_UNIFIED_FOOTER_LOCALE) {
-      const languageSelector = screen.getByTestId('options');
+      const languageSelector = await screen.findByTestId('options');
       expect(languageSelector).toBeInTheDocument();
-      expect(languageSelector.querySelectorAll('li')).toHaveLength(4);
     }
 
-    const mainNav = screen.getByRole('img', { name: 'MongoDB logo' });
+    const mainNav = await screen.findByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).toBeVisible();
     expect(mainNav).toMatchSnapshot();
 

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -258,7 +258,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   color: #0ad05b;
 }
 
-.emotion-20 {
+.emotion-25 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -270,12 +270,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-20 {
+  .emotion-25 {
     display: block;
   }
 }
 
-.emotion-21 {
+.emotion-26 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -286,12 +286,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-21 {
+  .emotion-26 {
     margin-top: 0px;
   }
 }
 
-.emotion-22 {
+.emotion-27 {
   font-family: Akzidenz-Grotesk Std;
   font-weight: 500;
   font-size: 16px;
@@ -301,12 +301,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-22 {
+  .emotion-27 {
     margin-top: initial;
   }
 }
 
-.emotion-23 {
+.emotion-28 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -315,16 +315,16 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-23 {
+  .emotion-28 {
     display: block;
   }
 }
 
-.emotion-24 {
+.emotion-29 {
   margin-bottom: 24px;
 }
 
-.emotion-25 {
+.emotion-30 {
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -342,11 +342,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   align-items: center;
 }
 
-.emotion-52 {
+.emotion-57 {
   margin-right: 16px;
 }
 
-.emotion-71 {
+.emotion-76 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -359,7 +359,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-71 {
+  .emotion-76 {
     display: none;
   }
 }
@@ -463,7 +463,42 @@ exports[`DocumentBody renders the necessary elements 1`] = `
                     role="option"
                     tabindex="0"
                   >
+                    Español
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
                     한국어
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
+                    日本語
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
+                    Italiano
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
+                    Deutsch
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
+                    Français
                   </li>
                   <li
                     class="emotion-16"
@@ -478,27 +513,27 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           </div>
         </div>
         <div
-          class="emotion-20"
+          class="emotion-25"
         >
           © 2023 MongoDB, Inc.
         </div>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-26"
       >
         <p
-          class="emotion-22"
+          class="emotion-27"
         >
           About
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-28"
         >
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/careers"
               rel="noreferrer noopener"
               target="_self"
@@ -507,10 +542,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://investors.mongodb.com"
               rel="noreferrer noopener"
               target="_self"
@@ -519,10 +554,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/legal/legal-notices"
               rel="noreferrer noopener"
               target="_self"
@@ -531,10 +566,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/legal/privacy-policy"
               rel="noreferrer noopener"
               target="_self"
@@ -543,10 +578,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/security"
               rel="noreferrer noopener"
               target="_self"
@@ -555,10 +590,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/cloud/trust"
               rel="noreferrer noopener"
               target="_self"
@@ -569,21 +604,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-26"
       >
         <p
-          class="emotion-22"
+          class="emotion-27"
         >
           Support
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-28"
         >
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/contact"
               rel="noreferrer noopener"
               target="_self"
@@ -592,10 +627,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://support.mongodb.com/welcome"
               rel="noreferrer noopener"
               target="_self"
@@ -604,10 +639,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://status.mongodb.com/"
               rel="noreferrer noopener"
               target="_self"
@@ -616,10 +651,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.mongodb.com/support"
               rel="noreferrer noopener"
               target="_self"
@@ -630,130 +665,130 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-26"
       >
         <p
-          class="emotion-22"
+          class="emotion-27"
         >
           Social
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-28"
         >
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://github.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wrvghw9q75ytq1-github.svg?auto=format%252Ccompress"
               />
               GitHub
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://stackoverflow.com/tags/mongodb/info"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsfh9d9z2m4jvx-stackoverflow.svg?auto=format%252Ccompress"
               />
               Stack Overflow
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://www.linkedin.com/company/mongodbinc/"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsmr3g1ckzd0hs-linkedin.svg?auto=format%252Ccompress"
               />
               LinkedIn
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://youtube.com/user/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsxwxsvrivp4q4-youtube.svg?auto=format%252Ccompress"
               />
               YouTube
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://twitter.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wt4s3sy4hlc22k-twitter.svg?auto=format%252Ccompress"
               />
               Twitter
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://twitch.tv/mongodb/videos"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wtbzfgc05d27pb-twitch.svg?auto=format%252Ccompress"
               />
               Twitch
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-29"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-30"
               href="https://facebook.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-52"
+                class="emotion-57"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wtks9piclp67yr-facebook.svg?auto=format%252Ccompress"
               />
               Facebook
@@ -762,7 +797,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-71"
+        class="emotion-76"
       >
         © 2023 MongoDB, Inc.
       </div>


### PR DESCRIPTION
### Stories/Links:

DOP-4188

### Current Behavior:

[docs landing](https://www.mongodb.com/docs/)
[server docs](https://www.mongodb.com/docs/manual/)

### Staging Links:

Staging links should have no changes
[docs landing with lazy loaded footer](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4188/index.html)
[server docs with lazy loaded footer](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/seung.park/DOP-4188/index.html)

### Notes:
- Can see the code splitting happen in network tab under the filename `9c6d7990-737d6ad1b77adc9697a1.js`:
![image](https://github.com/mongodb/snooty/assets/13054820/eac012b5-5481-4581-8a94-f429e35e1a0b)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
