### PR TITLE
Ensure crumb titles are strings, and fix truncated tooltip baseFontSize

### DIFF
--- a/src/components/Breadcrumbs/IndividualBreadcrumb.js
+++ b/src/components/Breadcrumbs/IndividualBreadcrumb.js
@@ -93,7 +93,7 @@ const IndividualBreadcrumb = ({ crumb, setIsExcessivelyTruncated, onClick }) => 
       <Tooltip
         // To get the tooltip above the topnav we have to pop up the z-index
         popoverZIndex={9001}
-        baseFontSize={theme.fontSize.small}
+        baseFontSize={13}
         triggerEvent="hover"
         align="top"
         justify="middle"

--- a/src/utils/get-complete-breadcrumb-data.js
+++ b/src/utils/get-complete-breadcrumb-data.js
@@ -2,6 +2,26 @@ import { baseUrl } from './base-url';
 import { assertTrailingSlash } from './assert-trailing-slash';
 import { removeLeadingSlash } from './remove-leading-slash';
 
+const nodesToString = (titleNodes) => {
+  if (typeof titleNodes === 'string') {
+    return titleNodes;
+  }
+
+  if (!titleNodes) {
+    return titleNodes;
+  }
+
+  return titleNodes
+    .map((node) => {
+      if (node.type === 'text') {
+        return node.value;
+      }
+
+      return nodesToString(node.children);
+    })
+    .join('');
+};
+
 export const getCompleteBreadcrumbData = ({ siteTitle, slug, queriedCrumbs, parentPaths }) => {
   //get intermediate breadcrumbs and property Url
   const propertyUrl = assertTrailingSlash(queriedCrumbs?.propertyUrl ?? baseUrl());
@@ -18,7 +38,7 @@ export const getCompleteBreadcrumbData = ({ siteTitle, slug, queriedCrumbs, pare
   let propertyCrumb;
   if (slug !== '/') {
     propertyCrumb = {
-      title: siteTitle,
+      title: nodesToString(siteTitle),
       url: propertyUrl,
     };
   }
@@ -26,7 +46,11 @@ export const getCompleteBreadcrumbData = ({ siteTitle, slug, queriedCrumbs, pare
   //get direct parents of the current page from parentPaths
   //add respective url to each direct parent crumb
   const parents = (parentPaths[slug] ?? []).map((crumb) => {
-    return { ...crumb, url: assertTrailingSlash(propertyUrl + removeLeadingSlash(crumb.path)) };
+    return {
+      ...crumb,
+      title: nodesToString(crumb.title),
+      url: assertTrailingSlash(propertyUrl + removeLeadingSlash(crumb.path)),
+    };
   });
 
   return propertyCrumb

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -254,6 +254,26 @@ exports[`renders correctly with siteTitle 1`] = `
   padding-right: 8px;
 }
 
+.emotion-15 {
+  overflow: hidden;
+  text-wrap: nowrap;
+  text-overflow: ellipsis;
+}
+
+.emotion-15:first-child {
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+}
+
+@media not all and (max-width: 480px) {
+  .emotion-15:last-child {
+    min-width: -webkit-max-content;
+    min-width: -moz-max-content;
+    min-width: max-content;
+  }
+}
+
 <div
     class="emotion-0"
   >
@@ -315,7 +335,7 @@ exports[`renders correctly with siteTitle 1`] = `
          / 
       </span>
       <div
-        class="emotion-3"
+        class="emotion-15"
       >
         <a
           class="lg-ui-0001 emotion-4"
@@ -333,7 +353,7 @@ exports[`renders correctly with siteTitle 1`] = `
          / 
       </span>
       <div
-        class="emotion-3"
+        class="emotion-15"
       >
         <a
           class="lg-ui-0001 emotion-4"


### PR DESCRIPTION

![image](https://github.com/mongodb/snooty/assets/334192/4b83454d-5728-4a51-b991-a41dc42ee078)


### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
