### PR TITLE
DOP-4406: Fixed React minified error in Suspense

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { lazy } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -6,6 +6,7 @@ import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme';
 import 'react-loading-skeleton/dist/skeleton.css';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { SuspenseHelper } from './SuspenseHelper';
 
 const SKELETON_BORDER_RADIUS = '12px';
 
@@ -94,18 +95,20 @@ const ChatbotUi = ({ template }) => {
   return (
     <StyledChatBotUiContainer data-testid="chatbot-ui" template={template}>
       {/* We wrapped this in a Suspense. We can use this opportunity to render a loading state if we decided we want that */}
-      <Suspense fallback={<Skeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
+      <SuspenseHelper fallback={<Skeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
         <Chatbot maxInputCharacters={DEFAULT_MAX_INPUT} serverBaseUrl={CHATBOT_SERVER_BASE_URL}>
-          <DocsChatbot
-            suggestedPrompts={[
-              'How do you deploy a free cluster in Atlas?',
-              'How do you import or migrate data into MongoDB Atlas?',
-              'Get started with MongoDB',
-              'Why should I use Atlas Search?',
-            ]}
-          />
+          <SuspenseHelper fallback={'Chatbot...'}>
+            <DocsChatbot
+              suggestedPrompts={[
+                'How do you deploy a free cluster in Atlas?',
+                'How do you import or migrate data into MongoDB Atlas?',
+                'Get started with MongoDB',
+                'Why should I use Atlas Search?',
+              ]}
+            />
+          </SuspenseHelper>
         </Chatbot>
-      </Suspense>
+      </SuspenseHelper>
     </StyledChatBotUiContainer>
   );
 };

--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -97,16 +97,14 @@ const ChatbotUi = ({ template }) => {
       {/* We wrapped this in a Suspense. We can use this opportunity to render a loading state if we decided we want that */}
       <SuspenseHelper fallback={<Skeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
         <Chatbot maxInputCharacters={DEFAULT_MAX_INPUT} serverBaseUrl={CHATBOT_SERVER_BASE_URL}>
-          <SuspenseHelper fallback={'Chatbot...'}>
-            <DocsChatbot
-              suggestedPrompts={[
-                'How do you deploy a free cluster in Atlas?',
-                'How do you import or migrate data into MongoDB Atlas?',
-                'Get started with MongoDB',
-                'Why should I use Atlas Search?',
-              ]}
-            />
-          </SuspenseHelper>
+          <DocsChatbot
+            suggestedPrompts={[
+              'How do you deploy a free cluster in Atlas?',
+              'How do you import or migrate data into MongoDB Atlas?',
+              'Get started with MongoDB',
+              'Why should I use Atlas Search?',
+            ]}
+          />
         </Chatbot>
       </SuspenseHelper>
     </StyledChatBotUiContainer>

--- a/src/components/ComponentFactoryLazy.js
+++ b/src/components/ComponentFactoryLazy.js
@@ -1,4 +1,5 @@
 import React, { lazy } from 'react';
+import { SuspenseHelper } from './SuspenseHelper';
 
 const ComponentMap = {
   openapi: lazy(() => import('./OpenAPI')),
@@ -11,9 +12,9 @@ const ComponentMap = {
 export const LAZY_COMPONENTS = Object.keys(ComponentMap).reduce((res, key) => {
   const LazyComponent = ComponentMap[key];
   res[key] = (props) => (
-    <React.Suspense>
+    <SuspenseHelper fallback={null}>
       <LazyComponent {...props} />
-    </React.Suspense>
+    </SuspenseHelper>
   );
   return res;
 }, {});

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useEffect, lazy } from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix, graphql } from 'gatsby';
 import { ImageContextProvider } from '../context/image-context';
@@ -21,6 +21,7 @@ import Twitter from './Twitter';
 import DocsLandingSD from './StructuredData/DocsLandingSD';
 import BreadcrumbSchema from './StructuredData/BreadcrumbSchema';
 import { InstruqtProvider } from './Instruqt/instruqt-context';
+import { SuspenseHelper } from './SuspenseHelper';
 
 // lazy load the unified footer to improve page load speed
 const LazyFooter = lazy(() =>
@@ -164,9 +165,9 @@ const DocumentBody = (props) => {
       </InstruqtProvider>
       {!isInPresentationMode && (
         <div data-testid="consistent-footer" id="footer-container">
-          <Suspense>
+          <SuspenseHelper fallback={null}>
             <LazyFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />
-          </Suspense>
+          </SuspenseHelper>
         </div>
       )}
     </>

--- a/src/components/SuspenseHelper.js
+++ b/src/components/SuspenseHelper.js
@@ -1,0 +1,14 @@
+import { useEffect, useState, Suspense } from 'react';
+
+/* Helper to avoid React minified errors. Compiles fallback component into the static HTML pages. */
+export const SuspenseHelper = ({ fallback, children }) => {
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (!isMounted) {
+      setMounted(true);
+    }
+  }, [isMounted]);
+
+  return <Suspense fallback={fallback}>{!isMounted ? fallback : children}</Suspense>;
+};

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -1,9 +1,10 @@
-import React, { Suspense, useContext } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { isBrowser } from '../../utils/is-browser';
 import { theme } from '../../theme/docsTheme';
 import { InstruqtContext } from '../Instruqt/instruqt-context';
+import { SuspenseHelper } from '../SuspenseHelper';
 import { FeedbackProvider, FeedbackForm, FeedbackButton, useFeedbackData } from './FeedbackWidget';
 import ChatbotFab from './ChatbotWidget/ChatbotFab';
 
@@ -54,13 +55,13 @@ const Widgets = ({ children, pageOptions, pageTitle, slug, isInPresentationMode,
       {children}
       {!isInPresentationMode && !hideFeedback && (
         /* Suspense at this level ensures that widgets will appear simultaneously rather than one-by-one as loaded */
-        <Suspense fallback={null}>
+        <SuspenseHelper fallback={null}>
           <WidgetsContainer className={widgetsContainer} hasOpenLabDrawer={isOpen}>
             <FeedbackButton />
             <FeedbackForm />
             {template !== 'landing' && <ChatbotFab />}
           </WidgetsContainer>
-        </Suspense>
+        </SuspenseHelper>
       )}
     </FeedbackProvider>
   );


### PR DESCRIPTION
### Stories/Links:

DOP-4406

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Cloud-docs](https://www.mongodb.com/docs/atlas/getting-started/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/matt.meigs/DOP-4406-suspense/index.html)
[Cloud-docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4406-suspense/index.html)

### Notes:

In the current prod site, you can see the react minified error #419 which is here. 

This happens because of SSR hydration differences when using `React.Suspense` and Gatsby. There are a couple [open issues](https://github.com/gatsbyjs/gatsby/issues/36678) with Gatsby for this (even one with our friend Grayson), but this PR introduces a very simple fix to allow the SSR to compile the static html with the fallback and allow stable hydration. Tricks on tricks. I would assume Gatsby will not be fixing this anytime soon.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
