### PR TITLE
DOP-4598 adds support to use Noto Sans for Japanese Docs Sites

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -44,6 +44,11 @@ export const onRenderBody = ({ setHeadComponents }) => {
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap"
       rel="stylesheet"
     />,
+    <link
+      key="notoSansJP"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap"
+      rel="stylesheet"
+    ></link>,
   ]);
 };
 

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -54,6 +54,7 @@ export const getCurrentLocaleFontFamilyValue = () => {
   const fontFamilyMap = {
     'zh-cn': 'Noto Sans SC',
     'ko-kr': 'Noto Sans KR',
+    'ja-jp': 'Noto Sans JP',
   };
   const locale = getCurrLocale();
   return fontFamilyMap[locale] ? `${fontFamilyMap[locale]}` : undefined;


### PR DESCRIPTION
### Stories/Links:

DOP-4598

### Current Behavior:

N/A

### Staging Links:

[Japanese Stagged Commit Site](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ja-jp/master/docs/caesarbell/DOP-4598/introduction/index.html)

### Notes:

I left a comment [here](https://jira.mongodb.org/browse/DOP-4598?focusedCommentId=6331814&focusedId=6331814&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6331814) asking about adding Japanese to the language selector. Currently, we only provide the following languages to our users when visiting the docs pages.

- English
- Simplified Chinese
- Korean
- Portuguese



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
