### PR TITLE
:bug: DOP-4572 Unused objects/props are included in reference links

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -9,6 +9,7 @@ import ArrowRightIcon from '@leafygreen-ui/icon/dist/ArrowRight';
 import { isRelativeUrl } from '../utils/is-relative-url';
 import { joinClassNames } from '../utils/join-class-names';
 import { isGatsbyPreview } from '../utils/is-gatsby-preview';
+import { validateHTMAttributes } from '../utils/validate-element-attributes';
 
 /*
  * Note: This component is not suitable for internal page navigation:
@@ -66,6 +67,8 @@ const Link = ({
   if (!to) to = '';
   const anchor = to.startsWith('#');
 
+  const anchorProps = validateHTMAttributes('anchor', other);
+
   //used instead of LG showLinkArrow prop for consistency between LGLinks and GatsbyLinks(GatsbyLinks don't have that prop)
   const decoration = showLinkArrow ? (
     <span>
@@ -103,7 +106,7 @@ const Link = ({
         activeClassName={activeClassName}
         partiallyActive={partiallyActive}
         to={to}
-        {...other}
+        {...anchorProps}
       >
         {children}
         {decoration}
@@ -122,7 +125,7 @@ const Link = ({
       href={to}
       hideExternalIcon={!showExtIcon}
       target={target}
-      {...other}
+      {...anchorProps}
     >
       {children}
       {decoration}

--- a/src/utils/validate-element-attributes.js
+++ b/src/utils/validate-element-attributes.js
@@ -1,0 +1,168 @@
+const globalEventHandlerAttributes = [
+  'onabort',
+  'onautocomplete',
+  'onautocompleteerror',
+  'onblur',
+  'oncancel',
+  'oncanplay',
+  'oncanplaythrough',
+  'onchange',
+  'onclick',
+  'onclose',
+  'oncontextmenu',
+  'oncuechange',
+  'ondblclick',
+  'ondrag',
+  'ondragend',
+  'ondragenter',
+  'ondragleave',
+  'ondragover',
+  'ondragstart',
+  'ondrop',
+  'ondurationchange',
+  'onemptied',
+  'onended',
+  'onerror',
+  'onfocus',
+  'oninput',
+  'oninvalid',
+  'onkeydown',
+  'onkeypress',
+  'onkeyup',
+  'onload',
+  'onloadeddata',
+  'onloadedmetadata',
+  'onloadstart',
+  'onmousedown',
+  'onmouseenter',
+  'onmouseleave',
+  'onmousemove',
+  'onmouseout',
+  'onmouseover',
+  'onmouseup',
+  'onmousewheel',
+  'onpause',
+  'onplay',
+  'onplaying',
+  'onprogress',
+  'onratechange',
+  'onreset',
+  'onresize',
+  'onscroll',
+  'onseeked',
+  'onseeking',
+  'onselect',
+  'onshow',
+  'onsort',
+  'onstalled',
+  'onsubmit',
+  'onsuspend',
+  'ontimeupdate',
+  'ontoggle',
+  'onvolumechange',
+  'onwaiting',
+];
+
+const globalHTMLAttributes = [
+  'accesskey',
+  'autocapitalize',
+  'autofocus',
+  'classname', // Handle React cases
+  'contenteditable',
+  'data-*', // Any attribute that starts with 'data-' is a global attribute
+  'dir',
+  'draggable',
+  'enterkeyhint',
+  'hidden',
+  'id',
+  'inert',
+  'inputmode',
+  'is',
+  'itemid',
+  'itemprop',
+  'itemref',
+  'itemscope',
+  'itemtype',
+  'lang',
+  'nonce',
+  'part',
+  'popover',
+  'role',
+  'slot',
+  'spellcheck',
+  'style',
+  'tabindex',
+  'title',
+  'translate',
+];
+
+// Validate component props from vendors
+const gatsbyLinkProps = [
+  'to',
+  'replace',
+  'state',
+  'getprops',
+  'innerref',
+  'partiallyactive',
+  'activeclassname',
+  'activestyle',
+];
+
+const anchorTagAttributes = [
+  ...globalEventHandlerAttributes,
+  ...globalHTMLAttributes,
+  ...gatsbyLinkProps,
+  'href',
+  'hreflang',
+  'media',
+  'ping',
+  'rel',
+  'target',
+  'type',
+  'referrerpolicy',
+  'download',
+];
+
+const dataAndRoleBasedAttributes = [
+  /^data-/, // Matches any data attribute
+  /^aria-/, // Matches any Role Aria base attribute
+];
+
+export const elements = {
+  anchor: anchorTagAttributes,
+};
+
+/**
+ * Filter props based on validAttributes and regexPatterns
+ * @param {string} elementType
+ * @param {any} props // potential suitor for HTML attributes
+ */
+export const validateHTMAttributes = (elementType, props) => {
+  const ele = elements[elementType];
+
+  if (ele) {
+    return (
+      props &&
+      Object.keys(props).reduce((attributes, propKey) => {
+        // propKey values should be lowercase to account for
+        // React's HTML attributes in camelCase
+        if (ele.includes(propKey.toLocaleLowerCase())) {
+          attributes[propKey] = props[propKey];
+        } else {
+          const isDataOrAriaAttribute = dataAndRoleBasedAttributes.some((pattern) => pattern.test(propKey));
+          if (isDataOrAriaAttribute) {
+            attributes[propKey] = props[propKey];
+          }
+        }
+
+        return attributes;
+      }, {})
+    );
+  }
+
+  // Provide hint to user on available element and return the props in it's origin form
+  console.error(
+    `Please check that you are using the correct elementType, available types are ${Object.keys(elements)}`
+  );
+  return props;
+};

--- a/src/utils/validate-element-attributes.js
+++ b/src/utils/validate-element-attributes.js
@@ -135,7 +135,7 @@ export const elements = {
 /**
  * Filter props based on validAttributes and regexPatterns
  * @param {string} elementType
- * @param {any} props // potential suitor for HTML attributes
+ * @param {object} props // potential suitor for HTML attributes
  */
 export const validateHTMAttributes = (elementType, props) => {
   const ele = elements[elementType];

--- a/src/utils/validate-element-attributes.js
+++ b/src/utils/validate-element-attributes.js
@@ -141,23 +141,22 @@ export const validateHTMAttributes = (elementType, props) => {
   const ele = elements[elementType];
 
   if (ele) {
-    return (
-      props &&
-      Object.keys(props).reduce((attributes, propKey) => {
-        // propKey values should be lowercase to account for
-        // React's HTML attributes in camelCase
-        if (ele.includes(propKey.toLocaleLowerCase())) {
-          attributes[propKey] = props[propKey];
-        } else {
-          const isDataOrAriaAttribute = dataAndRoleBasedAttributes.some((pattern) => pattern.test(propKey));
-          if (isDataOrAriaAttribute) {
+    return props
+      ? Object.keys(props).reduce((attributes, propKey) => {
+          // propKey values should be lowercase to account for
+          // React's HTML attributes in camelCase
+          if (ele.includes(propKey.toLocaleLowerCase())) {
             attributes[propKey] = props[propKey];
+          } else {
+            const isDataOrAriaAttribute = dataAndRoleBasedAttributes.some((pattern) => pattern.test(propKey));
+            if (isDataOrAriaAttribute) {
+              attributes[propKey] = props[propKey];
+            }
           }
-        }
 
-        return attributes;
-      }, {})
-    );
+          return attributes;
+        }, {})
+      : {};
   }
 
   // Provide hint to user on available element and return the props in it's origin form

--- a/tests/unit/utils/validate-element-attributes.test.js
+++ b/tests/unit/utils/validate-element-attributes.test.js
@@ -1,0 +1,50 @@
+import { validateHTMAttributes, elements } from '../../../src/utils/validate-element-attributes';
+
+describe('Validate Props', () => {
+  it('Should filter props based on valid attributes', () => {
+    const props = {
+      meta: {
+        project: 'docs',
+      },
+      page: {
+        type: 'root',
+      },
+      slug: 'query-api',
+      sectionDepth: 1,
+      title: 'MongoDB Query API',
+      'aria-current': 'false',
+      onClick: '[Function onClick]',
+    };
+
+    const validateAnchorProps = validateHTMAttributes('anchor', props);
+    expect(validateAnchorProps).toMatchObject({
+      title: 'MongoDB Query API',
+      'aria-current': 'false',
+      onClick: '[Function onClick]',
+    });
+  });
+
+  it('Should provide user with correct element types when incorrect element is used, and return props right back to the user', () => {
+    const props = {
+      meta: {
+        project: 'docs',
+      },
+      page: {
+        type: 'root',
+      },
+      slug: 'query-api',
+      sectionDepth: 1,
+      title: 'MongoDB Query API',
+      'aria-current': 'false',
+    };
+
+    const errorLogSpy = jest.spyOn(console, 'error');
+
+    const validateAnchorProps = validateHTMAttributes('some-element-type', props);
+    expect(validateAnchorProps).toMatchObject(props);
+    expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    expect(errorLogSpy).toHaveBeenCalledWith(
+      `Please check that you are using the correct elementType, available types are ${Object.keys(elements)}`
+    );
+  });
+});

--- a/tests/unit/utils/validate-element-attributes.test.js
+++ b/tests/unit/utils/validate-element-attributes.test.js
@@ -47,4 +47,11 @@ describe('Validate Props', () => {
       `Please check that you are using the correct elementType, available types are ${Object.keys(elements)}`
     );
   });
+
+  it('Should return an empty Object when null is passed as a prop', () => {
+    const props = null;
+
+    const validateAnchorProps = validateHTMAttributes('anchor', props);
+    expect(validateAnchorProps).toMatchObject({});
+  });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-4572

### Current Behavior:

[Current Behavior](https://www.mongodb.com/docs/manual/query-api/)

### Staging Links:

[New Behavior](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/7e656a70bc3127a7327a0223343def3e99e3af38/master/docs/caesarbell/DOP-4572/query-api/index.html)

### Notes:

This PR fixes the **Unused objects/props are included in reference links** issue by providing a validation filter for props that will become attached to an HTML element, in this case, it filters out the invalid props before being spread to GatsbyLink or LGLink which in turn passes those props into an anchor tag i.e. `<a></a>`

### Resources:
- [Reach Router Link API](https://reach.tech/router/api/Link)
- [Gatsby Link API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/)
- [Global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes)
- [Anchor attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
