### PR TITLE
DOP-4393: fix broken language selector

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -83,9 +83,9 @@ const Select = ({
           <Option
             className={cx(optionStyling)}
             key={choice.value}
-            glyph={choice.icon}
             value={choice.value}
             role="option"
+            glyph={choice.glyph ? choice.glyph : null}
           >
             {choice.text}
           </Option>

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -18,6 +18,13 @@ const portalStyle = css`
   position: relative;
 `;
 
+const iconStyling = css`
+  display: inline-block;
+  margin-right: ${theme.size.small};
+  max-height: 20px;
+  width: 30px;
+`;
+
 /* Override LG mobile style of enlarged mobile font */
 const selectStyle = css`
   @media ${theme.screenSize.upToLarge} {
@@ -80,7 +87,14 @@ const Select = ({
         {...props}
       >
         {choices.map((choice) => (
-          <Option className={cx(optionStyling)} key={choice.value} value={choice.value} role="option">
+          <Option
+            className={cx(optionStyling)}
+            key={choice.value}
+            value={choice.value}
+            glyph={choice.icon}
+            role="option"
+          >
+            {choice.tabSelectorIcon && <choice.tabSelectorIcon className={cx(iconStyling)} />}
             {choice.text}
           </Option>
         ))}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -80,13 +80,7 @@ const Select = ({
         {...props}
       >
         {choices.map((choice) => (
-          <Option
-            className={cx(optionStyling)}
-            key={choice.value}
-            value={choice.value}
-            role="option"
-            // glyph ={choice.icon ? : choice.icon : null}
-          >
+          <Option className={cx(optionStyling)} key={choice.value} value={choice.value} role="option">
             {choice.text}
           </Option>
         ))}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -85,7 +85,7 @@ const Select = ({
             key={choice.value}
             value={choice.value}
             role="option"
-            glyph={choice.glyph ? choice.glyph : null}
+            // glyph ={choice.icon ? : choice.icon : null}
           >
             {choice.text}
           </Option>

--- a/src/components/Tabs/TabSelectors.js
+++ b/src/components/Tabs/TabSelectors.js
@@ -24,7 +24,7 @@ const makeChoices = ({ name, iconMapping, options }) =>
   Object.entries(options).map(([tabId, title]) => ({
     text: getPlaintext(title),
     value: tabId,
-    ...(name === 'drivers' && { icon: iconMapping[tabId] }),
+    ...(name === 'drivers' && { tabSelectorIcon: iconMapping[tabId] }),
   }));
 
 const TabSelector = ({ activeTab, handleClick, iconMapping, name, options }) => {


### PR DESCRIPTION
### Stories/Links:

[DOP-4393](https://jira.mongodb.org/browse/DOP-4393)

### Current Behavior:

Clicking the language selector causes the screen to go blank.
example: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/


### Staging Links:

[Staging Link with working Language Selector](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/anabella.buckvar/DOP-4393/manage-connections-aws-lambda/)

[Staging Link with working Deprecated Version Selector](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/anabella.buckvar/DOP-4393/legacy/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
