### PR TITLE
Fix package.json to be current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snooty",
-  "version": "0.16.17",
+  "version": "0.16.20",
   "repository": "github:mongodb/snooty",
   "engines": {
     "node": "^18",


### PR DESCRIPTION
## Context

Snooty version is 0.16.20 but package.json is 0.16.17

Fixing before next release.
