### PR TITLE
DOP-4394: save files to public

### DIFF
--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -6,8 +6,13 @@ const GATSBY_IMAGE_EXTENSIONS = ['webp', 'png', 'avif'];
 const isPreview = isGatsbyPreview();
 
 const saveFile = async (file, data) => {
-  // if this is preview, always save to 'public'
-  // images saved in /src/images are transformed and processed by gatsby-source-filesystem and gatsby-transformer-sharp
+  // save files both to "public" and "src/images" directories
+  // the first is for public access, and the second is for image processing
+  await fs.mkdir(path.join('public', path.dirname(file)), {
+    recursive: true,
+  });
+  await fs.writeFile(path.join('public', file), data, 'binary');
+
   const pathList =
     !isPreview && GATSBY_IMAGE_EXTENSIONS.some((ext) => file.endsWith(ext)) ? ['src', 'images'] : ['public'];
   await fs.mkdir(path.join(...pathList, path.dirname(file)), {


### PR DESCRIPTION
### Stories/Links:

DOP-4394

### Current Behavior:

[atlas app service page with missing icons](https://www.mongodb.com/docs/atlas/app-services/sync/)

### Staging Links:

[staged atlas app service page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-app-services/seung.park/DOP-4394/index.html)

### Notes:
- This is a quick fix to allow directives that use images to work. Images will be stored in both `public` and `src/images` directories. The first is for public access, and the latter is for image processing

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
