### PR TITLE
DOP-4603: Add Japanese locale behind feature flag

### DIFF
--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -12,6 +12,10 @@ export const AVAILABLE_LANGUAGES = [
   { language: 'Português', code: 'pt-br' },
 ];
 
+if (process.env.GATSBY_FEATURE_SHOW_HIDDEN_LOCALES === 'true') {
+  AVAILABLE_LANGUAGES.push({ language: '日本語', code: 'ja-jp' });
+}
+
 const validateCode = (potentialCode) => !!AVAILABLE_LANGUAGES.find(({ code }) => potentialCode === code);
 
 /**


### PR DESCRIPTION
### Stories/Links:

DOP-4603

### Current Behavior:

[Atlas docs prod](https://mongodb.com/docs/atlas)

### Staging Links:

[With feature flag ON](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4603/index.html) - should include Japanese in the locale selector and hreflang links
[With feature flag OFF](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/flag-false/master/cloud-docs/raymund.rodriguez/DOP-4603/index.html) - should be the same as prod
[Japanese site example](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ja-jp/master/cloud-docs/raymund.rodriguez/DOP-4603/index.html) - to validate that the locale selector shows the Japanese language as the selected locale.

### Notes:

* Conditionally adds Japanese to the list of languages through a feature flag. This should automatically handle adding Japanese to both the locale selector and the hreflang links for SEO.
* Not adding it to the redirects list in the [head script](https://github.com/mongodb/snooty/blob/66e879a55b1b18a531ca4c48a6c75d8475be6423/src/utils/head-scripts/redirect-based-on-lang.js#L7) for now due to the limitation of not being allowed to use exports and not being able to access `process.env` for the feature flag. We'll most likely need to add it to the list later, whenever it's time for launch.

**To test**
1. Add `GATSBY_FEATURE_SHOW_HIDDEN_LOCALES=true` in your `.env.*` files.
2. Develop or build the docs.
3. Check that Japanese ("日本語") is now in the locale selector and can be clicked. Clicking should prepend `ja-jp` to the URL's pathname.
4. Check that an hreflang link for `ja-jp` is now present in the `head` tag of the HTML in both the DOM and in the page source.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
