### PR TITLE
DOP-4609: use emotion styled vs styled components

### DIFF
--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme';

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -3,6 +3,36 @@
 exports[`renders a page with next and previous links correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  padding-top: 2em;
+  padding-bottom: 2.5em;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+}
+
+@media print {
+  .emotion-0 {
+    display: none;
+  }
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-4 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -10,7 +40,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   color: #001E2B;
 }
 
-.emotion-1 {
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -24,12 +54,12 @@ exports[`renders a page with next and previous links correctly 1`] = `
   color: #016BF8;
 }
 
-.emotion-1>code {
+.emotion-5>code {
   color: #016BF8;
 }
 
-.emotion-1:focus,
-.emotion-1:hover {
+.emotion-5:focus,
+.emotion-5:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -37,32 +67,32 @@ exports[`renders a page with next and previous links correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-1:focus {
+.emotion-5:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-1:hover {
+.emotion-5:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-2 {
+.emotion-6 {
   line-height: 28px;
 }
 
 <div
-    class="sc-bcXHqe eFamjP"
+    class="emotion-0 emotion-1"
   >
     <div
-      class="sc-gswNZR UJFxm"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-0"
+        class="emotion-4"
       >
         ← 
       </span>
       <a
-        class="emotion-1 emotion-2"
+        class="emotion-5 emotion-6"
         href="/drivers/csharp/"
         title="Previous Section"
       >
@@ -70,17 +100,17 @@ exports[`renders a page with next and previous links correctly 1`] = `
       </a>
     </div>
     <div
-      class="sc-gswNZR UJFxm"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-1 emotion-2"
+        class="emotion-5 emotion-6"
         href="/drivers/java/"
         title="Next Section"
       >
         Java MongoDB Driver
       </a>
       <span
-        class="emotion-0"
+        class="emotion-4"
       >
          →
       </span>
@@ -92,6 +122,36 @@ exports[`renders a page with next and previous links correctly 1`] = `
 exports[`renders a page with no next link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  padding-top: 2em;
+  padding-bottom: 2.5em;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+}
+
+@media print {
+  .emotion-0 {
+    display: none;
+  }
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-4 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -99,7 +159,7 @@ exports[`renders a page with no next link correctly 1`] = `
   color: #001E2B;
 }
 
-.emotion-1 {
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -113,12 +173,12 @@ exports[`renders a page with no next link correctly 1`] = `
   color: #016BF8;
 }
 
-.emotion-1>code {
+.emotion-5>code {
   color: #016BF8;
 }
 
-.emotion-1:focus,
-.emotion-1:hover {
+.emotion-5:focus,
+.emotion-5:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -126,32 +186,32 @@ exports[`renders a page with no next link correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-1:focus {
+.emotion-5:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-1:hover {
+.emotion-5:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-2 {
+.emotion-6 {
   line-height: 28px;
 }
 
 <div
-    class="sc-bcXHqe eFamjP"
+    class="emotion-0 emotion-1"
   >
     <div
-      class="sc-gswNZR UJFxm"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-0"
+        class="emotion-4"
       >
         ← 
       </span>
       <a
-        class="emotion-1 emotion-2"
+        class="emotion-5 emotion-6"
         href="/drivers/go/"
         title="Previous Section"
       >
@@ -165,6 +225,36 @@ exports[`renders a page with no next link correctly 1`] = `
 exports[`renders a page with no previous link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  padding-top: 2em;
+  padding-bottom: 2.5em;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+}
+
+@media print {
+  .emotion-0 {
+    display: none;
+  }
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+}
+
+.emotion-4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -178,12 +268,12 @@ exports[`renders a page with no previous link correctly 1`] = `
   color: #016BF8;
 }
 
-.emotion-0>code {
+.emotion-4>code {
   color: #016BF8;
 }
 
-.emotion-0:focus,
-.emotion-0:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -191,20 +281,20 @@ exports[`renders a page with no previous link correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-0:focus {
+.emotion-4:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-0:hover {
+.emotion-4:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-1 {
+.emotion-5 {
   line-height: 28px;
 }
 
-.emotion-2 {
+.emotion-6 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -213,20 +303,20 @@ exports[`renders a page with no previous link correctly 1`] = `
 }
 
 <div
-    class="sc-bcXHqe eFamjP"
+    class="emotion-0 emotion-1"
   >
     <div
-      class="sc-gswNZR UJFxm"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-0 emotion-1"
+        class="emotion-4 emotion-5"
         href="/drivers/go/"
         title="Next Section"
       >
         MongoDB Go Driver
       </a>
       <span
-        class="emotion-2"
+        class="emotion-6"
       >
          →
       </span>


### PR DESCRIPTION
### Stories/Links:

DOP-4609

### Current Behavior:

[sample page showing hydration styling](https://www.mongodb.com/docs/atlas/create-connect-deployments/)

### Staging Links:

[page loads with prestyled component](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4609/create-connect-deployments/index.html)

### Notes:
Really small change to use styled from @emotion rather than `styled-components`

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
