### PR TITLE
Revert "DOP-4761: update LG/tabs to v12 to render content in HTML"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@leafygreen-ui/side-nav": "^14.1.3",
         "@leafygreen-ui/skeleton-loader": "^1.2.0",
         "@leafygreen-ui/table": "^6.1.0",
-        "@leafygreen-ui/tabs": "^12.0.1",
+        "@leafygreen-ui/tabs": "^11.2.0",
         "@leafygreen-ui/text-area": "^6.1.0",
         "@leafygreen-ui/text-input": "^10.1.0",
         "@leafygreen-ui/toast": "^6.1.4",
@@ -4552,56 +4552,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/@leafygreen-ui/descendants": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
-      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
-      "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/hooks": {
-      "version": "8.1.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
-      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
-      "dependencies": {
-        "@leafygreen-ui/lib": "^13.3.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@leafygreen-ui/descendants/node_modules/@leafygreen-ui/lib": {
-      "version": "13.6.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/descendants/node_modules/@storybook/csf": {
-      "version": "0.1.8",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
-      "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/descendants/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -4695,9 +4645,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.5.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
-      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
+      "version": "12.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
+      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -6039,19 +5989,19 @@
       "integrity": "sha512-AsvPlbvF7CERiZbAQR8hy3lAJ2/rieXI3cO0jsOwV8ztDqYNotKAdLujyr/NviudrRUenYiXrLizIKVlSPUMuA=="
     },
     "node_modules/@leafygreen-ui/tabs": {
-      "version": "12.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
-      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
+      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
       "dependencies": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/descendants": "^0.2.0",
+        "@leafygreen-ui/box": "^3.1.9",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.6.0",
+        "@leafygreen-ui/lib": "^13.3.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0",
-        "@leafygreen-ui/typography": "^19.2.0",
+        "@leafygreen-ui/portal": "^5.1.1",
+        "@leafygreen-ui/tokens": "^2.7.0",
+        "@leafygreen-ui/typography": "^19.1.1",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "peerDependencies": {
@@ -6068,9 +6018,9 @@
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/lib": {
-      "version": "13.6.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+      "version": "13.4.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
+      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -6085,26 +6035,29 @@
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
       "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
     },
-    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/polymorphic": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
-      "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
+    "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/portal": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
+      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.6.0",
-        "lodash": "^4.17.21"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
+      },
+      "peerDependencies": {
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@leafygreen-ui/tabs/node_modules/@leafygreen-ui/typography": {
-      "version": "19.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
-      "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
+      "version": "19.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
+      "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.5.4",
-        "@leafygreen-ui/lib": "^13.6.0",
+        "@leafygreen-ui/icon": "^12.2.0",
+        "@leafygreen-ui/lib": "^13.4.0",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0"
+        "@leafygreen-ui/polymorphic": "^1.3.7",
+        "@leafygreen-ui/tokens": "^2.7.0"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.12"
@@ -6392,18 +6345,18 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
-      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
+      "version": "2.8.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
+      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.6.0",
+        "@leafygreen-ui/lib": "^13.5.0",
         "@leafygreen-ui/palette": "^4.0.9"
       }
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "13.6.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-      "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+      "version": "13.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
+      "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -32462,49 +32415,6 @@
         }
       }
     },
-    "@leafygreen-ui/descendants": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/descendants/-/descendants-0.2.0.tgz",
-      "integrity": "sha512-BZ5tYt4s7GV0vgyDRFmHWXzDodLc4ZBs25kegyBdjsVWcZkVDw1wME1Pcu0u/4TeLhgPFelIW9fGLvr3UAUDXA==",
-      "requires": {
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@leafygreen-ui/hooks": {
-          "version": "8.1.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
-          "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
-          "requires": {
-            "@leafygreen-ui/lib": "^13.3.0",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@leafygreen-ui/lib": {
-          "version": "13.6.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@storybook/csf": {
-          "version": "0.1.8",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.8.tgz",
-          "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
-      }
-    },
     "@leafygreen-ui/emotion": {
       "version": "4.0.8",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
@@ -32587,9 +32497,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.5.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
-      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
+      "version": "12.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.0.tgz",
+      "integrity": "sha512-GGNMf4GCQAp0T+VlLJPqcnHjnwGwkeqCg2oAbaoqXqSlmQMcg94Inzs9f8xUhKNWOSZNAILqUfX8iLDGhMaw9w==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -33754,19 +33664,19 @@
       }
     },
     "@leafygreen-ui/tabs": {
-      "version": "12.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-12.0.1.tgz",
-      "integrity": "sha512-HaZEfLPEDdnAtHxkKEnV/dU1tJnRbYCgct6upFTBLyPeTnnO3pD4u2/zHUGkD3tzWQZbNYVbq0vvrEUKw/6shA==",
+      "version": "11.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tabs/-/tabs-11.2.0.tgz",
+      "integrity": "sha512-5J1rHPC1Gpn7/F5z8UYr7zUqDN6KcwQYrqHLjnl4RTUdFnT1Agr3itZSXFMpa6/fxo22jR62mjT0Jq0ZPSaGkw==",
       "requires": {
         "@leafygreen-ui/a11y": "^1.4.13",
-        "@leafygreen-ui/descendants": "^0.2.0",
+        "@leafygreen-ui/box": "^3.1.9",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.6.0",
+        "@leafygreen-ui/lib": "^13.3.0",
         "@leafygreen-ui/palette": "^4.0.9",
-        "@leafygreen-ui/polymorphic": "^2.0.0",
-        "@leafygreen-ui/tokens": "^2.9.0",
-        "@leafygreen-ui/typography": "^19.2.0",
+        "@leafygreen-ui/portal": "^5.1.1",
+        "@leafygreen-ui/tokens": "^2.7.0",
+        "@leafygreen-ui/typography": "^19.1.1",
         "@lg-tools/test-harnesses": "0.1.2"
       },
       "dependencies": {
@@ -33780,9 +33690,9 @@
           }
         },
         "@leafygreen-ui/lib": {
-          "version": "13.6.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+          "version": "13.4.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
+          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -33794,26 +33704,26 @@
           "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
           "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
         },
-        "@leafygreen-ui/polymorphic": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.0.tgz",
-          "integrity": "sha512-9ydiJf98umwOuwdyVpPhx+2SmlukrFbT8qENM4B/FyM3JlfogIBBafi+8Qym/gKmn3KrfggfFdfuEiXX2P/zgg==",
+        "@leafygreen-ui/portal": {
+          "version": "5.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
+          "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
           "requires": {
-            "@leafygreen-ui/lib": "^13.6.0",
-            "lodash": "^4.17.21"
+            "@leafygreen-ui/hooks": "^8.1.3",
+            "@leafygreen-ui/lib": "^13.3.0"
           }
         },
         "@leafygreen-ui/typography": {
-          "version": "19.2.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.0.tgz",
-          "integrity": "sha512-57O0eplpV3nYQMVtSYuOGafPhGC26ShPDTK46HF9I9xCgLRul4YHFM3jwXQEvdWcZO5JSMHzx5iH7ec2+pHBrA==",
+          "version": "19.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.1.1.tgz",
+          "integrity": "sha512-S6JDXHvMY+Cwqy9VOWZWvcnoxXpw16AzlpcPNHzq1j9Puf4cIV2HP5rFdbV/vMt7HyqoRoWVnTQa4OXPrg4W3g==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.5.4",
-            "@leafygreen-ui/lib": "^13.6.0",
+            "@leafygreen-ui/icon": "^12.2.0",
+            "@leafygreen-ui/lib": "^13.4.0",
             "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^2.0.0",
-            "@leafygreen-ui/tokens": "^2.9.0"
+            "@leafygreen-ui/polymorphic": "^1.3.7",
+            "@leafygreen-ui/tokens": "^2.7.0"
           }
         },
         "@storybook/csf": {
@@ -34067,18 +33977,18 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
-      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
+      "version": "2.8.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.8.0.tgz",
+      "integrity": "sha512-OTSJFGm2avqDVwbzdAEDXWuwRWBKkB6bP6eNnjNhq3wNRTQpLGiBmLXw191iZETBjYl1h/14JG5M1SbynnkqCg==",
       "requires": {
-        "@leafygreen-ui/lib": "^13.6.0",
+        "@leafygreen-ui/lib": "^13.5.0",
         "@leafygreen-ui/palette": "^4.0.9"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "13.6.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.0.tgz",
-          "integrity": "sha512-4TglZhImmJ5G13nEoBsNkwBEDZLS0Qo4b3hfPnJsXQ0+BYguxExevan6S7i7hQ4iwvZekCVKGd/yrp0UonrOHQ==",
+          "version": "13.5.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.5.0.tgz",
+          "integrity": "sha512-wrA8Au2DzgRFdgy+P023ChSDsdzRcRjXMFx4taCEJ368aVCeGJRNXQzsarpf89A4D46gSbqP9Fzi69TKij9Ktg==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@leafygreen-ui/side-nav": "^14.1.3",
     "@leafygreen-ui/skeleton-loader": "^1.2.0",
     "@leafygreen-ui/table": "^6.1.0",
-    "@leafygreen-ui/tabs": "^12.0.1",
+    "@leafygreen-ui/tabs": "^11.2.0",
     "@leafygreen-ui/text-area": "^6.1.0",
     "@leafygreen-ui/text-input": "^10.1.0",
     "@leafygreen-ui/toast": "^6.1.4",

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -24,7 +24,6 @@ const getPosition = (element) => {
 };
 
 const defaultTabsStyling = css`
-  margin-bottom: ${theme.size.medium};
   ${TAB_BUTTON_SELECTOR} {
     font-size: ${theme.size.default};
     align-items: center;
@@ -63,14 +62,11 @@ const getTabsStyling = ({ isHidden, isProductLanding }) => css`
   ${isProductLanding && landingTabsStyling};
 `;
 
-const tabContentStyling = css`
-  margin-top: ${theme.size.medium};
-`;
-
-const productLandingTabContentStyling = css`
+const landingTabStyling = css`
   display: grid;
   column-gap: ${theme.size.medium};
   grid-template-columns: repeat(2, 1fr);
+  margin-top: unset !important;
 
   img {
     border-radius: ${theme.size.small};
@@ -82,6 +78,11 @@ const productLandingTabContentStyling = css`
   @media ${theme.screenSize.upToLarge} {
     display: block;
   }
+`;
+
+const getTabStyling = ({ isProductLanding }) => css`
+  ${isProductLanding && landingTabStyling}
+  margin-top: 24px;
 `;
 
 const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
@@ -138,7 +139,6 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
           aria-label={`Tabs to describe usage of ${tabsetName}`}
           selected={activeTab}
           setSelected={handleClick}
-          forceRenderAllTabPanels={true}
         >
           {children.map((tab) => {
             if (tab.name !== 'tab') {
@@ -152,12 +152,10 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
                 : tabId;
 
             return (
-              <LeafyTab key={tabId} name={tabTitle}>
-                <div className={cx(tabContentStyling, isProductLanding ? productLandingTabContentStyling : '')}>
-                  {tab.children.map((child, i) => (
-                    <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
-                  ))}
-                </div>
+              <LeafyTab className={cx(getTabStyling({ isProductLanding }))} key={tabId} name={tabTitle}>
+                {tab.children.map((child, i) => (
+                  <ComponentFactory {...rest} key={`${tabId}-${i}`} nodeData={child} />
+                ))}
               </LeafyTab>
             );
           })}


### PR DESCRIPTION
Reverts mongodb/snooty#1141

During release, a bug was found with the Language Selectors. 

The icons for Python, Ruby, and Kotlin had color/spacing issues within the selector.

The upgrade in LG Tabs seems to have caused this either directly or in combination with other recent changes.