### PR TITLE
:zap: DOP-4502 turns the set functions in initializeFeedback into transitions

### DIFF
--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, createContext } from 'react';
+import React, { useState, useContext, createContext, useTransition } from 'react';
 import { getViewport } from '../../../hooks/useViewport';
 import { createNewFeedback, useRealmUser } from './realm';
 
@@ -12,14 +12,17 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
   const [view, setView] = useState(test.view || 'waiting');
   const [screenshotTaken, setScreenshotTaken] = useState(test.screenshotTaken || false);
   const [progress, setProgress] = useState([true, false, false]);
+  const [, startTransition] = useTransition();
   const { user, reassignCurrentUser } = useRealmUser();
 
   // Create a new feedback document
   const initializeFeedback = (nextView = 'rating') => {
     const newFeedback = {};
-    setFeedback({ newFeedback });
-    setView(nextView);
-    setProgress([true, false, false]);
+    startTransition(() => {
+      setFeedback({ newFeedback });
+      setView(nextView);
+      setProgress([true, false, false]);
+    });
     return { newFeedback };
   };
 

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -27,6 +27,8 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-8 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -38,37 +40,44 @@ exports[`renders correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-8:hover,
-.emotion-8:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-8:focus,
+.emotion-8:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-8:focus {
   outline: none;
 }
 
-.emotion-8:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-9 {
+  position: relative;
 }
 
-.emotion-8:focus {
-  text-decoration-color: #016BF8;
+.emotion-9::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-9::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-9::after {
+  background-color: #E8EDEB;
 }
 
 <blockquote>
@@ -108,7 +117,9 @@ exports[`renders correctly 1`] = `
             class="lg-ui-0001 emotion-8"
             href=""
           >
-            <span>
+            <span
+              class="emotion-9"
+            >
               programmatic access
             </span>
           </a>

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -3,6 +3,8 @@
 exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -14,12 +16,8 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -27,25 +25,14 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
-}
-
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-0:last-of-type {
@@ -63,12 +50,36 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
   color: #1C2D38;
 }
 
+.emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
 <a
     class="lg-ui-0001 emotion-0"
     href="https://www.mongodb.com/docs/"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       Docs Home
     </span>
   </a>
@@ -86,6 +97,8 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
      → 
   </span>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -97,12 +110,8 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -110,25 +119,14 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
-}
-
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-0:last-of-type {
@@ -146,12 +144,36 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
   color: #1C2D38;
 }
 
+.emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
 <a
     class="lg-ui-0001 emotion-0"
     href="https://www.mongodb.com/docs/view-analyze"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       View & Analyze
     </span>
   </a>
@@ -235,6 +257,8 @@ exports[`BreadcrumbContainer renders correctly with project parent 1`] = `
 exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -246,12 +270,8 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -259,25 +279,14 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
-}
-
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-0:last-of-type {
@@ -295,12 +304,36 @@ exports[`BreadcrumbContainer renders correctly without project parent 1`] = `
   color: #1C2D38;
 }
 
+.emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
 <a
     class="lg-ui-0001 emotion-0"
     href="https://www.mongodb.com/docs/"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       Docs Home
     </span>
   </a>

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -23,6 +23,8 @@ exports[`renders correctly with pageTitle 1`] = `
 }
 
 .emotion-1 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -34,12 +36,8 @@ exports[`renders correctly with pageTitle 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -47,25 +45,14 @@ exports[`renders correctly with pageTitle 1`] = `
 }
 
 .emotion-1:hover,
-.emotion-1:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-1:focus,
+.emotion-1:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-1:focus {
   outline: none;
-}
-
-.emotion-1:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-1:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-1:last-of-type {
@@ -84,14 +71,36 @@ exports[`renders correctly with pageTitle 1`] = `
 }
 
 .emotion-2 {
+  position: relative;
+}
+
+.emotion-2::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-2::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-2::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-3 {
   cursor: default;
 }
 
-.emotion-2:last-of-type {
+.emotion-3:last-of-type {
   color: #1C2D38;
 }
 
-.emotion-4 {
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -105,12 +114,12 @@ exports[`renders correctly with pageTitle 1`] = `
   color: #016BF8;
 }
 
-.emotion-4>code {
+.emotion-5>code {
   color: #016BF8;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-5:focus,
+.emotion-5:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -118,31 +127,31 @@ exports[`renders correctly with pageTitle 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-4:focus {
+.emotion-5:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-4:hover {
+.emotion-5:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-5 {
+.emotion-6 {
   font-size: 13px;
 }
 
-.emotion-5:last-of-type {
+.emotion-6:last-of-type {
   color: #1C2D38;
 }
 
-.emotion-5:hover,
-.emotion-5:focus {
+.emotion-6:hover,
+.emotion-6:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-5:hover:not(:last-of-type),
-.emotion-5:focus:not(:last-of-type) {
+.emotion-6:hover:not(:last-of-type),
+.emotion-6:focus:not(:last-of-type) {
   color: #1C2D38;
 }
 
@@ -154,17 +163,19 @@ exports[`renders correctly with pageTitle 1`] = `
       href="https://www.mongodb.com/docs/"
       target="_self"
     >
-      <span>
+      <span
+        class="emotion-2"
+      >
         Docs Home
       </span>
     </a>
     <span
-      class="emotion-2 emotion-3"
+      class="emotion-3 emotion-4"
     >
        → 
     </span>
     <a
-      class="emotion-4 emotion-5"
+      class="emotion-5 emotion-6"
       href="/view-analyze/"
     >
       View & Analyze Data
@@ -196,6 +207,8 @@ exports[`renders correctly with siteTitle 1`] = `
 }
 
 .emotion-1 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -207,12 +220,8 @@ exports[`renders correctly with siteTitle 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -220,25 +229,14 @@ exports[`renders correctly with siteTitle 1`] = `
 }
 
 .emotion-1:hover,
-.emotion-1:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-1:focus,
+.emotion-1:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-1:focus {
   outline: none;
-}
-
-.emotion-1:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-1:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-1:last-of-type {
@@ -257,14 +255,36 @@ exports[`renders correctly with siteTitle 1`] = `
 }
 
 .emotion-2 {
+  position: relative;
+}
+
+.emotion-2::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-2::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-2::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-3 {
   cursor: default;
 }
 
-.emotion-2:last-of-type {
+.emotion-3:last-of-type {
   color: #1C2D38;
 }
 
-.emotion-4 {
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -278,12 +298,12 @@ exports[`renders correctly with siteTitle 1`] = `
   color: #016BF8;
 }
 
-.emotion-4>code {
+.emotion-5>code {
   color: #016BF8;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-5:focus,
+.emotion-5:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -291,31 +311,31 @@ exports[`renders correctly with siteTitle 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-4:focus {
+.emotion-5:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-4:hover {
+.emotion-5:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-5 {
+.emotion-6 {
   font-size: 13px;
 }
 
-.emotion-5:last-of-type {
+.emotion-6:last-of-type {
   color: #1C2D38;
 }
 
-.emotion-5:hover,
-.emotion-5:focus {
+.emotion-6:hover,
+.emotion-6:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-5:hover:not(:last-of-type),
-.emotion-5:focus:not(:last-of-type) {
+.emotion-6:hover:not(:last-of-type),
+.emotion-6:focus:not(:last-of-type) {
   color: #1C2D38;
 }
 
@@ -327,17 +347,19 @@ exports[`renders correctly with siteTitle 1`] = `
       href="https://www.mongodb.com/docs/"
       target="_self"
     >
-      <span>
+      <span
+        class="emotion-2"
+      >
         Docs Home
       </span>
     </a>
     <span
-      class="emotion-2 emotion-3"
+      class="emotion-3 emotion-4"
     >
        → 
     </span>
     <a
-      class="emotion-4 emotion-5"
+      class="emotion-5 emotion-6"
       href="/"
     >
       MongoDB Compass

--- a/tests/unit/__snapshots__/CTABanner.test.js.snap
+++ b/tests/unit/__snapshots__/CTABanner.test.js.snap
@@ -98,6 +98,8 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -109,37 +111,44 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-7 {
+  position: relative;
 }
 
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -183,7 +192,9 @@ exports[`renders a CTABanner correctly when invalid icon is specified 1`] = `
         href="https://university.mongodb.com/"
         target="_self"
       >
-        <span>
+        <span
+          class="emotion-7"
+        >
           MongoDB University
         </span>
       </a>
@@ -290,6 +301,8 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -301,37 +314,44 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-7 {
+  position: relative;
 }
 
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -377,7 +397,9 @@ exports[`renders a CTABanner correctly when lowercase icon is specified 1`] = `
         href="https://university.mongodb.com/"
         target="_self"
       >
-        <span>
+        <span
+          class="emotion-7"
+        >
           MongoDB University
         </span>
       </a>
@@ -484,6 +506,8 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -495,37 +519,44 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-7 {
+  position: relative;
 }
 
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -569,7 +600,9 @@ exports[`renders a CTABanner correctly when no icon is specified 1`] = `
         href="https://university.mongodb.com/"
         target="_self"
       >
-        <span>
+        <span
+          class="emotion-7"
+        >
           MongoDB University
         </span>
       </a>
@@ -676,6 +709,8 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -687,37 +722,44 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-7 {
+  position: relative;
 }
 
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -761,7 +803,9 @@ exports[`renders a CTABanner correctly when non-default icon is specified 1`] = 
         href="https://university.mongodb.com/"
         target="_self"
       >
-        <span>
+        <span
+          class="emotion-7"
+        >
           MongoDB University
         </span>
       </a>

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -120,6 +120,8 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -131,37 +133,44 @@ exports[`renders correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-7 {
+  position: relative;
 }
 
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -202,7 +211,9 @@ exports[`renders correctly 1`] = `
           href="https://university.mongodb.com/courses/M001/about"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             Test card CTA
           </span>
         </a>

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -163,6 +163,8 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-7 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -174,37 +176,44 @@ exports[`renders correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-7:hover,
-.emotion-7:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-7:focus,
+.emotion-7:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-7:focus {
   outline: none;
 }
 
-.emotion-7:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-8 {
+  position: relative;
 }
 
-.emotion-7:focus {
-  text-decoration-color: #016BF8;
+.emotion-8::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-8::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-8::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -241,7 +250,9 @@ exports[`renders correctly 1`] = `
               href="https://www.mongodb.com/docs/atlas/getting-started/"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-8"
+              >
                 Read Atlas docs
               </span>
             </a>
@@ -280,7 +291,9 @@ exports[`renders correctly 1`] = `
               href="https://university.mongodb.com/courses/M001/about"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-8"
+              >
                 Learn MongoDB Basics
               </span>
             </a>
@@ -319,7 +332,9 @@ exports[`renders correctly 1`] = `
               href="https://www.mongodb.com/docs/manual/tutorial/getting-started/"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-8"
+              >
                 Read Server docs
               </span>
             </a>

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -270,6 +270,8 @@ exports[`card correctly with and without url 1`] = `
 }
 
 .emotion-26 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -281,37 +283,44 @@ exports[`card correctly with and without url 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-26:hover,
-.emotion-26:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-26:focus,
+.emotion-26:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-26:focus {
   outline: none;
 }
 
-.emotion-26:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-27 {
+  position: relative;
 }
 
-.emotion-26:focus {
-  text-decoration-color: #016BF8;
+.emotion-27::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-27::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-27::after {
+  background-color: #E8EDEB;
 }
 
 <div
@@ -432,7 +441,9 @@ exports[`card correctly with and without url 1`] = `
               href="https://docs.mongodb.com/realm/services/"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-27"
+              >
                 Learn more about MongoDB Realm Application Services
               </span>
             </a>

--- a/tests/unit/__snapshots__/ChangeList.test.js.snap
+++ b/tests/unit/__snapshots__/ChangeList.test.js.snap
@@ -52,6 +52,8 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
 }
 
 .emotion-9 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -63,44 +65,51 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
 }
 
 .emotion-9:hover,
-.emotion-9:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-9:focus,
+.emotion-9:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-9:focus {
   outline: none;
 }
 
-.emotion-9:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-9:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-10 {
+  position: relative;
+}
+
+.emotion-10::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-10::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-10::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-11 {
   color: #016BF8;
   word-break: break-all;
 }
 
-.emotion-12 {
+.emotion-13 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -110,11 +119,11 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
   color: #001E2B;
 }
 
-.emotion-13 {
+.emotion-14 {
   margin-top: 2px;
 }
 
-.emotion-15 {
+.emotion-16 {
   font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -139,17 +148,17 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
   color: #970606;
 }
 
-.emotion-16 {
+.emotion-17 {
   margin: 0;
   list-style-position: start;
 }
 
-.emotion-18 {
+.emotion-19 {
   margin-top: 12px;
   line-height: 28px;
 }
 
-.emotion-51 {
+.emotion-54 {
   font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -174,11 +183,11 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
   color: #00684A;
 }
 
-.emotion-56 {
+.emotion-59 {
   position: relative;
 }
 
-.emotion-57 {
+.emotion-60 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -191,7 +200,7 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
   margin-right: 5px;
 }
 
-.emotion-59 {
+.emotion-62 {
   color: #DB3030;
 }
 
@@ -218,25 +227,27 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-15"
+            class="emotion-14 emotion-15 emotion-16"
           >
             Removed
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             Resource version 2023-01-01 was removed, latest available resource version is 2023-02-01
           </li>
@@ -263,25 +274,27 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-15"
+            class="emotion-14 emotion-15 emotion-16"
           >
             Removed
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             This change should really definitely be hidden
           </li>
@@ -308,32 +321,34 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Projects/operation/getProjectByName"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 GET /api/atlas/v2/groups/byName/{groupName}
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-51"
+            class="emotion-14 emotion-15 emotion-54"
           >
             Released
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-59 emotion-60 emotion-61"
             >
               <svg
                 aria-label="Important With Circle Icon"
-                class="emotion-59"
+                class="emotion-62"
                 fill="none"
                 height="16"
                 role="img"
@@ -365,32 +380,34 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-51"
+            class="emotion-14 emotion-15 emotion-54"
           >
             Released
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-59 emotion-60 emotion-61"
             >
               <svg
                 aria-label="Important With Circle Icon"
-                class="emotion-59"
+                class="emotion-62"
                 fill="none"
                 height="16"
                 role="img"
@@ -409,14 +426,14 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             This change should be hidden
           </li>
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-59 emotion-60 emotion-61"
             >
               <svg
                 aria-label="Important With Circle Icon"
-                class="emotion-59"
+                class="emotion-62"
                 fill="none"
                 height="16"
                 role="img"
@@ -435,14 +452,14 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             Resource version added.
           </li>
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-59 emotion-60 emotion-61"
             >
               <svg
                 aria-label="Important With Circle Icon"
-                class="emotion-59"
+                class="emotion-62"
                 fill="none"
                 height="16"
                 role="img"
@@ -461,19 +478,19 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             For the 'query' request parameter 'clusterName', default value was changed from 'default' to 'cluster0'
           </li>
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             Added the optional property 'links' in the response with the '200' status.
           </li>
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-59 emotion-60 emotion-61"
             >
               <svg
                 aria-label="Important With Circle Icon"
-                class="emotion-59"
+                class="emotion-62"
                 fill="none"
                 height="16"
                 role="img"
@@ -505,30 +522,32 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Project-IP-Access-List/operation/createProjectIpAccessList"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 POST /api/atlas/v2/groups/{groupId}/accessList
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-51"
+            class="emotion-14 emotion-15 emotion-54"
           >
             Updated
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             Added the optional property 'name' in the response with the '200' status.
           </li>
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             Added the optional property 'comment' in the response with the '200' status.
           </li>
@@ -555,25 +574,27 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders all version changelog co
             href="//0/#tag/Projects/operation/getProjectByName"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-10"
+            >
               <h6
-                class="emotion-10 emotion-11 emotion-12"
+                class="emotion-11 emotion-12 emotion-13"
               >
                 GET /api/atlas/v2/groups/byName/{groupName}
               </h6>
             </span>
           </a>
           <div
-            class="emotion-13 emotion-14 emotion-51"
+            class="emotion-14 emotion-15 emotion-54"
           >
             Updated
           </div>
         </div>
         <ul
-          class="emotion-16 emotion-17"
+          class="emotion-17 emotion-18"
         >
           <li
-            class="emotion-18 emotion-19"
+            class="emotion-19 emotion-20"
           >
             Added the optional property 'withDefaultAlertsSettings' in the response with the '200' status.
           </li>
@@ -621,6 +642,8 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -632,44 +655,51 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
 }
 
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-7 {
+  position: relative;
+}
+
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-8 {
   color: #016BF8;
   word-break: break-all;
 }
 
-.emotion-9 {
+.emotion-10 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -679,21 +709,21 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
   color: #001E2B;
 }
 
-.emotion-10 {
+.emotion-11 {
   margin: 0;
   list-style-position: start;
 }
 
-.emotion-12 {
+.emotion-13 {
   margin-top: 12px;
   line-height: 28px;
 }
 
-.emotion-14 {
+.emotion-15 {
   position: relative;
 }
 
-.emotion-15 {
+.emotion-16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -706,7 +736,7 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
   margin-right: 5px;
 }
 
-.emotion-17 {
+.emotion-18 {
   color: #DB3030;
 }
 
@@ -725,9 +755,11 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           href="//0/#tag/Federated-Authentication/operation/listConnectedOrgConfigs"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             <h6
-              class="emotion-7 emotion-8 emotion-9"
+              class="emotion-8 emotion-9 emotion-10"
             >
               GET /api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs
             </h6>
@@ -735,17 +767,17 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
         </a>
       </div>
       <ul
-        class="emotion-10 emotion-11"
+        class="emotion-11 emotion-12"
       >
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-14 emotion-15 emotion-16"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-17"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -764,14 +796,14 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           A change
         </li>
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-14 emotion-15 emotion-16"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-17"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -790,24 +822,24 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           Removed the non-success response with the status '400'.
         </li>
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           Added the new optional 'query' request parameter 'envelope'.
         </li>
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           This change should be hidden!
         </li>
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-14 emotion-15 emotion-16"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-17"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -839,9 +871,11 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           href="//0/#tag/Project-IP-Access-List/operation/createProjectIpAccessList"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             <h6
-              class="emotion-7 emotion-8 emotion-9"
+              class="emotion-8 emotion-9 emotion-10"
             >
               POST /api/atlas/v2/groups/{groupId}/accessList
             </h6>
@@ -849,17 +883,17 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
         </a>
       </div>
       <ul
-        class="emotion-10 emotion-11"
+        class="emotion-11 emotion-12"
       >
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-14 emotion-15 emotion-16"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-17"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"
@@ -878,14 +912,14 @@ exports[`OpenAPIChangelog ChangeList ChangeList renders diff changelog correctly
           Removed the required property 'name' from the response with the '200' status.
         </li>
         <li
-          class="emotion-12 emotion-13"
+          class="emotion-13 emotion-14"
         >
           <div
-            class="emotion-14 emotion-15 emotion-16"
+            class="emotion-15 emotion-16 emotion-17"
           >
             <svg
               aria-label="Important With Circle Icon"
-              class="emotion-17"
+              class="emotion-18"
               fill="none"
               height="16"
               role="img"

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -50,6 +50,8 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-8 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -61,12 +63,8 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -106,25 +104,14 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-8:hover,
-.emotion-8:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-8:focus,
+.emotion-8:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-8:focus {
   outline: none;
-}
-
-.emotion-8:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-8:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-8:focus,
@@ -158,6 +145,28 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-9 {
+  position: relative;
+}
+
+.emotion-9::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-9::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-9::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-10 {
   overflow: hidden;
   position: absolute;
   top: 0;
@@ -167,7 +176,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   border-radius: 5px;
 }
 
-.emotion-10 {
+.emotion-11 {
   display: grid;
   grid-auto-flow: column;
   -webkit-box-pack: center;
@@ -189,7 +198,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   gap: 6px;
 }
 
-.emotion-11 {
+.emotion-12 {
   position: relative;
   -webkit-transition: 150ms ease-in-out;
   transition: 150ms ease-in-out;
@@ -209,13 +218,13 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-11 {
+  .emotion-12 {
     padding: 48px;
   }
 }
 
 @media not all and (max-width: 1024px) {
-  .emotion-11 {
+  .emotion-12 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -229,12 +238,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-12 {
+.emotion-13 {
   margin-bottom: 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-12 {
+  .emotion-13 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -244,7 +253,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-16 {
   background-color: #E3FCF7;
   border-radius: 4px;
   color: #001E2B;
@@ -257,17 +266,17 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-17 {
+.emotion-18 {
   color: #001E2B;
   font-weight: bold;
 }
 
-.emotion-19 {
+.emotion-20 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-21 {
+.emotion-22 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -281,11 +290,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   position: relative;
 }
 
-.emotion-21:not(:last-child) {
+.emotion-22:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-21:not(:last-child):before {
+.emotion-22:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -294,7 +303,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   border-left: solid 1px #00A35C;
 }
 
-.emotion-23 {
+.emotion-24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -314,11 +323,11 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   min-height: 20px;
 }
 
-.emotion-25 {
+.emotion-26 {
   color: #00A35C;
 }
 
-.emotion-26 {
+.emotion-27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -332,12 +341,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   color: #016BF8;
 }
 
-.emotion-26>code {
+.emotion-27>code {
   color: #016BF8;
 }
 
-.emotion-26:focus,
-.emotion-26:hover {
+.emotion-27:focus,
+.emotion-27:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -345,23 +354,23 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-26:focus {
+.emotion-27:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-26:hover {
+.emotion-27:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-27 {
+.emotion-28 {
   color: #001E2B;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-27:hover,
-.emotion-27:active {
+.emotion-28:hover,
+.emotion-28:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -392,12 +401,14 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
         target="_self"
         type="button"
       >
-        <span>
-          <div
-            class="emotion-9"
-          />
+        <span
+          class="emotion-9"
+        >
           <div
             class="emotion-10"
+          />
+          <div
+            class="emotion-11"
           >
             Learn More
           </div>
@@ -405,36 +416,36 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
       </span>
     </div>
     <div
-      class="emotion-11"
+      class="emotion-12"
     >
       <div
-        class="emotion-12 emotion-13"
+        class="emotion-13 emotion-14"
       >
         <div
-          class="emotion-14 emotion-15 emotion-16"
+          class="emotion-15 emotion-16 emotion-17"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-17 emotion-18"
+          class="emotion-18 emotion-19"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-19 emotion-20"
+        class="emotion-20 emotion-21"
       >
         <li
-          class="emotion-21 emotion-22"
+          class="emotion-22 emotion-23"
           color="#00A35C"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-24 emotion-25"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-25"
+              class="emotion-26"
               fill="none"
               height="16"
               role="img"
@@ -451,7 +462,7 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-26 emotion-27 emotion-28"
+            class="emotion-27 emotion-28 emotion-29"
             href="/server/read/"
           >
             Read Data in MongoDB

--- a/tests/unit/__snapshots__/IA.test.js.snap
+++ b/tests/unit/__snapshots__/IA.test.js.snap
@@ -81,6 +81,8 @@ exports[`renders a page IA with IA linked data 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -92,12 +94,8 @@ exports[`renders a page IA with IA linked data 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -144,25 +142,14 @@ exports[`renders a page IA with IA linked data 1`] = `
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
-}
-
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-6:hover {
@@ -213,7 +200,29 @@ exports[`renders a page IA with IA linked data 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-10 {
+.emotion-7 {
+  position: relative;
+}
+
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -227,12 +236,12 @@ exports[`renders a page IA with IA linked data 1`] = `
   color: #016BF8;
 }
 
-.emotion-10>code {
+.emotion-12>code {
   color: #016BF8;
 }
 
-.emotion-10:focus,
-.emotion-10:hover {
+.emotion-12:focus,
+.emotion-12:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -240,16 +249,16 @@ exports[`renders a page IA with IA linked data 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-10:hover {
+.emotion-12:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-11 {
+.emotion-13 {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -292,23 +301,23 @@ exports[`renders a page IA with IA linked data 1`] = `
   line-height: 20px;
 }
 
-.emotion-11:hover {
+.emotion-13:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus {
+.emotion-13:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-13::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-11:before {
+.emotion-13:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -325,14 +334,14 @@ exports[`renders a page IA with IA linked data 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-11:focus {
+.emotion-13:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0C2657;
   background-color: #C3E7FE;
 }
 
-.emotion-11:focus:before {
+.emotion-13:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
@@ -340,7 +349,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-14 {
+.emotion-17 {
   display: grid;
   -webkit-column-gap: 8px;
   column-gap: 8px;
@@ -352,7 +361,9 @@ exports[`renders a page IA with IA linked data 1`] = `
   padding: 8px;
 }
 
-.emotion-16 {
+.emotion-19 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -364,12 +375,8 @@ exports[`renders a page IA with IA linked data 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -413,45 +420,34 @@ exports[`renders a page IA with IA linked data 1`] = `
   height: 32px;
 }
 
-.emotion-16:hover,
-.emotion-16:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-19:hover,
+.emotion-19:focus,
+.emotion-19:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.emotion-16:focus {
+.emotion-19:focus {
   outline: none;
 }
 
-.emotion-16:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-16:focus {
-  text-decoration-color: #016BF8;
-}
-
-.emotion-16:hover {
+.emotion-19:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-16:focus {
+.emotion-19:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-16::-moz-focus-inner {
+.emotion-19::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-16:before {
+.emotion-19:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -468,14 +464,14 @@ exports[`renders a page IA with IA linked data 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-16:focus {
+.emotion-19:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0C2657;
   background-color: #C3E7FE;
 }
 
-.emotion-16:focus:before {
+.emotion-19:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
@@ -483,19 +479,19 @@ exports[`renders a page IA with IA linked data 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-16:focus {
+.emotion-19:focus {
   border: 1px solid #0498EC;
 }
 
-.emotion-16:focus:focus:before {
+.emotion-19:focus:focus:before {
   display: none;
 }
 
-.emotion-16:focus>span>span {
+.emotion-19:focus>span>span {
   position: relative;
 }
 
-.emotion-16:focus>span>span::after {
+.emotion-19:focus>span>span::after {
   content: '';
   position: absolute;
   width: 100%;
@@ -506,7 +502,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-16>span {
+.emotion-19>span {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -518,7 +514,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   gap: 8px;
 }
 
-.emotion-16>span:after {
+.emotion-19>span:after {
   display: none;
 }
 
@@ -552,7 +548,9 @@ exports[`renders a page IA with IA linked data 1`] = `
           href="https://www.mongodb.com/docs/atlas/getting-started/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             Atlas
           </span>
         </a>
@@ -567,7 +565,9 @@ exports[`renders a page IA with IA linked data 1`] = `
           href="https://www.mongodb.com/docs/manual/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             MongoDB Database Manual
           </span>
         </a>
@@ -578,7 +578,7 @@ exports[`renders a page IA with IA linked data 1`] = `
         <a
           aria-current="false"
           aria-disabled="false"
-          class="emotion-10 constant-classname emotion-11"
+          class="emotion-12 constant-classname emotion-13"
           href="/tools-and-connectors/"
         >
           Tools and Connectors
@@ -594,13 +594,15 @@ exports[`renders a page IA with IA linked data 1`] = `
           href="https://www.mongodb.com/docs/drivers/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             Client Libraries
           </span>
         </a>
       </li>
       <ul
-        class="emotion-14"
+        class="emotion-17"
       >
         <li
           class="emotion-5"
@@ -608,11 +610,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/c/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="C Driver icon"
                 height="16"
@@ -631,11 +635,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/cxx/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="C plus plus Driver icon"
                 height="16"
@@ -654,11 +660,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/csharp/current/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="C sharp Driver icon"
                 height="16"
@@ -677,11 +685,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/go/current/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Go Driver icon"
                 height="16"
@@ -700,11 +710,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/java-drivers/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Java Driver icon"
                 height="16"
@@ -723,11 +735,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/kotlin-drivers/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Kotlin Driver icon"
                 height="16"
@@ -746,11 +760,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/node/current/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Node Driver icon"
                 height="16"
@@ -769,11 +785,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/php/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="PHP Driver icon"
                 height="16"
@@ -792,11 +810,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/python/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Python Driver icon"
                 height="16"
@@ -815,11 +835,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/ruby/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Ruby Driver icon"
                 height="16"
@@ -838,11 +860,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/rust/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Rust Driver icon"
                 height="16"
@@ -861,11 +885,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/scala/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Scala Driver icon"
                 height="16"
@@ -884,11 +910,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/swift/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="Swift Driver icon"
                 height="16"
@@ -907,11 +935,13 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 constant-classname emotion-16"
+            class="lg-ui-0001 constant-classname emotion-19"
             href="https://www.mongodb.com/docs/drivers/typescript/"
             target="_self"
           >
-            <span>
+            <span
+              class="emotion-7"
+            >
               <img
                 alt="TypeScript Driver icon"
                 height="16"
@@ -1011,6 +1041,8 @@ exports[`renders a simple page IA correctly 1`] = `
 }
 
 .emotion-6 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1022,12 +1054,8 @@ exports[`renders a simple page IA correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -1074,25 +1102,14 @@ exports[`renders a simple page IA correctly 1`] = `
 }
 
 .emotion-6:hover,
-.emotion-6:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-6:focus,
+.emotion-6:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-6:focus {
   outline: none;
-}
-
-.emotion-6:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-6:focus {
-  text-decoration-color: #016BF8;
 }
 
 .emotion-6:hover {
@@ -1143,7 +1160,29 @@ exports[`renders a simple page IA correctly 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-10 {
+.emotion-7 {
+  position: relative;
+}
+
+.emotion-7::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-7::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-7::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1157,12 +1196,12 @@ exports[`renders a simple page IA correctly 1`] = `
   color: #016BF8;
 }
 
-.emotion-10>code {
+.emotion-12>code {
   color: #016BF8;
 }
 
-.emotion-10:focus,
-.emotion-10:hover {
+.emotion-12:focus,
+.emotion-12:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -1170,16 +1209,16 @@ exports[`renders a simple page IA correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-10:hover {
+.emotion-12:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-11 {
+.emotion-13 {
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -1222,23 +1261,23 @@ exports[`renders a simple page IA correctly 1`] = `
   line-height: 20px;
 }
 
-.emotion-11:hover {
+.emotion-13:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus {
+.emotion-13:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-13::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-11:before {
+.emotion-13:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -1255,14 +1294,14 @@ exports[`renders a simple page IA correctly 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-11:focus {
+.emotion-13:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0C2657;
   background-color: #C3E7FE;
 }
 
-.emotion-11:focus:before {
+.emotion-13:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
@@ -1300,7 +1339,9 @@ exports[`renders a simple page IA correctly 1`] = `
           href="https://www.mongodb.com/docs/atlas/getting-started/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             Atlas
           </span>
         </a>
@@ -1315,7 +1356,9 @@ exports[`renders a simple page IA correctly 1`] = `
           href="https://www.mongodb.com/docs/manual/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             MongoDB Database Manual
           </span>
         </a>
@@ -1326,7 +1369,7 @@ exports[`renders a simple page IA correctly 1`] = `
         <a
           aria-current="false"
           aria-disabled="false"
-          class="emotion-10 constant-classname emotion-11"
+          class="emotion-12 constant-classname emotion-13"
           href="/tools-and-connectors/"
         >
           Tools and Connectors
@@ -1342,7 +1385,9 @@ exports[`renders a simple page IA correctly 1`] = `
           href="https://www.mongodb.com/docs/drivers/"
           target="_self"
         >
-          <span>
+          <span
+            class="emotion-7"
+          >
             Client Libraries
           </span>
         </a>

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -165,6 +165,8 @@ exports[`renders a page with no next link correctly 1`] = `
 exports[`renders a page with no previous link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -176,12 +178,8 @@ exports[`renders a page with no previous link correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
@@ -189,28 +187,39 @@ exports[`renders a page with no previous link correctly 1`] = `
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-2 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -229,12 +238,14 @@ exports[`renders a page with no previous link correctly 1`] = `
         href=""
         title="Next Section"
       >
-        <span>
+        <span
+          class="emotion-1"
+        >
           MongoDB Go Driver
         </span>
       </a>
       <span
-        class="emotion-1"
+        class="emotion-2"
       >
          →
       </span>

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -3,6 +3,8 @@
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -14,44 +16,53 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
     class="lg-ui-0001 emotion-0"
     href=""
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       Empty string
     </span>
   </a>
@@ -61,6 +72,8 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 exports[`Link component renders a variety of strings correctly external MDB docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -72,37 +85,44 @@ exports[`Link component renders a variety of strings correctly external MDB docs
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
@@ -110,7 +130,9 @@ exports[`Link component renders a variety of strings correctly external MDB docs
     href="https://www.mongodb.com/docs/atlas/"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       MongoDB Atlas Docs
     </span>
   </a>
@@ -120,6 +142,8 @@ exports[`Link component renders a variety of strings correctly external MDB docs
 exports[`Link component renders a variety of strings correctly external MDB non-docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -131,37 +155,44 @@ exports[`Link component renders a variety of strings correctly external MDB non-
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
@@ -169,7 +200,9 @@ exports[`Link component renders a variety of strings correctly external MDB non-
     href="https://account.mongodb.com/account/"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       MongoDB Atlas Registration Page
     </span>
   </a>
@@ -179,6 +212,8 @@ exports[`Link component renders a variety of strings correctly external MDB non-
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -190,37 +225,44 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
@@ -228,7 +270,9 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
     href="http://mongodb.com"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       MongoDB Company
     </span>
   </a>
@@ -238,6 +282,8 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 exports[`Link component renders a variety of strings correctly external URL with hidden external icon 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -249,37 +295,44 @@ exports[`Link component renders a variety of strings correctly external URL with
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
@@ -287,7 +340,9 @@ exports[`Link component renders a variety of strings correctly external URL with
     href="http://mongodb.com"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       MongoDB Company
     </span>
   </a>
@@ -297,6 +352,8 @@ exports[`Link component renders a variety of strings correctly external URL with
 exports[`Link component renders a variety of strings correctly external non-MDB docs URL 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -308,40 +365,47 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -356,13 +420,15 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
     href="https://safety.google/authentication/"
     rel="noopener noreferrer"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       Google 2-Step Verification
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"
@@ -384,6 +450,8 @@ exports[`Link component renders a variety of strings correctly external non-MDB 
 exports[`Link component renders a variety of strings correctly identfies mailto links as external urls 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -395,37 +463,44 @@ exports[`Link component renders a variety of strings correctly identfies mailto 
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-1 {
+  position: relative;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
 }
 
 <a
@@ -433,7 +508,9 @@ exports[`Link component renders a variety of strings correctly identfies mailto 
     href="mailto:docs@mongodb.com"
     target="_self"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       docs@mongodb.com
     </span>
   </a>

--- a/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
+++ b/tests/unit/__snapshots__/OpenAPIChangelog.test.js.snap
@@ -688,6 +688,8 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
 }
 
 .emotion-52 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -699,44 +701,51 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
 }
 
 .emotion-52:hover,
-.emotion-52:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-52:focus,
+.emotion-52:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-52:focus {
   outline: none;
 }
 
-.emotion-52:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-52:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-53 {
+  position: relative;
+}
+
+.emotion-53::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-53::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-53::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-54 {
   color: #016BF8;
   word-break: break-all;
 }
 
-.emotion-55 {
+.emotion-56 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -746,11 +755,11 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   color: #001E2B;
 }
 
-.emotion-56 {
+.emotion-57 {
   margin-top: 2px;
 }
 
-.emotion-58 {
+.emotion-59 {
   font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -775,17 +784,17 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   color: #970606;
 }
 
-.emotion-59 {
+.emotion-60 {
   margin: 0;
   list-style-position: start;
 }
 
-.emotion-61 {
+.emotion-62 {
   margin-top: 12px;
   line-height: 28px;
 }
 
-.emotion-94 {
+.emotion-97 {
   font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -810,11 +819,11 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   color: #00684A;
 }
 
-.emotion-99 {
+.emotion-102 {
   position: relative;
 }
 
-.emotion-100 {
+.emotion-103 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -827,7 +836,7 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
   margin-right: 5px;
 }
 
-.emotion-102 {
+.emotion-105 {
   color: #DB3030;
 }
 
@@ -1032,25 +1041,27 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-57 emotion-58 emotion-59"
             >
               Removed
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               Resource version 2023-01-01 was removed, latest available resource version is 2023-02-01
             </li>
@@ -1077,25 +1088,27 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-58"
+              class="emotion-57 emotion-58 emotion-59"
             >
               Removed
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               This change should really definitely be hidden
             </li>
@@ -1122,32 +1135,34 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Projects/operation/getProjectByName"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   GET /api/atlas/v2/groups/byName/{groupName}
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-94"
+              class="emotion-57 emotion-58 emotion-97"
             >
               Released
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               <div
-                class="emotion-99 emotion-100 emotion-101"
+                class="emotion-102 emotion-103 emotion-104"
               >
                 <svg
                   aria-label="Important With Circle Icon"
-                  class="emotion-102"
+                  class="emotion-105"
                   fill="none"
                   height="16"
                   role="img"
@@ -1179,32 +1194,34 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Alert-Configurations/operation/updateAlertConfiguration"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   PUT /api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-94"
+              class="emotion-57 emotion-58 emotion-97"
             >
               Released
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               <div
-                class="emotion-99 emotion-100 emotion-101"
+                class="emotion-102 emotion-103 emotion-104"
               >
                 <svg
                   aria-label="Important With Circle Icon"
-                  class="emotion-102"
+                  class="emotion-105"
                   fill="none"
                   height="16"
                   role="img"
@@ -1223,14 +1240,14 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               This change should be hidden
             </li>
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               <div
-                class="emotion-99 emotion-100 emotion-101"
+                class="emotion-102 emotion-103 emotion-104"
               >
                 <svg
                   aria-label="Important With Circle Icon"
-                  class="emotion-102"
+                  class="emotion-105"
                   fill="none"
                   height="16"
                   role="img"
@@ -1249,14 +1266,14 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               Resource version added.
             </li>
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               <div
-                class="emotion-99 emotion-100 emotion-101"
+                class="emotion-102 emotion-103 emotion-104"
               >
                 <svg
                   aria-label="Important With Circle Icon"
-                  class="emotion-102"
+                  class="emotion-105"
                   fill="none"
                   height="16"
                   role="img"
@@ -1275,19 +1292,19 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               For the 'query' request parameter 'clusterName', default value was changed from 'default' to 'cluster0'
             </li>
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               Added the optional property 'links' in the response with the '200' status.
             </li>
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               <div
-                class="emotion-99 emotion-100 emotion-101"
+                class="emotion-102 emotion-103 emotion-104"
               >
                 <svg
                   aria-label="Important With Circle Icon"
-                  class="emotion-102"
+                  class="emotion-105"
                   fill="none"
                   height="16"
                   role="img"
@@ -1319,30 +1336,32 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Project-IP-Access-List/operation/createProjectIpAccessList"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   POST /api/atlas/v2/groups/{groupId}/accessList
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-94"
+              class="emotion-57 emotion-58 emotion-97"
             >
               Updated
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               Added the optional property 'name' in the response with the '200' status.
             </li>
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               Added the optional property 'comment' in the response with the '200' status.
             </li>
@@ -1369,25 +1388,27 @@ exports[`OpenAPIChangelog tests OpenAPIChangelog renders correctly 1`] = `
               href="//0/#tag/Projects/operation/getProjectByName"
               target="_self"
             >
-              <span>
+              <span
+                class="emotion-53"
+              >
                 <h6
-                  class="emotion-53 emotion-54 emotion-55"
+                  class="emotion-54 emotion-55 emotion-56"
                 >
                   GET /api/atlas/v2/groups/byName/{groupName}
                 </h6>
               </span>
             </a>
             <div
-              class="emotion-56 emotion-57 emotion-94"
+              class="emotion-57 emotion-58 emotion-97"
             >
               Updated
             </div>
           </div>
           <ul
-            class="emotion-59 emotion-60"
+            class="emotion-60 emotion-61"
           >
             <li
-              class="emotion-61 emotion-62"
+              class="emotion-62 emotion-63"
             >
               Added the optional property 'withDefaultAlertsSettings' in the response with the '200' status.
             </li>

--- a/tests/unit/__snapshots__/Paragraph.test.js.snap
+++ b/tests/unit/__snapshots__/Paragraph.test.js.snap
@@ -19,6 +19,8 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
 }
 
 .emotion-1 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -30,37 +32,44 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-1:hover,
-.emotion-1:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-1:focus,
+.emotion-1:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-1:focus {
   outline: none;
 }
 
-.emotion-1:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-2 {
+  position: relative;
 }
 
-.emotion-1:focus {
-  text-decoration-color: #016BF8;
+.emotion-2::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-2::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-2::after {
+  background-color: #E8EDEB;
 }
 
 <p
@@ -71,7 +80,9 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
       href="https://cloud.mongodb.com?tck=docs_realm"
       target="_self"
     >
-      <span>
+      <span
+        class="emotion-2"
+      >
         Deploy a Free Tier Cluster.
       </span>
     </a>
@@ -98,6 +109,8 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
 }
 
 .emotion-1 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -109,37 +122,44 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-1:hover,
-.emotion-1:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-1:focus,
+.emotion-1:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-1:focus {
   outline: none;
 }
 
-.emotion-1:hover {
-  text-decoration-color: #E8EDEB;
+.emotion-2 {
+  position: relative;
 }
 
-.emotion-1:focus {
-  text-decoration-color: #016BF8;
+.emotion-2::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-2::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-2::after {
+  background-color: #E8EDEB;
 }
 
 <p
@@ -150,7 +170,9 @@ exports[`Paragraph unit tests handles formatting dangling punctuation after Link
       href="https://cloud.mongodb.com?tck=docs_realm"
       target="_self"
     >
-      <span>
+      <span
+        class="emotion-2"
+      >
         Deploy a Free Tier Cluster.
       </span>
     </a>

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -3,6 +3,8 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  font-size: 13px;
+  line-height: 20px;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -14,40 +16,47 @@ exports[`renders correctly 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-decoration-color: transparent;
   cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
   font-weight: 400;
   display: inline;
 }
 
 .emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
+.emotion-0:focus,
+.emotion-0:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {
   outline: none;
 }
 
-.emotion-0:hover {
-  text-decoration-color: #E8EDEB;
-}
-
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
-}
-
 .emotion-1 {
+  position: relative;
+}
+
+.emotion-1::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  border-radius: 2px;
+}
+
+.lg-ui-0001:focus .emotion-1::after {
+  background-color: #0498EC;
+}
+
+.lg-ui-0001:hover .emotion-1::after {
+  background-color: #E8EDEB;
+}
+
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -62,13 +71,15 @@ exports[`renders correctly 1`] = `
     href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
     rel="noopener noreferrer"
   >
-    <span>
+    <span
+      class="emotion-1"
+    >
       mLab documentation
     </span>
     <svg
       alt=""
       aria-hidden="true"
-      class="emotion-1"
+      class="emotion-2"
       height="16"
       role="presentation"
       viewBox="0 0 16 16"

--- a/tests/unit/useViewport.test.js
+++ b/tests/unit/useViewport.test.js
@@ -52,26 +52,26 @@ describe('useViewport()', () => {
     window.removeEventListener = removeEventListener;
   });
 
-  function resize(width = global.window.innerWidth, height = global.window.innerHeight) {
+  async function resize(width = global.window.innerWidth, height = global.window.innerHeight) {
     const resizeEvent = document.createEvent('Event');
     resizeEvent.initEvent('resize', true, true);
 
     global.window.innerWidth = width || global.window.innerWidth;
     global.window.innerHeight = height || global.window.innerHeight;
     global.window.dispatchEvent(resizeEvent);
-    act(() => {
+    await act(async () => {
       listeners.resize();
     });
   }
 
-  function scroll(vertical = 0, horizontal = 0) {
+  async function scroll(vertical = 0, horizontal = 0) {
     const scrollEvent = document.createEvent('Event');
     scrollEvent.initEvent('scroll', true, true);
 
     global.window.pageYOffset = global.window.pageYOffset + vertical;
     global.window.pageXOffset = global.window.pageXOffset + horizontal;
     global.window.dispatchEvent(scrollEvent);
-    act(() => {
+    await act(async () => {
       listeners.scroll();
     });
   }

--- a/tests/unit/useViewport.test.js
+++ b/tests/unit/useViewport.test.js
@@ -52,26 +52,26 @@ describe('useViewport()', () => {
     window.removeEventListener = removeEventListener;
   });
 
-  async function resize(width = global.window.innerWidth, height = global.window.innerHeight) {
+  function resize(width = global.window.innerWidth, height = global.window.innerHeight) {
     const resizeEvent = document.createEvent('Event');
     resizeEvent.initEvent('resize', true, true);
 
     global.window.innerWidth = width || global.window.innerWidth;
     global.window.innerHeight = height || global.window.innerHeight;
     global.window.dispatchEvent(resizeEvent);
-    await act(async () => {
+    act(() => {
       listeners.resize();
     });
   }
 
-  async function scroll(vertical = 0, horizontal = 0) {
+  function scroll(vertical = 0, horizontal = 0) {
     const scrollEvent = document.createEvent('Event');
     scrollEvent.initEvent('scroll', true, true);
 
     global.window.pageYOffset = global.window.pageYOffset + vertical;
     global.window.pageXOffset = global.window.pageXOffset + horizontal;
     global.window.dispatchEvent(scrollEvent);
-    await act(async () => {
+    act(() => {
       listeners.scroll();
     });
   }


### PR DESCRIPTION
### Stories/Links:

DOP-4502

### Current Behavior:

[Atlas Prod](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Atlas Staged Commit](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/7ae5e68f3c92834abd53aeabf67abdead93af0a6/master/cloud-docs/caesarbell/DOP-4502/index.html)

### Notes:

The change here provides a solution to reduce the INP score, which originally was no bueno. It achieves this by introducing transitions from React's useTransition. Transitions in React allow the state to be updated without blocking the UI. For more information, check out the docs for [useTransition](https://react.dev/reference/react/useTransition#). 

**screenshots if you are into that kind of stuff**

Before transitions
![Screenshot 2024-04-05 at 5 01 15 PM](https://github.com/mongodb/snooty/assets/5807473/a6ed6a9d-e774-4f1d-ad53-7372adc59b81)

After transitions
![Screenshot 2024-04-05 at 5 11 13 PM](https://github.com/mongodb/snooty/assets/5807473/cb8527c6-9d7f-4c7f-8220-18bfc9438371)
![Screenshot 2024-04-05 at 5 02 07 PM](https://github.com/mongodb/snooty/assets/5807473/44a76b08-7379-4864-99af-9159e4f1f443)

**It works still*
![image](https://github.com/mongodb/snooty/assets/5807473/d5b173d6-0032-473c-9eda-ef3bbceeabd7)



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
