### PR TITLE
Dop 4782

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Link as GatsbyLink } from 'gatsby';
-import { css } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { Link as LGLink } from '@leafygreen-ui/typography';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { getTheme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
 import ArrowRightIcon from '@leafygreen-ui/icon/dist/ArrowRight';
 import { isRelativeUrl } from '../utils/is-relative-url';
@@ -18,19 +19,45 @@ import { getGatsbyPreviewLink } from '../utils/get-gatsby-preview-link';
  * https://www.gatsbyjs.org/docs/gatsby-link/#recommendations-for-programmatic-in-app-navigation
  */
 
-// CSS purloined from LG Link definition (source: https://bit.ly/3JpiPIt)
-const gatsbyLinkStyling = css`
+/**
+ * @typedef ThemeStyle
+ * @type {object}
+ * @property {string} color
+ * @property {string} focusTextDecorColor
+ * @property {string} hoverTextDecorColor
+ * @property {string | number} fontWeight
+ */
+const THEME_STYLES = {
+  light: {
+    color: palette.blue.base,
+    focusTextDecorColor: palette.blue.base,
+    hoverTextDecorColor: palette.gray.light2,
+    fontWeight: 'inherit',
+  },
+  dark: {
+    color: palette.blue.light1,
+    focusTextDecorColor: palette.blue.light1,
+    hoverTextDecorColor: palette.gray.dark2,
+    fontWeight: 700,
+  },
+};
+
+/**
+ * CSS purloined from LG Link definition (source: https://bit.ly/3JpiPIt)
+ * @param {ThemeStyle} theme
+ */
+const gatsbyLinkStyling = (theme) => css`
   align-items: center;
   cursor: pointer;
   position: relative;
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: ${theme.color};
+  font-weight: ${theme.fontWeight};
 
   > code {
-    color: var(--color);
+    color: ${theme.color};
   }
 
   &:focus,
@@ -41,11 +68,11 @@ const gatsbyLinkStyling = css`
     text-decoration-thickness: 2px;
   }
   &:focus {
-    text-decoration-color: var(--focus-text-decoration-color);
+    text-decoration-color: ${theme.focusTextDecorColor};
     outline: none;
   }
   &:hover {
-    text-decoration-color: var(--hover-text-decoration-color);
+    text-decoration-color: ${theme.hoverTextDecorColor};
   }
 `;
 
@@ -72,6 +99,7 @@ const Link = ({
 
   const anchorProps = validateHTMAttributes('anchor', other);
   const { darkMode } = useDarkMode();
+  const theme = getTheme(darkMode);
 
   //used instead of LG showLinkArrow prop for consistency between LGLinks and GatsbyLinks(GatsbyLinks don't have that prop)
   const decoration = showLinkArrow ? (
@@ -94,13 +122,7 @@ const Link = ({
 
     return (
       <GatsbyLink
-        className={joinClassNames(gatsbyLinkStyling, className)}
-        style={{
-          '--color': darkMode ? palette.blue.light1 : palette.blue.base,
-          '--focus-text-decoration-color': darkMode ? palette.blue.light1 : palette.blue.base,
-          '--hover-text-decoration-color': darkMode ? palette.gray.dark2 : palette.gray.light2,
-          '--font-weight': darkMode ? 700 : 'inherit',
-        }}
+        className={cx(gatsbyLinkStyling(THEME_STYLES[theme]), className)}
         activeClassName={activeClassName}
         partiallyActive={partiallyActive}
         to={to}

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -321,12 +321,15 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  font-size: 13px;
+  vertical-align: middle;
+  line-height: unset;
 }
 
 .emotion-11>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-11:focus,
@@ -339,22 +342,16 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
 }
 
 .emotion-11:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-11:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
-.emotion-12 {
-  font-size: 13px;
-  vertical-align: middle;
-  line-height: unset;
-}
-
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-11:hover,
+.emotion-11:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -402,9 +399,8 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
       class="emotion-2"
     >
       <a
-        class="emotion-11 emotion-12"
+        class="emotion-11"
         href="/sdk/cpp/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
       >
         Atlas Device SDK for C++
       </a>
@@ -418,9 +414,8 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
       class="emotion-2"
     >
       <a
-        class="emotion-11 emotion-12"
+        class="emotion-11"
         href="/sdk/cpp/application-services/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
       >
         Application Services - C++ SDK
       </a>
@@ -734,12 +729,15 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  font-size: 13px;
+  vertical-align: middle;
+  line-height: unset;
 }
 
 .emotion-11>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-11:focus,
@@ -752,22 +750,16 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
 }
 
 .emotion-11:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-11:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
-.emotion-12 {
-  font-size: 13px;
-  vertical-align: middle;
-  line-height: unset;
-}
-
-.emotion-12:hover,
-.emotion-12:focus {
+.emotion-11:hover,
+.emotion-11:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -815,9 +807,8 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
       class="emotion-2"
     >
       <a
-        class="emotion-11 emotion-12"
+        class="emotion-11"
         href="/sdk/cpp/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
       >
         Atlas Device SDK for C++
       </a>
@@ -831,9 +822,8 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
       class="emotion-2"
     >
       <a
-        class="emotion-11 emotion-12"
+        class="emotion-11"
         href="/sdk/cpp/application-services/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
       >
         Application Services - C++ SDK
       </a>

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -267,12 +267,15 @@ exports[`renders correctly with siteTitle 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  font-size: 13px;
+  vertical-align: middle;
+  line-height: unset;
 }
 
 .emotion-12>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-12:focus,
@@ -285,40 +288,34 @@ exports[`renders correctly with siteTitle 1`] = `
 }
 
 .emotion-12:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-12:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
-.emotion-13 {
-  font-size: 13px;
-  vertical-align: middle;
-  line-height: unset;
-}
-
-.emotion-13:hover,
-.emotion-13:focus {
+.emotion-12:hover,
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-.emotion-16:first-child {
+.emotion-15:first-child {
   min-width: -webkit-max-content;
   min-width: -moz-max-content;
   min-width: max-content;
 }
 
 @media not all and (max-width: 480px) {
-  .emotion-16:last-child {
+  .emotion-15:last-child {
     min-width: -webkit-max-content;
     min-width: -moz-max-content;
     min-width: max-content;
@@ -371,9 +368,8 @@ exports[`renders correctly with siteTitle 1`] = `
         class="emotion-3"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-12"
           href="/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Atlas Device SDKs
         </a>
@@ -384,12 +380,11 @@ exports[`renders correctly with siteTitle 1`] = `
          / 
       </span>
       <div
-        class="emotion-16"
+        class="emotion-15"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-12"
           href="/sdk/cpp/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Atlas Device SDK for C++
         </a>
@@ -400,12 +395,11 @@ exports[`renders correctly with siteTitle 1`] = `
          / 
       </span>
       <div
-        class="emotion-16"
+        class="emotion-15"
       >
         <a
-          class="emotion-12 emotion-13"
+          class="emotion-12"
           href="/sdk/cpp/application-services/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Application Services - C++ SDK
         </a>

--- a/tests/unit/__snapshots__/Button.test.js.snap
+++ b/tests/unit/__snapshots__/Button.test.js.snap
@@ -13,70 +13,8 @@ exports[`button component renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-0>code {
-  color: var(--color);
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  position: relative;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-decoration-color: transparent;
-  line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-0>code {
-  color: var(--color);
-}
-
-.emotion-0:focus,
-.emotion-0:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-1 {
+  color: #016BF8;
+  font-weight: inherit;
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -111,46 +49,68 @@ exports[`button component renders correctly 1`] = `
   height: 36px;
 }
 
-.emotion-1:focus-visible,
-.emotion-1[data-focus="true"] {
+.emotion-0>code {
+  color: #016BF8;
+}
+
+.emotion-0:focus,
+.emotion-0:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-0:focus {
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-1:active,
-.emotion-1[data-active="true"],
-.emotion-1:focus,
-.emotion-1:hover {
+.emotion-0:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-0:focus-visible,
+.emotion-0[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-0:active,
+.emotion-0[data-active="true"],
+.emotion-0:focus,
+.emotion-0:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-1:focus-visible,
-.emotion-1[data-focus="true"] {
+.emotion-0:focus-visible,
+.emotion-0[data-focus="true"] {
   color: #FFFFFF;
 }
 
-.emotion-1:hover,
-.emotion-1[data-hover="true"],
-.emotion-1:active,
-.emotion-1[data-active="true"] {
+.emotion-0:hover,
+.emotion-0[data-hover="true"],
+.emotion-0:active,
+.emotion-0[data-active="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
   box-shadow: 0 0 0 3px #C0FAE6;
 }
 
-.emotion-1:focus-visible,
-.emotion-1[data-focus="true"] {
+.emotion-0:focus-visible,
+.emotion-0[data-focus="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
-.emotion-1.button {
+.emotion-0.button {
   color: #ffffff;
 }
 
-.emotion-2 {
+.emotion-1 {
   overflow: hidden;
   position: absolute;
   top: 0;
@@ -160,7 +120,7 @@ exports[`button component renders correctly 1`] = `
   border-radius: 5px;
 }
 
-.emotion-3 {
+.emotion-2 {
   display: grid;
   grid-auto-flow: column;
   -webkit-box-pack: center;
@@ -187,16 +147,15 @@ exports[`button component renders correctly 1`] = `
 
 <a
     aria-disabled="false"
-    class="emotion-0 lg-ui-button-0000 button emotion-1"
+    class="lg-ui-button-0000 button emotion-0"
     data-lgid="lg-button"
     href="/install/"
-    style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
   >
     <div
-      class="emotion-2"
+      class="emotion-1"
     />
     <div
-      class="emotion-3"
+      class="emotion-2"
     >
       Download Compass
     </div>

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -153,33 +153,8 @@ exports[`card correctly with and without url 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-8>code {
-  color: var(--color);
-}
-
-.emotion-8:focus,
-.emotion-8:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-8:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-8:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-9 {
+  color: #016BF8;
+  font-weight: inherit;
   background: #F9FBFA;
   border-radius: 4px;
   border: 1px solid #C1C7C6;
@@ -192,11 +167,33 @@ exports[`card correctly with and without url 1`] = `
   padding: 4px;
 }
 
-.emotion-9:after {
+.emotion-8>code {
+  color: #016BF8;
+}
+
+.emotion-8:focus,
+.emotion-8:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-8:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-8:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-8:after {
   content: ' ➔';
 }
 
-.emotion-20 {
+.emotion-14 {
   position: relative;
   -webkit-transition: 150ms ease-in-out;
   transition: 150ms ease-in-out;
@@ -231,27 +228,27 @@ exports[`card correctly with and without url 1`] = `
   padding: 32px 24px;
 }
 
-.emotion-20:focus {
+.emotion-14:focus {
   outline: none;
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 10px -4px rgba(0,30,43,0.3);
 }
 
-.emotion-20:hover,
-.emotion-20:active {
+.emotion-14:hover,
+.emotion-14:active {
   border: 1px solid #E8EDEB;
   box-shadow: 0 4px 20px -4px rgba(0,30,43,0.2);
 }
 
-.emotion-20:hover:focus,
-.emotion-20:active:focus {
+.emotion-14:hover:focus,
+.emotion-14:active:focus {
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 20px -4px rgba(0,30,43,0.2);
 }
 
-.emotion-20 p:last-of-type {
+.emotion-14 p:last-of-type {
   margin-bottom: 0;
 }
 
-.emotion-25 {
+.emotion-19 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -261,16 +258,16 @@ exports[`card correctly with and without url 1`] = `
   font-weight: 400;
 }
 
-.emotion-25 strong,
-.emotion-25 b {
+.emotion-19 strong,
+.emotion-19 b {
   font-weight: 700;
 }
 
-.emotion-25 a {
+.emotion-19 a {
   line-height: unset;
 }
 
-.emotion-26 {
+.emotion-20 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -300,8 +297,8 @@ exports[`card correctly with and without url 1`] = `
   display: inline;
 }
 
-.emotion-26:hover,
-.emotion-26:focus {
+.emotion-20:hover,
+.emotion-20:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
@@ -310,15 +307,15 @@ exports[`card correctly with and without url 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-26:focus {
+.emotion-20:focus {
   outline: none;
 }
 
-.emotion-26:hover {
+.emotion-20:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-26:focus {
+.emotion-20:focus {
   text-decoration-color: #016BF8;
 }
 
@@ -356,54 +353,48 @@ exports[`card correctly with and without url 1`] = `
             class="emotion-6"
           >
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/sdk/android/#std-label-android-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               Android
             </a>
             
 
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/sdk/ios/#std-label-ios-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               iOS
             </a>
             
 
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/sdk/dotnet/#std-label-dotnet-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               .Net
             </a>
             
 
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/web/#std-label-web-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               Web
             </a>
             
 
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/sdk/react-native/#std-label-react-native-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               React Native
             </a>
             
 
             <a
-              class="emotion-8 emotion-9"
+              class="emotion-8"
               href="/sdk/node/#std-label-node-intro"
-              style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
             >
               Node.js
             </a>
@@ -412,7 +403,7 @@ exports[`card correctly with and without url 1`] = `
       </div>
     </div>
     <div
-      class="emotion-20"
+      class="emotion-14"
     >
       <img
         class="
@@ -439,10 +430,10 @@ exports[`card correctly with and without url 1`] = `
             Discover how to sync data, define permissions, and connect to other services, including MongoDB Atlas.
           </p>
           <p
-            class="emotion-25"
+            class="emotion-19"
           >
             <a
-              class="lg-ui-0001 emotion-26"
+              class="lg-ui-0001 emotion-20"
               href="https://docs.mongodb.com/realm/services/"
               target="_self"
             >

--- a/tests/unit/__snapshots__/Chapter.test.js.snap
+++ b/tests/unit/__snapshots__/Chapter.test.js.snap
@@ -144,12 +144,12 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-12>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-12:focus,
@@ -162,12 +162,12 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-12:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-12:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 .emotion-13 {
@@ -247,7 +247,6 @@ exports[`renders correctly 1`] = `
         <a
           class="emotion-12 emotion-13 emotion-14"
           href="/cloud/account/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           <span>
             Create and Manage a MongoDB Account
@@ -261,7 +260,6 @@ exports[`renders correctly 1`] = `
         <a
           class="emotion-12 emotion-13 emotion-14"
           href="/cloud/connectionstring/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           <span>
             Set Up Atlas Connectivity
@@ -273,7 +271,6 @@ exports[`renders correctly 1`] = `
         <a
           class="emotion-12 emotion-13 emotion-14"
           href="/cloud/migrate-from-aws-to-atlas/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           <span>
             Migrate a MongoDB Replicate Set from AWS to MongoDB Atlas

--- a/tests/unit/__snapshots__/GuideNext.test.js.snap
+++ b/tests/unit/__snapshots__/GuideNext.test.js.snap
@@ -344,12 +344,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-26>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-26:focus,
@@ -362,12 +362,12 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
 }
 
 .emotion-26:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-26:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 .emotion-27 {
@@ -471,7 +471,6 @@ exports[`GuideNext renders the default copy on the final guide 1`] = `
           <a
             class="emotion-26 emotion-27 emotion-28"
             href="/server/read/"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             Read Data in MongoDB
           </a>
@@ -542,33 +541,8 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-8>code {
-  color: var(--color);
-}
-
-.emotion-8:focus,
-.emotion-8:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-8:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-8:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-9 {
+  color: #016BF8;
+  font-weight: inherit;
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -604,42 +578,64 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   color: #ffffff!important;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8>code {
+  color: #016BF8;
+}
+
+.emotion-8:focus,
+.emotion-8:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-8:focus {
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-9:active,
-.emotion-9[data-active="true"],
-.emotion-9:focus,
-.emotion-9:hover {
+.emotion-8:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-8:active,
+.emotion-8[data-active="true"],
+.emotion-8:focus,
+.emotion-8:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
   color: #FFFFFF;
 }
 
-.emotion-9:hover,
-.emotion-9[data-hover="true"],
-.emotion-9:active,
-.emotion-9[data-active="true"] {
+.emotion-8:hover,
+.emotion-8[data-hover="true"],
+.emotion-8:active,
+.emotion-8[data-active="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
   box-shadow: 0 0 0 3px #C0FAE6;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
-.emotion-10 {
+.emotion-9 {
   overflow: hidden;
   position: absolute;
   top: 0;
@@ -649,7 +645,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   border-radius: 5px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: grid;
   grid-auto-flow: column;
   -webkit-box-pack: center;
@@ -674,7 +670,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   gap: 6px;
 }
 
-.emotion-12 {
+.emotion-11 {
   position: relative;
   -webkit-transition: 150ms ease-in-out;
   transition: 150ms ease-in-out;
@@ -694,13 +690,13 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-12 {
+  .emotion-11 {
     padding: 48px;
   }
 }
 
 @media not all and (max-width: 1024px) {
-  .emotion-12 {
+  .emotion-11 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -714,12 +710,12 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   }
 }
 
-.emotion-13 {
+.emotion-12 {
   margin-bottom: 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-13 {
+  .emotion-12 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -729,7 +725,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-15 {
   background-color: #E3FCF7;
   border-radius: 4px;
   color: #001E2B;
@@ -742,17 +738,17 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-18 {
+.emotion-17 {
   color: #001E2B;
   font-weight: bold;
 }
 
-.emotion-20 {
+.emotion-19 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-22 {
+.emotion-21 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -766,11 +762,11 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   position: relative;
 }
 
-.emotion-22:not(:last-child) {
+.emotion-21:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-22:not(:last-child):before {
+.emotion-21:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -779,7 +775,7 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   border-left: solid 1px #E8EDEB;
 }
 
-.emotion-24 {
+.emotion-23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -799,18 +795,55 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
   min-height: 20px;
 }
 
-.emotion-26 {
+.emotion-25 {
   color: #00A35C;
 }
 
-.emotion-28 {
+.emotion-26 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-decoration-color: transparent;
+  line-height: 13px;
+  color: #016BF8;
+  font-weight: inherit;
+}
+
+.emotion-26>code {
+  color: #016BF8;
+}
+
+.emotion-26:focus,
+.emotion-26:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-26:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-26:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-27 {
   color: #001E2B;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-28:hover,
-.emotion-28:active {
+.emotion-27:hover,
+.emotion-27:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -835,52 +868,51 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
       </div>
       <a
         aria-disabled="false"
-        class="emotion-8 lg-ui-button-0000 emotion-9"
+        class="lg-ui-button-0000 emotion-8"
         data-lgid="lg-button"
         href="/server/read/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         type="button"
       >
         <div
-          class="emotion-10"
+          class="emotion-9"
         />
         <div
-          class="emotion-11"
+          class="emotion-10"
         >
           Start Guide
         </div>
       </a>
     </div>
     <div
-      class="emotion-12"
+      class="emotion-11"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-12 emotion-13"
       >
         <div
-          class="emotion-15 emotion-16 emotion-17"
+          class="emotion-14 emotion-15 emotion-16"
         >
           Chapter 2
         </div>
         <div
-          class="emotion-18 emotion-19"
+          class="emotion-17 emotion-18"
         >
           CRUD
         </div>
       </div>
       <ul
-        class="emotion-20 emotion-21"
+        class="emotion-19 emotion-20"
       >
         <li
-          class="emotion-22 emotion-23"
+          class="emotion-21 emotion-22"
           color="#E8EDEB"
         >
           <div
-            class="emotion-24 emotion-25"
+            class="emotion-23 emotion-24"
             color="#00A35C"
           >
             <svg
-              class="emotion-26"
+              class="emotion-25"
               fill="currentColor"
               height="12"
               viewBox="0 0 7 12"
@@ -893,9 +925,8 @@ exports[`GuideNext renders the first guide in the next chapter 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-8 emotion-28 emotion-29"
+            class="emotion-26 emotion-27 emotion-28"
             href="/server/read/"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             Read Data in MongoDB
           </a>
@@ -966,33 +997,8 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-8>code {
-  color: var(--color);
-}
-
-.emotion-8:focus,
-.emotion-8:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-8:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-8:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-9 {
+  color: #016BF8;
+  font-weight: inherit;
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -1028,42 +1034,64 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   color: #ffffff!important;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8>code {
+  color: #016BF8;
+}
+
+.emotion-8:focus,
+.emotion-8:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-8:focus {
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-9:active,
-.emotion-9[data-active="true"],
-.emotion-9:focus,
-.emotion-9:hover {
+.emotion-8:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-8:active,
+.emotion-8[data-active="true"],
+.emotion-8:focus,
+.emotion-8:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
   color: #FFFFFF;
 }
 
-.emotion-9:hover,
-.emotion-9[data-hover="true"],
-.emotion-9:active,
-.emotion-9[data-active="true"] {
+.emotion-8:hover,
+.emotion-8[data-hover="true"],
+.emotion-8:active,
+.emotion-8[data-active="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   border-color: #00593f;
   box-shadow: 0 0 0 3px #C0FAE6;
 }
 
-.emotion-9:focus-visible,
-.emotion-9[data-focus="true"] {
+.emotion-8:focus-visible,
+.emotion-8[data-focus="true"] {
   color: #FFFFFF;
   background-color: #00593f;
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
 }
 
-.emotion-10 {
+.emotion-9 {
   overflow: hidden;
   position: absolute;
   top: 0;
@@ -1073,7 +1101,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   border-radius: 5px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: grid;
   grid-auto-flow: column;
   -webkit-box-pack: center;
@@ -1098,7 +1126,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   gap: 6px;
 }
 
-.emotion-12 {
+.emotion-11 {
   position: relative;
   -webkit-transition: 150ms ease-in-out;
   transition: 150ms ease-in-out;
@@ -1118,13 +1146,13 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-12 {
+  .emotion-11 {
     padding: 48px;
   }
 }
 
 @media not all and (max-width: 1024px) {
-  .emotion-12 {
+  .emotion-11 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -1138,12 +1166,12 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   }
 }
 
-.emotion-13 {
+.emotion-12 {
   margin-bottom: 24px;
 }
 
 @media not all and (max-width: 767px) {
-  .emotion-13 {
+  .emotion-12 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1153,7 +1181,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-15 {
   background-color: #E3FCF7;
   border-radius: 4px;
   color: #001E2B;
@@ -1166,17 +1194,17 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   margin-bottom: 8px;
 }
 
-.emotion-18 {
+.emotion-17 {
   color: #001E2B;
   font-weight: bold;
 }
 
-.emotion-20 {
+.emotion-19 {
   list-style: none;
   padding-left: 0;
 }
 
-.emotion-22 {
+.emotion-21 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1190,11 +1218,11 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   position: relative;
 }
 
-.emotion-22:not(:last-child) {
+.emotion-21:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-22:not(:last-child):before {
+.emotion-21:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -1203,7 +1231,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   border-left: solid 1px #00A35C;
 }
 
-.emotion-24 {
+.emotion-23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1223,24 +1251,61 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   min-height: 20px;
 }
 
-.emotion-26 {
+.emotion-25 {
   color: #00A35C;
 }
 
-.emotion-28 {
+.emotion-26 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-decoration-color: transparent;
+  line-height: 13px;
+  color: #016BF8;
+  font-weight: inherit;
+}
+
+.emotion-26>code {
+  color: #016BF8;
+}
+
+.emotion-26:focus,
+.emotion-26:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-26:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-26:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-27 {
   color: #001E2B;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-28:hover,
-.emotion-28:active {
+.emotion-27:hover,
+.emotion-27:active {
   color: currentColor;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-30 {
+.emotion-29 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1254,11 +1319,11 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   position: relative;
 }
 
-.emotion-30:not(:last-child) {
+.emotion-29:not(:last-child) {
   padding-bottom: 16px;
 }
 
-.emotion-30:not(:last-child):before {
+.emotion-29:not(:last-child):before {
   content: '';
   position: absolute;
   left: 10px;
@@ -1267,7 +1332,7 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   border-left: solid 1px #E8EDEB;
 }
 
-.emotion-32 {
+.emotion-31 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1287,11 +1352,11 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
   min-height: 20px;
 }
 
-.emotion-34 {
+.emotion-33 {
   color: #00A35C;
 }
 
-.emotion-42 {
+.emotion-41 {
   color: #3D4F58;
 }
 
@@ -1314,53 +1379,52 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
       </div>
       <a
         aria-disabled="false"
-        class="emotion-8 lg-ui-button-0000 emotion-9"
+        class="lg-ui-button-0000 emotion-8"
         data-lgid="lg-button"
         href="/cloud/connectionstring/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         type="button"
       >
         <div
-          class="emotion-10"
+          class="emotion-9"
         />
         <div
-          class="emotion-11"
+          class="emotion-10"
         >
           Start Guide
         </div>
       </a>
     </div>
     <div
-      class="emotion-12"
+      class="emotion-11"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-12 emotion-13"
       >
         <div
-          class="emotion-15 emotion-16 emotion-17"
+          class="emotion-14 emotion-15 emotion-16"
         >
           Chapter 1
         </div>
         <div
-          class="emotion-18 emotion-19"
+          class="emotion-17 emotion-18"
         >
           Atlas
         </div>
       </div>
       <ul
-        class="emotion-20 emotion-21"
+        class="emotion-19 emotion-20"
       >
         <li
-          class="emotion-22 emotion-23"
+          class="emotion-21 emotion-22"
           color="#00A35C"
         >
           <div
-            class="emotion-24 emotion-25"
+            class="emotion-23 emotion-24"
             color="transparent"
           >
             <svg
               aria-label="Checkmark Icon"
-              class="emotion-26"
+              class="emotion-25"
               fill="none"
               height="16"
               role="img"
@@ -1377,23 +1441,22 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-8 emotion-28 emotion-29"
+            class="emotion-26 emotion-27 emotion-28"
             href="/cloud/account/"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             Create and Manage a MongoDB Account
           </a>
         </li>
         <li
-          class="emotion-30 emotion-23"
+          class="emotion-29 emotion-22"
           color="#E8EDEB"
         >
           <div
-            class="emotion-32 emotion-25"
+            class="emotion-31 emotion-24"
             color="#00A35C"
           >
             <svg
-              class="emotion-34"
+              class="emotion-33"
               fill="currentColor"
               height="12"
               viewBox="0 0 7 12"
@@ -1406,23 +1469,22 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-8 emotion-28 emotion-29"
+            class="emotion-26 emotion-27 emotion-28"
             href="/cloud/connectionstring/"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             Set Up Atlas Connectivity
           </a>
         </li>
         <li
-          class="emotion-30 emotion-23"
+          class="emotion-29 emotion-22"
           color="#E8EDEB"
         >
           <div
-            class="emotion-24 emotion-25"
+            class="emotion-23 emotion-24"
             color="transparent"
           >
             <svg
-              class="emotion-42"
+              class="emotion-41"
               fill="currentColor"
               height="12"
               viewBox="0 0 7 12"
@@ -1435,9 +1497,8 @@ exports[`GuideNext renders the next guide in the same chapter 1`] = `
             </svg>
           </div>
           <a
-            class="emotion-8 emotion-28 emotion-29"
+            class="emotion-26 emotion-27 emotion-28"
             href="/cloud/migrate-from-aws-to-atlas/"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             Migrate a MongoDB Replicate Set from AWS to MongoDB Atlas
           </a>

--- a/tests/unit/__snapshots__/GuidesLandingTree.test.js.snap
+++ b/tests/unit/__snapshots__/GuidesLandingTree.test.js.snap
@@ -18,33 +18,8 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-1>code {
-  color: var(--color);
-}
-
-.emotion-1:focus,
-.emotion-1:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-1:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-1:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-2 {
+  color: #016BF8;
+  font-weight: inherit;
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -92,23 +67,45 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
 }
 
-.emotion-2:hover {
+.emotion-1>code {
+  color: #016BF8;
+}
+
+.emotion-1:focus,
+.emotion-1:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-1:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-1:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-1:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-2::-moz-focus-inner {
+.emotion-1::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -125,44 +122,44 @@ exports[`renders correctly 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-2:hover {
+.emotion-1:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-2,
-.emotion-2:hover {
+.emotion-1,
+.emotion-1:hover {
   background-color: #E3FCF7;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   background-color: #00A35C;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   background-color: #016BF8;
 }
 
@@ -172,9 +169,8 @@ exports[`renders correctly 1`] = `
     <a
       aria-current="page"
       aria-disabled="false"
-      class="emotion-1 lg-ui-side-nav-item-0000 emotion-2"
+      class="lg-ui-side-nav-item-0000 emotion-1"
       href="/"
-      style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
     >
       Overview
     </a>
@@ -195,33 +191,8 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-1>code {
-  color: var(--color);
-}
-
-.emotion-1:focus,
-.emotion-1:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-1:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-1:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-2 {
+  color: #016BF8;
+  font-weight: inherit;
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -264,23 +235,45 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
 }
 
-.emotion-2:hover {
+.emotion-1>code {
+  color: #016BF8;
+}
+
+.emotion-1:focus,
+.emotion-1:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-1:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-1:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-1:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-2::-moz-focus-inner {
+.emotion-1::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -297,28 +290,28 @@ exports[`renders correctly 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-2:hover {
+.emotion-1:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   background-color: #016BF8;
 }
 
@@ -328,9 +321,8 @@ exports[`renders correctly 1`] = `
     <a
       aria-current="false"
       aria-disabled="false"
-      class="emotion-1 lg-ui-side-nav-item-0000 emotion-2"
+      class="lg-ui-side-nav-item-0000 emotion-1"
       href="/cloud/account/"
-      style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
     >
       Atlas
     </a>
@@ -351,33 +343,8 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-1>code {
-  color: var(--color);
-}
-
-.emotion-1:focus,
-.emotion-1:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-1:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-1:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-2 {
+  color: #016BF8;
+  font-weight: inherit;
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -420,23 +387,45 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
 }
 
-.emotion-2:hover {
+.emotion-1>code {
+  color: #016BF8;
+}
+
+.emotion-1:focus,
+.emotion-1:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-1:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-1:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-1:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-2::-moz-focus-inner {
+.emotion-1::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -453,28 +442,28 @@ exports[`renders correctly 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-2:hover {
+.emotion-1:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-2:focus {
+.emotion-1:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-2:focus:before {
+.emotion-1:focus:before {
   background-color: #016BF8;
 }
 
@@ -484,9 +473,8 @@ exports[`renders correctly 1`] = `
     <a
       aria-current="false"
       aria-disabled="false"
-      class="emotion-1 lg-ui-side-nav-item-0000 emotion-2"
+      class="lg-ui-side-nav-item-0000 emotion-1"
       href="/server/read/"
-      style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
     >
       CRUD
     </a>

--- a/tests/unit/__snapshots__/IA.test.js.snap
+++ b/tests/unit/__snapshots__/IA.test.js.snap
@@ -240,33 +240,8 @@ exports[`renders a page IA with IA linked data 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-10>code {
-  color: var(--color);
-}
-
-.emotion-10:focus,
-.emotion-10:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-10:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-10:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-11 {
+  color: #016BF8;
+  font-weight: inherit;
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -309,23 +284,45 @@ exports[`renders a page IA with IA linked data 1`] = `
   line-height: 20px;
 }
 
-.emotion-11:hover {
+.emotion-10>code {
+  color: #016BF8;
+}
+
+.emotion-10:focus,
+.emotion-10:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-10:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-10:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-10:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-11:before {
+.emotion-10:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -342,32 +339,32 @@ exports[`renders a page IA with IA linked data 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus:before {
+.emotion-10:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-11:focus:before {
+.emotion-10:focus:before {
   background-color: #016BF8;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: grid;
   -webkit-column-gap: 8px;
   column-gap: 8px;
@@ -379,7 +376,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   padding: 8px;
 }
 
-.emotion-16 {
+.emotion-15 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -447,8 +444,8 @@ exports[`renders a page IA with IA linked data 1`] = `
   height: 32px;
 }
 
-.emotion-16:hover,
-.emotion-16:focus {
+.emotion-15:hover,
+.emotion-15:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
@@ -457,35 +454,35 @@ exports[`renders a page IA with IA linked data 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   outline: none;
 }
 
-.emotion-16:hover {
+.emotion-15:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   text-decoration-color: #016BF8;
 }
 
-.emotion-16:hover {
+.emotion-15:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-16::-moz-focus-inner {
+.emotion-15::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-16:before {
+.emotion-15:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -502,44 +499,44 @@ exports[`renders a page IA with IA linked data 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-16:hover {
+.emotion-15:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-16:focus:before {
+.emotion-15:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-16:focus:before {
+.emotion-15:focus:before {
   background-color: #016BF8;
 }
 
-.emotion-16:focus {
+.emotion-15:focus {
   border: 1px solid #0498EC;
 }
 
-.emotion-16:focus:focus:before {
+.emotion-15:focus:focus:before {
   display: none;
 }
 
-.emotion-16:focus>span>span {
+.emotion-15:focus>span>span {
   position: relative;
 }
 
-.emotion-16:focus>span>span::after {
+.emotion-15:focus>span>span::after {
   content: '';
   position: absolute;
   width: 100%;
@@ -550,7 +547,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   background-color: #0498EC;
 }
 
-.emotion-16>span {
+.emotion-15>span {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -562,7 +559,7 @@ exports[`renders a page IA with IA linked data 1`] = `
   gap: 8px;
 }
 
-.emotion-16>span:after {
+.emotion-15>span:after {
   display: none;
 }
 
@@ -622,9 +619,8 @@ exports[`renders a page IA with IA linked data 1`] = `
         <a
           aria-current="false"
           aria-disabled="false"
-          class="emotion-10 lg-ui-side-nav-item-0000 emotion-11"
+          class="lg-ui-side-nav-item-0000 emotion-10"
           href="/tools-and-connectors/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Tools and Connectors
         </a>
@@ -645,7 +641,7 @@ exports[`renders a page IA with IA linked data 1`] = `
         </a>
       </li>
       <ul
-        class="emotion-14"
+        class="emotion-13"
       >
         <li
           class="emotion-5"
@@ -653,7 +649,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/c/"
             target="_self"
           >
@@ -676,7 +672,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/cxx/"
             target="_self"
           >
@@ -699,7 +695,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/csharp/current/"
             target="_self"
           >
@@ -722,7 +718,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/go/current/"
             target="_self"
           >
@@ -745,7 +741,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/java-drivers/"
             target="_self"
           >
@@ -768,7 +764,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/kotlin-drivers/"
             target="_self"
           >
@@ -791,7 +787,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/node/current/"
             target="_self"
           >
@@ -814,7 +810,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/php/"
             target="_self"
           >
@@ -837,7 +833,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/python/"
             target="_self"
           >
@@ -860,7 +856,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/ruby/"
             target="_self"
           >
@@ -883,7 +879,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/rust/"
             target="_self"
           >
@@ -906,7 +902,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/scala/"
             target="_self"
           >
@@ -929,7 +925,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/swift/"
             target="_self"
           >
@@ -952,7 +948,7 @@ exports[`renders a page IA with IA linked data 1`] = `
           <a
             aria-current="false"
             aria-disabled="false"
-            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-16"
+            class="lg-ui-0001 lg-ui-side-nav-item-0000 emotion-15"
             href="https://www.mongodb.com/docs/drivers/typescript/"
             target="_self"
           >
@@ -1215,33 +1211,8 @@ exports[`renders a simple page IA correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
-}
-
-.emotion-10>code {
-  color: var(--color);
-}
-
-.emotion-10:focus,
-.emotion-10:hover {
-  text-decoration-line: underline;
-  -webkit-transition: text-decoration 150ms ease-in-out;
-  transition: text-decoration 150ms ease-in-out;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 2px;
-}
-
-.emotion-10:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
-  outline: none;
-}
-
-.emotion-10:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-11 {
+  color: #016BF8;
+  font-weight: inherit;
   margin: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -1284,23 +1255,45 @@ exports[`renders a simple page IA correctly 1`] = `
   line-height: 20px;
 }
 
-.emotion-11:hover {
+.emotion-10>code {
+  color: #016BF8;
+}
+
+.emotion-10:focus,
+.emotion-10:hover {
+  text-decoration-line: underline;
+  -webkit-transition: text-decoration 150ms ease-in-out;
+  transition: text-decoration 150ms ease-in-out;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-10:focus {
+  text-decoration-color: #016BF8;
+  outline: none;
+}
+
+.emotion-10:hover {
+  text-decoration-color: #E8EDEB;
+}
+
+.emotion-10:hover {
   background-color: #E8EDEB;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-11:before {
+.emotion-10:before {
   content: '';
   position: absolute;
   background-color: transparent;
@@ -1317,28 +1310,28 @@ exports[`renders a simple page IA correctly 1`] = `
   transform: scaleY(0.3);
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: #E8EDEB;
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-11:focus:before {
+.emotion-10:focus:before {
   -webkit-transform: scaleY(1);
   -moz-transform: scaleY(1);
   -ms-transform: scaleY(1);
   transform: scaleY(1);
 }
 
-.emotion-11:focus {
+.emotion-10:focus {
   color: #083C90;
   background-color: #E1F7FF;
 }
 
-.emotion-11:focus:before {
+.emotion-10:focus:before {
   background-color: #016BF8;
 }
 
@@ -1398,9 +1391,8 @@ exports[`renders a simple page IA correctly 1`] = `
         <a
           aria-current="false"
           aria-disabled="false"
-          class="emotion-10 lg-ui-side-nav-item-0000 emotion-11"
+          class="lg-ui-side-nav-item-0000 emotion-10"
           href="/tools-and-connectors/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Tools and Connectors
         </a>

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -51,12 +51,14 @@ exports[`renders a page with next and previous links correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  line-height: 28px;
+  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
 .emotion-5>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-5:focus,
@@ -69,17 +71,12 @@ exports[`renders a page with next and previous links correctly 1`] = `
 }
 
 .emotion-5:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-5:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-6 {
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -95,9 +92,8 @@ exports[`renders a page with next and previous links correctly 1`] = `
         ← 
       </span>
       <a
-        class="emotion-5 emotion-6"
+        class="emotion-5"
         href="/drivers/csharp/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         title="Previous Section"
       >
         MongoDB C#/.NET Driver
@@ -107,9 +103,8 @@ exports[`renders a page with next and previous links correctly 1`] = `
       class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-5 emotion-6"
+        class="emotion-5"
         href="/drivers/java/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         title="Next Section"
       >
         Java MongoDB Driver
@@ -175,12 +170,14 @@ exports[`renders a page with no next link correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  line-height: 28px;
+  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
 .emotion-5>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-5:focus,
@@ -193,17 +190,12 @@ exports[`renders a page with no next link correctly 1`] = `
 }
 
 .emotion-5:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-5:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
-}
-
-.emotion-6 {
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -219,9 +211,8 @@ exports[`renders a page with no next link correctly 1`] = `
         ← 
       </span>
       <a
-        class="emotion-5 emotion-6"
+        class="emotion-5"
         href="/drivers/go/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         title="Previous Section"
       >
         MongoDB Go Driver
@@ -274,12 +265,14 @@ exports[`renders a page with no previous link correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
+  line-height: 28px;
+  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
 .emotion-4>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-4:focus,
@@ -292,20 +285,15 @@ exports[`renders a page with no previous link correctly 1`] = `
 }
 
 .emotion-4:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-4:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 .emotion-5 {
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
-}
-
-.emotion-6 {
   line-height: 28px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -321,15 +309,14 @@ exports[`renders a page with no previous link correctly 1`] = `
       class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-4 emotion-5"
+        class="emotion-4"
         href="/drivers/go/"
-        style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         title="Next Section"
       >
         MongoDB Go Driver
       </a>
       <span
-        class="emotion-6"
+        class="emotion-5"
       >
          →
       </span>

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -502,12 +502,12 @@ exports[`Link component renders a variety of strings correctly internal link 1`]
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-0>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-0:focus,
@@ -520,18 +520,17 @@ exports[`Link component renders a variety of strings correctly internal link 1`]
 }
 
 .emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <a
     class="emotion-0 test-class"
     href="/drivers/c/"
-    style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
   >
     C Driver
   </a>
@@ -551,12 +550,12 @@ exports[`Link component renders a variety of strings correctly internal link que
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-0>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-0:focus,
@@ -569,18 +568,17 @@ exports[`Link component renders a variety of strings correctly internal link que
 }
 
 .emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <a
     class="emotion-0 test-class"
     href="/drivers/ruby/?site=drivers"
-    style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
   >
     C Driver
   </a>
@@ -600,12 +598,12 @@ exports[`Link component renders a variety of strings correctly internal link tha
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-0>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-0:focus,
@@ -618,18 +616,17 @@ exports[`Link component renders a variety of strings correctly internal link tha
 }
 
 .emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <a
     class="emotion-0 test-class"
     href="/drivers/nodejs/#installation"
-    style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
   >
     C Driver
   </a>
@@ -649,12 +646,12 @@ exports[`Link component renders a variety of strings correctly internal link wit
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-0>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-0:focus,
@@ -667,18 +664,17 @@ exports[`Link component renders a variety of strings correctly internal link wit
 }
 
 .emotion-0:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-0:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <a
     class="emotion-0 test-class"
     href="/drivers/pymongo/#installation"
-    style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
   >
     C Driver
   </a>

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -115,12 +115,12 @@ exports[`renders correctly 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-11>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-11:focus,
@@ -133,12 +133,12 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-11:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-11:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -173,7 +173,6 @@ exports[`renders correctly 1`] = `
           <a
             class="emotion-11"
             href="/connect/#std-label-connect-run-compass"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             To learn more, see Connect to MongoDB
           </a>
@@ -208,7 +207,6 @@ exports[`renders correctly 1`] = `
           <a
             class="emotion-11"
             href="/import-export/#std-label-compass-import-export"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             To learn more, see Import and Export Data
           </a>
@@ -867,12 +865,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-11>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-11:focus,
@@ -885,12 +883,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 }
 
 .emotion-11:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-11:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -924,7 +922,6 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
           <a
             class="emotion-11"
             href="/connect/#std-label-connect-run-compass"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             To learn more, see Connect to MongoDB
           </a>
@@ -958,7 +955,6 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
           <a
             class="emotion-11"
             href="/import-export/#std-label-compass-import-export"
-            style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
           >
             To learn more, see Import and Export Data
           </a>

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -97,12 +97,12 @@ exports[`renders with "connected" styling 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-9>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-9:focus,
@@ -115,12 +115,12 @@ exports[`renders with "connected" styling 1`] = `
 }
 
 .emotion-9:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-9:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -151,7 +151,6 @@ exports[`renders with "connected" styling 1`] = `
         <a
           class="emotion-9"
           href="/import-export/#std-label-compass-import-export"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           To learn more, see Import and Export Data
         </a>
@@ -258,12 +257,12 @@ exports[`renders with "connected" styling by default 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-9>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-9:focus,
@@ -276,12 +275,12 @@ exports[`renders with "connected" styling by default 1`] = `
 }
 
 .emotion-9:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-9:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -312,7 +311,6 @@ exports[`renders with "connected" styling by default 1`] = `
         <a
           class="emotion-9"
           href="/import-export/#std-label-compass-import-export"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           To learn more, see Import and Export Data
         </a>
@@ -390,12 +388,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-9>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-9:focus,
@@ -408,12 +406,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 }
 
 .emotion-9:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-9:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <div
@@ -443,7 +441,6 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
         <a
           class="emotion-9"
           href="/import-export/#std-label-compass-import-export"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           To learn more, see Import and Export Data
         </a>

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -85,12 +85,12 @@ a .emotion-0 {
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  color: var(--color);
-  font-weight: var(--font-weight);
+  color: #016BF8;
+  font-weight: inherit;
 }
 
 .emotion-6>code {
-  color: var(--color);
+  color: #016BF8;
 }
 
 .emotion-6:focus,
@@ -103,12 +103,12 @@ a .emotion-0 {
 }
 
 .emotion-6:focus {
-  text-decoration-color: var(--focus-text-decoration-color);
+  text-decoration-color: #016BF8;
   outline: none;
 }
 
 .emotion-6:hover {
-  text-decoration-color: var(--hover-text-decoration-color);
+  text-decoration-color: #E8EDEB;
 }
 
 <dl
@@ -160,7 +160,6 @@ configuration file is the preferred method for runtime configuration of
         <a
           class="emotion-6"
           href="/reference/program/mongos/#std-program-mongos"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           <code
             class="emotion-0"
@@ -173,7 +172,6 @@ configuration options. See
         <a
           class="emotion-6"
           href="/reference/configuration-options/"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           Configuration File Options
         </a>
@@ -187,7 +185,6 @@ more information.
         <a
           class="emotion-6"
           href="/reference/program/mongos/#std-program-mongos"
-          style="--color: #016BF8; --focus-text-decoration-color: #016BF8; --hover-text-decoration-color: #E8EDEB; --font-weight: inherit;"
         >
           <code
             class="emotion-0"


### PR DESCRIPTION
### Stories/Links:

DOP-4782

### Current Behavior:

[Prod](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/main/tutorial/create-atlas-account/index.html) - main branch

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4782/index.html) - PLP
[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4782/tutorial/create-atlas-account/index.html) - Docs page

### Notes:

This change touches the Link component only to: 
* Help sus out if Smartling resolves a lot of the strings marked for translation. A lot of the strings (that I saw) Smartling flagged for translation included anchor tags. This would make sense since inline elements like anchor tags are part of a content string.
* Determine if this pattern is acceptable for organize dark vs. light mode styling. Declaring CSS vars in a `css` string and putting it through `cx` like `cx(darkMode ? darkModeVars : lightModeVars)` will trigger changes in the class name hash anyways. I'm not strictly married to the pattern introduced in this PR, so I'm okay with redeclaring things as CSS vars if that's the direction most preferred.

Next steps:
* Merge as part of upcoming frontend release.
* Redeploy all production-ready sites (avoid sites like railsmdb, which probably isn't ready for prod deploy)
* Confirm with Smartling team if that resolves the issue with `style` attributes or if we need to apply to more/all of our components.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
