### PR TITLE
DOP-4569 - include home button in sidenav of openapi preview

### DIFF
--- a/src/components/OpenAPI/index.js
+++ b/src/components/OpenAPI/index.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import PropTypes from 'prop-types';
 import { RedocStandalone } from 'redoc';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { palette } from '@leafygreen-ui/palette';
 import ComponentFactory from '../ComponentFactory';
+import DocsHomeButton from '../Sidenav/DocsHomeButton';
+import { Border } from '../Sidenav/Sidenav';
 import Spinner from '../Spinner';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import useStickyTopValues from '../../hooks/useStickyTopValues';
@@ -123,10 +125,11 @@ const LoadingWidget = ({ className }) => (
   </LoadingContainer>
 );
 
-const MenuTitleContainer = ({ siteTitle, pageTitle }) => {
+const MenuTitleContainer = ({ pageTitle }) => {
   return (
     <>
-      {/* TODO: Add DocsHomeButton here - see comment below */}
+      <DocsHomeButton />
+      <Border />
       <MenuTitle>{pageTitle}</MenuTitle>
     </>
   );
@@ -201,10 +204,7 @@ const OpenAPI = ({ metadata, nodeData: { argument, children, options = {} }, pag
                 menuTitleContainerEl.className = menuTitleContainerClass;
                 sidebarEl.insertBefore(menuTitleContainerEl, searchEl);
                 const pageTitle = page?.options?.title || '';
-                const siteTitle = metadata?.title;
-                /* TODO: The below function is deprecated with React 18, need to replace it (potentially with 
-                  createRoot() and .render() (see React documentation) */
-                render(<MenuTitleContainer siteTitle={siteTitle} pageTitle={pageTitle} />, menuTitleContainerEl);
+                createRoot(menuTitleContainerEl).render(<MenuTitleContainer pageTitle={pageTitle} />);
               }
             }
           }}

--- a/src/components/Sidenav/DocsHomeButton.js
+++ b/src/components/Sidenav/DocsHomeButton.js
@@ -3,7 +3,7 @@ import { SideNavItem } from '@leafygreen-ui/side-nav';
 import Icon from '@leafygreen-ui/icon';
 import { css as LeafyCSS, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
-import Link from '../Link';
+import { Link } from '@leafygreen-ui/typography';
 import { baseUrl } from '../../utils/base-url';
 import { sideNavItemBasePadding } from './styles/sideNavItem';
 import { titleStyle } from './styles/sideNavItem';
@@ -23,7 +23,12 @@ const homeLinkStyle = LeafyCSS`
 
 const DocsHomeButton = () => {
   return (
-    <SideNavItem className={cx(titleStyle, sideNavItemBasePadding, homeLinkStyle)} as={Link} to={baseUrl()}>
+    <SideNavItem
+      className={cx(titleStyle, sideNavItemBasePadding, homeLinkStyle)}
+      as={Link}
+      href={baseUrl()}
+      hideExternalIcon={true}
+    >
       <Icon glyph="Home"></Icon>
       Docs Home
     </SideNavItem>

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -125,7 +125,7 @@ const Spaceholder = styled('div')`
   min-height: ${theme.size.medium};
 `;
 
-const Border = styled('hr')`
+export const Border = styled('hr')`
   border: unset;
   border-bottom: 1px solid ${palette.gray.light2};
   margin: ${theme.size.small} 0;


### PR DESCRIPTION
### Stories/Links:

DOP-4569

### Current Behavior:

[open api preview page on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/main/openapi/preview/index.html)

### Staging Links:

[open api preview page on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4569/openapi/preview/index.html)
[regression check - atlas docs with changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4569/index.html)

### Notes:
- Minor conversion from using `components/link` to using `LG/link` in `DocsHomeButton` due to errors of `"useLocation()" may be used only in the context of a <Router> component` within a callback of Redoc component

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
