### PR TITLE
DOP-4419: Remove feature flag to hide footer language selector

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,8 +4,6 @@ import { UnifiedFooter } from '@mdb/consistent-nav';
 import { isBrowser } from '../utils/is-browser';
 import { AVAILABLE_LANGUAGES, getLocaleMapping } from '../utils/locale';
 
-const HIDE_UNIFIED_FOOTER_LOCALE = process.env['GATSBY_HIDE_UNIFIED_FOOTER_LOCALE'] === 'true';
-
 const Footer = ({ slug }) => {
   const location = useLocation();
 
@@ -19,27 +17,25 @@ const Footer = ({ slug }) => {
 
   // A workaround to remove the other locale options
   useEffect(() => {
-    if (!HIDE_UNIFIED_FOOTER_LOCALE) {
-      const footer = document.getElementById('footer-container');
-      const footerUlElement = footer?.querySelector('ul[role=listbox]');
-      if (footerUlElement) {
-        // For DOP-4296 we only want to support English, Simple Chinese, Korean, and Portuguese.
-        const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
-          if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
-            accumulator.push(child);
-          }
-          return accumulator;
-        }, []);
+    const footer = document.getElementById('footer-container');
+    const footerUlElement = footer?.querySelector('ul[role=listbox]');
+    if (footerUlElement) {
+      // For DOP-4296 we only want to support English, Simple Chinese, Korean, and Portuguese.
+      const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
+        if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
+          accumulator.push(child);
+        }
+        return accumulator;
+      }, []);
 
-        footerUlElement.innerHTML = null;
-        availableOptions.forEach((child) => {
-          footerUlElement.appendChild(child);
-        });
-      }
+      footerUlElement.innerHTML = null;
+      availableOptions.forEach((child) => {
+        footerUlElement.appendChild(child);
+      });
     }
   }, []);
 
-  return <UnifiedFooter hideLocale={HIDE_UNIFIED_FOOTER_LOCALE} onSelectLocale={onSelectLocale} />;
+  return <UnifiedFooter onSelectLocale={onSelectLocale} />;
 };
 
 export default Footer;

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -41,10 +41,8 @@ describe('DocumentBody', () => {
     expect(footer).toBeVisible();
     expect(footer).toMatchSnapshot();
 
-    if (!process.env.GATSBY_HIDE_UNIFIED_FOOTER_LOCALE) {
-      const languageSelector = await screen.findByTestId('options');
-      expect(languageSelector).toBeInTheDocument();
-    }
+    const languageSelector = await screen.findByTestId('options');
+    expect(languageSelector).toBeInTheDocument();
 
     const mainNav = await screen.findByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).toBeVisible();


### PR DESCRIPTION
### Stories/Links:

DOP-4419

### Current Behavior:

[Server prod](https://www.mongodb.com/docs/manual/) - no language/locale selector
[Server staging on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/main/index.html) - language/locale selector should be visible

### Staging Links:

[Server staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4419/index.html) - language/locale selector should be visible

### Notes:

* Logic that was gated by the `GATSBY_HIDE_UNIFIED_FOOTER_LOCALE` env variable has been removed in favor of showing the locale selector by default, regardless of the env's value from the Autobuilder.
* In case of emergency, a rollback of behavior will require reverting this commit and then redeploying all docs properties.
* Removal of the feature flag from our system (Autobuilder, Parameter Store, etc.) should be handled in a separate ticket once the feature is officially live next week.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
