### PR TITLE
DOP-4761: update LG/tabs to v12 to render content in HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@leafygreen-ui/select": "^7.0.0",
         "@leafygreen-ui/side-nav": "^14.1.3",
         "@leafygreen-ui/table": "^6.1.0",
-        "@leafygreen-ui/tabs": "^11.2.0",
+        "@leafygreen-ui/tabs": "^12.0.1",
         "@leafygreen-ui/text-area": "^6.1.0",
         "@leafygreen-ui/text-input": "^10.1.0",
         "@leafygreen-ui/toast": "^6.1.4",
@@ -4551,6 +4551,56 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/@leafygreen-ui/descendants": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
+      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.1.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.3.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/lib": {
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@storybook/csf": {
+      "version": "0.1.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
+      "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -4644,9 +4694,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
-      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
+      "version": "12.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -5988,19 +6038,19 @@
       "integrity": "sha512-AsvPlbvF7CERiZbAQR8hy3lAJ2/rieXI3cO0jsOwV8ztDqYNotKAdLujyr/NviudrRUenYiXrLizIKVlSPUMuA=="
     },
     "node_modules/@leafygreen-ui/tabs": {
-      "version": "11.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
-      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
+      "version": "12.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
+      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
       "dependencies": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/descendants": "^0.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.7.0",
-        "@leafygreen-ui/typography": "^19.1.1",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.0",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "peerDependencies": {
@@ -6017,9 +6067,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/lib": {
-      "version": "13.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -6034,29 +6084,26 @@
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
       "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
     },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
+    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
+      "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
-      },
-      "peerDependencies": {
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/lib": "^13.6.0",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/typography": {
-      "version": "19.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
-      "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
+      "version": "19.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
+      "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.2.0",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.7.0"
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.12"
@@ -6344,18 +6391,18 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
-      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
+      "version": "2.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
+      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9"
       }
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "13.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
-      "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -32414,6 +32461,49 @@
         }
       }
     },
+    "@leafygreen-ui/descendants": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
+      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
+      "requires": {
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@leafygreen-ui/hooks": {
+          "version": "8.1.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+          "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.3.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+          "requires": {
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@storybook/csf": {
+          "version": "0.1.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
+          "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -32496,9 +32586,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
-      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
+      "version": "12.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -33663,19 +33753,19 @@
       }
     },
     "@leafygreen-ui/tabs": {
-      "version": "11.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
-      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
+      "version": "12.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
+      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
       "requires": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/descendants": "^0.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.7.0",
-        "@leafygreen-ui/typography": "^19.1.1",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.0",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "dependencies": {
@@ -33689,9 +33779,9 @@
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "13.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -33703,26 +33793,26 @@
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
           "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
         },
-        "@leafygreen-ui/portal": {
-          "version": "5.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
+          "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
           "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
+            "@leafygreen-ui/lib": "^13.6.0",
+            "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/typography": {
-          "version": "19.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
-          "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
+          "version": "19.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
+          "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.2.0",
-            "@leafygreen-ui/lib": "^13.4.0",
+            "@leafygreen-ui/icon": "^12.5.4",
+            "@leafygreen-ui/lib": "^13.6.0",
             "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.7.0"
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
           }
         },
         "@storybook/csf": {
@@ -33976,18 +34066,18 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
-      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
+      "version": "2.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
+      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
       "requires": {
-        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "13.5.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
-          "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@leafygreen-ui/select": "^7.0.0",
     "@leafygreen-ui/side-nav": "^14.1.3",
     "@leafygreen-ui/table": "^6.1.0",
-    "@leafygreen-ui/tabs": "^11.2.0",
+    "@leafygreen-ui/tabs": "^12.0.1",
     "@leafygreen-ui/text-area": "^6.1.0",
     "@leafygreen-ui/text-input": "^10.1.0",
     "@leafygreen-ui/toast": "^6.1.4",

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
 import { CodeProvider } from '../Code/code-context';
@@ -64,11 +63,12 @@ const getTabsStyling = ({ isHidden, isProductLanding }) => css`
   ${isProductLanding && landingTabsStyling};
 `;
 
-const TabContent = styled('div')`
+const tabContentStyling = css`
   margin-top: ${theme.size.medium};
-  ${(props) =>
-    props.isProductLanding &&
-    `  display: grid;
+`;
+
+const productLandingTabContentStyling = css`
+  display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
 
@@ -81,7 +81,7 @@ const TabContent = styled('div')`
 
   @media ${theme.screenSize.upToLarge} {
     display: block;
-  }`}
+  }
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
@@ -153,11 +153,14 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
 
             return (
               <LeafyTab key={tabId} name={tabTitle}>
-                <TabContent isProductLanding={isProductLanding}>
+                <div
+                  className={cx(tabContentStyling, isProductLanding ? productLandingTabContentStyling : '')}
+                  isProductLanding={isProductLanding}
+                >
                   {tab.children.map((child, i) => (
                     <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
                   ))}
-                </TabContent>
+                </div>
               </LeafyTab>
             );
           })}

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -153,10 +153,7 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
 
             return (
               <LeafyTab key={tabId} name={tabTitle}>
-                <div
-                  className={cx(tabContentStyling, isProductLanding ? productLandingTabContentStyling : '')}
-                  isProductLanding={isProductLanding}
-                >
+                <div className={cx(tabContentStyling, isProductLanding ? productLandingTabContentStyling : '')}>
                   {tab.children.map((child, i) => (
                     <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
                   ))}

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
 import { CodeProvider } from '../Code/code-context';
@@ -24,6 +25,7 @@ const getPosition = (element) => {
 };
 
 const defaultTabsStyling = css`
+  margin-bottom: ${theme.size.medium};
   ${TAB_BUTTON_SELECTOR} {
     font-size: ${theme.size.default};
     align-items: center;
@@ -80,9 +82,25 @@ const landingTabStyling = css`
   }
 `;
 
-const getTabStyling = ({ isProductLanding }) => css`
-  ${isProductLanding && landingTabStyling}
-  margin-top: 24px;
+const TabContent = styled('div')`
+  margin-top: ${theme.size.medium};
+  ${(props) =>
+    props.isProductLanding
+      ? `  display: grid;
+  column-gap: ${theme.size.medium};
+  grid-template-columns: repeat(2, 1fr);
+
+  img {
+    border-radius: ${theme.size.small};
+    grid-column: 2;
+    margin-top: 0px;
+    display: block;
+  }
+
+  @media ${theme.screenSize.upToLarge} {
+    display: block;
+  }`
+      : ''}
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
@@ -139,6 +157,7 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
           aria-label={`Tabs to describe usage of ${tabsetName}`}
           selected={activeTab}
           setSelected={handleClick}
+          forceRenderAllTabPanels={true}
         >
           {children.map((tab) => {
             if (tab.name !== 'tab') {
@@ -152,10 +171,12 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
                 : tabId;
 
             return (
-              <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
-                {tab.children.map((child, i) => (
-                  <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
-                ))}
+              <LeafyTab className={cx(isProductLanding ? landingTabStyling : '')} key={tabId} name={tabTitle}>
+                <TabContent isProductLanding={isProductLanding}>
+                  {tab.children.map((child, i) => (
+                    <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
+                  ))}
+                </TabContent>
               </LeafyTab>
             );
           })}

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
 import { CodeProvider } from '../Code/code-context';
@@ -64,29 +64,11 @@ const getTabsStyling = ({ isHidden, isProductLanding }) => css`
   ${isProductLanding && landingTabsStyling};
 `;
 
-const landingTabStyling = css`
-  display: grid;
-  column-gap: ${theme.size.medium};
-  grid-template-columns: repeat(2, 1fr);
-  margin-top: unset !important;
-
-  img {
-    border-radius: ${theme.size.small};
-    grid-column: 2;
-    margin-top: 0px;
-    display: block;
-  }
-
-  @media ${theme.screenSize.upToLarge} {
-    display: block;
-  }
-`;
-
 const TabContent = styled('div')`
   margin-top: ${theme.size.medium};
   ${(props) =>
-    props.isProductLanding
-      ? `  display: grid;
+    props.isProductLanding &&
+    `  display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
 
@@ -99,8 +81,7 @@ const TabContent = styled('div')`
 
   @media ${theme.screenSize.upToLarge} {
     display: block;
-  }`
-      : ''}
+  }`}
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
@@ -171,7 +152,7 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
                 : tabId;
 
             return (
-              <LeafyTab className={cx(isProductLanding ? landingTabStyling : '')} key={tabId} name={tabTitle}>
+              <LeafyTab key={tabId} name={tabTitle}>
                 <TabContent isProductLanding={isProductLanding}>
                   {tab.children.map((child, i) => (
                     <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />


### PR DESCRIPTION
### Stories/Links:

DOP-4761

### Current Behavior:

[Tab behavior on homepage](https://www.mongodb.com/docs/atlas/)
[Tabs in inner content page](https://www.mongodb.com/docs/atlas/access-tracking/)

### Staging Links:

[Tabs on a landing page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4761/index.html)
[Tabs in inner content page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4761/access-tracking/index.html)

### Notes:
- Styling and user interaction should see no change
- Tabbed content is visible in the HTML produced (as well as the page HTML). You can verify this by going to the [S3 bucket](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=master/cloud-docs/seung.park/DOP-4761/index.html) and downloading the HTML file and seeing the tabbed content within

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
