### PR TITLE
DOP-4449: Add locale to footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { UnifiedFooter } from '@mdb/consistent-nav';
 import { isBrowser } from '../utils/is-browser';
-import { AVAILABLE_LANGUAGES, getLocaleMapping } from '../utils/locale';
+import { AVAILABLE_LANGUAGES, getCurrLocale, getLocaleMapping } from '../utils/locale';
 
 const Footer = ({ slug }) => {
   const location = useLocation();
@@ -35,7 +35,7 @@ const Footer = ({ slug }) => {
     }
   }, []);
 
-  return <UnifiedFooter onSelectLocale={onSelectLocale} />;
+  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} />;
 };
 
 export default Footer;

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -47,7 +47,7 @@ const stripLocale = (slug) => {
  * Returns the locale code based on the current location pathname of the page.
  * @returns {string}
  */
-const getCurrLocale = () => {
+export const getCurrLocale = () => {
   const defaultLang = 'en-us';
 
   if (!isBrowser) {


### PR DESCRIPTION
### Stories/Links:

DOP-4449

### Current Behavior:

[English Server prod](https://www.mongodb.com/docs/manual/)
[Korean server prod](https://www.mongodb.com/ko-kr/docs/manual/)
[Simplified Chinese server prod](https://www.mongodb.com/zh-cn/docs/manual/)
[Portuguese server prod](https://www.mongodb.com/pt-br/docs/manual/)

### Staging Links:

[Regular staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-4449/index.html) - expected to be English by default
[English staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/docs/raymund/manual/index.html)
[Korean staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ko-kr/docs/raymund/manual/index.html)
[Simplified Chinese staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/docs/raymund/manual/index.html)
[Portuguese staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/pt-br/docs/raymund/manual/index.html)

### Notes:

The main problem is that translated sites do not have the correct locale selected in the footer's locale selector (by default it's English). Passing in a locale to the footer would allow the proper locale to be selected.

To test, go to the different staging links and scroll down to the footer. The locale selector should show the expected locale, and marketing's translations.

All staging links above were manually staged with custom prefixes to have some semblance of what the URLs would be like on prod. Unfortunately, this is the best we can currently do for staging since Smartling is only hooked up on production. Fortunately, the logic should be fairly safe (i.e. no major regressions on the English site) given the function we're exporting is a dependency of the existing `localizePath` util function, which is already unit tested, and we know that the function works on production currently (hreflang links, version dropdown, and footer's locale selector).

We are intentionally only doing this to the `UnifiedFooter` and not the `UnifiedNav` because Smartling is currently applying specific logic to localize the top nav for certain things. We'll probably do this in the future

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
