### PR TITLE
DOP-4398: Add hreflang links to every page

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -166,6 +166,7 @@ export const Head = ({ pageContext }) => {
         pageTitle={pageTitle}
         siteTitle={siteTitle}
         showDocsLandingTitle={isDocsLandingHomepage}
+        slug={slug}
       />
       {meta.length > 0 && meta.map((c, i) => <Meta key={`meta-${i}`} nodeData={c} />)}
       {twitter.length > 0 && twitter.map((c) => <Twitter {...c} />)}

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, lazy } from 'react';
+import React, { useState, lazy } from 'react';
 import PropTypes from 'prop-types';
-import { withPrefix, graphql } from 'gatsby';
+import { graphql } from 'gatsby';
 import { ImageContextProvider } from '../context/image-context';
 import { usePresentationMode } from '../hooks/use-presentation-mode';
 import { useCanonicalUrl } from '../hooks/use-canonical-url';
@@ -9,9 +9,7 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { getMetaFromDirective } from '../utils/get-meta-from-directive';
 import { getPlaintext } from '../utils/get-plaintext';
 import { getTemplate } from '../utils/get-template';
-import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
-import { isBrowser } from '../utils/is-browser';
 import Widgets from './Widgets';
 import SEO from './SEO';
 import FootnoteContext from './Footnote/footnote-context';
@@ -24,11 +22,7 @@ import { InstruqtProvider } from './Instruqt/instruqt-context';
 import { SuspenseHelper } from './SuspenseHelper';
 
 // lazy load the unified footer to improve page load speed
-const LazyFooter = lazy(() =>
-  import('@mdb/consistent-nav').then((module) => ({
-    default: module.UnifiedFooter,
-  }))
-);
+const LazyFooter = lazy(() => import('./Footer'));
 
 // Identify the footnotes on a page and all footnote_reference nodes that refer to them.
 // Returns a map wherein each key is the footnote name, and each value is an object containing:
@@ -79,35 +73,10 @@ const getAnonymousFootnoteReferences = (index, numAnonRefs) => {
   return index > numAnonRefs ? [] : [`id${index + 1}`];
 };
 
-const HIDE_UNIFIED_FOOTER_LOCALE = process.env['GATSBY_HIDE_UNIFIED_FOOTER_LOCALE'] === 'true';
-const AVAILABLE_LANGUAGES = ['English', '简体中文', '한국어', 'Português'];
-
 const DocumentBody = (props) => {
   const { location, data, pageContext } = props;
   const page = data?.page?.ast;
   const { slug, template } = pageContext;
-
-  useEffect(() => {
-    // A workaround to remove the other locale options.
-    if (!HIDE_UNIFIED_FOOTER_LOCALE) {
-      const footer = document.getElementById('footer-container');
-      const footerUlElement = footer?.querySelector('ul[role=listbox]');
-      if (footerUlElement) {
-        // For DOP-4296 we only want to support English,Simple Chinese,Korean, and Portuguese.
-        const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
-          if (AVAILABLE_LANGUAGES.includes(child.textContent)) {
-            accumulator.push(child);
-          }
-          return accumulator;
-        }, []);
-
-        footerUlElement.innerHTML = null;
-        availableOptions.forEach((child) => {
-          footerUlElement.appendChild(child);
-        });
-      }
-    }
-  }, []);
 
   const initialization = () => {
     const pageNodes = getNestedValue(['children'], page) || [];
@@ -126,20 +95,6 @@ const DocumentBody = (props) => {
   const { Template, useChatbot } = getTemplate(template);
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
-
-  const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`; // handle the `/` path
-  const onSelectLocale = (locale) => {
-    const localeHrefMap = {
-      'zh-cn': `${location.origin}/zh-cn${slugForUrl}`,
-      'en-us': `${location.origin}${slugForUrl}`,
-      'ko-kr': `${location.origin}/ko-kr${slugForUrl}`,
-      'pt-br': `${location.origin}/pt-br${slugForUrl}`,
-    };
-
-    if (isBrowser) {
-      window.location.href = assertTrailingSlash(localeHrefMap[locale]);
-    }
-  };
 
   return (
     <>
@@ -166,7 +121,7 @@ const DocumentBody = (props) => {
       {!isInPresentationMode && (
         <div data-testid="consistent-footer" id="footer-container">
           <SuspenseHelper fallback={null}>
-            <LazyFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />
+            <LazyFooter slug={slug} />
           </SuspenseHelper>
         </div>
       )}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -10,7 +10,7 @@ const Footer = ({ slug }) => {
   const location = useLocation();
 
   const onSelectLocale = (locale) => {
-    const localeHrefMap = getLocaleMapping(location, slug);
+    const localeHrefMap = getLocaleMapping(location.origin, slug);
 
     if (isBrowser) {
       window.location.href = localeHrefMap[locale];

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,28 +1,19 @@
 import React, { useEffect } from 'react';
-import { withPrefix } from 'gatsby';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { UnifiedFooter } from '@mdb/consistent-nav';
 import { isBrowser } from '../utils/is-browser';
-import { assertTrailingSlash } from '../utils/assert-trailing-slash';
+import { AVAILABLE_LANGUAGES, getLocaleMapping } from '../utils/locale';
 
 const HIDE_UNIFIED_FOOTER_LOCALE = process.env['GATSBY_HIDE_UNIFIED_FOOTER_LOCALE'] === 'true';
-const AVAILABLE_LANGUAGES = ['English', '简体中文', '한국어', 'Português'];
 
 const Footer = ({ slug }) => {
   const location = useLocation();
-  // handle the `/` path
-  const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`;
 
   const onSelectLocale = (locale) => {
-    const localeHrefMap = {
-      'zh-cn': `${location.origin}/zh-cn${slugForUrl}`,
-      'en-us': `${location.origin}${slugForUrl}`,
-      'ko-kr': `${location.origin}/ko-kr${slugForUrl}`,
-      'pt-br': `${location.origin}/pt-br${slugForUrl}`,
-    };
+    const localeHrefMap = getLocaleMapping(location, slug);
 
     if (isBrowser) {
-      window.location.href = assertTrailingSlash(localeHrefMap[locale]);
+      window.location.href = localeHrefMap[locale];
     }
   };
 
@@ -34,7 +25,7 @@ const Footer = ({ slug }) => {
       if (footerUlElement) {
         // We only want to support English, Simple Chinese, Korean, and Portuguese for now.
         const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
-          if (AVAILABLE_LANGUAGES.includes(child.textContent)) {
+          if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
             accumulator.push(child);
           }
           return accumulator;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import { withPrefix } from 'gatsby';
+import { useLocation } from '@gatsbyjs/reach-router';
+import { UnifiedFooter } from '@mdb/consistent-nav';
+import { isBrowser } from '../utils/is-browser';
+import { assertTrailingSlash } from '../utils/assert-trailing-slash';
+
+const HIDE_UNIFIED_FOOTER_LOCALE = process.env['GATSBY_HIDE_UNIFIED_FOOTER_LOCALE'] === 'true';
+const AVAILABLE_LANGUAGES = ['English', '简体中文', '한국어', 'Português'];
+
+const Footer = ({ slug }) => {
+  const location = useLocation();
+  // handle the `/` path
+  const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`;
+
+  const onSelectLocale = (locale) => {
+    const localeHrefMap = {
+      'zh-cn': `${location.origin}/zh-cn${slugForUrl}`,
+      'en-us': `${location.origin}${slugForUrl}`,
+      'ko-kr': `${location.origin}/ko-kr${slugForUrl}`,
+      'pt-br': `${location.origin}/pt-br${slugForUrl}`,
+    };
+
+    if (isBrowser) {
+      window.location.href = assertTrailingSlash(localeHrefMap[locale]);
+    }
+  };
+
+  // A workaround to remove the other locale options
+  useEffect(() => {
+    if (!HIDE_UNIFIED_FOOTER_LOCALE) {
+      const footer = document.getElementById('footer-container');
+      const footerUlElement = footer?.querySelector('ul[role=listbox]');
+      if (footerUlElement) {
+        // We only want to support English, Simple Chinese, Korean, and Portuguese for now.
+        const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
+          if (AVAILABLE_LANGUAGES.includes(child.textContent)) {
+            accumulator.push(child);
+          }
+          return accumulator;
+        }, []);
+
+        footerUlElement.innerHTML = null;
+        availableOptions.forEach((child) => {
+          footerUlElement.appendChild(child);
+        });
+      }
+    }
+  }, []);
+
+  return <UnifiedFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />;
+};
+
+export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -23,7 +23,7 @@ const Footer = ({ slug }) => {
       const footer = document.getElementById('footer-container');
       const footerUlElement = footer?.querySelector('ul[role=listbox]');
       if (footerUlElement) {
-        // We only want to support English, Simple Chinese, Korean, and Portuguese for now.
+        // For DOP-4296 we only want to support English, Simple Chinese, Korean, and Portuguese.
         const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
           if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
             accumulator.push(child);

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -12,7 +12,9 @@ const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug }) =>
 
   const hrefLangLinks = Object.entries(localeHrefMap).map(([langCode, href]) => {
     const hrefLang = langCode === 'en-us' ? 'x-default' : langCode;
-    return <link rel="alternate" hrefLang={hrefLang} href={href} />;
+    // Do not remove class. This is used to prevent Smartling's CDN from potentially overwriting these links
+    const smartlingNoRewriteClass = 'sl_norewrite';
+    return <link className={smartlingNoRewriteClass} rel="alternate" hrefLang={hrefLang} href={href} />;
   });
 
   return (

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -15,7 +15,7 @@ const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug }) =>
     const hrefLang = langCode === 'en-us' ? 'x-default' : langCode;
     // Do not remove class. This is used to prevent Smartling's CDN from potentially overwriting these links
     const smartlingNoRewriteClass = 'sl_norewrite';
-    return <link className={smartlingNoRewriteClass} rel="alternate" hrefLang={hrefLang} href={href} />;
+    return <link key={hrefLang} className={smartlingNoRewriteClass} rel="alternate" hrefLang={hrefLang} href={href} />;
   });
 
   return (

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,21 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useLocation } from '@gatsbyjs/reach-router';
+import { getLocaleMapping } from '../utils/locale';
 
 const DEFAULT_TWITTER_SITE = '@mongodb';
 const metaUrl = `https://www.mongodb.com/docs/assets/meta_generic.png`;
 
-const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical }) => (
-  <>
-    <title>{showDocsLandingTitle ? 'MongoDB Documentation' : `${pageTitle} — ${siteTitle}`}</title>
-    {/* Twitter Tags - default values, may be overwritten by Twitter component */}
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content={DEFAULT_TWITTER_SITE} />
-    <meta property="twitter:title" content={pageTitle} />
-    <meta name="twitter:image" content={metaUrl} />
-    <meta name="twitter:image:alt" content="MongoDB logo featuring a green leaf on a dark green background." />
-    {canonical && <link data-testid="canonical" id="canonical" rel="canonical" key={canonical} href={canonical} />}
-  </>
-);
+const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug }) => {
+  const location = useLocation();
+  const localeHrefMap = getLocaleMapping(location, slug);
+
+  const hrefLangLinks = Object.entries(localeHrefMap).map(([langCode, href]) => {
+    const hrefLang = langCode === 'en-us' ? 'x-default' : langCode;
+    return <link rel="alternate" hrefLang={hrefLang} href={href} />;
+  });
+
+  return (
+    <>
+      <title>{showDocsLandingTitle ? 'MongoDB Documentation' : `${pageTitle} — ${siteTitle}`}</title>
+      {hrefLangLinks}
+      {/* Twitter Tags - default values, may be overwritten by Twitter component */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content={DEFAULT_TWITTER_SITE} />
+      <meta property="twitter:title" content={pageTitle} />
+      <meta name="twitter:image" content={metaUrl} />
+      <meta name="twitter:image:alt" content="MongoDB logo featuring a green leaf on a dark green background." />
+      {canonical && <link data-testid="canonical" id="canonical" rel="canonical" key={canonical} href={canonical} />}
+    </>
+  );
+};
 
 SEO.propTypes = {
   pageTitle: PropTypes.string.isRequired,

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from '@gatsbyjs/reach-router';
 import { getLocaleMapping } from '../utils/locale';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 const DEFAULT_TWITTER_SITE = '@mongodb';
 const metaUrl = `https://www.mongodb.com/docs/assets/meta_generic.png`;
 
 const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug }) => {
-  const location = useLocation();
-  const localeHrefMap = getLocaleMapping(location, slug);
+  // Using static siteUrl instead of location.origin due to origin being undefined at build time
+  const { siteUrl } = useSiteMetadata();
+  const localeHrefMap = getLocaleMapping(siteUrl, slug);
 
   const hrefLangLinks = Object.entries(localeHrefMap).map(([langCode, href]) => {
     const hrefLang = langCode === 'en-us' ? 'x-default' : langCode;

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -13,7 +13,7 @@ const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug }) =>
 
   const hrefLangLinks = Object.entries(localeHrefMap).map(([langCode, href]) => {
     const hrefLang = langCode === 'en-us' ? 'x-default' : langCode;
-    // Do not remove class. This is used to prevent Smartling's CDN from potentially overwriting these links
+    // Do not remove class. This is used to prevent Smartling from potentially overwriting these links
     const smartlingNoRewriteClass = 'sl_norewrite';
     return <link key={hrefLang} className={smartlingNoRewriteClass} rel="alternate" hrefLang={hrefLang} href={href} />;
   });

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -1,0 +1,28 @@
+import { withPrefix } from 'gatsby';
+import { assertTrailingSlash } from './assert-trailing-slash';
+
+// Update this as more languages are introduced
+export const AVAILABLE_LANGUAGES = [
+  { language: 'English', code: 'en-us' },
+  { language: '简体中文', code: 'zh-cn' },
+  { language: '한국어', code: 'ko-kr' },
+  { language: 'Português', code: 'pt-br' },
+];
+
+/**
+ * Returns a mapping of a page's URL and its equivalent URLs in different languages.
+ * @param {string} slug
+ */
+export const getLocaleMapping = (location, slug) => {
+  // handle the `/` path
+  const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`;
+  const localeHrefMap = {};
+
+  AVAILABLE_LANGUAGES.forEach(({ code }) => {
+    const langPrefix = code === 'en-us' ? '' : `/${code}`;
+    const targetUrl = `${location.origin}${langPrefix}${slugForUrl}`;
+    localeHrefMap[code] = assertTrailingSlash(targetUrl);
+  });
+
+  return localeHrefMap;
+};

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -13,14 +13,14 @@ export const AVAILABLE_LANGUAGES = [
  * Returns a mapping of a page's URL and its equivalent URLs for different languages.
  * @param {string} slug
  */
-export const getLocaleMapping = (location, slug) => {
+export const getLocaleMapping = (siteUrl, slug) => {
   // handle the `/` path
   const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`;
   const localeHrefMap = {};
 
   AVAILABLE_LANGUAGES.forEach(({ code }) => {
     const langPrefix = code === 'en-us' ? '' : `/${code}`;
-    const targetUrl = `${location.origin}${langPrefix}${slugForUrl}`;
+    const targetUrl = `${siteUrl}${langPrefix}${slugForUrl}`;
     localeHrefMap[code] = assertTrailingSlash(targetUrl);
   });
 

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -11,16 +11,19 @@ export const AVAILABLE_LANGUAGES = [
 
 /**
  * Returns a mapping of a page's URL and its equivalent URLs for different languages.
+ * @param {string} siteUrl
  * @param {string} slug
+ * @returns {object}
  */
 export const getLocaleMapping = (siteUrl, slug) => {
   // handle the `/` path
-  const slugForUrl = slug === '/' ? `${withPrefix('')}` : `${withPrefix(slug)}`;
+  const slugForUrl = slug === '/' ? withPrefix('') : withPrefix(slug);
+  const normalizedSiteUrl = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
   const localeHrefMap = {};
 
   AVAILABLE_LANGUAGES.forEach(({ code }) => {
     const langPrefix = code === 'en-us' ? '' : `/${code}`;
-    const targetUrl = `${siteUrl}${langPrefix}${slugForUrl}`;
+    const targetUrl = `${normalizedSiteUrl}${langPrefix}${slugForUrl}`;
     localeHrefMap[code] = assertTrailingSlash(targetUrl);
   });
 

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -10,7 +10,7 @@ export const AVAILABLE_LANGUAGES = [
 ];
 
 /**
- * Returns a mapping of a page's URL and its equivalent URLs in different languages.
+ * Returns a mapping of a page's URL and its equivalent URLs for different languages.
  * @param {string} slug
  */
 export const getLocaleMapping = (location, slug) => {

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -18,7 +18,7 @@ export const AVAILABLE_LANGUAGES = [
 export const getLocaleMapping = (siteUrl, slug) => {
   // handle the `/` path
   const slugForUrl = slug === '/' ? withPrefix('') : withPrefix(slug);
-  const normalizedSiteUrl = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
+  const normalizedSiteUrl = siteUrl?.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
   const localeHrefMap = {};
 
   AVAILABLE_LANGUAGES.forEach(({ code }) => {

--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -5,6 +5,8 @@ import mockStaticQuery from '../utils/mockStaticQuery';
 import { useSiteMetadata } from '../../src/hooks/use-site-metadata';
 import { usePathPrefix } from '../../src/hooks/use-path-prefix';
 import useSnootyMetadata from '../../src/utils/use-snooty-metadata';
+import { AVAILABLE_LANGUAGES } from '../../src/utils/locale';
+import { DOTCOM_BASE_URL } from '../../src/utils/base-url';
 import mockCompleteEOLPageContext from './data/CompleteEOLPageContext.json';
 import mockEOLSnootyMetadata from './data/EOLSnootyMetadata.json';
 import mockHeadPageContext from './data/HeadPageContext.test.json';
@@ -121,6 +123,23 @@ describe('Head', () => {
 
       const canonicalTag = screen.getByTestId('canonical');
       expectCanonicalTagToBeCorrect(canonicalTag);
+    });
+  });
+
+  describe('hreflang links', () => {
+    beforeEach(() => {
+      mockStaticQuery({
+        siteUrl: DOTCOM_BASE_URL,
+      });
+      useSnootyMetadata.mockImplementation(() => ({ ...mockEOLSnootyMetadata, eol: false }));
+    });
+
+    it.each([['/'], ['foo']])('renders based on slug', (slug) => {
+      const mockPageContext = { ...mockHeadPageContext, slug };
+      const { container } = render(<Head pageContext={mockPageContext} />);
+      const hrefLangLinks = container.querySelectorAll('link.sl_norewrite');
+      expect(hrefLangLinks).toHaveLength(AVAILABLE_LANGUAGES.length);
+      expect(hrefLangLinks).toMatchSnapshot();
     });
   });
 });

--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -14,9 +14,14 @@ import mockHeadPageContext from './data/HeadPageContext.test.json';
 jest.mock(`../../src/utils/use-snooty-metadata`, () => jest.fn());
 
 describe('Head', () => {
+  beforeEach(() => {
+    mockStaticQuery({
+      siteUrl: DOTCOM_BASE_URL,
+    });
+  });
+
   describe("Canonical for completely EOL'd", () => {
     beforeEach(() => {
-      mockStaticQuery({});
       useSnootyMetadata.mockImplementation(() => mockEOLSnootyMetadata);
     });
     it('renders the canonical tag from the snooty.toml', () => {
@@ -32,7 +37,7 @@ describe('Head', () => {
 
   describe("Canonical for EOL'd version", () => {
     beforeEach(() => {
-      mockStaticQuery({}, mockEOLSnootyMetadata);
+      useSnootyMetadata.mockImplementation(() => mockEOLSnootyMetadata);
     });
     it('renders the canonical tag structured from the Head component with trailing slash', () => {
       render(<Head pageContext={mockHeadPageContext} />);
@@ -116,7 +121,7 @@ describe('Head', () => {
     it('renders the canonical tag from directive rather than pulling from default logic', () => {
       //need to override what happens in the beforeEach of this describe
       const modMockEOLSnootyMetadataToBeNotEOL = { ...mockEOLSnootyMetadata, eol: false };
-      mockStaticQuery({}, modMockEOLSnootyMetadataToBeNotEOL);
+      useSnootyMetadata.mockImplementation(() => modMockEOLSnootyMetadataToBeNotEOL);
 
       mockPageContext.page.children.push(metaCanonical);
       render(<Head pageContext={mockPageContext} />);
@@ -128,9 +133,6 @@ describe('Head', () => {
 
   describe('hreflang links', () => {
     beforeEach(() => {
-      mockStaticQuery({
-        siteUrl: DOTCOM_BASE_URL,
-      });
       useSnootyMetadata.mockImplementation(() => ({ ...mockEOLSnootyMetadata, eol: false }));
     });
 

--- a/tests/unit/__snapshots__/Head.test.js.snap
+++ b/tests/unit/__snapshots__/Head.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Head hreflang links renders based on slug 1`] = `
+NodeList [
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/"
+    hreflang="x-default"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/zh-cn/"
+    hreflang="zh-cn"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/ko-kr/"
+    hreflang="ko-kr"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/pt-br/"
+    hreflang="pt-br"
+    rel="alternate"
+  />,
+]
+`;
+
+exports[`Head hreflang links renders based on slug 2`] = `
+NodeList [
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/foo/"
+    hreflang="x-default"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/zh-cn/foo/"
+    hreflang="zh-cn"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/ko-kr/foo/"
+    hreflang="ko-kr"
+    rel="alternate"
+  />,
+  <link
+    class="sl_norewrite"
+    href="https://www.mongodb.com/pt-br/foo/"
+    hreflang="pt-br"
+    rel="alternate"
+  />,
+]
+`;

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -258,7 +258,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   color: #0ad05b;
 }
 
-.emotion-25 {
+.emotion-20 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -270,12 +270,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-25 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-26 {
+.emotion-21 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -286,12 +286,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-26 {
+  .emotion-21 {
     margin-top: 0px;
   }
 }
 
-.emotion-27 {
+.emotion-22 {
   font-family: Akzidenz-Grotesk Std;
   font-weight: 500;
   font-size: 16px;
@@ -301,12 +301,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-27 {
+  .emotion-22 {
     margin-top: initial;
   }
 }
 
-.emotion-28 {
+.emotion-23 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -315,16 +315,16 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-28 {
+  .emotion-23 {
     display: block;
   }
 }
 
-.emotion-29 {
+.emotion-24 {
   margin-bottom: 24px;
 }
 
-.emotion-30 {
+.emotion-25 {
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -342,11 +342,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   align-items: center;
 }
 
-.emotion-57 {
+.emotion-52 {
   margin-right: 16px;
 }
 
-.emotion-76 {
+.emotion-71 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -359,7 +359,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-76 {
+  .emotion-71 {
     display: none;
   }
 }
@@ -463,42 +463,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
                     role="option"
                     tabindex="0"
                   >
-                    Español
-                  </li>
-                  <li
-                    class="emotion-16"
-                    role="option"
-                    tabindex="0"
-                  >
                     한국어
-                  </li>
-                  <li
-                    class="emotion-16"
-                    role="option"
-                    tabindex="0"
-                  >
-                    日本語
-                  </li>
-                  <li
-                    class="emotion-16"
-                    role="option"
-                    tabindex="0"
-                  >
-                    Italiano
-                  </li>
-                  <li
-                    class="emotion-16"
-                    role="option"
-                    tabindex="0"
-                  >
-                    Deutsch
-                  </li>
-                  <li
-                    class="emotion-16"
-                    role="option"
-                    tabindex="0"
-                  >
-                    Français
                   </li>
                   <li
                     class="emotion-16"
@@ -513,27 +478,27 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           </div>
         </div>
         <div
-          class="emotion-25"
+          class="emotion-20"
         >
           © 2023 MongoDB, Inc.
         </div>
       </div>
       <div
-        class="emotion-26"
+        class="emotion-21"
       >
         <p
-          class="emotion-27"
+          class="emotion-22"
         >
           About
         </p>
         <ul
-          class="emotion-28"
+          class="emotion-23"
         >
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/careers"
               rel="noreferrer noopener"
               target="_self"
@@ -542,10 +507,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://investors.mongodb.com"
               rel="noreferrer noopener"
               target="_self"
@@ -554,10 +519,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/legal/legal-notices"
               rel="noreferrer noopener"
               target="_self"
@@ -566,10 +531,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/legal/privacy-policy"
               rel="noreferrer noopener"
               target="_self"
@@ -578,10 +543,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/security"
               rel="noreferrer noopener"
               target="_self"
@@ -590,10 +555,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/cloud/trust"
               rel="noreferrer noopener"
               target="_self"
@@ -604,21 +569,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-26"
+        class="emotion-21"
       >
         <p
-          class="emotion-27"
+          class="emotion-22"
         >
           Support
         </p>
         <ul
-          class="emotion-28"
+          class="emotion-23"
         >
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/contact"
               rel="noreferrer noopener"
               target="_self"
@@ -627,10 +592,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://support.mongodb.com/welcome"
               rel="noreferrer noopener"
               target="_self"
@@ -639,10 +604,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://status.mongodb.com/"
               rel="noreferrer noopener"
               target="_self"
@@ -651,10 +616,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.mongodb.com/support"
               rel="noreferrer noopener"
               target="_self"
@@ -665,130 +630,130 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-26"
+        class="emotion-21"
       >
         <p
-          class="emotion-27"
+          class="emotion-22"
         >
           Social
         </p>
         <ul
-          class="emotion-28"
+          class="emotion-23"
         >
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://github.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wrvghw9q75ytq1-github.svg?auto=format%252Ccompress"
               />
               GitHub
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://stackoverflow.com/tags/mongodb/info"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsfh9d9z2m4jvx-stackoverflow.svg?auto=format%252Ccompress"
               />
               Stack Overflow
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://www.linkedin.com/company/mongodbinc/"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsmr3g1ckzd0hs-linkedin.svg?auto=format%252Ccompress"
               />
               LinkedIn
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://youtube.com/user/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wsxwxsvrivp4q4-youtube.svg?auto=format%252Ccompress"
               />
               YouTube
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://twitter.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wt4s3sy4hlc22k-twitter.svg?auto=format%252Ccompress"
               />
               Twitter
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://twitch.tv/mongodb/videos"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wtbzfgc05d27pb-twitch.svg?auto=format%252Ccompress"
               />
               Twitch
             </a>
           </li>
           <li
-            class="emotion-29"
+            class="emotion-24"
           >
             <a
-              class=" emotion-30"
+              class=" emotion-25"
               href="https://facebook.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
               <img
                 alt=""
-                class="emotion-57"
+                class="emotion-52"
                 src="https://webimages.mongodb.com/_com_assets/cms/kr6wtks9piclp67yr-facebook.svg?auto=format%252Ccompress"
               />
               Facebook
@@ -797,7 +762,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-76"
+        class="emotion-71"
       >
         © 2023 MongoDB, Inc.
       </div>

--- a/tests/unit/utils/__snapshots__/locale.test.js.snap
+++ b/tests/unit/utils/__snapshots__/locale.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`returns a valid mapping of URLs 1`] = `
+{
+  "en-us": "https://www.mongodb.com/docs/",
+  "ko-kr": "https://www.mongodb.com/docs/ko-kr/",
+  "pt-br": "https://www.mongodb.com/docs/pt-br/",
+  "zh-cn": "https://www.mongodb.com/docs/zh-cn/",
+}
+`;
+
+exports[`returns a valid mapping of URLs 2`] = `
+{
+  "en-us": "https://www.mongodb.com/docs/about/page/",
+  "ko-kr": "https://www.mongodb.com/docs/ko-kr/about/page/",
+  "pt-br": "https://www.mongodb.com/docs/pt-br/about/page/",
+  "zh-cn": "https://www.mongodb.com/docs/zh-cn/about/page/",
+}
+`;
+
+exports[`returns a valid mapping of URLs 3`] = `
+{
+  "en-us": "https://www.mongodb.com/introduction/",
+  "ko-kr": "https://www.mongodb.com/ko-kr/introduction/",
+  "pt-br": "https://www.mongodb.com/pt-br/introduction/",
+  "zh-cn": "https://www.mongodb.com/zh-cn/introduction/",
+}
+`;

--- a/tests/unit/utils/locale.test.js
+++ b/tests/unit/utils/locale.test.js
@@ -1,0 +1,11 @@
+import { AVAILABLE_LANGUAGES, getLocaleMapping } from '../../../src/utils/locale';
+
+it.each([
+  ['https://www.mongodb.com/docs/', '/'],
+  ['https://www.mongodb.com/docs', '/about/page/'],
+  ['https://www.mongodb.com', 'introduction'],
+])('returns a valid mapping of URLs', (siteUrl, slug) => {
+  const mapping = getLocaleMapping(siteUrl, slug);
+  expect(Object.keys(mapping)).toHaveLength(AVAILABLE_LANGUAGES.length);
+  expect(mapping).toMatchSnapshot();
+});


### PR DESCRIPTION
### Stories/Links:

DOP-4398

### Current Behavior:

[Server docs on prod](https://www.mongodb.com/docs/manual)
[Server docs on pre-prod](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/manual/)
[Server docs on main](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/main/index.html) - Note that the footer at the bottom has access to many languages

### Staging Links:

[Server docs staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4398/index.html)

### Notes:

Alternate links for different languages have been introduced. Note that these currently use the static `siteUrl` config value to ensure that the base URL is defined at build time. This does mean that when built in staging links or pre-prod, the links will always point to the main https://mongodb.com site. Since SEO isn't typically taken into account for non-prod sites, this _should_ be fine (canonical links and sitemaps have similar behavior). 

To validate, either inspect the page or look at the page source (make sure to add `index.html` to the end), and then search for `hreflang` to see all 4 links. Each link for a page should match the pathname of that page.

This PR also fixes a bug regarding languages available through the UnifiedFooter's dropdown. Since we only want to show valid languages, and the footer doesn't currently have a way to pass in available languages, we use client side logic to filter the languages that we want. However, this breaks when the UnifiedFooter is lazy loaded since the client side logic would begin before the component loaded. The solution was to wrap the footer in its own component and move the client side logic there to ensure all of the logic is done at the same time.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
