### PR TITLE
:sparkles: DOP-4662 adds community pill to cards for when using tags

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -10,7 +10,7 @@ import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
 import ConditionalWrapper from '../ConditionalWrapper';
 import Link from '../Link';
-import Tag from '../Tag';
+import CommunityPillLink from '../CommunityPillLink';
 import { isRelativeUrl } from '../../utils/is-relative-url';
 import { getSuitableIcon } from '../../utils/get-suitable-icon';
 
@@ -92,10 +92,6 @@ const headingStyling = ({ isCompact, isExtraCompact, isLargeIconStyle }) => css`
   ${isLargeIconStyle && 'margin-bottom: 36px;'}
 `;
 
-const FlexTag = styled(Tag)`
-  margin-right: auto;
-`;
-
 const compactCardStyling = css`
   align-items: flex-start;
   flex-direction: row;
@@ -175,7 +171,7 @@ const Card = ({
         condition={isCompact || isExtraCompact}
         wrapper={(children) => <CompactTextWrapper>{children}</CompactTextWrapper>}
       >
-        {tag && <FlexTag>{tag}</FlexTag>}
+        {tag && <CommunityPillLink variant="green" text={tag} />}
         <div>
           {headline && (
             <Body className={cx(headingStyling({ isCompact, isExtraCompact, isLargeIconStyle }))} weight="medium">

--- a/src/components/CommunityPillLink.js
+++ b/src/components/CommunityPillLink.js
@@ -13,18 +13,6 @@ const communityPillVariants = {
   green: Variant.Green,
 };
 
-/**
- * CommunityPillLink component
- *
- * @param {Object} param0 - The parameters object
- * @param {Object} param0.nodeData - Data for the node
- * @param {String} param0.nodeData.argument - Text to display for Link
- * @param {Object} [param0.nodeData.options] - Options for the node data
- * @param {string} [param0.nodeData.options.url] - URL in the options
- * @param {string} param0.variant - Variant of the community pill link
- * @param {string} [param0.text='community built'] - Text to display, defaults to 'community built'
- * @returns {JSX.Element} The rendered CommunityPillLink component
- */
 const CommunityPillLink = ({ nodeData, variant, text = 'community built' }) => {
   const { argument, options: { url } = {} } = nodeData || {};
 

--- a/src/components/CommunityPillLink.js
+++ b/src/components/CommunityPillLink.js
@@ -13,13 +13,13 @@ const communityPillVariants = {
   green: Variant.Green,
 };
 
-const CommunityPillLink = ({ nodeData, variant, text = 'community built' }) => {
+const CommunityPillLink = ({ nodeData, variant = 'lightGray', text = 'community built' }) => {
   const { argument, options: { url } = {} } = nodeData || {};
 
   return (
     <div>
       {nodeData && argument && url && <Link to={url}>{getPlaintext(argument)}</Link>}
-      <Badge variant={communityPillVariants[variant] || Variant.LightGray}>{text}</Badge>
+      <Badge variant={communityPillVariants[variant]}>{text}</Badge>
     </div>
   );
 };

--- a/src/components/CommunityPillLink.js
+++ b/src/components/CommunityPillLink.js
@@ -1,19 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Badge from '@leafygreen-ui/badge';
+import Badge, { Variant } from '@leafygreen-ui/badge';
 import { getPlaintext } from '../utils/get-plaintext';
 import Link from './Link';
 
-const CommunityPillLink = ({
-  nodeData: {
-    argument,
-    options: { url },
-  },
-}) => {
+const communityPillVariants = {
+  darkGray: Variant.DarkGray,
+  lightGray: Variant.LightGray,
+  red: Variant.Red,
+  yellow: Variant.Yellow,
+  blue: Variant.Blue,
+  green: Variant.Green,
+};
+
+/**
+ * CommunityPillLink component
+ *
+ * @param {Object} param0 - The parameters object
+ * @param {Object} param0.nodeData - Data for the node
+ * @param {String} param0.nodeData.argument - Text to display for Link
+ * @param {Object} [param0.nodeData.options] - Options for the node data
+ * @param {string} [param0.nodeData.options.url] - URL in the options
+ * @param {string} param0.variant - Variant of the community pill link
+ * @param {string} [param0.text='community built'] - Text to display, defaults to 'community built'
+ * @returns {JSX.Element} The rendered CommunityPillLink component
+ */
+const CommunityPillLink = ({ nodeData, variant, text = 'community built' }) => {
+  const { argument, options: { url } = {} } = nodeData || {};
+
   return (
     <div>
-      <Link to={url}>{getPlaintext(argument)}</Link>
-      <Badge variant="lightgray">{'community built'}</Badge>
+      {nodeData && argument && url && <Link to={url}>{getPlaintext(argument)}</Link>}
+      <Badge variant={communityPillVariants[variant] || Variant.LightGray}>{text}</Badge>
     </div>
   );
 };
@@ -22,7 +40,9 @@ CommunityPillLink.propTypes = {
   nodeData: PropTypes.shape({
     argument: PropTypes.arrayOf(PropTypes.object).isRequired,
     options: PropTypes.shape({ url: PropTypes.string.isRequired }),
-  }).isRequired,
+  }),
+  variant: PropTypes.oneOf(Object.values(communityPillVariants)),
+  text: PropTypes.string,
 };
 
 export default CommunityPillLink;

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -49,24 +49,32 @@ exports[`renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 4px;
+.emotion-1 {
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  padding: 4px 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 16px;
+  border-radius: 24px;
+  height: 18px;
+  padding-left: 6px;
+  padding-right: 6px;
+  text-transform: uppercase;
+  border: 1px solid;
+  letter-spacing: 0.4px;
   background-color: #E3FCF7;
-  border: 1px solid #C0FAE6;
+  border-color: #C0FAE6;
   color: #00684A;
-  margin-right: auto;
 }
 
-.emotion-3 {
+.emotion-2 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -77,6 +85,22 @@ exports[`renders correctly 1`] = `
   font-weight: 500;
   letter-spacing: 0.5px;
   margin: 16px 0 8px 0;
+}
+
+.emotion-2 strong,
+.emotion-2 b {
+  font-weight: 700;
+}
+
+.emotion-3 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  margin-bottom: 16px;
 }
 
 .emotion-3 strong,
@@ -92,7 +116,6 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
   color: #001E2B;
   font-weight: 400;
-  margin-bottom: 16px;
 }
 
 .emotion-4 strong,
@@ -100,26 +123,11 @@ exports[`renders correctly 1`] = `
   font-weight: 700;
 }
 
-.emotion-5 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-}
-
-.emotion-5 strong,
-.emotion-5 b {
-  font-weight: 700;
-}
-
-.emotion-5 a {
+.emotion-4 a {
   line-height: unset;
 }
 
-.emotion-6 {
+.emotion-5 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -149,8 +157,8 @@ exports[`renders correctly 1`] = `
   display: inline;
 }
 
-.emotion-6:hover,
-.emotion-6:focus {
+.emotion-5:hover,
+.emotion-5:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
@@ -159,15 +167,15 @@ exports[`renders correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   outline: none;
 }
 
-.emotion-6:hover {
+.emotion-5:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-6:focus {
+.emotion-5:focus {
   text-decoration-color: #016BF8;
 }
 
@@ -185,27 +193,29 @@ exports[`renders correctly 1`] = `
       src="/images/icons/university.svg"
       width="24px"
     />
-    <span
-      class="emotion-1 emotion-2"
-    >
-      Test card tag
-    </span>
+    <div>
+      <div
+        class="emotion-1"
+      >
+        Test card tag
+      </div>
+    </div>
     <div>
       <p
-        class="emotion-3"
+        class="emotion-2"
       >
         Test card headline
       </p>
       <p
-        class="emotion-4"
+        class="emotion-3"
       >
         Test card paragraph
       </p>
       <p
-        class="emotion-5"
+        class="emotion-4"
       >
         <a
-          class="lg-ui-0001 emotion-6"
+          class="lg-ui-0001 emotion-5"
           href="https://university.mongodb.com/courses/M001/about"
           target="_self"
         >


### PR DESCRIPTION
### Stories/Links:

DOP-4662

### Current Behavior:

[Python Landing](https://www.mongodb.com/docs/languages/python/)

[Docs Landing](https://www.mongodb.com/docs/)

### Staging Links:

[Staged: Python Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/caesarbell/DOP-4662/languages/python/index.html)

[Staged: Docs Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/forked/dark-icons/landing/caesarbell/DOP-4662/index.html) (built from a forked repo)

### Notes:

- For this PR, I modified the community pill component to be reusable and swapped out the Tag component to use the new community pill component.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
