### PR TITLE
DOP-4789: Re-enable redirects based on browser language

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -87,7 +87,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
             }();
           `,
         }}
-      />,
+      />
     );
   }
   setHeadComponents(headComponents);

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,7 +4,7 @@ import { renderStylesToString } from '@leafygreen-ui/emotion';
 import { renderToString } from 'react-dom/server';
 import { theme } from './src/theme/docsTheme';
 import EuclidCircularASemiBold from './src/styles/fonts/EuclidCircularA-Semibold-WebXL.woff';
-// import redirectBasedOnLang from './src/utils/head-scripts/redirect-based-on-lang';
+import redirectBasedOnLang from './src/utils/head-scripts/redirect-based-on-lang';
 
 export const onRenderBody = ({ setHeadComponents }) => {
   const headComponents = [
@@ -24,15 +24,15 @@ export const onRenderBody = ({ setHeadComponents }) => {
         __html: `!function(e,t,r,n){if(!e[n]){for(var a=e[n]=[],i=["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],s=0;s<i.length;s++){var c=i[s];a[c]=a[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);a.push([e,t])}}(c)}a.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+r+"/"+n+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,"Dk30CC86ba0nATlK","delighted");`,
       }}
     />,
-    // Disabling language-based redirects for now until locale selector is present in top nav (DOP-4715)
-    // <script
-    //   key="browser-lang-redirect"
-    //   type="text/javascript"
-    //   dangerouslySetInnerHTML={{
-    //     // Call function immediately on load
-    //     __html: `!${redirectBasedOnLang}()`,
-    //   }}
-    // />,
+    // Client-side redirect based on browser's language settings
+    <script
+      key="browser-lang-redirect"
+      type="text/javascript"
+      dangerouslySetInnerHTML={{
+        // Call function immediately on load
+        __html: `!${redirectBasedOnLang}()`,
+      }}
+    />,
     <link
       rel="preload"
       href={EuclidCircularASemiBold}
@@ -87,7 +87,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
             }();
           `,
         }}
-      />
+      />,
     );
   }
   setHeadComponents(headComponents);


### PR DESCRIPTION
### Stories/Links:

DOP-4789

### Current Behavior:

[Atlas docs (English)](https://mongodb.com/docs/atlas/)
[Atlas docs (Chinese)](https://mongodb.com/zh-cn/docs/atlas/)
[Atlas docs (Portuguese)](https://mongodb.com/pt-br/docs/atlas/)
[Atlas docs (Korean)](https://mongodb.com/ko-kr/docs/atlas/)

### Staging Links:

[English staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4789/index.html)
[Chinese staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/master/cloud-docs/raymund.rodriguez/DOP-4789/index.html)
[Portuguese staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/pt-br/master/cloud-docs/raymund.rodriguez/DOP-4789/index.html)
[Korean staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ko-kr/master/cloud-docs/raymund.rodriguez/DOP-4789/index.html)

### Notes:

* Undoes the changes from #1133.
* No functionality change from original implementation in #1094. This is simply to re-enable functionality.

**To test:**

1) Go to your browser's language settings and add a language or 12. Rearrange the languages based on desired precedence.
2) Go to the **English** docs staging link. After page render, the URL should change to the localized path of the page. The redirect should only apply to the first non-English language that is compatible with the footer's locale selector.
3) Go to the **Portuguese** docs staging link. You should remain on the Portuguese site regardless of precedent language.
4) On the **Portuguese** docs staging link, use the footer's locale selector to go back to the English docs site.
5) Go to the **English** docs staging link and/or refresh the page. The page should not redirect.

Feel free to remove the new `preferredLocale` key from the `mongodb-docs` object in your browser's local storage if you need to reset settings.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
