### PR TITLE
:bug: DOP-4363 fixes bug for submitting a feedback with a screenshot

### DIFF
--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -6,6 +6,7 @@ import { theme } from '../../../../src/theme/docsTheme';
 import useScreenSize from '../../../hooks/useScreenSize';
 import useStickyTopValues from '../../../hooks/useStickyTopValues';
 import { InstruqtContext } from '../../Instruqt/instruqt-context';
+import { elementZIndex } from '../../../utils/dynamically-set-z-index';
 import ProgressBar from './components/PageIndicators';
 import CloseButton from './components/CloseButton';
 import { useFeedbackContext } from './context';
@@ -52,11 +53,18 @@ const FeedbackCard = ({ isOpen, children }) => {
   const { topSmall } = useStickyTopValues();
   useNoScroll(isMobile);
 
+  const onClose = () => {
+    abandon();
+    // reset the z-index set by the screenshot button on line
+    // 185 in ScreenshotButton.js
+    elementZIndex.resetZIndex('.widgets');
+  };
+
   return (
     isOpen && (
       <FloatingContainer top={topSmall} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
         <Card top={topSmall}>
-          <CloseButton onClick={() => abandon()} />
+          <CloseButton onClick={onClose} />
           <ProgressBar />
           <div>{children}</div>
         </Card>

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -55,8 +55,7 @@ const FeedbackCard = ({ isOpen, children }) => {
 
   const onClose = () => {
     abandon();
-    // reset the z-index set by the screenshot button on line
-    // 185 in ScreenshotButton.js
+    // reset the z-index set by the screenshot button in ScreenshotButton.js
     elementZIndex.resetZIndex('.widgets');
   };
 

--- a/src/components/Widgets/FeedbackWidget/FeedbackForm.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackForm.js
@@ -3,7 +3,6 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import Loadable from '@loadable/component';
 import { createPortal } from 'react-dom';
 import useScreenSize from '../../../hooks/useScreenSize';
-import { theme } from '../../../theme/docsTheme';
 import { useFeedbackContext } from './context';
 import FeedbackCard from './FeedbackCard';
 import RatingView from './views/RatingView';
@@ -21,7 +20,6 @@ export const FeedbackContent = ({ view }) => {
 
 const formStyle = css`
   position: relative;
-  z-index: ${theme.zIndexes.widgets};
 `;
 
 const FeedbackForm = () => {

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -182,8 +182,6 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
   const takeNewScreenshot = useCallback(() => {
     setIsScreenshotButtonClicked(true);
     domElementClickedRef.current = 'dashed';
-    //conditionally set the z-index on the widget card when the screenshot is clicked
-    elementZIndex.setZIndex('.widgets', 14);
     setSelectedElementBorderStyle('dashed');
   }, []);
 
@@ -200,10 +198,14 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
     setIsScreenshotButtonClicked(false);
     setCurrElemState(null);
     setScreenshotTaken(false);
+    elementZIndex.resetZIndex('.widgets');
   };
 
   const handleDOMElementClick = (e) => {
     e.preventDefault();
+
+    //conditionally set the z-index on the widget card when the screenshot is clicked
+    elementZIndex.setZIndex('.widgets', 14);
 
     domElementClickedRef.current = 'solid';
     setSelectedElementBorderStyle(domElementClickedRef.current);

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -11,6 +11,7 @@ import { isBrowser } from '../../../../utils/is-browser';
 import useNoScroll from '../hooks/useNoScroll';
 import { theme } from '../../../../theme/docsTheme';
 import { SCREENSHOT_BUTTON_TEXT, SCREENSHOT_OVERLAY_ALT_TEXT } from '../constants';
+import { elementZIndex } from '../../../../utils/dynamically-set-z-index';
 
 const HIGHLIGHT_BORDER_SIZE = 5;
 
@@ -181,6 +182,8 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
   const takeNewScreenshot = useCallback(() => {
     setIsScreenshotButtonClicked(true);
     domElementClickedRef.current = 'dashed';
+    //conditionally set the z-index on the widget card when the screenshot is clicked
+    elementZIndex.setZIndex('.widgets', 14);
     setSelectedElementBorderStyle('dashed');
   }, []);
 

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -183,6 +183,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
     setIsScreenshotButtonClicked(true);
     domElementClickedRef.current = 'dashed';
     setSelectedElementBorderStyle('dashed');
+    elementZIndex.resetZIndex('.widgets');
   }, []);
 
   // close out the instructions panel

--- a/src/components/Widgets/FeedbackWidget/views/CommentView.js
+++ b/src/components/Widgets/FeedbackWidget/views/CommentView.js
@@ -20,6 +20,7 @@ import {
   EMAIL_PLACEHOLDER_TEXT,
   FEEDBACK_SUBMIT_BUTTON_TEXT,
 } from '../constants';
+import { elementZIndex } from '../../../../utils/dynamically-set-z-index';
 const ScreenshotButton = Loadable(() => import('../components/ScreenshotButton'));
 
 const SubmitButton = styled(Button)`
@@ -106,6 +107,8 @@ const CommentView = () => {
   const { isMobile } = useScreenSize();
 
   const handleSubmit = async () => {
+    elementZIndex.resetZIndex('.widgets');
+
     if (isValidEmail) {
       if (screenshotTaken) {
         const dataUri = await retrieveDataUri();

--- a/src/utils/dynamically-set-z-index.js
+++ b/src/utils/dynamically-set-z-index.js
@@ -1,0 +1,27 @@
+export const elementZIndex = {
+  setZIndex: (selector, zIndex) => {
+    const ele = document.querySelector(selector);
+
+    if (!ele) {
+      console.error('selector not found');
+      return;
+    }
+
+    if (typeof zIndex !== 'number') {
+      console.error('z-index value has to be a number');
+      return;
+    }
+
+    document.querySelector(selector).style.zIndex = zIndex;
+  },
+  resetZIndex: (selector) => {
+    const ele = document.querySelector(selector);
+
+    if (!ele) {
+      console.error('selector not found');
+      return;
+    }
+
+    ele.style.zIndex = 1;
+  },
+};

--- a/src/utils/dynamically-set-z-index.js
+++ b/src/utils/dynamically-set-z-index.js
@@ -22,6 +22,6 @@ export const elementZIndex = {
       return;
     }
 
-    ele.style.zIndex = 1;
+    ele.style.zIndex = 0;
   },
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4363

### Current Behavior:

https://www.mongodb.com/docs/manual/

### Staging Links:

[staging commit](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/260c33fea31807930b73a0375bded1e908a79879/master/docs/caesarbell/DOP-4363/index.html)

### Notes:

This PR, fixes the "Submit Feedback with Screenshot" bug, by dynamically setting the z-index on the widget container. It also provides a utility for dynamically setting and resetting a z-index based on the selector given.

**Screenshots**

<img width="1241" alt="Screenshot 2024-03-19 at 1 01 40 PM" src="https://github.com/mongodb/snooty/assets/5807473/b7adbfa7-374c-45b1-a6e7-c83c7d920700">

![Screenshot 2024-03-19 at 12 39 43 PM](https://github.com/mongodb/snooty/assets/5807473/6ade4891-68af-43e1-9c12-4ead153e6db7)

![Screenshot 2024-03-19 at 12 39 27 PM](https://github.com/mongodb/snooty/assets/5807473/3d3de409-6355-45e0-be76-d83ed707d6bb)

**Stored Screenshot**

https://docs-feedback-screenshots.s3.us-east-2.amazonaws.com/screenshot-65f9c1141ea69e0248784367.png


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
