### PR TITLE
DOP-4671 - detect system for light/dark modes

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -58,7 +58,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
         key="dark-mode"
         dangerouslySetInnerHTML={{
           __html: `
-            function () {
+            !function () {
               try {
                 var d = document.documentElement.classList;
                 d.remove("light-theme", "dark-theme");

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -23,6 +23,28 @@ export const onRenderBody = ({ setHeadComponents }) => {
         __html: `!function(e,t,r,n){if(!e[n]){for(var a=e[n]=[],i=["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],s=0;s<i.length;s++){var c=i[s];a[c]=a[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);a.push([e,t])}}(c)}a.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+r+"/"+n+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,"Dk30CC86ba0nATlK","delighted");`,
       }}
     />,
+    // Detect dark mode
+    <script
+      dangerouslySetInnerHTML={{
+        // __html: `alert('this is an alert test')()`
+        __html: `!function(){  try {
+          debugger;
+          var d = document.documentElement.classList;
+          d.remove("light-theme", "dark-theme");
+          var e = JSON.parse(localStorage.getItem("mongodb-docs"))?.['theme'];
+          if ("system" === e || (!e && true)) {
+            var t = "(prefers-color-scheme: dark)",
+              m = window.matchMedia(t);
+            m.media !== t || m.matches ? d.add("dark-theme") : d.add("light-theme");
+          } else if (e) {
+            var x = { "light-theme": "light-theme", "dark-theme": "dark-theme" };
+            d.add(x[e]);
+          }
+        } catch (e) {
+         console.error(e)
+        }}()`,
+      }}
+    />,
     <link
       rel="preload"
       href={EuclidCircularASemiBold}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -6,7 +6,7 @@ import { theme } from './src/theme/docsTheme';
 import EuclidCircularASemiBold from './src/styles/fonts/EuclidCircularA-Semibold-WebXL.woff';
 
 export const onRenderBody = ({ setHeadComponents }) => {
-  setHeadComponents([
+  const headComponents = [
     // GTM Pathway
     <script
       key="pathway"
@@ -21,28 +21,6 @@ export const onRenderBody = ({ setHeadComponents }) => {
       type="text/javascript"
       dangerouslySetInnerHTML={{
         __html: `!function(e,t,r,n){if(!e[n]){for(var a=e[n]=[],i=["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],s=0;s<i.length;s++){var c=i[s];a[c]=a[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);a.push([e,t])}}(c)}a.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+r+"/"+n+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,"Dk30CC86ba0nATlK","delighted");`,
-      }}
-    />,
-    // Detect dark mode
-    <script
-      dangerouslySetInnerHTML={{
-        // __html: `alert('this is an alert test')()`
-        __html: `!function(){  try {
-          debugger;
-          var d = document.documentElement.classList;
-          d.remove("light-theme", "dark-theme");
-          var e = JSON.parse(localStorage.getItem("mongodb-docs"))?.['theme'];
-          if ("system" === e || (!e && true)) {
-            var t = "(prefers-color-scheme: dark)",
-              m = window.matchMedia(t);
-            m.media !== t || m.matches ? d.add("dark-theme") : d.add("light-theme");
-          } else if (e) {
-            var x = { "light-theme": "light-theme", "dark-theme": "dark-theme" };
-            d.add(x[e]);
-          }
-        } catch (e) {
-         console.error(e)
-        }}()`,
       }}
     />,
     <link
@@ -70,7 +48,39 @@ export const onRenderBody = ({ setHeadComponents }) => {
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap"
       rel="stylesheet"
     ></link>,
-  ]);
+  ];
+  if (process.env['GATSBY_ENABLE_DARK_MODE'] === 'true') {
+    // Detect dark mode
+    // before document body
+    // to prevent flash of incorrect theme
+    headComponents.push(
+      <script
+        key="dark-mode"
+        dangerouslySetInnerHTML={{
+          __html: `
+            function () {
+              try {
+                var d = document.documentElement.classList;
+                d.remove("light-theme", "dark-theme");
+                var e = JSON.parse(localStorage.getItem("mongodb-docs"))?.["theme"];
+                if ("system" === e || (!e)) {
+                  var t = "(prefers-color-scheme: dark)",
+                    m = window.matchMedia(t);
+                  m.media !== t || m.matches ? d.add("dark-theme") : d.add("light-theme");
+                } else if (e) {
+                  var x = { "light-theme": "light-theme", "dark-theme": "dark-theme" };
+                  x[e] && d.add(x[e]);
+                }
+              } catch (e) {
+                console.error(e);
+              }
+            }();
+          `,
+        }}
+      />
+    );
+  }
+  setHeadComponents(headComponents);
 };
 
 // Support SSR for LeafyGreen components

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -140,6 +140,10 @@ const DocumentBody = (props) => {
           #template-container *:not(:is(code, code *)) {
             font-family: ${fontFamily};
           }
+          // TESTING initial load background
+          // html.dark-theme body {
+          //   background: black
+          // }
         `}
       />
     </>

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -140,10 +140,6 @@ const DocumentBody = (props) => {
           #template-container *:not(:is(code, code *)) {
             font-family: ${fontFamily};
           }
-          // TESTING initial load background
-          // html.dark-theme body {
-          //   background: black
-          // }
         `}
       />
     </>

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -47,14 +47,15 @@ const DarkModeContextProvider = ({ children }) => {
   return (
     <DarkModeContex.Provider value={{ darkMode, setDarkMode }}>
       <LeafyGreenProvider baseFontSize={16} darkMode={darkMode}>
-        {/* TODO: remove button for testing */}
-        <Button
-          onClick={() => {
-            setDarkMode(!darkMode);
-          }}
-        >
-          Click to toggle Dark Mode
-        </Button>
+        {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && (
+          <Button
+            onClick={() => {
+              setDarkMode(!darkMode);
+            }}
+          >
+            Click to toggle Dark Mode
+          </Button>
+        )}
         {children}
       </LeafyGreenProvider>
     </DarkModeContex.Provider>

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -8,32 +8,40 @@
 import React, { createContext, useEffect, useRef, useState } from 'react';
 import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import Button from '@leafygreen-ui/button';
-import { getLocalValue, setLocalValue } from '../utils/browser-storage';
+import { setLocalValue } from '../utils/browser-storage';
+import { isBrowser } from '../utils/is-browser';
 
 const DarkModeContex = createContext({
   darkMode: false,
   setDarkMode: () => {},
 });
 
+const DARK_THEME_CLASSNAME = 'dark-theme';
+const LIGHT_THEME_CLASSNAME = 'light-theme';
+
 const DarkModeContextProvider = ({ children }) => {
-  const [darkMode, setDarkMode] = useState();
+  const [darkMode, setDarkMode] = useState(false);
   const loaded = useRef();
 
   // save to local value when darkmode changes, besides initial load
   useEffect(() => {
-    if (loaded.current) {
-      console.log('setting local value for darkMode ', darkMode);
-      setLocalValue('darkMode', darkMode);
-    } else {
+    if (!loaded.current) {
       loaded.current = true;
+      return;
+    }
+    setLocalValue('theme', darkMode ? DARK_THEME_CLASSNAME : LIGHT_THEME_CLASSNAME);
+    if (isBrowser) {
+      const documentClasses = window.document.documentElement.classList;
+      documentClasses.remove(LIGHT_THEME_CLASSNAME, DARK_THEME_CLASSNAME);
+      documentClasses.add(darkMode ? DARK_THEME_CLASSNAME : LIGHT_THEME_CLASSNAME);
     }
   }, [darkMode]);
 
-  // NOTE: client side read of darkmode from local storage
-  // occurs after component mounts, not during build time
-  // TODO: DOP-4671 - set based on system setting as well as previous selection
+  // NOTE: client side read of darkmode from document classnames
+  // which is derived from local storage (see gatsby-ssr script).
+  // This occurs after component mounts, not during build time
   useEffect(() => {
-    setDarkMode(getLocalValue('darkMode'));
+    setDarkMode(isBrowser ? window?.document?.documentElement?.classList?.contains(DARK_THEME_CLASSNAME) : false);
   }, []);
 
   return (


### PR DESCRIPTION
### Stories/Links:

DOP-4671

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

[staged site that should read from your system settings](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/drivers/seung.park/DOP-4671/index.html)

### Notes:
- Local testing requires env variable `GATSBY_ENABLE_DARK_MODE=true` to have all the effects take place (from [this PR](https://github.com/mongodb/snooty/pull/1099))
- To test system detection, change your system appearance to light/dark and staged site should respect your system settings
- Added to the previous PR's logic of saving to the local storage - the HTML document will also be added a classname for `dark-theme` (or `light-theme`) via a pre render script that reads the local storage. This allows for our own styling ie. page background before hydration occurs. How this can be pre-rendered remains a mystery as we are serving static sites.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
