### PR TITLE
DOP-4587: Bump consistent-nav package to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@leafygreen-ui/tooltip": "^7.1.0",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.0.3-rc.23",
+        "@mdb/consistent-nav": "^2.0.7",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
@@ -7688,9 +7688,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.0.3-rc.23",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.23.tgz",
-      "integrity": "sha512-ezKai7VISwdrJHWN+kRpIEZXigl7wA7ziClBpE4qMxUZLy+Mg9QO3YXrcWSXpAQebSFo0TZySjzlVnNBJQqPbQ==",
+      "version": "2.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
+      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -35295,9 +35295,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.0.3-rc.23",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.3-rc.23.tgz",
-      "integrity": "sha512-ezKai7VISwdrJHWN+kRpIEZXigl7wA7ziClBpE4qMxUZLy+Mg9QO3YXrcWSXpAQebSFo0TZySjzlVnNBJQqPbQ=="
+      "version": "2.0.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
+      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@leafygreen-ui/tooltip": "^7.1.0",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.0.3-rc.23",
+    "@mdb/consistent-nav": "^2.0.7",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
### Stories/Links:

DOP-4587

### Staging Links:

[docs-landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/maya/DOP-4587/index.html)
[cloud-docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4587/index.html)
[docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/DOP-4587/)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
