### PR TITLE
EAI-280: Add register for atlas as a suggested prompt

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -8,6 +8,14 @@ import 'react-loading-skeleton/dist/skeleton.css';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { SuspenseHelper } from './SuspenseHelper';
 
+export const defaultSuggestedPrompts = [
+  'Get started with MongoDB',
+  'How do I register for Atlas?',
+  'How do you deploy a free cluster in Atlas?',
+  'How do you import or migrate data into MongoDB Atlas?',
+  'Why should I use Atlas Search?',
+];
+
 const SKELETON_BORDER_RADIUS = '12px';
 
 // Match landing template max width for alignment purposes
@@ -97,14 +105,7 @@ const ChatbotUi = ({ template }) => {
       {/* We wrapped this in a Suspense. We can use this opportunity to render a loading state if we decided we want that */}
       <SuspenseHelper fallback={<Skeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
         <Chatbot maxInputCharacters={DEFAULT_MAX_INPUT} serverBaseUrl={CHATBOT_SERVER_BASE_URL}>
-          <DocsChatbot
-            suggestedPrompts={[
-              'How do you deploy a free cluster in Atlas?',
-              'How do you import or migrate data into MongoDB Atlas?',
-              'Get started with MongoDB',
-              'Why should I use Atlas Search?',
-            ]}
-          />
+          <DocsChatbot suggestedPrompts={defaultSuggestedPrompts} />
         </Chatbot>
       </SuspenseHelper>
     </StyledChatBotUiContainer>

--- a/src/components/Widgets/ChatbotWidget/ChatbotFab.js
+++ b/src/components/Widgets/ChatbotWidget/ChatbotFab.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 import styled from '@emotion/styled';
 import { useSiteMetadata } from '../../../hooks/use-site-metadata';
-import { DEFAULT_MAX_INPUT } from '../../ChatbotUi';
+import { DEFAULT_MAX_INPUT, defaultSuggestedPrompts } from '../../ChatbotUi';
 import MongoDbLegalDisclosure from './MongoDBLegal';
 
 const Chatbot = lazy(() => import('mongodb-chatbot-ui'));
@@ -19,12 +19,6 @@ const StyledChatBotFabContainer = styled.div`
 
 const ChatbotFab = () => {
   const { snootyEnv } = useSiteMetadata();
-
-  const suggestedPrompts = [
-    'How do you deploy a free cluster in Atlas?',
-    'How do you import or migrate data into MongoDB?',
-    'Get started with MongoDB',
-  ];
   const CHATBOT_SERVER_BASE_URL =
     snootyEnv === 'dotcomprd'
       ? 'https://knowledge.mongodb.com/api/v1'
@@ -39,7 +33,7 @@ const ChatbotFab = () => {
         <ModalView
           disclaimer={<MongoDbLegalDisclosure />}
           initialMessageText="Welcome to MongoDB AI Assistant. What can I help you with?"
-          initialMessageSuggestedPrompts={suggestedPrompts}
+          initialMessageSuggestedPrompts={defaultSuggestedPrompts}
           inputBottomText={BOTTOM_TEXT}
         />
       </Chatbot>


### PR DESCRIPTION
Re-do of https://github.com/mongodb/snooty/pull/1036 (CI failing on that one because I don't have creds on my fork)

- Adds a new suggested prompt to the AI chatbot
- Moves the list of suggested prompts into an exported object called `defaultSuggestedPrompts`
- Uses `defaultSuggestedPrompts` for both versions of the chatbot instead of different lists

### Stories/Links:

[EAI-280: Add register for atlas as a suggested prompt](https://jira.mongodb.org/browse/EAI-280)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

_I don't have a staging env - would appreciate if someone could stage or send me setup info_

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
