### PR TITLE
:art: DOP-4635 using static css approach

### DIFF
--- a/src/components/Footnote/index.js
+++ b/src/components/Footnote/index.js
@@ -22,12 +22,12 @@ const tableStyling = (darkMode) => css`
   ${darkMode &&
   `
       tbody tr td a {
-        color: var(--color);
+        color: ${palette.blue.light1};
       }
     `}
 
   :target {
-    background-color: var(--background-color);
+    background-color: ${darkMode ? palette.gray.dark2 : '#ffa'};
   }
 `;
 
@@ -49,25 +49,8 @@ const Footnote = ({ nodeData: { children, id, name }, ...rest }) => {
     </a>
   ));
 
-  let footnoteDynamicStyles = {
-    '--background-color': '#ffa',
-  };
-
-  if (darkMode) {
-    footnoteDynamicStyles = {
-      '--background-color': palette.gray.dark2,
-      '--color': palette.blue.light1,
-    };
-  }
   return (
-    <table
-      className="header-buffer"
-      css={tableStyling(darkMode)}
-      style={footnoteDynamicStyles}
-      frame="void"
-      id={`footnote-${ref}`}
-      rules="none"
-    >
+    <table className="header-buffer" css={tableStyling(darkMode)} frame="void" id={`footnote-${ref}`} rules="none">
       <colgroup>
         <col />
       </colgroup>

--- a/src/components/Footnote/index.js
+++ b/src/components/Footnote/index.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
-import { css } from '@emotion/react';
+import { css, cx } from '@leafygreen-ui/emotion';
 import ComponentFactory from '../ComponentFactory';
 import { getNestedValue } from '../../utils/get-nested-value';
 import { intersperse } from '../../utils/intersperse';
@@ -50,17 +50,17 @@ const Footnote = ({ nodeData: { children, id, name }, ...rest }) => {
   ));
 
   return (
-    <table className="header-buffer" css={tableStyling(darkMode)} frame="void" id={`footnote-${ref}`} rules="none">
+    <table className={cx('header-buffer', tableStyling(darkMode))} frame="void" id={`footnote-${ref}`} rules="none">
       <colgroup>
         <col />
       </colgroup>
       <tbody valign="top">
         <tr>
-          <td css={tdStyling}>
+          <td className={cx(tdStyling)}>
             [{footnoteReferenceNodes.length !== 1 ? label : <a href={`#ref-${uid}${footnoteReferences[0]}`}>{label}</a>}
             ]
           </td>
-          <td css={tdStyling}>
+          <td className={cx(tdStyling)}>
             {footnoteReferenceNodes.length > 1 && <em>({intersperse(footnoteReferenceNodes)})</em>}{' '}
             {children.map((child, index) => (
               <ComponentFactory {...rest} nodeData={child} key={index} parentNode="footnote" />

--- a/tests/unit/__snapshots__/Footnote.test.js.snap
+++ b/tests/unit/__snapshots__/Footnote.test.js.snap
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-0:target {
-  background-color: var(--background-color);
+  background-color: #ffa;
 }
 
 .emotion-1 {
@@ -28,7 +28,6 @@ exports[`renders correctly 1`] = `
     frame="void"
     id="footnote-1"
     rules="none"
-    style="--background-color: #ffa;"
   >
     <colgroup>
       <col />


### PR DESCRIPTION
### Stories/Links:

DOP-4635

### Current Behavior:

[Previous Staged: Docs Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/caesarbell/DOP-4635/tutorial/install-mongodb-enterprise-on-red-hat-tarball/index.html#footnote-oracle-linux)

### Staging Links:

[New Staged without Style Prop: Docs Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/caesarbell/DOP-4635-ClassName/tutorial/install-mongodb-enterprise-on-red-hat-tarball/index.html#platform-support)

### Notes:

- Same styles applied, but now using only `classnames` rather than using the style props. 

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
