### PR TITLE
DOP-4502 turns the set functions in initializeFeedback into transitions

### DIFF
--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, createContext } from 'react';
+import React, { useState, useContext, createContext, useTransition } from 'react';
 import { getViewport } from '../../../hooks/useViewport';
 import { createNewFeedback, useRealmUser } from './realm';
 
@@ -12,15 +12,18 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
   const [view, setView] = useState(test.view || 'waiting');
   const [screenshotTaken, setScreenshotTaken] = useState(test.screenshotTaken || false);
   const [progress, setProgress] = useState([true, false, false]);
+  const [, startTransition] = useTransition();
   const { user, reassignCurrentUser } = useRealmUser();
 
   // Create a new feedback document
   // Maybe use transitions?
   const initializeFeedback = (nextView = 'rating') => {
     const newFeedback = {};
-    setFeedback({ newFeedback });
-    setView(nextView);
-    setProgress([true, false, false]);
+    startTransition(() => {
+      setFeedback({ newFeedback });
+      setView(nextView);
+      setProgress([true, false, false]);
+    });
     return { newFeedback };
   };
 

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -15,6 +15,7 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
   const { user, reassignCurrentUser } = useRealmUser();
 
   // Create a new feedback document
+  // Maybe use transitions?
   const initializeFeedback = (nextView = 'rating') => {
     const newFeedback = {};
     setFeedback({ newFeedback });

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -16,7 +16,6 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
   const { user, reassignCurrentUser } = useRealmUser();
 
   // Create a new feedback document
-  // Maybe use transitions?
   const initializeFeedback = (nextView = 'rating') => {
     const newFeedback = {};
     startTransition(() => {

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -56,7 +56,7 @@ describe('DocumentBody', () => {
         const chatbotWidget = screen.getByText(CHATBOT_WIDGET_TEXT);
         expect(chatbotWidget).toBeVisible();
       },
-      { timeout: 8000 }
+      { timeout: 10000 }
     );
   });
 


### PR DESCRIPTION
### Stories/Links:

DOP-4502

### Current Behavior:

[Atlas Prod](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Atlas Staged Commit](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/7ae5e68f3c92834abd53aeabf67abdead93af0a6/master/cloud-docs/caesarbell/DOP-4502/index.html)

### Notes:

The change here provides a solution to reduce the INP score, which originally was no bueno. It achieves this by introducing transitions from React's useTransition. Transitions in React allow the state to be updated without blocking the UI. For more information, check out the docs for [useTransition](https://react.dev/reference/react/useTransition#). 

**screenshots if you are into that kind of stuff**

Before transitions
![Screenshot 2024-04-05 at 5 01 15 PM](https://github.com/mongodb/snooty/assets/5807473/a6ed6a9d-e774-4f1d-ad53-7372adc59b81)

After transitions
![Screenshot 2024-04-05 at 5 11 13 PM](https://github.com/mongodb/snooty/assets/5807473/cb8527c6-9d7f-4c7f-8220-18bfc9438371)
![Screenshot 2024-04-05 at 5 02 07 PM](https://github.com/mongodb/snooty/assets/5807473/44a76b08-7379-4864-99af-9159e4f1f443)

**It works still*
![image](https://github.com/mongodb/snooty/assets/5807473/d5b173d6-0032-473c-9eda-ef3bbceeabd7)



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README