### PR TITLE
DOP-4470: Bump LG search-input version to fix localized input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@leafygreen-ui/modal": "^10.1.0",
         "@leafygreen-ui/pagination": "^1.0.9",
         "@leafygreen-ui/palette": "^3.4.7",
-        "@leafygreen-ui/search-input": "^2.0.8",
+        "@leafygreen-ui/search-input": "^2.1.4",
         "@leafygreen-ui/segmented-control": "^8.0.0",
         "@leafygreen-ui/select": "^7.0.0",
         "@leafygreen-ui/side-nav": "^10.0.0",
@@ -4243,9 +4243,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "11.23.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.23.0.tgz",
-      "integrity": "sha512-TaK9mlQO2K1Y4urL69FzLXMfW/hoSChlsA0WSj4IEFEyaC/bwVQTJFq9qStcRPTwf18G1rwsEQB1TlKDvlPIFA==",
+      "version": "11.29.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
+      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "lodash": "^4.17.21"
@@ -4276,44 +4276,60 @@
       }
     },
     "node_modules/@leafygreen-ui/input-option": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.5.tgz",
-      "integrity": "sha512-gU051Rr5oB6CelLziN1xpbymexEP28DsbhgN+KTXxzpOM5q4l1dNAv12UDuCSEJS/xPP0kzkBkMWT/WPOEE/uQ==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.1.1.tgz",
+      "integrity": "sha512-ix6QQmnRGqnvZWERATO0jsMiziG2CWBe9t3ng++sBWaF1nqQXPqcBSZihuuJaoY7hg9qA7MCQMEb5XuZqhi59w==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
+        "@leafygreen-ui/a11y": "^1.4.12",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/lib": "^13.2.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/typography": "^18.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
       }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/lib": {
-      "version": "10.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-      "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+      "version": "13.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
+      "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+    },
+    "node_modules/@leafygreen-ui/input-option/node_modules/@leafygreen-ui/typography": {
+      "version": "18.2.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.2.2.tgz",
+      "integrity": "sha512-RuJcZ7XkxDj8ZJADJ50LGhWQFOIYcwRdJhe05JjpM26+JwHjBlESIU9XhSMjcg1bZDBSvg6AVP/LAD5Vb7VItA==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.29.1",
+        "@leafygreen-ui/lib": "^13.2.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.5.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
+      }
     },
     "node_modules/@leafygreen-ui/input-option/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
+      "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4782,92 +4798,122 @@
       }
     },
     "node_modules/@leafygreen-ui/search-input": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-2.0.8.tgz",
-      "integrity": "sha512-ijMpZgyUpOQM1fOnUs1XavIYAcD9P5PNRWp2hprgWMJZp8FrcopsslMJJIDaM00Sdj0MjSDAti9+aXeo+2ZgSw==",
+      "version": "2.1.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-2.1.4.tgz",
+      "integrity": "sha512-oCH4WD6AQ+SMfusoaM54OVyKIETNv/Nx8mNQyjGoC/VmQHdMmpMY3frRut76S4l+HFHcOUqAuhqLOgTgD2aHhQ==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.3",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.5",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/icon-button": "^15.0.12",
-        "@leafygreen-ui/input-option": "^1.0.5",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/popover": "^11.0.12",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1",
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.1.2",
+        "@leafygreen-ui/icon": "^11.29.1",
+        "@leafygreen-ui/icon-button": "^15.0.19",
+        "@leafygreen-ui/input-option": "^1.1.1",
+        "@leafygreen-ui/lib": "^13.2.1",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/popover": "^11.3.0",
+        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/typography": "^18.2.2",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.7.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.5.tgz",
-      "integrity": "sha512-Spk36yndhplGfCdLl14RWuoDPGYfEgA6AwqbaI4T45i+A2QtDTvdSFyMUkNmDK5vzk5cWmR/SmkRS/o5T9zgMA==",
+      "version": "8.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.2.tgz",
+      "integrity": "sha512-XJlTqPx1RqjGRk1v5MWtISWfHBudAqYDsc7NzRCgK+bfwGa4LvsrJ89ZcJJdxUHH2Coz/z+Vxp+zNJThxtaf5A==",
       "dependencies": {
+        "@leafygreen-ui/lib": "^13.2.1",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.12.tgz",
-      "integrity": "sha512-19tXprK4/jIZq19o6Y2OnPw5ifuLIhpxAJ4/gs/lIFk/4A5PZJOnZzy6ABdiMaFk/1miSjoDQ5B+lncvgAx1gA==",
+      "version": "15.0.19",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+      "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/box": "^3.1.4",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/tokens": "^2.1.1"
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/box": "^3.1.8",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.22.2",
+        "@leafygreen-ui/lib": "^13.0.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/tokens": "^2.1.4"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/lib": {
-      "version": "10.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-      "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+      "version": "13.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
+      "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-      "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+      "version": "4.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/popover": {
-      "version": "11.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.12.tgz",
-      "integrity": "sha512-zF8axGB+RhpoG0xgb4K/p8ydS5JAEXpwqdLrcrY9r7cAYzxX0F4mhIpYg+oyK2K5TIbgGR/fsFPbhKYsmreuMA==",
+      "version": "11.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.3.0.tgz",
+      "integrity": "sha512-tSTuDw0JAs1w6Kj1mQdRe+XhuVQKcaOaf6BLxDB2kTCkdGmnwN1s+/vaDyERguv00VI4ttM4QbvC9kZ8t+fAdA==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.5",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/portal": "^4.1.4",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "react-transition-group": "^4.4.1"
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.1.2",
+        "@leafygreen-ui/lib": "^13.2.0",
+        "@leafygreen-ui/portal": "^5.1.0",
+        "@leafygreen-ui/tokens": "^2.5.1",
+        "@types/react-transition-group": "^4.4.5",
+        "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.3"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/portal": {
+      "version": "5.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.0.tgz",
+      "integrity": "sha512-zvbxF0YN4YLA3KECm1wVM/Ag96CjjhFYORoWwQM6KRbHP/Brg9/g7mPd2aJj/xpPZlJYSTeAwhKM9JJkrnm6Dg==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.1.2",
+        "@leafygreen-ui/lib": "^13.0.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/search-input/node_modules/@leafygreen-ui/typography": {
+      "version": "18.2.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.2.2.tgz",
+      "integrity": "sha512-RuJcZ7XkxDj8ZJADJ50LGhWQFOIYcwRdJhe05JjpM26+JwHjBlESIU9XhSMjcg1bZDBSvg6AVP/LAD5Vb7VItA==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/icon": "^11.29.1",
+        "@leafygreen-ui/lib": "^13.2.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.5.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
       }
     },
     "node_modules/@leafygreen-ui/search-input/node_modules/@storybook/csf": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-      "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+      "version": "0.1.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
+      "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5415,9 +5461,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.2.0.tgz",
-      "integrity": "sha512-hmRT1Sz6J9tv84ty1YPs1zmFewOCt/TghfbR0So5UtA5S2q4sVqjPZEpSvLmlxmtXIyl77fjU+uZYHpW2EID6w==",
+      "version": "2.5.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.5.1.tgz",
+      "integrity": "sha512-sC0fQ578tsQan54kQ9SCidUgSY2R31o787N7Umzji44CcnqZCPj2Lrbyp3tideUw+FcdapTAxkA+mpppPfGgRA==",
       "dependencies": {
         "@leafygreen-ui/palette": "^4.0.7"
       }
@@ -7736,6 +7782,14 @@
     "node_modules/@types/react-is": {
       "version": "17.0.3",
       "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.10",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -28255,9 +28309,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "11.23.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.23.0.tgz",
-      "integrity": "sha512-TaK9mlQO2K1Y4urL69FzLXMfW/hoSChlsA0WSj4IEFEyaC/bwVQTJFq9qStcRPTwf18G1rwsEQB1TlKDvlPIFA==",
+      "version": "11.29.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
+      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.7",
         "lodash": "^4.17.21"
@@ -28283,23 +28337,23 @@
       }
     },
     "@leafygreen-ui/input-option": {
-      "version": "1.0.5",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.0.5.tgz",
-      "integrity": "sha512-gU051Rr5oB6CelLziN1xpbymexEP28DsbhgN+KTXxzpOM5q4l1dNAv12UDuCSEJS/xPP0kzkBkMWT/WPOEE/uQ==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-1.1.1.tgz",
+      "integrity": "sha512-ix6QQmnRGqnvZWERATO0jsMiziG2CWBe9t3ng++sBWaF1nqQXPqcBSZihuuJaoY7hg9qA7MCQMEb5XuZqhi59w==",
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.2",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1"
+        "@leafygreen-ui/a11y": "^1.4.12",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/lib": "^13.2.0",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/typography": "^18.2.2"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "10.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-          "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+          "version": "13.2.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
+          "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -28307,14 +28361,27 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+        },
+        "@leafygreen-ui/typography": {
+          "version": "18.2.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.2.2.tgz",
+          "integrity": "sha512-RuJcZ7XkxDj8ZJADJ50LGhWQFOIYcwRdJhe05JjpM26+JwHjBlESIU9XhSMjcg1bZDBSvg6AVP/LAD5Vb7VItA==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.29.1",
+            "@leafygreen-ui/lib": "^13.2.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/polymorphic": "^1.3.6",
+            "@leafygreen-ui/tokens": "^2.5.1"
+          }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
+          "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -28717,52 +28784,53 @@
       }
     },
     "@leafygreen-ui/search-input": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-2.0.8.tgz",
-      "integrity": "sha512-ijMpZgyUpOQM1fOnUs1XavIYAcD9P5PNRWp2hprgWMJZp8FrcopsslMJJIDaM00Sdj0MjSDAti9+aXeo+2ZgSw==",
+      "version": "2.1.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-2.1.4.tgz",
+      "integrity": "sha512-oCH4WD6AQ+SMfusoaM54OVyKIETNv/Nx8mNQyjGoC/VmQHdMmpMY3frRut76S4l+HFHcOUqAuhqLOgTgD2aHhQ==",
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.3",
-        "@leafygreen-ui/emotion": "^4.0.4",
-        "@leafygreen-ui/hooks": "^7.7.5",
-        "@leafygreen-ui/icon": "^11.17.0",
-        "@leafygreen-ui/icon-button": "^15.0.12",
-        "@leafygreen-ui/input-option": "^1.0.5",
-        "@leafygreen-ui/lib": "^10.4.0",
-        "@leafygreen-ui/palette": "^4.0.4",
-        "@leafygreen-ui/polymorphic": "^1.3.2",
-        "@leafygreen-ui/popover": "^11.0.12",
-        "@leafygreen-ui/tokens": "^2.1.1",
-        "@leafygreen-ui/typography": "^16.5.1",
+        "@leafygreen-ui/a11y": "^1.4.11",
+        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/hooks": "^8.1.2",
+        "@leafygreen-ui/icon": "^11.29.1",
+        "@leafygreen-ui/icon-button": "^15.0.19",
+        "@leafygreen-ui/input-option": "^1.1.1",
+        "@leafygreen-ui/lib": "^13.2.1",
+        "@leafygreen-ui/palette": "^4.0.7",
+        "@leafygreen-ui/polymorphic": "^1.3.6",
+        "@leafygreen-ui/popover": "^11.3.0",
+        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/typography": "^18.2.2",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.7.5",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-7.7.5.tgz",
-          "integrity": "sha512-Spk36yndhplGfCdLl14RWuoDPGYfEgA6AwqbaI4T45i+A2QtDTvdSFyMUkNmDK5vzk5cWmR/SmkRS/o5T9zgMA==",
+          "version": "8.1.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.2.tgz",
+          "integrity": "sha512-XJlTqPx1RqjGRk1v5MWtISWfHBudAqYDsc7NzRCgK+bfwGa4LvsrJ89ZcJJdxUHH2Coz/z+Vxp+zNJThxtaf5A==",
           "requires": {
+            "@leafygreen-ui/lib": "^13.2.1",
             "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/icon-button": {
-          "version": "15.0.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.12.tgz",
-          "integrity": "sha512-19tXprK4/jIZq19o6Y2OnPw5ifuLIhpxAJ4/gs/lIFk/4A5PZJOnZzy6ABdiMaFk/1miSjoDQ5B+lncvgAx1gA==",
+          "version": "15.0.19",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon-button/-/icon-button-15.0.19.tgz",
+          "integrity": "sha512-TXNFHpfuMXIcMQHW/D31GEFby63qhBLyeI5CLL8KQjD5Xom3Q6fqviu/eyXE097jTzQtd1dO/2IIiqyyLRW30g==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.2",
-            "@leafygreen-ui/box": "^3.1.4",
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/icon": "^11.17.0",
-            "@leafygreen-ui/lib": "^10.4.0",
-            "@leafygreen-ui/palette": "^4.0.4",
-            "@leafygreen-ui/tokens": "^2.1.1"
+            "@leafygreen-ui/a11y": "^1.4.11",
+            "@leafygreen-ui/box": "^3.1.8",
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.22.2",
+            "@leafygreen-ui/lib": "^13.0.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/tokens": "^2.1.4"
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "10.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-10.4.0.tgz",
-          "integrity": "sha512-gGZBJ0Mjo2/hHfECbERGJbx1nPFNDqkge7L1K5y5LwBjpiOYjUNa1OsyBRwc9pr+zucdAF2FHSo+EdoT83Mbtg==",
+          "version": "13.2.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
+          "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -28770,27 +28838,50 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.4.tgz",
-          "integrity": "sha512-nuZy2RtKHAGpIKrDduqC8P8PvajJRT1hQURoisYMiB32NmEEHGEhtHw4MlS+Kv92HFA0jxgMdZUHKTXq83BhjA=="
+          "version": "4.0.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
+          "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
         },
         "@leafygreen-ui/popover": {
-          "version": "11.0.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.0.12.tgz",
-          "integrity": "sha512-zF8axGB+RhpoG0xgb4K/p8ydS5JAEXpwqdLrcrY9r7cAYzxX0F4mhIpYg+oyK2K5TIbgGR/fsFPbhKYsmreuMA==",
+          "version": "11.3.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.3.0.tgz",
+          "integrity": "sha512-tSTuDw0JAs1w6Kj1mQdRe+XhuVQKcaOaf6BLxDB2kTCkdGmnwN1s+/vaDyERguv00VI4ttM4QbvC9kZ8t+fAdA==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.4",
-            "@leafygreen-ui/hooks": "^7.7.5",
-            "@leafygreen-ui/lib": "^10.4.0",
-            "@leafygreen-ui/portal": "^4.1.4",
-            "@leafygreen-ui/tokens": "^2.1.1",
-            "react-transition-group": "^4.4.1"
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/hooks": "^8.1.2",
+            "@leafygreen-ui/lib": "^13.2.0",
+            "@leafygreen-ui/portal": "^5.1.0",
+            "@leafygreen-ui/tokens": "^2.5.1",
+            "@types/react-transition-group": "^4.4.5",
+            "react-transition-group": "^4.4.5"
+          }
+        },
+        "@leafygreen-ui/portal": {
+          "version": "5.1.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.0.tgz",
+          "integrity": "sha512-zvbxF0YN4YLA3KECm1wVM/Ag96CjjhFYORoWwQM6KRbHP/Brg9/g7mPd2aJj/xpPZlJYSTeAwhKM9JJkrnm6Dg==",
+          "requires": {
+            "@leafygreen-ui/hooks": "^8.1.2",
+            "@leafygreen-ui/lib": "^13.0.0"
+          }
+        },
+        "@leafygreen-ui/typography": {
+          "version": "18.2.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-18.2.2.tgz",
+          "integrity": "sha512-RuJcZ7XkxDj8ZJADJ50LGhWQFOIYcwRdJhe05JjpM26+JwHjBlESIU9XhSMjcg1bZDBSvg6AVP/LAD5Vb7VItA==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.7",
+            "@leafygreen-ui/icon": "^11.29.1",
+            "@leafygreen-ui/lib": "^13.2.0",
+            "@leafygreen-ui/palette": "^4.0.7",
+            "@leafygreen-ui/polymorphic": "^1.3.6",
+            "@leafygreen-ui/tokens": "^2.5.1"
           }
         },
         "@storybook/csf": {
-          "version": "0.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.1.tgz",
-          "integrity": "sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==",
+          "version": "0.1.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
+          "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -29268,9 +29359,9 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.2.0.tgz",
-      "integrity": "sha512-hmRT1Sz6J9tv84ty1YPs1zmFewOCt/TghfbR0So5UtA5S2q4sVqjPZEpSvLmlxmtXIyl77fjU+uZYHpW2EID6w==",
+      "version": "2.5.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.5.1.tgz",
+      "integrity": "sha512-sC0fQ578tsQan54kQ9SCidUgSY2R31o787N7Umzji44CcnqZCPj2Lrbyp3tideUw+FcdapTAxkA+mpppPfGgRA==",
       "requires": {
         "@leafygreen-ui/palette": "^4.0.7"
       },
@@ -30776,6 +30867,14 @@
     },
     "@types/react-is": {
       "version": "17.0.3",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.10",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@leafygreen-ui/modal": "^10.1.0",
     "@leafygreen-ui/pagination": "^1.0.9",
     "@leafygreen-ui/palette": "^3.4.7",
-    "@leafygreen-ui/search-input": "^2.0.8",
+    "@leafygreen-ui/search-input": "^2.1.4",
     "@leafygreen-ui/segmented-control": "^8.0.0",
     "@leafygreen-ui/select": "^7.0.0",
     "@leafygreen-ui/side-nav": "^10.0.0",

--- a/tests/unit/__snapshots__/SearchResults.test.js.snap
+++ b/tests/unit/__snapshots__/SearchResults.test.js.snap
@@ -739,12 +739,12 @@ exports[`Search Results Page considers a given search filter query param and dis
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -789,15 +789,15 @@ exports[`Search Results Page considers a given search filter query param and dis
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -821,25 +821,25 @@ exports[`Search Results Page considers a given search filter query param and dis
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -866,7 +866,7 @@ exports[`Search Results Page considers a given search filter query param and dis
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -2366,12 +2366,12 @@ exports[`Search Results Page does not return results for a given search term wit
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -2416,15 +2416,15 @@ exports[`Search Results Page does not return results for a given search term wit
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -2448,25 +2448,25 @@ exports[`Search Results Page does not return results for a given search term wit
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -2493,7 +2493,7 @@ exports[`Search Results Page does not return results for a given search term wit
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -3830,12 +3830,12 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -3880,15 +3880,15 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -3912,25 +3912,25 @@ exports[`Search Results Page renders correctly without browser 1`] = `
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -4253,12 +4253,12 @@ exports[`Search Results Page renders loading images before returning no results 
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -4303,15 +4303,15 @@ exports[`Search Results Page renders loading images before returning no results 
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -4335,25 +4335,25 @@ exports[`Search Results Page renders loading images before returning no results 
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -4380,7 +4380,7 @@ exports[`Search Results Page renders loading images before returning no results 
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -5927,12 +5927,12 @@ exports[`Search Results Page renders loading images before returning nonempty re
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -5977,15 +5977,15 @@ exports[`Search Results Page renders loading images before returning nonempty re
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -6009,25 +6009,25 @@ exports[`Search Results Page renders loading images before returning nonempty re
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -6054,7 +6054,7 @@ exports[`Search Results Page renders loading images before returning nonempty re
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }
@@ -7601,12 +7601,12 @@ exports[`Search Results Page renders results from a given search term query para
   padding: 0;
 }
 
-.emotion-8:disabled {
+.emotion-8[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.emotion-8:disabled:hover,
-.emotion-8:disabled:active {
+.emotion-8[aria-disabled='true']:hover,
+.emotion-8[aria-disabled='true']:active {
   box-shadow: none;
 }
 
@@ -7651,15 +7651,15 @@ exports[`Search Results Page renders results from a given search term query para
   -webkit-text-fill-color: inherit;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled) {
+.emotion-8:-webkit-autofill[aria-disabled='false'] {
   box-shadow: 0 0 0 100px #FFFFFF inset;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):focus {
+.emotion-8:-webkit-autofill[aria-disabled='false']:focus {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #0498EC;
 }
 
-.emotion-8:-webkit-autofill:not(:disabled):hover:not(:focus) {
+.emotion-8:-webkit-autofill[aria-disabled='false']:hover:not(:focus) {
   box-shadow: 0 0 0 100px #FFFFFF inset,0 0 0 3px #E8EDEB;
 }
 
@@ -7683,25 +7683,25 @@ exports[`Search Results Page renders results from a given search term query para
   font-weight: 400;
 }
 
-.emotion-8:disabled::-webkit-input-placeholder {
+.emotion-8[aria-disabled='true']::-webkit-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::-moz-placeholder {
+.emotion-8[aria-disabled='true']::-moz-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-ms-input-placeholder {
+.emotion-8[aria-disabled='true']:-ms-input-placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled::placeholder {
+.emotion-8[aria-disabled='true']::placeholder {
   color: #889397;
 }
 
-.emotion-8:disabled:-webkit-autofill,
-.emotion-8:disabled:-webkit-autofill:hover,
-.emotion-8:disabled:-webkit-autofill:focus {
+.emotion-8[aria-disabled='true']:-webkit-autofill,
+.emotion-8[aria-disabled='true']:-webkit-autofill:hover,
+.emotion-8[aria-disabled='true']:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -7728,7 +7728,7 @@ exports[`Search Results Page renders results from a given search term query para
   background-color: rgba(255, 255, 255, 0);
   height: 28px;
   width: 28px;
-  color: #889397;
+  color: #5C6C75;
   height: 28px;
   width: 28px;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4470

### Current Behavior:

[Prod search page](https://www.mongodb.com/ko-kr/docs/search/) - typing "유" results in its individual characters being used as input "ㅇㅠ"
[Staging search page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/main/search/index.html) - on the `main` branch, to confirm that this isn't only happening in prod

### Staging Links:

[Staging search page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-4470/search/index.html) - typing "유" results in "유"

### Notes:

* The fix was to just bump the `@leafygreen-ui/search-input` package to its latest version. Couldn't figure out why this fixed it, but I'm assuming there was just some sort of incompatibility in our version.
* To test locally, you may need to add Korean as a language on your keyboard. I also checked in with both Hyejin and Ryan from MongoDB, who are helping out with translations for Korean and Simplified Chinese respectively, and they said the input in the staging link was working as expected.
* Since the search results are currently in English, input in different languages may not have any available search results in the staging link. Search results will need to be validated in production since Smartling handles translations

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
