### PR TITLE
DOP-4524: use nextslug for link

### DIFF
--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -54,7 +54,7 @@ const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
       {nextSlug && (
         <React.Fragment>
           <LinkContentContainer>
-            <Link className={cx(titleSpanStyling)} to={prevSlug} title="Next Section">
+            <Link className={cx(titleSpanStyling)} to={nextSlug} title="Next Section">
               {getPageTitle(nextSlug, slugTitleMapping)}
             </Link>
             <span className={cx([arrowStyling])}>&nbsp;→</span>

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -74,7 +74,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
     >
       <a
         class="emotion-1 emotion-2"
-        href="/drivers/csharp/"
+        href="/drivers/java/"
         title="Next Section"
       >
         Java MongoDB Driver
@@ -165,40 +165,26 @@ exports[`renders a page with no next link correctly 1`] = `
 exports[`renders a page with no previous link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  cursor: pointer;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-decoration-color: transparent;
-  cursor: pointer;
-  font-size: inherit;
-  line-height: inherit;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  -ms-appearance: none;
-  appearance: none;
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: 13px;
-  line-height: 20px;
+  line-height: 13px;
   color: #016BF8;
-  font-weight: 400;
-  display: inline;
-  line-height: 28px;
 }
 
-.emotion-0:hover,
-.emotion-0:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+.emotion-0>code {
+  color: #016BF8;
+}
+
+.emotion-0:focus,
+.emotion-0:hover {
+  text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
   text-underline-offset: 4px;
@@ -206,6 +192,7 @@ exports[`renders a page with no previous link correctly 1`] = `
 }
 
 .emotion-0:focus {
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
@@ -213,11 +200,11 @@ exports[`renders a page with no previous link correctly 1`] = `
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-0:focus {
-  text-decoration-color: #016BF8;
+.emotion-1 {
+  line-height: 28px;
 }
 
-.emotion-1 {
+.emotion-2 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -232,16 +219,14 @@ exports[`renders a page with no previous link correctly 1`] = `
       class="sc-gswNZR UJFxm"
     >
       <a
-        class="lg-ui-0001 emotion-0"
-        href=""
+        class="emotion-0 emotion-1"
+        href="/drivers/go/"
         title="Next Section"
       >
-        <span>
-          MongoDB Go Driver
-        </span>
+        MongoDB Go Driver
       </a>
       <span
-        class="emotion-1"
+        class="emotion-2"
       >
          →
       </span>


### PR DESCRIPTION
### Stories/Links:

DOP-4524

### Current Behavior:

[server docs page showing next page, but linking to prev page](https://www.mongodb.com/docs/manual/core/timeseries/timeseries-limitations/)

### Staging Links:

[staged server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/seung.park/DOP-4524/core/timeseries/timeseries-limitations/index.html)

### Notes:
Bug originated from [this change](https://github.com/mongodb/snooty/pull/1049/files#diff-6a4d349ee7d923a3ad2abf378f68b402e44b8bd6f8ba7f77ff9e0b7ccfc0bbc5R56-R61) while fixing link styling.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
