### PR TITLE
DOP-4567: remove fixed height for image in lightbox

### DIFF
--- a/src/components/Figure/Lightbox.js
+++ b/src/components/Figure/Lightbox.js
@@ -7,18 +7,30 @@ import { theme } from '../../theme/docsTheme.js';
 import CaptionLegend from './CaptionLegend';
 
 const CAPTION_TEXT = 'click to enlarge';
+
+const MODAL_PADDING = '64px';
+const MODAL_DIALOG_PADDING = '40px';
+
 const StyledModal = styled(Modal)`
   // Set z-index to appear above side nav and top navbar
   z-index: 10;
-  margin-top: 64px;
+  margin-top: ${theme.header.navbarHeight};
+
+  div[role='dialog'] {
+    max-width: 80%;
+    max-height: calc(100vh - ${theme.header.navbarHeight} - ${MODAL_DIALOG_PADDING});
+    transition: none;
+  }
+
+  img {
+    max-height: calc(
+      100vh - ${theme.header.navbarHeight} - ${MODAL_DIALOG_PADDING} - ${MODAL_PADDING} - ${MODAL_PADDING} -
+        ${MODAL_DIALOG_PADDING}
+    );
+    width: auto;
+  }
 
   @media ${theme.screenSize.largeAndUp} {
-    div[role='dialog'] {
-      max-width: 80%;
-    }
-    img {
-      max-height: 620px;
-    }
   }
 
   @media ${theme.screenSize.upToLarge} {

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -70,7 +70,7 @@ const screenSize = {
 
 const header = {
   bannerHeight: '40px',
-  navbarHeight: '88px',
+  navbarHeight: '95px',
   navbarMobileHeight: '56px',
   docsMobileMenuHeight: '52px',
   // used for scrolling elements into place, considering sticky header

--- a/tests/unit/useStickyTopValues.test.js
+++ b/tests/unit/useStickyTopValues.test.js
@@ -36,14 +36,14 @@ const TestComponent = ({ mockBannerContent, HelperComponent }) => {
 describe('useStickyTopValues()', () => {
   it('provides the correct top values without any banner content and eol false', () => {
     const wrapper = render(<TestComponent mockBannerContent={null} HelperComponent={HelperComponent} />);
-    expect(wrapper.queryByText('88px')).toBeTruthy();
+    expect(wrapper.queryByText('95px')).toBeTruthy();
     expect(wrapper.queryByText('56px')).toBeTruthy();
     expect(wrapper.queryByText('108px')).toBeTruthy();
   });
 
   it('provides the correct top values with banner content and eol false', () => {
     const wrapper = render(<TestComponent mockBannerContent={{ isEnabled: true }} HelperComponent={HelperComponent} />);
-    expect(wrapper.queryByText('128px')).toBeTruthy();
+    expect(wrapper.queryByText('135px')).toBeTruthy();
     expect(wrapper.queryByText('96px')).toBeTruthy();
     expect(wrapper.queryByText('148px')).toBeTruthy();
   });


### PR DESCRIPTION
### Stories/Links:

DOP-4567

### Current Behavior:

[original slack message of k8s docs shows figure with distorted image 1](https://preview-mongodbjuliamongo.gatsbyjs.io/docs-k8s-operator/om-ha/tutorial/om-diagram-multi-cluster/)

[example 2 from k8s docs](https://preview-mongodbjuliamongo.gatsbyjs.io/docs-k8s-operator/om-ha/tutorial/om-nw-lb-mesh-multi-cluster/#diagram-example-1--external-load-balancer)

[atlas example of lighthouse figure](https://www.mongodb.com/docs/atlas/atlas-search/create-index/)

### Staging Links:

[k8s docs example 1 with staged changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/om-ha/docs-k8s-operator/seung.park/DOP-4567/tutorial/om-diagram-multi-cluster/index.html)

[staged example 2 from k8s docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/om-ha/docs-k8s-operator/seung.park/DOP-4567/tutorial/om-nw-lb-mesh-multi-cluster/index.html)

[atlas example updated](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4567/atlas-search/create-index/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
