### PR TITLE
DOP-4543: Generalize card styles for programming language landing pages

### DIFF
--- a/src/components/Card/CardGroup.js
+++ b/src/components/Card/CardGroup.js
@@ -104,13 +104,7 @@ const CardGroup = ({
 
   return (
     <StyledGrid
-      className={[
-        'card-group',
-        isCompact ? 'compact' : '',
-        isExtraCompact ? 'extra-compact' : '',
-        isDriversTemplate ? 'drivers' : '',
-        className,
-      ].join(' ')}
+      className={['card-group', className].join(' ')}
       columns={columns}
       noMargin={true}
       isCarousel={isCarousel}

--- a/src/components/Card/CardGroup.js
+++ b/src/components/Card/CardGroup.js
@@ -98,6 +98,7 @@ const CardGroup = ({
   const isCarousel = layout === 'carousel';
   // Keep "type" for backwards compatibility, but it might be good to generalize to "style"
   const isCenterContentStyle = type === 'drivers' || style === 'center-content';
+  const isLargeIconStyle = style === 'large-icon';
   const isDriversTemplate = page?.options?.template === 'drivers-index';
   const isLanding = page?.options?.template === 'landing';
 
@@ -124,6 +125,7 @@ const CardGroup = ({
           isCompact={isCompact}
           isExtraCompact={isExtraCompact}
           isCenterContentStyle={isCenterContentStyle}
+          isLargeIconStyle={isLargeIconStyle}
           page={page}
         />
       ))}

--- a/src/components/Card/CardGroup.js
+++ b/src/components/Card/CardGroup.js
@@ -96,7 +96,9 @@ const CardGroup = ({
   const isCompact = style === 'compact';
   const isExtraCompact = style === 'extra-compact';
   const isCarousel = layout === 'carousel';
-  const isForDrivers = type === 'drivers';
+  // Keep "type" for backwards compatibility, but it might be good to generalize to "style"
+  const isCenterContentStyle = type === 'drivers' || style === 'center-content';
+  const isDriversTemplate = page?.options?.template === 'drivers-index';
   const isLanding = page?.options?.template === 'landing';
 
   return (
@@ -105,13 +107,13 @@ const CardGroup = ({
         'card-group',
         isCompact ? 'compact' : '',
         isExtraCompact ? 'extra-compact' : '',
-        isForDrivers ? 'drivers' : '',
+        isDriversTemplate ? 'drivers' : '',
         className,
       ].join(' ')}
       columns={columns}
       noMargin={true}
       isCarousel={isCarousel}
-      isForDrivers={isForDrivers}
+      isForDrivers={isDriversTemplate}
       isLanding={isLanding}
     >
       {children.map((child, i) => (
@@ -121,7 +123,7 @@ const CardGroup = ({
           nodeData={child}
           isCompact={isCompact}
           isExtraCompact={isExtraCompact}
-          isForDrivers={isForDrivers}
+          isCenterContentStyle={isCenterContentStyle}
           page={page}
         />
       ))}

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -71,26 +71,17 @@ const centerContentStyling = css`
   }
 `;
 
-const landingBottomStyling = css`
-  img {
-    width: 50px;
-  }
-  p {
-    font-weight: 500;
-    line-height: ${theme.size.medium};
-  }
-`;
-
 const compactIconStyle = `
   @media ${theme.screenSize.upToSmall} {
     width: 20px;
   }
 `;
 
-const headingStyling = ({ isCompact, isExtraCompact }) => css`
-  font-weight: 600;
+const headingStyling = ({ isCompact, isExtraCompact, isLargeIconStyle }) => css`
+  font-weight: 500;
   letter-spacing: 0.5px;
   margin: ${isCompact || isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
+  ${isLargeIconStyle && 'margin-bottom: 36px;'}
 `;
 
 const FlexTag = styled(Tag)`
@@ -131,6 +122,7 @@ const Card = ({
   isCompact,
   isExtraCompact,
   isCenterContentStyle,
+  isLargeIconStyle,
   page,
   nodeData: {
     children,
@@ -141,12 +133,8 @@ const Card = ({
 
   const isLanding = template === 'landing';
 
-  /* If tag == 'landing-bottom', this is 2nd group of cards on 
-  landing page which we want to keep exempt from landing styles */
-  const isLandingBottom = tag === 'landing-bottom';
-
   let imgSize;
-  if (isLanding && isLandingBottom) imgSize = '50px';
+  if (isLargeIconStyle) imgSize = '50px';
   else if (isLanding) imgSize = theme.size.xlarge;
   else if (template === 'product-landing') imgSize = theme.size.large;
   else imgSize = theme.size.medium;
@@ -155,10 +143,9 @@ const Card = ({
 
   const styling = [
     cardBaseStyles,
-    isLanding && !isLandingBottom ? landingStyles : '', // must come after other styles to override
-    isLandingBottom ? landingBottomStyling : '',
     isCenterContentStyle ? centerContentStyling : cardStyling,
     isCompact || isExtraCompact ? compactCardStyling : '',
+    isLanding && !isLargeIconStyle ? landingStyles : '', // must come after other styles to override
   ];
 
   return (
@@ -176,10 +163,10 @@ const Card = ({
         condition={isCompact || isExtraCompact}
         wrapper={(children) => <CompactTextWrapper>{children}</CompactTextWrapper>}
       >
-        {tag && !isLandingBottom && <FlexTag>{tag}</FlexTag>}
+        {tag && <FlexTag>{tag}</FlexTag>}
         <div>
           {headline && (
-            <Body className={cx(headingStyling({ isCompact, isExtraCompact }))} weight="medium">
+            <Body className={cx(headingStyling({ isCompact, isExtraCompact, isLargeIconStyle }))} weight="medium">
               {headline}
             </Body>
           )}
@@ -200,7 +187,10 @@ const Card = ({
 };
 
 Card.propTypes = {
+  isCompact: PropTypes.bool,
+  isExtraCompact: PropTypes.bool,
   isCenterContentStyle: PropTypes.bool,
+  isLargeIconStyle: PropTypes.bool,
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object),
     options: PropTypes.shape({

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -56,7 +56,7 @@ const cardStyling = css`
   }
 `;
 
-const cardDriverStyle = css`
+const centerContentStyling = css`
   padding: ${theme.size.default} ${theme.size.medium};
   align-items: center;
 
@@ -130,7 +130,7 @@ const onCardClick = (url) => {
 const Card = ({
   isCompact,
   isExtraCompact,
-  isForDrivers,
+  isCenterContentStyle,
   page,
   nodeData: {
     children,
@@ -155,9 +155,9 @@ const Card = ({
 
   const styling = [
     cardBaseStyles,
-    isForDrivers ? cardDriverStyle : cardStyling,
     isLanding && !isLandingBottom ? landingStyles : '', // must come after other styles to override
     isLandingBottom ? landingBottomStyling : '',
+    isCenterContentStyle ? centerContentStyling : cardStyling,
     isCompact || isExtraCompact ? compactCardStyling : '',
   ];
 
@@ -204,7 +204,7 @@ const Card = ({
 };
 
 Card.propTypes = {
-  isForDrivers: PropTypes.bool,
+  isCenterContentStyle: PropTypes.bool,
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object),
     options: PropTypes.shape({

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -179,11 +179,7 @@ const Card = ({
         {tag && !isLandingBottom && <FlexTag>{tag}</FlexTag>}
         <div>
           {headline && (
-            <Body
-              className={cx(headingStyling({ isCompact, isExtraCompact }))}
-              compact={isCompact || isExtraCompact}
-              weight="medium"
-            >
+            <Body className={cx(headingStyling({ isCompact, isExtraCompact }))} weight="medium">
               {headline}
             </Body>
           )}

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -71,6 +71,12 @@ const centerContentStyling = css`
   }
 `;
 
+const largeIconStyling = css`
+  p {
+    line-height: ${theme.size.medium};
+  }
+`;
+
 const compactIconStyle = `
   @media ${theme.screenSize.upToSmall} {
     width: 20px;
@@ -145,6 +151,7 @@ const Card = ({
     cardBaseStyles,
     isCenterContentStyle ? centerContentStyling : cardStyling,
     isCompact || isExtraCompact ? compactCardStyling : '',
+    isLargeIconStyle ? largeIconStyling : '',
     isLanding && !isLargeIconStyle ? landingStyles : '', // must come after other styles to override
   ];
 

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -74,7 +74,7 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
   color: #001E2B;
   font-weight: 500;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.5px;
   margin: 16px 0 8px 0;
 }

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -215,7 +215,7 @@ exports[`renders correctly 1`] = `
 }
 
 <div
-    class="card-group compact    emotion-0 emotion-1"
+    class="card-group  emotion-0 emotion-1"
   >
     <div
       class="emotion-2"

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -322,7 +322,7 @@ exports[`card correctly with and without url 1`] = `
 }
 
 <div
-    class="card-group  extra-compact   emotion-0 emotion-1"
+    class="card-group  emotion-0 emotion-1"
   >
     <div
       class="emotion-2"

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -116,7 +116,7 @@ exports[`card correctly with and without url 1`] = `
   line-height: 20px;
   color: #001E2B;
   font-weight: 500;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.5px;
   margin: 0 0 8px;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4543

### Current Behavior:

[Drivers prod](https://www.mongodb.com/docs/drivers/)
[Landing prod](https://www.mongodb.com/docs/)

### Staging Links:

[Drivers staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4510/drivers/raymund.rodriguez/DOP-4543/index.html)
[Mocked programming language landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4510/drivers/raymund.rodriguez/DOP-4543/php-libraries/index.html)
[Landing staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-4543/index.html)

### Notes:

* The programming language landing pages will be using cards in the same format/shape as the cards of the drivers homepage. However, the margins that come with the card group for the drivers homepage are coupled with the `:type: drivers` option.
* Solution: Decouple the margins styles from the card styles such that the margins.
  * Since the margins are only (currently) desired for the drivers homepage, the `drivers-index` template used for that homepage will determine whether the margins are used. To test, change browser screen size.
  * Since the card style will be used for more than just drivers (semantically), we use the style based on whether the card group's `type` is `drivers` (to avoid immediate breaking changes) or when using the `style` `center-content` (potentially preferable as a generalized style option). See this [parser PR](https://github.com/mongodb/snooty-parser/pull/584) to see introduction of new style. Support for the `drivers` `type` can potentially be removed whenever reStructuredText pages no longer rely on that option.
* (Based on discussion below) Also generalizes the styling for cards associated with the bottom cards on the `docs-landing` homepage. This is to allow new programming landing pages to reuse a similar style. After this is merged and released, I should be able to update the styles accordingly. 

To test on a page:

```
.. card-group::
   :columns: 3
   :style: center-content

   .. cards here

.. card-group::
   :columns: 3
   :style: large-icon

   .. cards here
```

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
