### PR TITLE
DOP-4541: Support max-width paragraphs for product-landing template

### DIFF
--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -34,7 +34,7 @@ const Wrapper = styled('main')`
 
   section p {
     grid-column: 2;
-    max-width: 500px;
+    ${({ hasMaxWidthParagraphs }) => !hasMaxWidthParagraphs && 'max-width: 500px;'}
   }
 
   // realm PLP has full width p
@@ -165,11 +165,13 @@ const Wrapper = styled('main')`
   }
 `;
 
-const ProductLanding = ({ children }) => {
+const ProductLanding = ({ children, data: { page } }) => {
   const { project } = useSnootyMetadata();
   const useHero = ['guides', 'realm'].includes(project);
   const isGuides = project === 'guides';
   const isRealm = project === 'realm';
+  const pageOptions = page?.ast?.options;
+  const hasMaxWidthParagraphs = ['', 'true'].includes(pageOptions?.['pl-max-width-paragraphs']);
 
   // shallow copy children, and search for existence of banner
   const shallowChildren = children.reduce((res, child) => {
@@ -189,7 +191,13 @@ const ProductLanding = ({ children }) => {
   const bannerNode = findKeyValuePair([{ children: shallowChildren }], 'name', 'banner');
 
   return (
-    <Wrapper isGuides={isGuides} isRealm={isRealm} useHero={useHero} hasBanner={!!bannerNode}>
+    <Wrapper
+      isGuides={isGuides}
+      isRealm={isRealm}
+      useHero={useHero}
+      hasBanner={!!bannerNode}
+      hasMaxWidthParagraphs={hasMaxWidthParagraphs}
+    >
       {children}
     </Wrapper>
   );


### PR DESCRIPTION
### Stories/Links:

DOP-4541

### Current Behavior:

[Atlas Search prod](https://www.mongodb.com/docs/atlas/atlas-search/)
[Mock programming language landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4510/drivers/raymund.rodriguez/DOP-4543/php-libraries/index.html)

### Staging Links:

Atlas Search staging (expected no change)
Mock programming language landing page (using the new page option)

### Notes:

Expects a net new page option that can be used with `product-landing` templates. To use on a page:

```
:template: product-landing
:pl-max-width-paragraphs:
```

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
