### PR TITLE
DOP-4667 - create dark mode context

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,15 +1,10 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
-import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { theme } from './src/theme/docsTheme';
 import './src/styles/mongodb-docs.css';
 import './src/styles/icons.css';
 
-export const wrapRootElement = ({ element }) => (
-  <ThemeProvider theme={theme}>
-    <LeafyGreenProvider baseFontSize={16}>{element}</LeafyGreenProvider>
-  </ThemeProvider>
-);
+export const wrapRootElement = ({ element }) => <ThemeProvider theme={theme}>{element}</ThemeProvider>;
 
 export const shouldUpdateScroll = ({ routerProps: { location } }) => {
   if (location?.state?.preserveScroll) {

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { renderStylesToString } from '@leafygreen-ui/emotion';
-import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { renderToString } from 'react-dom/server';
 import { theme } from './src/theme/docsTheme';
 import EuclidCircularASemiBold from './src/styles/fonts/EuclidCircularA-Semibold-WebXL.woff';
@@ -57,8 +56,4 @@ export const onRenderBody = ({ setHeadComponents }) => {
 export const replaceRenderer = ({ replaceBodyHTMLString, bodyComponent }) =>
   replaceBodyHTMLString(renderStylesToString(renderToString(bodyComponent)));
 
-export const wrapRootElement = ({ element }) => (
-  <ThemeProvider theme={theme}>
-    <LeafyGreenProvider baseFontSize={16}>{element}</LeafyGreenProvider>
-  </ThemeProvider>
-);
+export const wrapRootElement = ({ element }) => <ThemeProvider theme={theme}>{element}</ThemeProvider>;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -6,7 +6,7 @@ import { theme } from './src/theme/docsTheme';
 import EuclidCircularASemiBold from './src/styles/fonts/EuclidCircularA-Semibold-WebXL.woff';
 
 export const onRenderBody = ({ setHeadComponents }) => {
-  setHeadComponents([
+  const headComponents = [
     // GTM Pathway
     <script
       key="pathway"
@@ -48,7 +48,39 @@ export const onRenderBody = ({ setHeadComponents }) => {
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap"
       rel="stylesheet"
     ></link>,
-  ]);
+  ];
+  if (process.env['GATSBY_ENABLE_DARK_MODE'] === 'true') {
+    // Detect dark mode
+    // before document body
+    // to prevent flash of incorrect theme
+    headComponents.push(
+      <script
+        key="dark-mode"
+        dangerouslySetInnerHTML={{
+          __html: `
+            !function () {
+              try {
+                var d = document.documentElement.classList;
+                d.remove("light-theme", "dark-theme");
+                var e = JSON.parse(localStorage.getItem("mongodb-docs"))?.["theme"];
+                if ("system" === e || (!e)) {
+                  var t = "(prefers-color-scheme: dark)",
+                    m = window.matchMedia(t);
+                  m.media !== t || m.matches ? d.add("dark-theme") : d.add("light-theme");
+                } else if (e) {
+                  var x = { "light-theme": "light-theme", "dark-theme": "dark-theme" };
+                  x[e] && d.add(x[e]);
+                }
+              } catch (e) {
+                console.error(e);
+              }
+            }();
+          `,
+        }}
+      />
+    );
+  }
+  setHeadComponents(headComponents);
 };
 
 // Support SSR for LeafyGreen components

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@leafygreen-ui/icon": "^11.6.1",
         "@leafygreen-ui/icon-button": "^9.1.6",
         "@leafygreen-ui/inline-definition": "^4.0.2",
-        "@leafygreen-ui/leafygreen-provider": "^2.3.2",
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12",
         "@leafygreen-ui/lib": "^9.5.2",
         "@leafygreen-ui/logo": "^4.0.2",
         "@leafygreen-ui/modal": "^10.1.0",
@@ -4682,18 +4682,50 @@
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "2.3.5",
-      "license": "Apache-2.0",
+      "version": "3.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
+      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/lib": "^9.5.1"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/hooks": {
-      "version": "7.6.0",
-      "license": "Apache-2.0",
+      "version": "8.1.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
       "dependencies": {
+        "@leafygreen-ui/lib": "^13.3.0",
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@leafygreen-ui/lib": {
+      "version": "13.4.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
+      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/@storybook/csf": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.7.tgz",
+      "integrity": "sha512-53JeLZBibjQxi0Ep+/AJTfxlofJlxy1jXcSKENlnKxHjWEYyHQCumMP5yTFjf7vhNnMjEpV3zx6t23ssFiGRyw==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/leafygreen-provider/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/lib": {
@@ -6616,15 +6648,6 @@
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@lg-chat/fixed-chat-window/node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
-      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
       }
     },
     "node_modules/@lg-chat/fixed-chat-window/node_modules/@leafygreen-ui/lib": {
@@ -22798,15 +22821,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
-      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
-      }
-    },
     "node_modules/mongodb-chatbot-ui/node_modules/@leafygreen-ui/lib": {
       "version": "13.4.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
@@ -32841,17 +32855,45 @@
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
-      "version": "2.3.5",
+      "version": "3.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
+      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
       "requires": {
-        "@leafygreen-ui/hooks": "^7.3.3",
-        "@leafygreen-ui/lib": "^9.5.1"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       },
       "dependencies": {
         "@leafygreen-ui/hooks": {
-          "version": "7.6.0",
+          "version": "8.1.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+          "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
           "requires": {
+            "@leafygreen-ui/lib": "^13.3.0",
             "lodash": "^4.17.21"
           }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "13.4.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
+          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+          "requires": {
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@storybook/csf": {
+          "version": "0.1.7",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.7.tgz",
+          "integrity": "sha512-53JeLZBibjQxi0Ep+/AJTfxlofJlxy1jXcSKENlnKxHjWEYyHQCumMP5yTFjf7vhNnMjEpV3zx6t23ssFiGRyw==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -34524,15 +34566,6 @@
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
             "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/leafygreen-provider": {
-          "version": "3.1.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
-          "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
-          "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
           }
         },
         "@leafygreen-ui/lib": {
@@ -45294,15 +45327,6 @@
                 "lodash": "^4.17.21"
               }
             }
-          }
-        },
-        "@leafygreen-ui/leafygreen-provider": {
-          "version": "3.1.12",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
-          "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
-          "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
           }
         },
         "@leafygreen-ui/lib": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@leafygreen-ui/icon": "^11.6.1",
     "@leafygreen-ui/icon-button": "^9.1.6",
     "@leafygreen-ui/inline-definition": "^4.0.2",
-    "@leafygreen-ui/leafygreen-provider": "^2.3.2",
+    "@leafygreen-ui/leafygreen-provider": "^3.1.12",
     "@leafygreen-ui/lib": "^9.5.2",
     "@leafygreen-ui/logo": "^4.0.2",
     "@leafygreen-ui/modal": "^10.1.0",

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -2,21 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VersionContextProvider } from '../context/version-context';
 import { TocContextProvider } from '../context/toc-context';
+import { DarkModeContexProvider } from '../context/dark-mode-context';
 import { HeaderContextProvider } from './Header/header-context';
 import { SidenavContextProvider } from './Sidenav';
 import { ContentsProvider } from './Contents/contents-context';
 
 const RootProvider = ({ children, headingNodes, slug, repoBranches, remoteMetadata }) => {
   return (
-    <ContentsProvider headingNodes={headingNodes}>
-      <HeaderContextProvider>
-        <VersionContextProvider repoBranches={repoBranches} slug={slug}>
-          <TocContextProvider remoteMetadata={remoteMetadata}>
-            <SidenavContextProvider>{children}</SidenavContextProvider>
-          </TocContextProvider>
-        </VersionContextProvider>
-      </HeaderContextProvider>
-    </ContentsProvider>
+    <DarkModeContexProvider>
+      <ContentsProvider headingNodes={headingNodes}>
+        <HeaderContextProvider>
+          <VersionContextProvider repoBranches={repoBranches} slug={slug}>
+            <TocContextProvider remoteMetadata={remoteMetadata}>
+              <SidenavContextProvider>{children}</SidenavContextProvider>
+            </TocContextProvider>
+          </VersionContextProvider>
+        </HeaderContextProvider>
+      </ContentsProvider>
+    </DarkModeContexProvider>
   );
 };
 

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VersionContextProvider } from '../context/version-context';
 import { TocContextProvider } from '../context/toc-context';
-import { DarkModeContexProvider } from '../context/dark-mode-context';
+import { DarkModeContextProvider } from '../context/dark-mode-context';
 import { HeaderContextProvider } from './Header/header-context';
 import { SidenavContextProvider } from './Sidenav';
 import { ContentsProvider } from './Contents/contents-context';
 
 const RootProvider = ({ children, headingNodes, slug, repoBranches, remoteMetadata }) => {
   return (
-    <DarkModeContexProvider>
+    <DarkModeContextProvider>
       <ContentsProvider headingNodes={headingNodes}>
         <HeaderContextProvider>
           <VersionContextProvider repoBranches={repoBranches} slug={slug}>
@@ -19,7 +19,7 @@ const RootProvider = ({ children, headingNodes, slug, repoBranches, remoteMetada
           </VersionContextProvider>
         </HeaderContextProvider>
       </ContentsProvider>
-    </DarkModeContexProvider>
+    </DarkModeContextProvider>
   );
 };
 

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -11,7 +11,7 @@ import Button from '@leafygreen-ui/button';
 import { setLocalValue } from '../utils/browser-storage';
 import { isBrowser } from '../utils/is-browser';
 
-const DarkModeContex = createContext({
+const DarkModeContext = createContext({
   darkMode: false,
   setDarkMode: () => {},
 });
@@ -45,7 +45,7 @@ const DarkModeContextProvider = ({ children }) => {
   }, []);
 
   return (
-    <DarkModeContex.Provider value={{ darkMode, setDarkMode }}>
+    <DarkModeContext.Provider value={{ darkMode, setDarkMode }}>
       <LeafyGreenProvider baseFontSize={16} darkMode={darkMode}>
         {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && (
           <Button
@@ -58,8 +58,8 @@ const DarkModeContextProvider = ({ children }) => {
         )}
         {children}
       </LeafyGreenProvider>
-    </DarkModeContex.Provider>
+    </DarkModeContext.Provider>
   );
 };
 
-export { DarkModeContex, DarkModeContextProvider };
+export { DarkModeContext, DarkModeContextProvider };

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -1,0 +1,51 @@
+import React, { createContext, useEffect, useRef } from 'react';
+import LeafyGreenProvider, { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import Button from '@leafygreen-ui/button';
+import { getLocalValue, setLocalValue } from '../utils/browser-storage';
+
+const DarkModeContex = createContext({
+  darkMode: false,
+  setDarkMode: () => {},
+});
+
+const DarkModeContexProvider = ({ children }) => {
+  const { setDarkMode, darkMode } = useDarkMode();
+  const loaded = useRef();
+
+  // save to local value when darkmode changes, besides initial load
+  useEffect(() => {
+    if (loaded.current) {
+      console.log('setting local value for darkMode ', darkMode);
+      setLocalValue('darkMode', darkMode);
+    } else {
+      loaded.current = true;
+    }
+  }, [darkMode]);
+
+  // TODO: investigate why this is not upading dark mode
+  // seems to set dark mode to local value, but no change
+  useEffect(() => {
+    console.log('on init local value for darkmode is ', getLocalValue('darkMode'));
+    setDarkMode(getLocalValue('darkMode'));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <DarkModeContex.Provider value={{ darkMode: darkMode, setDarkMode }}>
+      <LeafyGreenProvider baseFontSize={16} darkMode={darkMode}>
+        {/* TODO: remove button for testing */}
+        <Button
+          onClick={() => {
+            setDarkMode(!darkMode);
+          }}
+        >
+          Click to toggle Dark Mode
+        </Button>
+        {/* {renderReady && children} */}
+        {children}
+      </LeafyGreenProvider>
+    </DarkModeContex.Provider>
+  );
+};
+
+export { DarkModeContex, DarkModeContexProvider };

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -1,5 +1,12 @@
-import React, { createContext, useEffect, useRef } from 'react';
-import LeafyGreenProvider, { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+/**
+ * Context to dictate dark mode UI for rest of page
+ * Should be on top level, and dictates LG Provider Context
+ * which in turn controls all UI elements within the page
+ * https://github.com/mongodb/leafygreen-ui/blob/main/STYLEGUIDE.md#consuming-darkmode-from-leafygreenprovider
+ */
+
+import React, { createContext, useEffect, useRef, useState } from 'react';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import Button from '@leafygreen-ui/button';
 import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 
@@ -8,8 +15,8 @@ const DarkModeContex = createContext({
   setDarkMode: () => {},
 });
 
-const DarkModeContexProvider = ({ children }) => {
-  const { setDarkMode, darkMode } = useDarkMode();
+const DarkModeContextProvider = ({ children }) => {
+  const [darkMode, setDarkMode] = useState();
   const loaded = useRef();
 
   // save to local value when darkmode changes, besides initial load
@@ -22,16 +29,15 @@ const DarkModeContexProvider = ({ children }) => {
     }
   }, [darkMode]);
 
-  // TODO: investigate why this is not upading dark mode
-  // seems to set dark mode to local value, but no change
+  // NOTE: client side read of darkmode from local storage
+  // occurs after component mounts, not during build time
+  // TODO: DOP-4671 - set based on system setting as well as previous selection
   useEffect(() => {
-    console.log('on init local value for darkmode is ', getLocalValue('darkMode'));
     setDarkMode(getLocalValue('darkMode'));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <DarkModeContex.Provider value={{ darkMode: darkMode, setDarkMode }}>
+    <DarkModeContex.Provider value={{ darkMode, setDarkMode }}>
       <LeafyGreenProvider baseFontSize={16} darkMode={darkMode}>
         {/* TODO: remove button for testing */}
         <Button
@@ -41,11 +47,10 @@ const DarkModeContexProvider = ({ children }) => {
         >
           Click to toggle Dark Mode
         </Button>
-        {/* {renderReady && children} */}
         {children}
       </LeafyGreenProvider>
     </DarkModeContex.Provider>
   );
 };
 
-export { DarkModeContex, DarkModeContexProvider };
+export { DarkModeContex, DarkModeContextProvider };


### PR DESCRIPTION
### Stories/Links:

DOP-4667

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

[sample drivers page for dark mode](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/drivers/seung.park/DOP-4667/index.html)

### Notes:
- Dark mode setting is stored in local storage - Caveat is that this can only be read by the clients' browser local storage which means users will see an initial load of default (non dark) before switching to dark mode. 
- Includes changes from DOP-4669 (feature flag) and DOP-4671 (detecting system dark mode)
- Test locally with env variable `GATSBY_ENABLE_DARK_MODE=true`

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
