### PR TITLE
DOP-4632: Make feedback widget submitted links use LG Typography

### DIFF
--- a/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
+++ b/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Button from '@leafygreen-ui/button';
 import styled from '@emotion/styled';
-import { Subtitle } from '@leafygreen-ui/typography';
+import { Link, Subtitle } from '@leafygreen-ui/typography';
 import { useFeedbackContext } from '../context';
 import useScreenSize from '../../../../hooks/useScreenSize';
 import { Layout, Subheading } from '../components/view-components';
@@ -35,7 +35,9 @@ const SubmittedView = () => {
         {SUBMITTED_VIEW_RESOURCE_LINKS.map(({ text, href }, index) => (
           <React.Fragment key={index}>
             <br />
-            <a href={href}>{text}</a>
+            <Link href={href} baseFontSize={13} hideExternalIcon={true}>
+              {text}
+            </Link>
           </React.Fragment>
         ))}
         {shouldShowSupportLink && (


### PR DESCRIPTION
### Stories/Links:

DOP-4632

This page isn't reflected in Figma, so I ran this change by Amelia Short!

### Staging Screenshot:

![image](https://github.com/mongodb/snooty/assets/334192/a2721658-4892-40ea-bd19-ffc0dc26d1d1)
![image](https://github.com/mongodb/snooty/assets/334192/2b9fa6a0-9d54-4ba7-ac55-a636e92122ae)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
