### PR TITLE
GH Actions lock in mac os version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.platform }}
     env:
       NPM_BASE_64_AUTH: ${{ secrets.NPM_BASE_64_AUTH }}


### PR DESCRIPTION
See [thread here](https://mongodb.enterprise.slack.com/archives/GGPUBUMLN/p1713985548584339)

Pinning macOS to v12 to mitigate errors for installation (example [here](https://github.com/mongodb/snooty/actions/runs/8821753902/job/24218337881))

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
