### PR TITLE
DOP-4408: add robust way of providing image props

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -8,6 +8,61 @@ import ImageContext from '../context/image-context';
 import { getNestedValue } from '../utils/get-nested-value';
 import { removeLeadingSlash } from '../utils/remove-leading-slash';
 
+const defaultStyling = css`
+  max-width: 100%;
+  height: auto;
+`;
+const borderStyling = css`
+  border: 0.5px solid ${palette.gray.light1};
+  border-radius: 4px;
+`;
+const gatsbyContainerStyle = css`
+  height: max-content;
+`;
+
+function getImageProps({
+  altText,
+  userOptionStyle,
+  width,
+  height,
+  gatsbyImage,
+  hasBorder,
+  customAlign,
+  className,
+  directiveClass,
+  imgSrc,
+  srcSet,
+}) {
+  const imageProps = {
+    alt: altText ?? '',
+    style: userOptionStyle,
+  };
+  if (width) {
+    imageProps['width'] = width;
+  }
+  if (height) {
+    imageProps['height'] = height;
+  }
+
+  if (gatsbyImage) {
+    imageProps['image'] = gatsbyImage;
+    imageProps['imgClassName'] = cx(defaultStyling, hasBorder ? borderStyling : '');
+    imageProps['className'] = cx(gatsbyContainerStyle, directiveClass, customAlign, className);
+  } else {
+    imageProps['src'] = imgSrc;
+    imageProps['srcSet'] = srcSet;
+    imageProps['className'] = cx(
+      defaultStyling,
+      hasBorder ? borderStyling : '',
+      directiveClass,
+      customAlign,
+      className
+    );
+  }
+
+  return imageProps;
+}
+
 const Image = ({ nodeData, className }) => {
   const scale = (parseInt(getNestedValue(['options', 'scale'], nodeData), 10) || 100) / 100;
   const widthOption = getNestedValue(['options', 'width'], nodeData);
@@ -20,29 +75,18 @@ const Image = ({ nodeData, className }) => {
   const imgAlignment = getNestedValue(['options', 'align'], nodeData);
   const customAlign = imgAlignment ? `align-${imgAlignment}` : '';
 
-  const defaultStyling = css`
-    max-width: 100%;
-    height: auto;
-  `;
   const hasBorder = getNestedValue(['options', 'border'], nodeData);
-  const borderStyling = css`
-    border: 0.5px solid ${palette.gray.light1};
-    border-radius: 4px;
-  `;
-  const gatsbyContainerStyle = css`
-    height: max-content;
-  `;
 
   const { imageByPath } = useContext(ImageContext);
-  const image = imageByPath[removeLeadingSlash(imgSrc)];
+  const gatsbyImage = imageByPath[removeLeadingSlash(imgSrc)];
   // if there is a preprocessed image, use those new values for
   // src, srcset, width, height
   let srcSet, width;
-  if (image) {
-    width = image.width * scale;
-    height = image.height * scale;
-    imgSrc = image.images.fallback.src;
-    srcSet = image.images.fallback.srcSet;
+  if (gatsbyImage) {
+    width = gatsbyImage.width * scale;
+    height = gatsbyImage.height * scale;
+    imgSrc = gatsbyImage.images.fallback.src;
+    srcSet = gatsbyImage.images.fallback.srcSet;
   } else {
     width = parseInt(widthOption, 10) * scale;
     height *= scale;
@@ -54,32 +98,27 @@ const Image = ({ nodeData, className }) => {
     userOptionStyle['width'] = widthOption;
   }
 
-  if (loading === 'lazy' && image) {
-    // loading option comes from parser. if image is to be lazy loaded, use gatsby image
-    return (
-      <GatsbyImage
-        image={image}
-        width={width}
-        height={height}
-        alt={altText}
-        style={userOptionStyle}
-        imgClassName={cx(defaultStyling, hasBorder ? borderStyling : '')}
-        className={cx(gatsbyContainerStyle, directiveClass, customAlign, className)}
-      />
-    );
+  const imageProps = getImageProps({
+    altText,
+    userOptionStyle,
+    width,
+    height,
+    gatsbyImage,
+    hasBorder,
+    customAlign,
+    className,
+    directiveClass,
+    imgSrc,
+    srcSet,
+  });
+
+  if (loading === 'lazy' && gatsbyImage) {
+    return <GatsbyImage {...imageProps} />;
   }
 
-  return (
-    <img
-      src={imgSrc}
-      srcSet={srcSet}
-      width={width}
-      height={height}
-      alt={altText}
-      style={userOptionStyle}
-      className={cx(defaultStyling, hasBorder ? borderStyling : '', directiveClass, customAlign, className)}
-    />
-  );
+  // imageProps contains altText prop
+  // eslint-disable-next-line jsx-a11y/alt-text
+  return <img {...imageProps} />;
 };
 
 Image.propTypes = {

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -22,9 +22,7 @@ exports[`renders border correctly when specified as an option 1`] = `
     <img
       alt="/images/firstcluster.png"
       class="emotion-1"
-      height="NaN"
       src="/images/firstcluster.png"
-      width="NaN"
     />
   </div>
 </DocumentFragment>
@@ -92,9 +90,7 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
       <img
         alt="/images/firstcluster.png"
         class="emotion-2"
-        height="NaN"
         src="/images/firstcluster.png"
-        width="NaN"
       />
       <div
         class="emotion-3 emotion-4"


### PR DESCRIPTION
### Stories/Links:

DOP-4408

### Current Behavior:

[docs landing shows SVG hero with NaN dimensions](https://www.mongodb.com/docs/)
[cloud docs shows SVG images with NaN dimensions](https://www.mongodb.com/docs/atlas/backup/cloud-backup/backup-early-access/)


### Staging Links:

[docs landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4408/index.html)
[cloud docs shows SVG without NaN dimensions](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4408/backup/cloud-backup/backup-early-access/index.html)

[cloud docs with SVG values defined from parser](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/c077494d33ab88ab38e05f862cb0a3e8e5dbb9fe/master/cloud-docs/seung.park/DOP-4408/backup/cloud-backup/backup-early-access/index.html)

### Notes:
- If you inspect the image elements at the pages above, you will see a `NaN` value for width and height properties. The same images (SVG types) should have these attributes non-number values removed.
- There is also (not required) [a parser change](https://github.com/mongodb/snooty-parser/pull/569) that sets the values for these SVG images so we can further optimize.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
