### PR TITLE
DOP-4408: skip gatsby image props if not lazy loaded

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -32,6 +32,7 @@ function getImageProps({
   directiveClass,
   imgSrc,
   srcSet,
+  loading,
 }) {
   const imageProps = {
     alt: altText ?? '',
@@ -44,7 +45,7 @@ function getImageProps({
     imageProps['height'] = height;
   }
 
-  if (gatsbyImage) {
+  if (gatsbyImage && loading === 'lazy') {
     imageProps['image'] = gatsbyImage;
     imageProps['imgClassName'] = cx(defaultStyling, hasBorder ? borderStyling : '');
     imageProps['className'] = cx(gatsbyContainerStyle, directiveClass, customAlign, className);
@@ -110,6 +111,7 @@ const Image = ({ nodeData, className }) => {
     directiveClass,
     imgSrc,
     srcSet,
+    loading,
   });
 
   if (loading === 'lazy' && gatsbyImage) {


### PR DESCRIPTION
### Stories/Links:

DOP-4408

### Current Behavior:

[server docs on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/c077494d33ab88ab38e05f862cb0a3e8e5dbb9fe/v7.0/docs/seung.park/main/index.html)

### Staging Links:

[server docs on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/c077494d33ab88ab38e05f862cb0a3e8e5dbb9fe/v7.0/docs/seung.park/DOP-4408-follow-up/index.html)

### Notes:
- This is a follow up to the [previous PR ](https://github.com/mongodb/snooty/pull/1029) which provided gatsby image props without checking for lazy load. Gatsby image should be used for lazy loading images, and regular image DOM with a `srcset` property should be used for non lazy (hero image in example)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
