### PR TITLE
DOP-4715: Upgrade consistent nav to "v2.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@leafygreen-ui/tooltip": "^11.0.4",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.1.1-rc.1",
+        "@mdb/consistent-nav": "^2.1.1",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
@@ -7712,9 +7712,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.1.1-rc.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
-      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw==",
+      "version": "2.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.2.tgz",
+      "integrity": "sha512-tQewVuDi+ZJcnEylHul5AA/bxZ2c5+VE4Cw4siNFdnLRD7Q9FzQO7G6/4fh9PwuAQ0cYAWA5OK5BLjn7QOJrQA==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -35186,9 +35186,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.1.1-rc.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
-      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw=="
+      "version": "2.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.2.tgz",
+      "integrity": "sha512-tQewVuDi+ZJcnEylHul5AA/bxZ2c5+VE4Cw4siNFdnLRD7Q9FzQO7G6/4fh9PwuAQ0cYAWA5OK5BLjn7QOJrQA=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@leafygreen-ui/side-nav": "^14.1.3",
         "@leafygreen-ui/skeleton-loader": "^1.2.0",
         "@leafygreen-ui/table": "^6.1.0",
-        "@leafygreen-ui/tabs": "^11.2.0",
+        "@leafygreen-ui/tabs": "^12.0.1",
         "@leafygreen-ui/text-area": "^6.1.0",
         "@leafygreen-ui/text-input": "^10.1.0",
         "@leafygreen-ui/toast": "^6.1.4",
@@ -4552,6 +4552,56 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/@leafygreen-ui/descendants": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
+      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
+      "dependencies": {
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/hooks": {
+      "version": "8.1.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.3.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/lib": {
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/@storybook/csf": {
+      "version": "0.1.8",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
+      "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/descendants/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -4645,9 +4695,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
-      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
+      "version": "12.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -5989,19 +6039,19 @@
       "integrity": "sha512-AsvPlbvF7CERiZbAQR8hy3lAJ2/rieXI3cO0jsOwV8ztDqYNotKAdLujyr/NviudrRUenYiXrLizIKVlSPUMuA=="
     },
     "node_modules/@leafygreen-ui/tabs": {
-      "version": "11.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
-      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
+      "version": "12.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
+      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
       "dependencies": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/descendants": "^0.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.7.0",
-        "@leafygreen-ui/typography": "^19.1.1",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.0",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "peerDependencies": {
@@ -6018,9 +6068,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/lib": {
-      "version": "13.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -6035,29 +6085,26 @@
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
       "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
     },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
+    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
+      "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
-      },
-      "peerDependencies": {
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@leafygreen-ui/lib": "^13.6.0",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/typography": {
-      "version": "19.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
-      "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
+      "version": "19.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
+      "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.2.0",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.7.0"
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.12"
@@ -6345,18 +6392,18 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
-      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
+      "version": "2.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
+      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9"
       }
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "13.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
-      "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
+      "version": "13.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -32415,6 +32462,49 @@
         }
       }
     },
+    "@leafygreen-ui/descendants": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
+      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
+      "requires": {
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@leafygreen-ui/hooks": {
+          "version": "8.1.3",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+          "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.3.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+          "requires": {
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@storybook/csf": {
+          "version": "0.1.8",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
+          "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -32497,9 +32587,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.5.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
-      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
+      "version": "12.5.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -33664,19 +33754,19 @@
       }
     },
     "@leafygreen-ui/tabs": {
-      "version": "11.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
-      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
+      "version": "12.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
+      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
       "requires": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/descendants": "^0.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.7.0",
-        "@leafygreen-ui/typography": "^19.1.1",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.0",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "dependencies": {
@@ -33690,9 +33780,9 @@
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "13.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -33704,26 +33794,26 @@
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
           "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
         },
-        "@leafygreen-ui/portal": {
-          "version": "5.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
-          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
+          "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
           "requires": {
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0"
+            "@leafygreen-ui/lib": "^13.6.0",
+            "lodash": "^4.17.21"
           }
         },
         "@leafygreen-ui/typography": {
-          "version": "19.1.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
-          "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
+          "version": "19.2.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
+          "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.2.0",
-            "@leafygreen-ui/lib": "^13.4.0",
+            "@leafygreen-ui/icon": "^12.5.4",
+            "@leafygreen-ui/lib": "^13.6.0",
             "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.7.0"
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
           }
         },
         "@storybook/csf": {
@@ -33977,18 +34067,18 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
-      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
+      "version": "2.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
+      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
       "requires": {
-        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/lib": "^13.6.0",
         "@leafygreen-ui/palette": "^4.0.9"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "13.5.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
-          "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
+          "version": "13.6.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
+          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@leafygreen-ui/tooltip": "^11.0.4",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.0.7",
+        "@mdb/consistent-nav": "^2.1.1-rc.1",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
@@ -7712,9 +7712,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
-      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g==",
+      "version": "2.1.1-rc.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
+      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
@@ -35186,9 +35186,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.0.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.0.8.tgz",
-      "integrity": "sha512-IBh66kn7VJhGF4lZVELE92C80qvx2J/5i7kIskOJQDBnWc2Z1xDdh5+BUGAGV11l1SrRBGPcgqsEWFof9/fy9g=="
+      "version": "2.1.1-rc.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.1.1-rc.1.tgz",
+      "integrity": "sha512-T7YEogTO38i84TezAKbext5OJsiqzdEZ/jkoGK0nTkYncDuqIx2bwYTDZ1F+NTsrqxQ4sxrh/KIcTFJyiaf8gw=="
     },
     "@mdb/flora": {
       "version": "1.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@leafygreen-ui/tooltip": "^11.0.4",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.1.1",
+        "@mdb/consistent-nav": "^2.1.2",
         "@mdb/flora": "^1.5.6",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@leafygreen-ui/tooltip": "^11.0.4",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.0.7",
+    "@mdb/consistent-nav": "^2.1.1-rc.1",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@leafygreen-ui/tooltip": "^11.0.4",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.1.1-rc.1",
+    "@mdb/consistent-nav": "^2.1.1",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@leafygreen-ui/side-nav": "^14.1.3",
     "@leafygreen-ui/skeleton-loader": "^1.2.0",
     "@leafygreen-ui/table": "^6.1.0",
-    "@leafygreen-ui/tabs": "^11.2.0",
+    "@leafygreen-ui/tabs": "^12.0.1",
     "@leafygreen-ui/text-area": "^6.1.0",
     "@leafygreen-ui/text-input": "^10.1.0",
     "@leafygreen-ui/toast": "^6.1.4",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@leafygreen-ui/tooltip": "^11.0.4",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.1.1",
+    "@mdb/consistent-nav": "^2.1.2",
     "@mdb/flora": "^1.5.6",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,42 +1,10 @@
-import React, { useEffect } from 'react';
-import { useLocation } from '@gatsbyjs/reach-router';
+import React from 'react';
 import { UnifiedFooter } from '@mdb/consistent-nav';
-import { isBrowser } from '../utils/is-browser';
-import { AVAILABLE_LANGUAGES, STORAGE_KEY_PREF_LOCALE, getCurrLocale, localizePath } from '../utils/locale';
-import { setLocalValue } from '../utils/browser-storage';
+import { AVAILABLE_LANGUAGES, getCurrLocale, onSelectLocale } from '../utils/locale';
 
 const Footer = () => {
-  const location = useLocation();
-
-  const onSelectLocale = (locale) => {
-    if (isBrowser) {
-      setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
-      const localizedPath = localizePath(location.pathname, locale);
-      window.location.href = localizedPath;
-    }
-  };
-
-  // A workaround to remove the other locale options
-  useEffect(() => {
-    const footer = document.getElementById('footer-container');
-    const footerUlElement = footer?.querySelector('ul[role=listbox]');
-    if (footerUlElement) {
-      // For DOP-4296 we only want to support English, Simple Chinese, Korean, and Portuguese.
-      const availableOptions = Array.from(footerUlElement.childNodes).reduce((accumulator, child) => {
-        if (AVAILABLE_LANGUAGES.find(({ language }) => child.textContent === language)) {
-          accumulator.push(child);
-        }
-        return accumulator;
-      }, []);
-
-      footerUlElement.innerHTML = null;
-      availableOptions.forEach((child) => {
-        footerUlElement.appendChild(child);
-      });
-    }
-  }, []);
-
-  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} />;
+  const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
+  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} enabledLocales={enabledLocales} />;
 };
 
 export default Footer;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,6 +5,7 @@ import { UnifiedNav } from '@mdb/consistent-nav';
 import { SidenavMobileMenuDropdown } from '../Sidenav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
+import { AVAILABLE_LANGUAGES, getCurrLocale, onSelectLocale } from '../../utils/locale';
 
 const StyledHeaderContainer = styled.header(
   (props) => `
@@ -18,11 +19,22 @@ const StyledHeaderContainer = styled.header(
 const Header = ({ sidenav, eol, template }) => {
   const unifiedNavProperty = 'DOCS';
 
+  const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
   return (
     <StyledHeaderContainer template={template}>
       <SiteBanner />
       <>
-        {!eol && <UnifiedNav fullWidth="true" position="relative" property={{ name: unifiedNavProperty }} />}
+        {!eol && (
+          <UnifiedNav
+            fullWidth="true"
+            position="relative"
+            property={{ name: unifiedNavProperty }}
+            showLanguageSelector={true}
+            onSelectLocale={onSelectLocale}
+            locale={getCurrLocale()}
+            enabledLocales={enabledLocales}
+          />
+        )}
         {sidenav && <SidenavMobileMenuDropdown />}
       </>
     </StyledHeaderContainer>

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -24,6 +24,7 @@ const getPosition = (element) => {
 };
 
 const defaultTabsStyling = css`
+  margin-bottom: ${theme.size.medium};
   ${TAB_BUTTON_SELECTOR} {
     font-size: ${theme.size.default};
     align-items: center;
@@ -62,11 +63,14 @@ const getTabsStyling = ({ isHidden, isProductLanding }) => css`
   ${isProductLanding && landingTabsStyling};
 `;
 
-const landingTabStyling = css`
+const tabContentStyling = css`
+  margin-top: ${theme.size.medium};
+`;
+
+const productLandingTabContentStyling = css`
   display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
-  margin-top: unset !important;
 
   img {
     border-radius: ${theme.size.small};
@@ -78,11 +82,6 @@ const landingTabStyling = css`
   @media ${theme.screenSize.upToLarge} {
     display: block;
   }
-`;
-
-const getTabStyling = ({ isProductLanding }) => css`
-  ${isProductLanding && landingTabStyling}
-  margin-top: 24px;
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
@@ -139,6 +138,7 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
           aria-label={`Tabs to describe usage of ${tabsetName}`}
           selected={activeTab}
           setSelected={handleClick}
+          forceRenderAllTabPanels={true}
         >
           {children.map((tab) => {
             if (tab.name !== 'tab') {
@@ -152,10 +152,12 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
                 : tabId;
 
             return (
-              <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
-                {tab.children.map((child, i) => (
-                  <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
-                ))}
+              <LeafyTab key={tabId} name={tabTitle}>
+                <div className={cx(tabContentStyling, isProductLanding ? productLandingTabContentStyling : '')}>
+                  {tab.children.map((child, i) => (
+                    <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
+                  ))}
+                </div>
               </LeafyTab>
             );
           })}

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -3,6 +3,7 @@ import { assertTrailingSlash } from './assert-trailing-slash';
 import { isBrowser } from './is-browser';
 import { normalizePath } from './normalize-path';
 import { removeLeadingSlash } from './remove-leading-slash';
+import { setLocalValue } from './browser-storage';
 
 /**
  * Key used to access browser storage for user's preferred locale
@@ -138,4 +139,11 @@ export const getLocaleMapping = (siteUrl, slug) => {
   });
 
   return localeHrefMap;
+};
+
+export const onSelectLocale = (locale) => {
+  const location = window.location;
+  setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
+  const localizedPath = localizePath(location.pathname, locale);
+  window.location.href = localizedPath;
 };

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -344,12 +344,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   align-items: center;
 }
 
-.emotion-52 {
-  margin-right: 16px;
-  max-width: 16px;
-}
-
-.emotion-71 {
+.emotion-58 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -362,7 +357,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-71 {
+  .emotion-58 {
     display: none;
   }
 }
@@ -529,11 +524,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           >
             <a
               class=" emotion-25"
-              href="https://www.mongodb.com/legal/legal-notices"
+              href="https://www.mongodb.com/legal"
               rel="noreferrer noopener"
               target="_self"
             >
-              Legal Notices
+              Legal
             </a>
           </li>
           <li
@@ -541,11 +536,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           >
             <a
               class=" emotion-25"
-              href="https://www.mongodb.com/legal/privacy-policy"
+              href="https://github.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
             >
-              Privacy Notices
+              GitHub
             </a>
           </li>
           <li
@@ -570,6 +565,18 @@ exports[`DocumentBody renders the necessary elements 1`] = `
               target="_self"
             >
               Trust Center
+            </a>
+          </li>
+          <li
+            class="emotion-24"
+          >
+            <a
+              class=" emotion-25"
+              href="https://www.mongodb.com/company/contact/social-media-hub"
+              rel="noreferrer noopener"
+              target="_self"
+            >
+              Connect with Us
             </a>
           </li>
         </ul>
@@ -641,7 +648,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         <p
           class="emotion-22"
         >
-          Social
+          Deployment Options
         </p>
         <ul
           class="emotion-23"
@@ -651,18 +658,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           >
             <a
               class=" emotion-25"
-              href="https://github.com/mongodb"
+              href="https://www.mongodb.com/cloud/atlas/register"
               rel="noreferrer noopener"
               target="_self"
             >
-              <img
-                alt="GitHub"
-                class="emotion-52"
-                height="16"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wrvghw9q75ytq1-github.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              GitHub
+              MongoDB Atlas
             </a>
           </li>
           <li
@@ -670,18 +670,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           >
             <a
               class=" emotion-25"
-              href="https://stackoverflow.com/tags/mongodb/info"
+              href="https://www.mongodb.com/try/download/enterprise"
               rel="noreferrer noopener"
               target="_self"
             >
-              <img
-                alt="Stack Overflow"
-                class="emotion-52"
-                height="22"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wsfh9d9z2m4jvx-stackoverflow.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              Stack Overflow
+              Enterprise Advanced
             </a>
           </li>
           <li
@@ -689,100 +682,17 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           >
             <a
               class=" emotion-25"
-              href="https://www.linkedin.com/company/mongodbinc/"
+              href=" https://www.mongodb.com/try/download/community"
               rel="noreferrer noopener"
               target="_self"
             >
-              <img
-                alt="LinkedIn"
-                class="emotion-52"
-                height="16"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wsmr3g1ckzd0hs-linkedin.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              LinkedIn
-            </a>
-          </li>
-          <li
-            class="emotion-24"
-          >
-            <a
-              class=" emotion-25"
-              href="https://youtube.com/user/mongodb"
-              rel="noreferrer noopener"
-              target="_self"
-            >
-              <img
-                alt="YouTube"
-                class="emotion-52"
-                height="12"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wsxwxsvrivp4q4-youtube.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              YouTube
-            </a>
-          </li>
-          <li
-            class="emotion-24"
-          >
-            <a
-              class=" emotion-25"
-              href="https://twitter.com/mongodb"
-              rel="noreferrer noopener"
-              target="_self"
-            >
-              <img
-                alt="X"
-                class="emotion-52"
-                height="16"
-                src="https://webimages.mongodb.com/_com_assets/cms/lrym6kl0k3hc1rjgc-x_light.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              X
-            </a>
-          </li>
-          <li
-            class="emotion-24"
-          >
-            <a
-              class=" emotion-25"
-              href="https://twitch.tv/mongodb/videos"
-              rel="noreferrer noopener"
-              target="_self"
-            >
-              <img
-                alt="Twitch"
-                class="emotion-52"
-                height="18"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wtbzfgc05d27pb-twitch.svg?auto=format%252Ccompress"
-                width="16"
-              />
-              Twitch
-            </a>
-          </li>
-          <li
-            class="emotion-24"
-          >
-            <a
-              class=" emotion-25"
-              href="https://facebook.com/mongodb"
-              rel="noreferrer noopener"
-              target="_self"
-            >
-              <img
-                alt="Facebook"
-                class="emotion-52"
-                height="16"
-                src="https://webimages.mongodb.com/_com_assets/cms/kr6wtks9piclp67yr-facebook.svg?auto=format%252Ccompress"
-                width="9"
-              />
-              Facebook
+              Community Edition
             </a>
           </li>
         </ul>
       </div>
       <div
-        class="emotion-71"
+        class="emotion-58"
       >
         © 2024 MongoDB, Inc.
       </div>


### PR DESCRIPTION
DOP-4715

Reverts mongodb/snooty#1120 which reverted mongodb/snooty#1108. Bringing back the header language selector! :tada:

Also upgraded from `v2.1.1-rc.1` to `v2.1.1`, which does change some of the content of the Footer.

[Cloud docs English Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/revert-1120-revert-1108-DOP-4715-b/index.html)
[Cloud docs Portuguese](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/pt-br/master/cloud-docs/maya/revert-1120-revert-1108-DOP-4715-b/index.html)
[Cloud docs Korean](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ko-kr/master/cloud-docs/maya/revert-1120-revert-1108-DOP-4715-b/index.html)
[Cloud docs Simplified Chinese](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/master/cloud-docs/maya/revert-1120-revert-1108-DOP-4715-b/index.html)