### PR TITLE
DOP-4707: Icon mapping for tab selectors missing keys for rust-async and rust-sync

### DIFF
--- a/src/components/Tabs/tab-context.js
+++ b/src/components/Tabs/tab-context.js
@@ -49,6 +49,8 @@ const DRIVER_ICON_MAP = {
   python: IconPython,
   ruby: IconRuby,
   rust: IconRust,
+  'rust-sync': IconRust,
+  'rust-async': IconRust,
   scala: IconScala,
   shell: IconShell,
   swift: IconSwift,


### PR DESCRIPTION
### Stories/Links:

DOP-4707

### Current Behavior:

[Connect via drivers page in cloud docs](https://www.mongodb.com/docs/atlas/driver-connection/)
You can also look at the selector specific to a code block [here](https://www.mongodb.com/docs/atlas/driver-connection/#driver-examples).

### Staging Links:

[Same page as above](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4707/driver-connection/index.html)
[Code block](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4707/driver-connection/index.html#driver-examples)

### Notes:

To test, check that when you select "Rust (Async)" or "Rust (Sync)" on the language flipper there is a logo that appears next to the title, and it is the same as the Rust icon in the drivers icons.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
