### PR TITLE
imgs in screenshot bugfix

### DIFF
--- a/src/components/Widgets/FeedbackWidget/handleScreenshot.js
+++ b/src/components/Widgets/FeedbackWidget/handleScreenshot.js
@@ -11,6 +11,13 @@ import { fwFormId } from './FeedbackForm';
 async function takeScreenshot(subject, config = {}) {
   // Convert the page into a "clean" html document that inlines all styles, images, etc.
   const htmlDocument = capture(OutputType.OBJECT, subject, config);
+
+  // Remove srcset from Gatsby images - it messes with the drawn image of the html
+  const imgs = htmlDocument.querySelectorAll('img[srcset]');
+  imgs.forEach((img) => {
+    img.removeAttribute('srcset');
+  });
+
   // Convert the "clean" document into a rasterized <img />. It has the same dimensions as the user's window.
   const { image } = await rasterizeHTML.drawHTML(htmlDocument.innerHTML);
   // Create a <canvas /> and draw the image on it. Set the canvas dimensions to match the image.


### PR DESCRIPTION
### Stories/Links:

DOP-4471

### Current Behavior:

<img width="513" alt="Screenshot 2024-04-15 at 2 27 12 PM" src="https://github.com/mongodb/snooty/assets/22421112/94c51505-2593-48a1-b5f3-99bbb149a759">


### Staging Behavior:

<img width="513" alt="Screenshot 2024-04-15 at 2 24 21 PM" src="https://github.com/mongodb/snooty/assets/22421112/dd1351fb-cf2a-4076-86de-d32aa2383374">


### Notes:

Some images were not being captured in screenshots. 

This took quite a bit of investigation and experimentation. I did not really find this issue out on the web, but after taking the time to compare which images did and didn't carry over. The fix was to remove the attribute srcset just for the screenshots.


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
