### PR TITLE
DOP-4505: Lighthouse Server scores for desktop and mobile

### DIFF
--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -1,0 +1,17 @@
+const { urlsToRunPerProject } = require('./lighthouserc');
+
+module.exports = {
+  ci: {
+    collect: {
+      settings: {
+        additive: 'true',
+        preset: 'desktop',
+      },
+      // "staticDistDir": "./public",
+      url: [
+        // "http://localhost/company/about/index.html?desktop",
+        `${urlsToRunPerProject[process.env.GATSBY_SITE]}?desktop`,
+      ],
+    },
+  },
+};

--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -1,13 +1,13 @@
 const urlsToRunPerProject = {
   docs: [
-    `http://localhost:9000/docs/runner/master/`,
-    `http://localhost:9000/docs/runner/master/changeStreams/`,
-    `http://localhost:9000/docs/runner/master/replication/`,
+    `http://localhost:9000/docs/runner/master/?desktop`,
+    `http://localhost:9000/docs/runner/master/changeStreams/?desktop`,
+    `http://localhost:9000/docs/runner/master/replication/?desktop`,
   ],
   'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+    `http://localhost:9000/cloud-docs/runner/master/?desktop`,
+    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/?desktop`,
+    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/?desktop`,
   ],
 };
 module.exports = {
@@ -18,10 +18,7 @@ module.exports = {
         preset: 'desktop',
       },
       // "staticDistDir": "./public",
-      url: [
-        // "http://localhost/company/about/index.html?desktop",
-        `${urlsToRunPerProject[process.env.GATSBY_SITE]}`,
-      ],
+      url: urlsToRunPerProject[process.env.GATSBY_SITE],
     },
   },
 };

--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -13,12 +13,14 @@ const urlsToRunPerProject = {
 module.exports = {
   ci: {
     collect: {
+      startServerCommand: 'npm run serve',
       settings: {
         additive: 'true',
         preset: 'desktop',
       },
       // "staticDistDir": "./public",
       url: urlsToRunPerProject[process.env.GATSBY_SITE],
+      numberOfRuns: 3,
     },
   },
 };

--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -20,7 +20,7 @@ module.exports = {
       // "staticDistDir": "./public",
       url: [
         // "http://localhost/company/about/index.html?desktop",
-        `${urlsToRunPerProject[process.env.GATSBY_SITE]}?desktop`,
+        `${urlsToRunPerProject[process.env.GATSBY_SITE]}`,
       ],
     },
   },

--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -1,5 +1,15 @@
-const { urlsToRunPerProject } = require('./lighthouserc');
-
+const urlsToRunPerProject = {
+  docs: [
+    `http://localhost:9000/docs/runner/master/`,
+    `http://localhost:9000/docs/runner/master/changeStreams/`,
+    `http://localhost:9000/docs/runner/master/replication/`,
+  ],
+  'cloud-docs': [
+    `http://localhost:9000/cloud-docs/runner/master/`,
+    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
+    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+  ],
+};
 module.exports = {
   ci: {
     collect: {

--- a/.desktop-lighthouserc.js
+++ b/.desktop-lighthouserc.js
@@ -1,15 +1,5 @@
-const urlsToRunPerProject = {
-  docs: [
-    `http://localhost:9000/docs/runner/master/?desktop`,
-    `http://localhost:9000/docs/runner/master/changeStreams/?desktop`,
-    `http://localhost:9000/docs/runner/master/replication/?desktop`,
-  ],
-  'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/?desktop`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/?desktop`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/?desktop`,
-  ],
-};
+const { urlsToRunPerProject } = require('./.github/constants/lighthouse-urls');
+
 module.exports = {
   ci: {
     collect: {
@@ -18,8 +8,7 @@ module.exports = {
         additive: 'true',
         preset: 'desktop',
       },
-      // "staticDistDir": "./public",
-      url: urlsToRunPerProject[process.env.GATSBY_SITE],
+      url: urlsToRunPerProject[process.env.GATSBY_SITE].map((url) => `${url}?desktop`),
       numberOfRuns: 3,
     },
   },

--- a/.github/constants/lighthouse-urls.js
+++ b/.github/constants/lighthouse-urls.js
@@ -1,0 +1,12 @@
+export const urlsToRunPerProject = {
+  docs: [
+    `http://localhost:9000/docs/runner/master/`,
+    `http://localhost:9000/docs/runner/master/changeStreams/`,
+    `http://localhost:9000/docs/runner/master/replication/`,
+  ],
+  'cloud-docs': [
+    `http://localhost:9000/cloud-docs/runner/master/`,
+    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
+    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+  ],
+};

--- a/.github/constants/lighthouse-urls.js
+++ b/.github/constants/lighthouse-urls.js
@@ -1,12 +1,14 @@
-export const urlsToRunPerProject = {
-  docs: [
-    `http://localhost:9000/docs/runner/master/`,
-    `http://localhost:9000/docs/runner/master/changeStreams/`,
-    `http://localhost:9000/docs/runner/master/replication/`,
-  ],
-  'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
-  ],
+module.exports = {
+  urlsToRunPerProject: {
+    docs: [
+      `http://localhost:9000/docs/runner/master/`,
+      `http://localhost:9000/docs/runner/master/changeStreams/`,
+      `http://localhost:9000/docs/runner/master/replication/`,
+    ],
+    'cloud-docs': [
+      `http://localhost:9000/cloud-docs/runner/master/`,
+      `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
+      `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+    ],
+  },
 };

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,7 +39,5 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci collect --additive --config=.mobile-lighthouserc.js
-          lhci collect --additive --config=.desktop-lighthouserc.js
-          lhci assert
-          lhci upload
+          lhci autorun --additive --config=.mobile-lighthouserc.js
+          lhci autorun --additive --config=.desktop-lighthouserc.js

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,3 +41,5 @@ jobs:
           npm install -g @lhci/cli
           lhci collect --additive --config=.mobile-lighthouserc.js
           lhci collect --additive --config=.desktop-lighthouserc.js
+          lhci assert
+          lhci upload

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,7 +39,7 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci collect --additive --config=.mobile-lighthouserc.js
-          lhci collect --additive --config=.desktop-lighthouserc.js
+          lhci collect --additive --config=.mobile-lighthouserc.js --githubStatusContextSuffix=/mobile
+          lhci collect --additive --config=.desktop-lighthouserc.js --githubStatusContextSuffix=/desktop
           lhci assert
           lhci upload

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - "main"
-      - "DOP-4505-lh-desktop-mobile"
 name: Run and Upload Lighthouse Report
 jobs: 
   staging:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - "main"
+      - "DOP-4505-lh-desktop-mobile"
 name: Run and Upload Lighthouse Report
 jobs: 
   staging:
@@ -38,4 +39,7 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci autorun
+          lhci collect --additive --config=.mobile-lighthouserc.js
+          lhci collect --additive --config=.desktop-lighthouserc.js
+          lhci assert
+          lhci upload

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,5 +39,7 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci autorun --additive --config=.mobile-lighthouserc.js
-          lhci autorun --additive --config=.desktop-lighthouserc.js
+          lhci collect --additive --config=.mobile-lighthouserc.js
+          lhci collect --additive --config=.desktop-lighthouserc.js
+          lhci assert
+          lhci upload

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,5 +39,5 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci autorun --additive --config=.mobile-lighthouserc.js
-          lhci autorun --additive --config=.desktop-lighthouserc.js
+          lhci collect --additive --config=.mobile-lighthouserc.js
+          lhci collect --additive --config=.desktop-lighthouserc.js

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,5 +41,4 @@ jobs:
           npm install -g @lhci/cli
           lhci collect --additive --config=.mobile-lighthouserc.js
           lhci collect --additive --config=.desktop-lighthouserc.js
-          lhci assert
           lhci upload

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,5 +39,5 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci autorun --additive --config=.mobile-lighthouserc.js --githubStatusContextSuffix=/mobile
-          lhci autorun --additive --config=.desktop-lighthouserc.js --githubStatusContextSuffix=/desktop
+          lhci autorun --additive --config=.mobile-lighthouserc.js
+          lhci autorun --additive --config=.desktop-lighthouserc.js

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,7 +39,5 @@ jobs:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ matrix.project }}
         run: |
           npm install -g @lhci/cli
-          lhci collect --additive --config=.mobile-lighthouserc.js --githubStatusContextSuffix=/mobile
-          lhci collect --additive --config=.desktop-lighthouserc.js --githubStatusContextSuffix=/desktop
-          lhci assert
-          lhci upload
+          lhci autorun --additive --config=.mobile-lighthouserc.js --githubStatusContextSuffix=/mobile
+          lhci autorun --additive --config=.desktop-lighthouserc.js --githubStatusContextSuffix=/desktop

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -1,0 +1,16 @@
+const { urlsToRunPerProject } = require('./lighthouserc');
+
+module.exports = {
+  ci: {
+    collect: {
+      settings: {
+        additive: 'true',
+      },
+      // "staticDistDir": "./public",
+      url: [
+        // "http://localhost/company/about/index.html?mobile",
+        `${urlsToRunPerProject[process.env.GATSBY_SITE]}?mobile`,
+      ],
+    },
+  },
+};

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -1,13 +1,13 @@
 const urlsToRunPerProject = {
   docs: [
-    `http://localhost:9000/docs/runner/master/`,
-    `http://localhost:9000/docs/runner/master/changeStreams/`,
-    `http://localhost:9000/docs/runner/master/replication/`,
+    `http://localhost:9000/docs/runner/master/?mobile`,
+    `http://localhost:9000/docs/runner/master/changeStreams/?mobile`,
+    `http://localhost:9000/docs/runner/master/replication/?mobile`,
   ],
   'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+    `http://localhost:9000/cloud-docs/runner/master/?mobile`,
+    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/?mobile`,
+    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/?mobile`,
   ],
 };
 module.exports = {
@@ -17,10 +17,7 @@ module.exports = {
         additive: 'true',
       },
       // "staticDistDir": "./public",
-      url: [
-        // "http://localhost/company/about/index.html?mobile",
-        `${urlsToRunPerProject[process.env.GATSBY_SITE]}`,
-      ],
+      url: urlsToRunPerProject[process.env.GATSBY_SITE],
     },
   },
 };

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -1,15 +1,5 @@
-const urlsToRunPerProject = {
-  docs: [
-    `http://localhost:9000/docs/runner/master/?mobile`,
-    `http://localhost:9000/docs/runner/master/changeStreams/?mobile`,
-    `http://localhost:9000/docs/runner/master/replication/?mobile`,
-  ],
-  'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/?mobile`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/?mobile`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/?mobile`,
-  ],
-};
+const { urlsToRunPerProject } = require('./.github/constants/lighthouse-urls');
+
 module.exports = {
   ci: {
     collect: {
@@ -17,7 +7,6 @@ module.exports = {
       settings: {
         additive: 'true',
       },
-      // "staticDistDir": "./public",
       url: urlsToRunPerProject[process.env.GATSBY_SITE],
       numberOfRuns: 3,
     },

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -19,7 +19,7 @@ module.exports = {
       // "staticDistDir": "./public",
       url: [
         // "http://localhost/company/about/index.html?mobile",
-        `${urlsToRunPerProject[process.env.GATSBY_SITE]}?mobile`,
+        `${urlsToRunPerProject[process.env.GATSBY_SITE]}`,
       ],
     },
   },

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -13,11 +13,13 @@ const urlsToRunPerProject = {
 module.exports = {
   ci: {
     collect: {
+      startServerCommand: 'npm run serve',
       settings: {
         additive: 'true',
       },
       // "staticDistDir": "./public",
       url: urlsToRunPerProject[process.env.GATSBY_SITE],
+      numberOfRuns: 3,
     },
   },
 };

--- a/.mobile-lighthouserc.js
+++ b/.mobile-lighthouserc.js
@@ -1,5 +1,15 @@
-const { urlsToRunPerProject } = require('./lighthouserc');
-
+const urlsToRunPerProject = {
+  docs: [
+    `http://localhost:9000/docs/runner/master/`,
+    `http://localhost:9000/docs/runner/master/changeStreams/`,
+    `http://localhost:9000/docs/runner/master/replication/`,
+  ],
+  'cloud-docs': [
+    `http://localhost:9000/cloud-docs/runner/master/`,
+    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
+    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
+  ],
+};
 module.exports = {
   ci: {
     collect: {

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,23 +1,5 @@
-const urlsToRunPerProject = {
-  docs: [
-    `http://localhost:9000/docs/runner/master/`,
-    `http://localhost:9000/docs/runner/master/changeStreams/`,
-    `http://localhost:9000/docs/runner/master/replication/`,
-  ],
-  'cloud-docs': [
-    `http://localhost:9000/cloud-docs/runner/master/`,
-    `http://localhost:9000/cloud-docs/runner/master/atlas-search/atlas-search-overview/`,
-    `http://localhost:9000/cloud-docs/runner/master/manage-clusters/`,
-  ],
-};
-
 module.exports = {
   ci: {
-    collect: {
-      startServerCommand: 'npm run serve',
-      url: urlsToRunPerProject[process.env.GATSBY_SITE],
-      numberOfRuns: 3,
-    },
     upload: {
       target: 'lhci',
       serverBaseUrl: process.env.LIGHTHOUSE_SERVER_URL,

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,4 +1,4 @@
-export const urlsToRunPerProject = {
+const urlsToRunPerProject = {
   docs: [
     `http://localhost:9000/docs/runner/master/`,
     `http://localhost:9000/docs/runner/master/changeStreams/`,

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,4 +1,4 @@
-const urlsToRunPerProject = {
+export const urlsToRunPerProject = {
   docs: [
     `http://localhost:9000/docs/runner/master/`,
     `http://localhost:9000/docs/runner/master/changeStreams/`,


### PR DESCRIPTION
### Stories/Links:

DOP-4505

### Links:

[Docs Lighthouse Server](https://docs-lighthouse-server.docs.prod.corp.mongodb.com/app/projects/docs-lighthouse-server/dashboard)

### Notes:

Now, we will have both desktop and mobile scores. These can be seen by switching the url field. I decided not to add a query param to indicate the mobile scores just so that we would continue to have a continuous look-back history of the scores! If we would rather have the obvious "?mobile" on the url strings and don't care about linking the past runs with the future runs, we can do that too.


<img width="1611" alt="Screenshot 2024-04-29 at 11 41 24 AM" src="https://github.com/mongodb/snooty/assets/22421112/57cb4948-5d69-4a9c-af96-d46d291650be">



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
