### PR TITLE
Breadcrumbs follow - removing extra padding on drivers index page - verify this is wanted

### DIFF
--- a/src/templates/drivers-index.js
+++ b/src/templates/drivers-index.js
@@ -14,7 +14,6 @@ const DocumentContainer = styled('div')`
 
 const StyledMainColumn = styled(MainColumn)`
   grid-area: main;
-  padding-top: 40px;
 `;
 
 const DriversIndex = ({ children, pageContext: { slug } }) => {


### PR DESCRIPTION
### Stories/Links:

Minor fix to address this extra padding that was bothering me while inspecting different breadcrumbs

### Current Behavior:

[QA drivers homepage](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/drivers/)
[drivers homepage (seems like this hasn't been deployed since latest snooty release)](https://www.mongodb.com/docs/drivers/)<img width="541" alt="image" src="https://github.com/mongodb/snooty/assets/13054820/f2b8b617-ffa7-4217-8329-50b1d720a267">


### Staging Links:

[staged drivers homepage ](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/drivers/seung.park/drivers-index-remove-padding/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
