### PR TITLE
DOP-4443: Remove GATSBY_SHOW_CHATBOT feature flag from the frontend

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -8,14 +8,12 @@ import { isBrowser } from '../../utils/is-browser';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import { theme } from '../../theme/docsTheme';
 
-const CHATBOT_ENABLED = process.env['GATSBY_SHOW_CHATBOT'] === 'true';
-
 const StyledHeaderContainer = styled.header(
   (props) => `
   grid-area: header;
   top: 0;
   z-index: ${theme.zIndexes.header};
-  ${props.template !== 'landing' || !CHATBOT_ENABLED ? 'position: sticky;' : ''}
+  ${props.template === 'landing' ? '' : 'position: sticky;'}
   `
 );
 

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -108,7 +108,7 @@ const getTopAndHeight = (topValue, template) => css`
   `}
 `;
 
-// Keep the side nav container sticky to allow LG's side nav to push content seemlessly
+// Keep the side nav container sticky to allow LG's side nav to push content seamlessly
 const SidenavContainer = styled.div(
   ({ topLarge, topMedium, topSmall, template }) => css`
     grid-area: sidenav;

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -29,7 +29,6 @@ import Toctree from './Toctree';
 import { sideNavItemBasePadding, sideNavItemFontSize } from './styles/sideNavItem';
 
 const SIDENAV_WIDTH = 268;
-const CHATBOT_ENABLED = process.env['GATSBY_SHOW_CHATBOT'] === 'true';
 
 // Use LG's css here to style the component without passing props
 const sideNavStyling = ({ hideMobile, isCollapsed }) => LeafyCSS`
@@ -99,7 +98,7 @@ const disableScroll = (shouldDisableScroll) => css`
 
 // use eol status to determine side nav styling
 const getTopAndHeight = (topValue, template) => css`
-  ${template === 'landing' && CHATBOT_ENABLED
+  ${template === 'landing'
     ? `
     top: 0px;
     height: calc(100vh);`

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -7,8 +7,6 @@ import ChatbotUi from '../components/ChatbotUi';
 
 const CONTENT_MAX_WIDTH = 1440;
 
-const SHOW_CHATBOT = process.env['GATSBY_SHOW_CHATBOT'] === 'true';
-
 const Wrapper = styled('main')`
   margin: 0 auto;
   width: 100%;
@@ -54,8 +52,8 @@ const Landing = ({ children, pageContext, useChatbot }) => {
   return (
     <>
       <div>
-        <Wrapper newChatbotLanding={SHOW_CHATBOT && useChatbot}>
-          {SHOW_CHATBOT && useChatbot && <ChatbotUi template={pageContext?.template} />}
+        <Wrapper newChatbotLanding={useChatbot}>
+          {useChatbot && <ChatbotUi template={pageContext?.template} />}
           {children}
         </Wrapper>
       </div>


### PR DESCRIPTION
### Stories/Links:

DOP-4443

### Current Behavior:

Currently, while the chatbot is visible in production, in other environments the `GATSBY_SHOW_CHATBOT` environment variable needs to be true for the chatbot to show up. This PR removes the need for that!

### Staging Links:

[Cloud docs staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4443/index.html)
[Docs landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/maya/DOP-4443/)

### Notes:

This is a tiny, tiny issue but I noticed that when the chatbot is shown, there's a larger, somewhat more awkward (in my opinion) gap under the "View All Products" drop down in the Sidenav (no-chatbot staging link [here](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/maya/main/)). I'm wondering if that's something that should be changed? Happy to leave it or check with design.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
