### PR TITLE
DOP-4643: strict rules for image borders

### DIFF
--- a/src/components/Figure/Lightbox.js
+++ b/src/components/Figure/Lightbox.js
@@ -60,6 +60,7 @@ const LightboxWrapper = styled('div')`
   margin-top: ${theme.size.medium};
   margin-bottom: ${theme.size.medium};
   display: block;
+  max-width: 100%;
 `;
 
 const Lightbox = ({ nodeData, ...rest }) => {
@@ -74,7 +75,7 @@ const Lightbox = ({ nodeData, ...rest }) => {
     <React.Fragment>
       <LightboxWrapper figwidth={figureWidth}>
         <div onClick={openModal} role="button" tabIndex="-1">
-          <Image nodeData={nodeData} />
+          <Image nodeData={nodeData} {...rest} />
           <LightboxCaption
             style={{
               '--color': darkMode ? palette.gray.light2 : '#444',

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -16,7 +16,7 @@ const Figure = ({ ...props }) => {
   const { nodeData, ...rest } = props;
 
   if (isLightboxSize || (nodeData.options && nodeData.options.lightbox)) {
-    return <Lightbox nodeData={nodeData} />;
+    return <Lightbox {...props} nodeData={nodeData} />;
   }
 
   return (
@@ -29,7 +29,7 @@ const Figure = ({ ...props }) => {
       `}
       style={{ width: getNestedValue(['options', 'figwidth'], nodeData) || 'auto' }}
     >
-      <Image nodeData={nodeData} />
+      <Image nodeData={nodeData} {...props} />
       <CaptionLegend {...rest} nodeData={nodeData} />
     </div>
   );

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -12,18 +12,24 @@ import { removeLeadingSlash } from '../utils/remove-leading-slash';
 import { theme } from '../theme/docsTheme';
 
 const defaultImageStyling = css`
-  img,
+  max-width: 100%;
+  height: auto;
+`;
+
+const defaultContainerStyling = css`
   > img {
-    max-width: 100%;
-    height: auto;
+    ${defaultImageStyling}
   }
 `;
 
 const borderStyling = css`
-  img,
+  border-radius: ${theme.size.default};
+  border: 0.5px solid var(--border-color);
+`;
+
+const borderContainerStyling = css`
   > img {
-    border-radius: ${theme.size.default};
-    border: 0.5px solid var(--border-color);
+    ${borderStyling}
   }
 `;
 const gatsbyContainerStyle = css`
@@ -68,8 +74,8 @@ function getImageProps({
       directiveClass,
       customAlign,
       className,
-      defaultImageStyling,
-      applyBorder ? borderStyling : ''
+      defaultContainerStyling,
+      applyBorder ? borderContainerStyling : ''
     );
     imageProps['imgStyle'] = {
       '--border-color': darkMode ? palette.gray.dark2 : palette.gray.light1,

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -16,12 +16,6 @@ const defaultImageStyling = css`
   height: auto;
 `;
 
-const defaultContainerStyling = css`
-  > img {
-    ${defaultImageStyling}
-  }
-`;
-
 const borderStyling = css`
   border-radius: ${theme.size.default};
   border: 0.5px solid var(--border-color);
@@ -32,9 +26,13 @@ const borderContainerStyling = css`
     ${borderStyling}
   }
 `;
+
 const gatsbyContainerStyle = css`
   height: max-content;
   overflow: hidden;
+  > img {
+    ${defaultImageStyling}
+  }
 `;
 
 function getImageProps({
@@ -66,6 +64,7 @@ function getImageProps({
   }
 
   const applyBorder = hasBorder || (darkMode && getPageSlug(slug) !== '/' && sectionDepth > 1);
+  const borderColor = darkMode && hasBorder ? palette.gray.dark2 : darkMode ? 'transparent' : palette.gray.light1;
 
   if (gatsbyImage && loading === 'lazy') {
     imageProps['image'] = gatsbyImage;
@@ -74,11 +73,10 @@ function getImageProps({
       directiveClass,
       customAlign,
       className,
-      defaultContainerStyling,
       applyBorder ? borderContainerStyling : ''
     );
     imageProps['imgStyle'] = {
-      '--border-color': darkMode ? palette.gray.dark2 : palette.gray.light1,
+      '--border-color': borderColor,
     };
   } else {
     imageProps['src'] = imgSrc;
@@ -91,7 +89,7 @@ function getImageProps({
       className
     );
     imageProps['style'] = {
-      '--border-color': darkMode ? palette.gray.dark2 : palette.gray.light1,
+      '--border-color': borderColor,
     };
   }
 

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -8,14 +8,9 @@ exports[`renders border correctly when specified as an option 1`] = `
   margin-bottom: 24px;
 }
 
-.emotion-1 img,
-.emotion-1>img {
+.emotion-1 {
   max-width: 100%;
   height: auto;
-}
-
-.emotion-1 img,
-.emotion-1>img {
   border-radius: 16px;
   border: 0.5px solid var(--border-color);
 }
@@ -42,8 +37,7 @@ exports[`renders correctly 1`] = `
   margin-bottom: 24px;
 }
 
-.emotion-1 img,
-.emotion-1>img {
+.emotion-1 {
   max-width: 100%;
   height: auto;
 }
@@ -75,8 +69,7 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
   max-width: 100%;
 }
 
-.emotion-2 img,
-.emotion-2>img {
+.emotion-2 {
   max-width: 100%;
   height: auto;
 }

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -8,11 +8,16 @@ exports[`renders border correctly when specified as an option 1`] = `
   margin-bottom: 24px;
 }
 
-.emotion-1 {
+.emotion-1 img,
+.emotion-1>img {
   max-width: 100%;
   height: auto;
-  border: 0.5px solid #C1C7C6;
+}
+
+.emotion-1 img,
+.emotion-1>img {
   border-radius: 16px;
+  border: 0.5px solid var(--border-color);
 }
 
 <div
@@ -23,6 +28,7 @@ exports[`renders border correctly when specified as an option 1`] = `
       alt="/images/firstcluster.png"
       class="emotion-1"
       src="/images/firstcluster.png"
+      style="--border-color: #C1C7C6;"
     />
   </div>
 </DocumentFragment>
@@ -36,7 +42,8 @@ exports[`renders correctly 1`] = `
   margin-bottom: 24px;
 }
 
-.emotion-1 {
+.emotion-1 img,
+.emotion-1>img {
   max-width: 100%;
   height: auto;
 }
@@ -50,6 +57,7 @@ exports[`renders correctly 1`] = `
       class="emotion-1 hero-img align-test-align"
       height="3000"
       src="/images/firstcluster.png"
+      style="--border-color: #C1C7C6;"
       width="5000"
     />
   </div>
@@ -64,9 +72,11 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
   margin-top: 24px;
   margin-bottom: 24px;
   display: block;
+  max-width: 100%;
 }
 
-.emotion-2 {
+.emotion-2 img,
+.emotion-2>img {
   max-width: 100%;
   height: auto;
 }
@@ -91,6 +101,7 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
         alt="/images/firstcluster.png"
         class="emotion-2"
         src="/images/firstcluster.png"
+        style="--border-color: #C1C7C6;"
       />
       <div
         class="emotion-3 emotion-4"

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -8,9 +8,11 @@ exports[`Lightbox renders correctly 1`] = `
   margin-top: 24px;
   margin-bottom: 24px;
   display: block;
+  max-width: 100%;
 }
 
-.emotion-2 {
+.emotion-2 img,
+.emotion-2>img {
   max-width: 100%;
   height: auto;
 }
@@ -36,6 +38,7 @@ exports[`Lightbox renders correctly 1`] = `
         class="emotion-2 hero-img align-test-align"
         height="3000"
         src="/images/firstcluster.png"
+        style="--border-color: #C1C7C6;"
         width="5000"
       />
       <div

--- a/tests/unit/__snapshots__/Lightbox.test.js.snap
+++ b/tests/unit/__snapshots__/Lightbox.test.js.snap
@@ -11,8 +11,7 @@ exports[`Lightbox renders correctly 1`] = `
   max-width: 100%;
 }
 
-.emotion-2 img,
-.emotion-2>img {
+.emotion-2 {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4643

### Current Behavior:

[previous staged link showed borders around hero image in dark mode](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4643/index.html)

### Staging Links:

[docs landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4643-followup/index.html)
[language pages from docs landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4643-followup/languages/cpp/)
[atlas docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4643-followup/index.html)
[atlas docs with image example](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4643-followup/atlas-search/create-index/index.html#node-status)
[regression check](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4643-followup/data-federation/index.html)

### Notes:
- Adds checks to see if this is a landing page or sectionDepth must be greater than 2 to apply border styling in dark mode only

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
