### PR TITLE
Fix ChatbotUI background inheritance

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -1,6 +1,7 @@
 import React, { lazy } from 'react';
 import PropTypes from 'prop-types';
 import Skeleton from 'react-loading-skeleton';
+import { palette } from '@leafygreen-ui/palette';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { theme } from '../theme/docsTheme';
@@ -58,7 +59,7 @@ const StyledChatBotUiContainer = styled.div`
   padding: ${theme.size.default} 50px;
   z-index: 1;
   width: 100%;
-  background: inherit;
+  background: ${process.env.GATSBY_ENABLE_DARK_MODE === 'true' ? 'inherit' : palette.white};
   min-height: 96px;
   align-items: center;
 


### PR DESCRIPTION
### Current Behavior:

[Prod landing](https://www.mongodb.com/docs/)
[Prev landing staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-disabled/master/landing/caesarbell/DOP-4624/index.html) - Dark mode **disabled**
[Prev landing staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enabled/master/landing/caesarbell/DOP-4624/index.html) - Dark mode **enabled**

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/feature-off/master/landing/raymund.rodriguez/fix-chatbot-landing/index.html) - Dark mode **disabled**; background behind Chatbot should stay white.
[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/feature-on/master/landing/raymund.rodriguez/fix-chatbot-landing/index.html) - Dark mode **enabled**; background behind Chatbot should conform to the color of the action bar based on theme settings.

### Notes:

* Fixes an issue in #1137 that would lead to the chatbot UI background being transparent when the dark mode feature flag was disabled.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
