### PR TITLE
:bug: DOP-4514 using normalizePath as a catch-all for double slashes

### DIFF
--- a/src/hooks/use-canonical-url.js
+++ b/src/hooks/use-canonical-url.js
@@ -11,7 +11,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
   const pathPrefix = generatePrefix(urlSlug, siteMetadata, siteBasePrefix);
 
   // Use default logic assuming there is no canonical provided from the meta directive
-  let canonical = `${siteUrl}${normalizePath(`${pathPrefix}/${slug === '/' ? '' : slug}`)}`;
+  let canonical = `${siteUrl}/${normalizePath(`${pathPrefix}/${slug === '/' ? '' : slug}`)}`;
 
   // checks to see if the canonical is provided from the
   // meta directive and grab the index
@@ -41,7 +41,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
     if (stableBranch) {
       // if a stable branch is found, use the following canonical tag
       // which points to the most current version
-      canonical = `${siteUrl}${normalizePath(`${siteBasePrefix}/${stableBranch.urlSlug}`)}`;
+      canonical = `${siteUrl}/${normalizePath(`${siteBasePrefix}/${stableBranch.urlSlug}`)}`;
     } else {
       // this means the entire page is EoL'd and a writer should provide the canonical tag
       let _canonical = `${siteUrl}`;

--- a/src/hooks/use-canonical-url.js
+++ b/src/hooks/use-canonical-url.js
@@ -1,5 +1,6 @@
 import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 import { generatePrefix } from '../components/VersionDropdown/utils';
+import { normalizePath } from '../utils/normalize-path';
 import { useSiteMetadata } from './use-site-metadata';
 
 export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
@@ -10,7 +11,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
   const pathPrefix = generatePrefix(urlSlug, siteMetadata, siteBasePrefix);
 
   // Use default logic assuming there is no canonical provided from the meta directive
-  let canonical = `${siteUrl}${pathPrefix}/${slug === '/' ? '' : slug}`;
+  let canonical = `${siteUrl}${normalizePath(`${pathPrefix}/${slug === '/' ? '' : slug}`)}`;
 
   // checks to see if the canonical is provided from the
   // meta directive and grab the index
@@ -40,7 +41,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
     if (stableBranch) {
       // if a stable branch is found, use the following canonical tag
       // which points to the most current version
-      canonical = `${siteUrl}/${siteBasePrefix}/${stableBranch.urlSlug}`;
+      canonical = `${siteUrl}${normalizePath(`${siteBasePrefix}/${stableBranch.urlSlug}`)}`;
     } else {
       // this means the entire page is EoL'd and a writer should provide the canonical tag
       let _canonical = `${siteUrl}`;

--- a/src/hooks/use-canonical-url.js
+++ b/src/hooks/use-canonical-url.js
@@ -11,7 +11,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
   const pathPrefix = generatePrefix(urlSlug, siteMetadata, siteBasePrefix);
 
   // Use default logic assuming there is no canonical provided from the meta directive
-  let canonical = `${siteUrl}/${normalizePath(`${pathPrefix}/${slug === '/' ? '' : slug}`)}`;
+  let canonical = `${siteUrl}${normalizePath(`${pathPrefix}/${slug === '/' ? '' : slug}`)}`;
 
   // checks to see if the canonical is provided from the
   // meta directive and grab the index


### PR DESCRIPTION
### Stories/Links:

DOP-4514

### Current Behavior:

[Customize Cluster Storage](https://www.mongodb.com/docs/atlas/customize-storage/)

### Staging Links:

[Staged Commit](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/795b0c49fad7fe1754f35c17d2dea1fa72f691f9/master/cloud-docs/caesarbell/DOP-4514/index.html)

### Notes:

This PR does the following; 

-  Uses `normalizePath` as a catch-all for double slashes within the canonical URL.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
