### PR TITLE
DOP-4715: Upgrade consistent nav to "v2.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@leafygreen-ui/tooltip": "^11.0.4",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.0.7",
+        "@mdb/consistent-nav": "^2.1.1-rc.1",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
@@ -7852,9 +7852,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
-      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g==",
+      "version": "2.1.1-rc.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
+      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -35590,9 +35590,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
-      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g=="
+      "version": "2.1.1-rc.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
+      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@leafygreen-ui/tooltip": "^11.0.4",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.0.7",
+    "@mdb/consistent-nav": "^2.1.1-rc.1",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,15 +1,10 @@
 import React from 'react';
 import { UnifiedFooter } from '@mdb/consistent-nav';
-import { getCurrLocale, onSelectLocale } from '../utils/locale';
+import { AVAILABLE_LANGUAGES, getCurrLocale, onSelectLocale } from '../utils/locale';
 
 const Footer = () => {
-  return (
-    <UnifiedFooter
-      onSelectLocale={onSelectLocale}
-      locale={getCurrLocale()}
-      enabledLocales={['en-us', 'pt-br', 'ko-kr', 'zh-cn']}
-    />
-  );
+  const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
+  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} enabledLocales={enabledLocales} />;
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,42 +1,15 @@
-import React, { useEffect } from 'react';
-import { useLocation } from '@gatsbyjs/reach-router';
+import React from 'react';
 import { UnifiedFooter } from '@mdb/consistent-nav';
-import { isBrowser } from '../utils/is-browser';
-import { AVAILABLE_LANGUAGES, STORAGE_KEY_PREF_LOCALE, getCurrLocale, localizePath } from '../utils/locale';
-import { setLocalValue } from '../utils/browser-storage';
+import { getCurrLocale, onSelectLocale } from '../utils/locale';
 
 const Footer = () => {
-  const location = useLocation();
-
-  const onSelectLocale = (locale) => {
-    if (isBrowser) {
-      setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
-      const localizedPath = localizePath(location.pathname, locale);
-      window.location.href = localizedPath;
-    }
-  };
-
-  // A workaround to remove the other locale options
-  useEffect(() => {
-    const footer = document.getElementById('footer-container');
-    const footerUlElement = footer?.querySelector('ul[role=listbox]');
-    if (footerUlElement) {
-      // For DOP-4296 we only want to support English, Simple Chinese, Korean, and Portuguese.
-      const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
-        if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
-          accumulator.push(child);
-        }
-        return accumulator;
-      }, []);
-
-      footerUlElement.innerHTML = null;
-      availableOptions.forEach((child) => {
-        footerUlElement.appendChild(child);
-      });
-    }
-  }, []);
-
-  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} />;
+  return (
+    <UnifiedFooter
+      onSelectLocale={onSelectLocale}
+      locale={getCurrLocale()}
+      enabledLocales={['en-us', 'pt-br', 'ko-kr', 'zh-cn']}
+    />
+  );
 };
 
 export default Footer;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,7 +5,7 @@ import { UnifiedNav } from '@mdb/consistent-nav';
 import { SidenavMobileMenuDropdown } from '../Sidenav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
-import { getCurrLocale, onSelectLocale } from '../../utils/locale';
+import { AVAILABLE_LANGUAGES, getCurrLocale, onSelectLocale } from '../../utils/locale';
 
 const StyledHeaderContainer = styled.header(
   (props) => `
@@ -19,6 +19,7 @@ const StyledHeaderContainer = styled.header(
 const Header = ({ sidenav, eol, template }) => {
   const unifiedNavProperty = 'DOCS';
 
+  const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
   return (
     <StyledHeaderContainer template={template}>
       <SiteBanner />
@@ -31,7 +32,7 @@ const Header = ({ sidenav, eol, template }) => {
             showLanguageSelector={true}
             onSelectLocale={onSelectLocale}
             locale={getCurrLocale()}
-            enabledLocales={['en-us', 'pt-br', 'ko-kr', 'zh-cn']}
+            enabledLocales={enabledLocales}
           />
         )}
         {sidenav && <SidenavMobileMenuDropdown />}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,6 +5,7 @@ import { UnifiedNav } from '@mdb/consistent-nav';
 import { SidenavMobileMenuDropdown } from '../Sidenav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
+import { getCurrLocale, onSelectLocale } from '../../utils/locale';
 
 const StyledHeaderContainer = styled.header(
   (props) => `
@@ -22,7 +23,17 @@ const Header = ({ sidenav, eol, template }) => {
     <StyledHeaderContainer template={template}>
       <SiteBanner />
       <>
-        {!eol && <UnifiedNav fullWidth="true" position="relative" property={{ name: unifiedNavProperty }} />}
+        {!eol && (
+          <UnifiedNav
+            fullWidth="true"
+            position="relative"
+            property={{ name: unifiedNavProperty }}
+            showLanguageSelector={true}
+            onSelectLocale={onSelectLocale}
+            locale={getCurrLocale()}
+            enabledLocales={['en-us', 'pt-br', 'ko-kr', 'zh-cn']}
+          />
+        )}
         {sidenav && <SidenavMobileMenuDropdown />}
       </>
     </StyledHeaderContainer>

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -3,6 +3,7 @@ import { assertTrailingSlash } from './assert-trailing-slash';
 import { isBrowser } from './is-browser';
 import { normalizePath } from './normalize-path';
 import { removeLeadingSlash } from './remove-leading-slash';
+import { setLocalValue } from './browser-storage';
 
 /**
  * Key used to access browser storage for user's preferred locale
@@ -134,4 +135,13 @@ export const getLocaleMapping = (siteUrl, slug) => {
   });
 
   return localeHrefMap;
+};
+
+export const onSelectLocale = (locale) => {
+  const location = window.location;
+  if (isBrowser) {
+    setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
+    const localizedPath = localizePath(location.pathname, locale);
+    window.location.href = localizedPath;
+  }
 };

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -143,9 +143,7 @@ export const getLocaleMapping = (siteUrl, slug) => {
 
 export const onSelectLocale = (locale) => {
   const location = window.location;
-  if (isBrowser) {
-    setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
-    const localizedPath = localizePath(location.pathname, locale);
-    window.location.href = localizedPath;
-  }
+  setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
+  const localizedPath = localizePath(location.pathname, locale);
+  window.location.href = localizedPath;
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4715

### Current Behavior:

[Cloud docs landing page](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[English cloud-docs landing page (has Japanese language available in dropdown)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4715-b/index.html)
["Japanese" cloud-docs landing page (only navigable from English page)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ja-jp/master/cloud-docs/maya/DOP-4715-b/index.html)
["Portuguese" cloud-docs landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/pt-br/master/cloud-docs/maya/DOP-4715-b/index.html)
["Korean" cloud-docs landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ko-kr/master/cloud-docs/maya/DOP-4715-b/index.html)
["Simplified Chinese" cloud-docs landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/master/cloud-docs/maya/DOP-4715-b/index.html)

You can switch between these pages using the header or footer (will need to append `index.html` after the switch). The footer/header should match and correspond to the current link.

### Notes:

The original request of this ticket was to upgrade the @mdb/consistent-nav package to v2.1.0 so the Language Selector would be available in the header. However, it was quite difficult to get the selector to only display the four languages supported by docs (English, Portuguese, Korean, Simplified Chinese)—fortunately, the web team is including a feature to enable that in v2.1.1-rc.1 (see [ticket comment](https://jira.mongodb.org/browse/WEBSITE-17118?focusedCommentId=6402254&focusedId=6402254&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6402254)). 

Therefore, this PR is updating the consistent nav to v2.1.1-rc.1 to make use of the aforementioned feature, as well as adds support for locale changes to the header. The `onSelectLocale` function was also moved to the `locale.js` file to reduce duplication.

You can test locally by setting `COMMIT_HASH` as one of the `enabledLocales` (`en-us`, `pt-br`, `ko-kr`, `zh-cn`) in your `.env.*` files.

Might need to update tests? Not so sure, would love input on that

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
