### PR TITLE
DOP-4698: Hide IA header on Search

### DIFF
--- a/src/components/Sidenav/IA.js
+++ b/src/components/Sidenav/IA.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { SideNavGroup, SideNavItem } from '@leafygreen-ui/side-nav';
 import { cx, css } from '@leafygreen-ui/emotion';
@@ -11,6 +11,12 @@ import IALinkedData from './IALinkedData';
 const headerPadding = css`
   > div {
     ${sideNavItemBasePadding}
+  }
+`;
+
+const collapseHeaderPadding = css`
+  > div {
+    padding: 0 !important;
   }
 `;
 
@@ -52,11 +58,10 @@ const findIALinkedData = (iaTree) => {
 const IA = ({ handleClick, header, ia }) => {
   const { iatree } = useSnootyMetadata();
   const linkedDataMapping = findIALinkedData(iatree);
-
-  console.log('headerrrr ', header);
+  const sideNavGroupClassname = useMemo(() => (header ? cx(headerPadding) : cx(collapseHeaderPadding)), [header]);
 
   return (
-    <SideNavGroup className={header ? cx(headerPadding) : ''} header={header}>
+    <SideNavGroup className={sideNavGroupClassname} header={header}>
       {ia.map(({ title, slug, url, id }, index) => {
         const target = slug || url;
         // We use the linked data from the mapping since the linked data and the

--- a/src/components/Sidenav/IA.js
+++ b/src/components/Sidenav/IA.js
@@ -53,8 +53,10 @@ const IA = ({ handleClick, header, ia }) => {
   const { iatree } = useSnootyMetadata();
   const linkedDataMapping = findIALinkedData(iatree);
 
+  console.log('headerrrr ', header);
+
   return (
-    <SideNavGroup className={cx(headerPadding)} header={header}>
+    <SideNavGroup className={header ? cx(headerPadding) : ''} header={header}>
       {ia.map(({ title, slug, url, id }, index) => {
         const target = slug || url;
         // We use the linked data from the mapping since the linked data and the

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -181,7 +181,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
   const ia = page?.options?.ia;
 
   const template = page?.options?.template;
-  const isLanding = template === 'landing';
+  const hideIaHeader = template === 'landing' || template === 'search';
   const isGuidesLanding = project === 'guides' && template === 'product-landing';
   const isGuidesTemplate = template === 'guide';
 
@@ -248,7 +248,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 <Border />
                 {ia && (
                   <IA
-                    header={!isLanding && <span className={cx([titleStyle])}>{formatText(pageTitle)}</span>}
+                    header={!hideIaHeader && <span className={cx([titleStyle])}>{formatText(pageTitle)}</span>}
                     handleClick={() => {
                       setBack(false);
                       hideMobileSidenav();

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -182,7 +182,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
 
   const template = page?.options?.template;
   const hideIaHeader = template === 'landing' || template === 'search';
-  console.log('hide ia header ', hideIaHeader);
   const isGuidesLanding = project === 'guides' && template === 'product-landing';
   const isGuidesTemplate = template === 'guide';
 
@@ -209,8 +208,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
       );
     }
 
-    console.log('in navcontent ');
-
     if (!Object.keys(activeToc).length) {
       return null;
     }
@@ -227,9 +224,6 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
     const chapterName = guides?.[slug]?.['chapter_name'];
     return chapters[chapterName]?.['chapter_number'];
   }, [chapters, guides, isGuidesTemplate, slug]);
-
-  console.log('ia ', ia);
-  console.log('navTitle ', navTitle);
 
   return (
     <>

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -182,6 +182,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
 
   const template = page?.options?.template;
   const hideIaHeader = template === 'landing' || template === 'search';
+  console.log('hide ia header ', hideIaHeader);
   const isGuidesLanding = project === 'guides' && template === 'product-landing';
   const isGuidesTemplate = template === 'guide';
 
@@ -208,6 +209,8 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
       );
     }
 
+    console.log('in navcontent ');
+
     if (!Object.keys(activeToc).length) {
       return null;
     }
@@ -224,6 +227,9 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
     const chapterName = guides?.[slug]?.['chapter_name'];
     return chapters[chapterName]?.['chapter_number'];
   }, [chapters, guides, isGuidesTemplate, slug]);
+
+  console.log('ia ', ia);
+  console.log('navTitle ', navTitle);
 
   return (
     <>
@@ -248,7 +254,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                 <Border />
                 {ia && (
                   <IA
-                    header={!hideIaHeader && <span className={cx([titleStyle])}>{formatText(pageTitle)}</span>}
+                    header={!hideIaHeader ? <span className={cx([titleStyle])}>{formatText(pageTitle)}</span> : null}
                     handleClick={() => {
                       setBack(false);
                       hideMobileSidenav();

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -39,6 +39,7 @@ const scrollBehavior = { block: 'nearest', behavior: 'smooth' };
  */
 const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, parentProj = '' }) => {
   const { title, slug, url, children, options = {} } = node;
+  console.log('tocnode ', node);
   const { activeVersions } = useContext(VersionContext);
   const target = options.urls?.[activeVersions[options.project]] || slug || url;
   const hasChildren = !!children?.length;

--- a/src/components/Sidenav/TOCNode.js
+++ b/src/components/Sidenav/TOCNode.js
@@ -39,7 +39,6 @@ const scrollBehavior = { block: 'nearest', behavior: 'smooth' };
  */
 const TOCNode = ({ activeSection, handleClick, level = BASE_NODE_LEVEL, node, parentProj = '' }) => {
   const { title, slug, url, children, options = {} } = node;
-  console.log('tocnode ', node);
   const { activeVersions } = useContext(VersionContext);
   const target = options.urls?.[activeVersions[options.project]] || slug || url;
   const hasChildren = !!children?.length;

--- a/tests/unit/__snapshots__/IA.test.js.snap
+++ b/tests/unit/__snapshots__/IA.test.js.snap
@@ -18,10 +18,7 @@ exports[`renders a page IA with IA linked data 1`] = `
 }
 
 .emotion-0>div {
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding: 0!important;
 }
 
 .emotion-1 {
@@ -962,10 +959,7 @@ exports[`renders a simple page IA correctly 1`] = `
 }
 
 .emotion-0>div {
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding: 0!important;
 }
 
 .emotion-1 {


### PR DESCRIPTION
### Stories/Links:

DOP-4598

### Current Behavior:

https://www.mongodb.com/docs/search/

### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/no-ia-header/landing/matt.meigs/DOP-4698-hide-ia-header/search/index.html

### Notes:

Consolidates the two pages that need to hide the Docs Home. Includes Search page now.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
