### PR TITLE
bugfix. add whitespace:nowrap for safari

### DIFF
--- a/src/components/Breadcrumbs/IndividualBreadcrumb.js
+++ b/src/components/Breadcrumbs/IndividualBreadcrumb.js
@@ -22,7 +22,6 @@ const ellipsisStyling = LeafyCss`
 
 const linkWrapperLayoutStyling = LeafyCss`
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 
   :first-child {

--- a/src/components/Breadcrumbs/IndividualBreadcrumb.js
+++ b/src/components/Breadcrumbs/IndividualBreadcrumb.js
@@ -23,6 +23,7 @@ const ellipsisStyling = LeafyCss`
 const linkWrapperLayoutStyling = LeafyCss`
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 
   :first-child {
     min-width: max-content;

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -15,7 +15,6 @@ exports[`BreadcrumbContainer renders a driver site correctly with intermediate b
 
 .emotion-2 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -206,7 +205,6 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
 
 .emotion-2 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -292,7 +290,6 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
 
 .emotion-6 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
@@ -398,7 +395,6 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
 
 .emotion-2 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -484,7 +480,6 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
 
 .emotion-10 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
@@ -574,7 +569,6 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
 
 .emotion-2 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -660,7 +654,6 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
 
 .emotion-6 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -16,6 +16,7 @@ exports[`BreadcrumbContainer renders a driver site correctly with intermediate b
 .emotion-2 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-2:first-child {
@@ -206,6 +207,7 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
 .emotion-2 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-2:first-child {
@@ -291,6 +293,7 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
 .emotion-6 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 
@@ -396,6 +399,7 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
 .emotion-2 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-2:first-child {
@@ -481,6 +485,7 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
 .emotion-10 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 
@@ -570,6 +575,7 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
 .emotion-2 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-2:first-child {
@@ -655,6 +661,7 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
 .emotion-6 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -23,7 +23,6 @@ exports[`renders correctly as a homepage 1`] = `
 
 .emotion-3 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -172,7 +171,6 @@ exports[`renders correctly with siteTitle 1`] = `
 
 .emotion-3 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
 }
 
@@ -258,7 +256,6 @@ exports[`renders correctly with siteTitle 1`] = `
 
 .emotion-15 {
   overflow: hidden;
-  text-wrap: nowrap;
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -24,6 +24,7 @@ exports[`renders correctly as a homepage 1`] = `
 .emotion-3 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-3:first-child {
@@ -172,6 +173,7 @@ exports[`renders correctly with siteTitle 1`] = `
 .emotion-3 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .emotion-3:first-child {
@@ -257,6 +259,7 @@ exports[`renders correctly with siteTitle 1`] = `
 .emotion-15 {
   overflow: hidden;
   text-wrap: nowrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
### Notes:

Fix Safari bug. Older Safari versions do not support text-wrap: nowrap.

This adds white-space: nowrap to allow all Browsers to keep breadcrumbs on one line.

Picture of fixed in safari:

![Screen Shot 2024-05-01 at 2 57 21 PM](https://github.com/mongodb/snooty/assets/22421112/8e840b0f-f114-42e0-a308-4725ca6be8a1)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
