### PR TITLE
:art: DOP-4760 sets the letter-spacing for p and a tags within the landing template

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -87,7 +87,7 @@ const compactIconStyle = `
 
 const headingStyling = ({ isCompact, isExtraCompact, isLargeIconStyle }) => css`
   font-weight: 500;
-  letter-spacing: 0;
+  letter-spacing: normal;
   margin: ${isCompact || isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
   ${isLargeIconStyle && 'margin-bottom: 36px;'}
 `;

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -87,7 +87,7 @@ const compactIconStyle = `
 
 const headingStyling = ({ isCompact, isExtraCompact, isLargeIconStyle }) => css`
   font-weight: 500;
-  letter-spacing: 0.5px;
+  letter-spacing: 0;
   margin: ${isCompact || isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
   ${isLargeIconStyle && 'margin-bottom: 36px;'}
 `;

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -81,13 +81,13 @@ const Landing = ({ children, pageContext, useChatbot }) => {
           p {
             color: ${palette.black};
             font-size: ${fontSize.small};
-            letter-spacing: 0.5px;
+            letter-spacing: 0;
             margin-bottom: ${size.default};
           }
           a {
             color: ${palette.blue.base};
             font-size: ${fontSize.small};
-            letter-spacing: 0.5px;
+            letter-spacing: 0;
           }
           a:hover {
             text-decoration: none;

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -81,13 +81,13 @@ const Landing = ({ children, pageContext, useChatbot }) => {
           p {
             color: ${palette.black};
             font-size: ${fontSize.small};
-            letter-spacing: 0;
+            letter-spacing: normal;
             margin-bottom: ${size.default};
           }
           a {
             color: ${palette.blue.base};
             font-size: ${fontSize.small};
-            letter-spacing: 0;
+            letter-spacing: normal;
           }
           a:hover {
             text-decoration: none;

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -83,7 +83,7 @@ exports[`renders correctly 1`] = `
   color: #001E2B;
   font-weight: 500;
   font-weight: 500;
-  letter-spacing: 0.5px;
+  letter-spacing: normal;
   margin: 16px 0 8px 0;
 }
 

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -117,7 +117,7 @@ exports[`card correctly with and without url 1`] = `
   color: #001E2B;
   font-weight: 500;
   font-weight: 500;
-  letter-spacing: 0.5px;
+  letter-spacing: normal;
   margin: 0 0 8px;
 }
 


### PR DESCRIPTION
### Stories/Links:

DOP-4760

### Current Behavior:

[Docs Landing](https://www.mongodb.com/docs/)

### Staging Links:

[Staged Docs Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/caesarbell/DOP-4760/index.html)

### Notes:

- Sets the `letter-spacing` to `0` from `0.5px` for `<p>` and `<a>` tags on the landing template.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
