### PR TITLE
:sparkles: DOP-4791 introduces new next/prev button

### DIFF
--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -10,13 +10,18 @@ import { getPageTitle } from '../utils/get-page-title';
 import Link from './Link';
 
 const styledContainer = css`
-  padding-top: 2em;
   padding-bottom: 2.5em;
   width: 100%;
   display: flex;
   justify-content: space-between;
   column-gap: ${theme.size.default};
   margin-top: 88px;
+
+  @media ${theme.screenSize.upToSmall} {
+    flex-direction: column-reverse;
+    row-gap: 64px;
+    margin-top: 66px;
+  }
 
   @media print {
     display: none;
@@ -34,12 +39,10 @@ const commonNextPrevTextStyling = css`
 `;
 
 const nextTextStyling = css`
-  ${commonNextPrevTextStyling}
   text-align: end;
 `;
 
 const prevTextStyling = css`
-  ${commonNextPrevTextStyling}
   text-align: start;
 `;
 
@@ -73,8 +76,8 @@ const NextPrevLink = ({ icon, direction, pageTitle }) => {
       <Button size="large">
         <Icon glyph={icon} />
       </Button>
-      <div>
-        <Body className={cx({ [nextTextStyling]: isNext }, { [prevTextStyling]: isPrev })}>{direction}</Body>
+      <div className={cx({ [nextTextStyling]: isNext }, { [prevTextStyling]: isPrev })}>
+        <Body className={cx(commonNextPrevTextStyling)}>{direction}</Body>
         <Body className={cx(nextPrevTitleTextStyling)}>{pageTitle}</Body>
       </div>
     </div>

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -16,6 +16,7 @@ const styledContainer = css`
   display: flex;
   justify-content: space-between;
   column-gap: ${theme.size.default};
+  margin-top: 88px;
 
   @media print {
     display: none;

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -9,7 +9,7 @@ import { theme } from '../theme/docsTheme';
 import { getPageTitle } from '../utils/get-page-title';
 import Link from './Link';
 
-const styledContainer = css`
+const containerStyling = css`
   padding-bottom: 2.5em;
   width: 100%;
   display: flex;
@@ -33,7 +33,7 @@ const commonTextStyles = css`
   line-height: 20px;
 `;
 
-const commonNextPrevTextStyling = css`
+const nextPrevTextStyling = css`
   ${commonTextStyles}
   font-weight: 500;
 `;
@@ -51,19 +51,19 @@ const nextPrevTitleTextStyling = css`
   color: ${palette.gray.base};
 `;
 
-const commonLinkContentContainer = css`
+const commonLinkContentContainerStyling = css`
   align-items: center;
   display: flex;
   column-gap: 14px;
 `;
 
-const nextLinkContainer = css`
-  ${commonLinkContentContainer}
+const nextLinkContainerStyling = css`
+  ${commonLinkContentContainerStyling}
   flex-direction: row-reverse;
 `;
 
-const prevLinkContainer = css`
-  ${commonLinkContentContainer}
+const prevLinkContainerStyling = css`
+  ${commonLinkContentContainerStyling}
   flex-direction: row;
 `;
 
@@ -72,12 +72,12 @@ const NextPrevLink = ({ icon, direction, pageTitle }) => {
   const isPrev = direction?.toLowerCase() === 'back';
 
   return (
-    <div className={cx({ [nextLinkContainer]: isNext, [prevLinkContainer]: isPrev })}>
+    <div className={cx({ [nextLinkContainerStyling]: isNext, [prevLinkContainerStyling]: isPrev })}>
       <Button size="large">
         <Icon glyph={icon} />
       </Button>
       <div className={cx({ [nextTextStyling]: isNext }, { [prevTextStyling]: isPrev })}>
-        <Body className={cx(commonNextPrevTextStyling)}>{direction}</Body>
+        <Body className={cx(nextPrevTextStyling)}>{direction}</Body>
         <Body className={cx(nextPrevTitleTextStyling)}>{pageTitle}</Body>
       </div>
     </div>
@@ -89,7 +89,7 @@ const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
   const prevSlug = slugIndex > 0 ? toctreeOrder[slugIndex - 1] : null;
   const nextSlug = slugIndex < toctreeOrder.length - 1 ? toctreeOrder[slugIndex + 1] : null;
   return (
-    <div className={cx(styledContainer)}>
+    <div className={cx(containerStyling)}>
       {prevSlug && (
         <Link to={prevSlug} title="Previous Section">
           <NextPrevLink

--- a/src/components/InternalPageNav.js
+++ b/src/components/InternalPageNav.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
+import Button from '@leafygreen-ui/button';
+import { Body } from '@leafygreen-ui/typography';
+import Icon, { glyphs } from '@leafygreen-ui/icon';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
-import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { theme } from '../theme/docsTheme';
 import { getPageTitle } from '../utils/get-page-title';
 import Link from './Link';
 
-const StyledContainer = styled.div`
+const styledContainer = css`
   padding-top: 2em;
   padding-bottom: 2.5em;
   width: 100%;
@@ -21,55 +22,89 @@ const StyledContainer = styled.div`
   }
 `;
 
-const arrowStyling = css`
-  line-height: 28px;
-  align-content: center;
-  color: var(--arrow-color);
+const commonTextStyles = css`
+  font-size: ${theme.fontSize.small};
+  line-height: 20px;
 `;
 
-const titleSpanStyling = css`
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color) !important;
+const commonNextPrevTextStyling = css`
+  ${commonTextStyles}
+  font-weight: 500;
 `;
 
-const LinkContentContainer = styled.div`
+const nextTextStyling = css`
+  ${commonNextPrevTextStyling}
+  text-align: end;
+`;
+
+const prevTextStyling = css`
+  ${commonNextPrevTextStyling}
+  text-align: start;
+`;
+
+const nextPrevTitleTextStyling = css`
+  ${commonTextStyles}
+  color: ${palette.gray.base};
+`;
+
+const commonLinkContentContainer = css`
+  align-items: center;
   display: flex;
-  column-gap: ${theme.size.tiny};
+  column-gap: 14px;
 `;
+
+const nextLinkContainer = css`
+  ${commonLinkContentContainer}
+  flex-direction: row-reverse;
+`;
+
+const prevLinkContainer = css`
+  ${commonLinkContentContainer}
+  flex-direction: row;
+`;
+
+const NextPrevLink = ({ icon, direction, pageTitle }) => {
+  const isNext = direction?.toLowerCase() === 'next';
+  const isPrev = direction?.toLowerCase() === 'back';
+
+  return (
+    <div className={cx({ [nextLinkContainer]: isNext, [prevLinkContainer]: isPrev })}>
+      <Button size="large">
+        <Icon glyph={icon} />
+      </Button>
+      <div>
+        <Body className={cx({ [nextTextStyling]: isNext }, { [prevTextStyling]: isPrev })}>{direction}</Body>
+        <Body className={cx(nextPrevTitleTextStyling)}>{pageTitle}</Body>
+      </div>
+    </div>
+  );
+};
 
 const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
-  const { darkMode } = useDarkMode();
   const slugIndex = toctreeOrder.indexOf(slug);
   const prevSlug = slugIndex > 0 ? toctreeOrder[slugIndex - 1] : null;
   const nextSlug = slugIndex < toctreeOrder.length - 1 ? toctreeOrder[slugIndex + 1] : null;
   return (
-    <StyledContainer
-      style={{
-        '--arrow-color': darkMode ? palette.gray.light2 : palette.black,
-        '--underline-color': darkMode ? palette.gray.dark1 : palette.gray.light2,
-      }}
-    >
+    <div className={cx(styledContainer)}>
       {prevSlug && (
-        <React.Fragment>
-          <LinkContentContainer>
-            <span className={cx([arrowStyling])}>←&nbsp;</span>
-            <Link className={cx(titleSpanStyling)} to={prevSlug} title="Previous Section">
-              {getPageTitle(prevSlug, slugTitleMapping)}
-            </Link>
-          </LinkContentContainer>
-        </React.Fragment>
+        <Link to={prevSlug} title="Previous Section">
+          <NextPrevLink
+            icon={glyphs.ArrowLeft.displayName}
+            direction="Back"
+            pageTitle={getPageTitle(prevSlug, slugTitleMapping)}
+          />
+        </Link>
       )}
       {nextSlug && (
-        <React.Fragment>
-          <LinkContentContainer>
-            <Link className={cx(titleSpanStyling)} to={nextSlug} title="Next Section">
-              {getPageTitle(nextSlug, slugTitleMapping)}
-            </Link>
-            <span className={cx([arrowStyling])}>&nbsp;→</span>
-          </LinkContentContainer>
-        </React.Fragment>
+        <Link to={nextSlug} title="Next Section">
+          <NextPrevLink
+            icon={glyphs.ArrowRight.displayName}
+            direction="Next"
+            pageTitle={getPageTitle(nextSlug, slugTitleMapping)}
+          />
+        </Link>
       )}
-    </StyledContainer>
+    </div>
   );
 };
 

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -15,6 +15,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   justify-content: space-between;
   -webkit-column-gap: 16px;
   column-gap: 16px;
+  margin-top: 88px;
 }
 
 @media print {
@@ -377,6 +378,7 @@ exports[`renders a page with no next link correctly 1`] = `
   justify-content: space-between;
   -webkit-column-gap: 16px;
   column-gap: 16px;
+  margin-top: 88px;
 }
 
 @media print {
@@ -653,6 +655,7 @@ exports[`renders a page with no previous link correctly 1`] = `
   justify-content: space-between;
   -webkit-column-gap: 16px;
   column-gap: 16px;
+  margin-top: 88px;
 }
 
 @media print {

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -23,24 +23,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   }
 }
 
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-column-gap: 4px;
-  column-gap: 4px;
-}
-
-.emotion-4 {
-  line-height: 28px;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  color: var(--arrow-color);
-}
-
-.emotion-5 {
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -53,16 +36,14 @@ exports[`renders a page with next and previous links correctly 1`] = `
   line-height: 13px;
   color: #016BF8;
   font-weight: inherit;
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
-.emotion-5>code {
+.emotion-1>code {
   color: #016BF8;
 }
 
-.emotion-5:focus,
-.emotion-5:hover {
+.emotion-1:focus,
+.emotion-1:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -70,51 +51,313 @@ exports[`renders a page with next and previous links correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-5:focus {
+.emotion-1:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-5:hover {
+.emotion-1:hover {
   text-decoration-color: #E8EDEB;
 }
 
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 14px;
+  column-gap: 14px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.emotion-3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 1px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #F9FBFA;
+  border-color: #889397;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  height: 48px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-3:active,
+.emotion-3[data-active="true"],
+.emotion-3:focus,
+.emotion-3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  color: #001E2B;
+}
+
+.emotion-3:hover,
+.emotion-3[data-hover="true"],
+.emotion-3:active,
+.emotion-3[data-active="true"] {
+  color: #001E2B;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 3px #E8EDEB;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
+}
+
+.emotion-4 {
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 5px;
+}
+
+.emotion-5 {
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 0;
+  -webkit-transition: all 150 ease-in-out;
+  transition: all 150 ease-in-out;
+  padding: 0 15px;
+  gap: 8px;
+}
+
+.emotion-6 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  text-align: start;
+}
+
+.emotion-6 strong,
+.emotion-6 b {
+  font-weight: 700;
+}
+
+.emotion-7 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-7 strong,
+.emotion-7 b {
+  font-weight: 700;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 14px;
+  column-gap: 14px;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-13 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  text-align: end;
+}
+
+.emotion-13 strong,
+.emotion-13 b {
+  font-weight: 700;
+}
+
 <div
-    class="emotion-0 emotion-1"
-    style="--arrow-color: #001E2B; --underline-color: #E8EDEB;"
+    class="emotion-0"
   >
-    <div
-      class="emotion-2 emotion-3"
+    <a
+      class="emotion-1"
+      href="/drivers/csharp/"
+      title="Previous Section"
     >
-      <span
-        class="emotion-4"
+      <div
+        class="emotion-2"
       >
-        ← 
-      </span>
-      <a
-        class="emotion-5"
-        href="/drivers/csharp/"
-        title="Previous Section"
-      >
-        MongoDB C#/.NET Driver
-      </a>
-    </div>
-    <div
-      class="emotion-2 emotion-3"
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 emotion-3"
+          data-lgid="lg-button"
+          type="button"
+        >
+          <div
+            class="emotion-4"
+          />
+          <div
+            class="emotion-5"
+          >
+            <svg
+              aria-label="Arrow Left Icon"
+              class=""
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13 6.832H6.056L7.59 5.297a1 1 0 0 0 0-1.414l-.24-.239a1 1 0 0 0-1.414 0L2.555 7.027c-.01.008-.018.017-.027.026l-.24.239a1 1 0 0 0 0 1.414l3.652 3.651a1 1 0 0 0 1.414 0l.239-.239a1 1 0 0 0 0-1.414L6.059 9.17H13a1 1 0 0 0 1-1v-.338a1 1 0 0 0-1-1Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </button>
+        <div>
+          <p
+            class="emotion-6"
+          >
+            Back
+          </p>
+          <p
+            class="emotion-7"
+          >
+            MongoDB C#/.NET Driver
+          </p>
+        </div>
+      </div>
+    </a>
+    <a
+      class="emotion-1"
+      href="/drivers/java/"
+      title="Next Section"
     >
-      <a
-        class="emotion-5"
-        href="/drivers/java/"
-        title="Next Section"
+      <div
+        class="emotion-9"
       >
-        Java MongoDB Driver
-      </a>
-      <span
-        class="emotion-4"
-      >
-         →
-      </span>
-    </div>
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 emotion-3"
+          data-lgid="lg-button"
+          type="button"
+        >
+          <div
+            class="emotion-4"
+          />
+          <div
+            class="emotion-5"
+          >
+            <svg
+              aria-label="Arrow Right Icon"
+              class=""
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 6.832h6.944L8.41 5.297a1 1 0 0 1 0-1.414l.24-.239a1 1 0 0 1 1.414 0l3.382 3.383c.01.008.018.017.027.026l.24.239a1 1 0 0 1 0 1.414l-3.652 3.651a1 1 0 0 1-1.414 0l-.239-.239a1 1 0 0 1 0-1.414L9.941 9.17H3a1 1 0 0 1-1-1v-.338a1 1 0 0 1 1-1Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </button>
+        <div>
+          <p
+            class="emotion-13"
+          >
+            Next
+          </p>
+          <p
+            class="emotion-7"
+          >
+            Java MongoDB Driver
+          </p>
+        </div>
+      </div>
+    </a>
   </div>
 </DocumentFragment>
 `;
@@ -142,24 +385,7 @@ exports[`renders a page with no next link correctly 1`] = `
   }
 }
 
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-column-gap: 4px;
-  column-gap: 4px;
-}
-
-.emotion-4 {
-  line-height: 28px;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  color: var(--arrow-color);
-}
-
-.emotion-5 {
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -172,16 +398,14 @@ exports[`renders a page with no next link correctly 1`] = `
   line-height: 13px;
   color: #016BF8;
   font-weight: inherit;
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
-.emotion-5>code {
+.emotion-1>code {
   color: #016BF8;
 }
 
-.emotion-5:focus,
-.emotion-5:hover {
+.emotion-1:focus,
+.emotion-1:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -189,35 +413,227 @@ exports[`renders a page with no next link correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-5:focus {
+.emotion-1:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-5:hover {
+.emotion-1:hover {
   text-decoration-color: #E8EDEB;
 }
 
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 14px;
+  column-gap: 14px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.emotion-3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 1px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #F9FBFA;
+  border-color: #889397;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  height: 48px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-3:active,
+.emotion-3[data-active="true"],
+.emotion-3:focus,
+.emotion-3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  color: #001E2B;
+}
+
+.emotion-3:hover,
+.emotion-3[data-hover="true"],
+.emotion-3:active,
+.emotion-3[data-active="true"] {
+  color: #001E2B;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 3px #E8EDEB;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
+}
+
+.emotion-4 {
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 5px;
+}
+
+.emotion-5 {
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 0;
+  -webkit-transition: all 150 ease-in-out;
+  transition: all 150 ease-in-out;
+  padding: 0 15px;
+  gap: 8px;
+}
+
+.emotion-6 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  text-align: start;
+}
+
+.emotion-6 strong,
+.emotion-6 b {
+  font-weight: 700;
+}
+
+.emotion-7 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-7 strong,
+.emotion-7 b {
+  font-weight: 700;
+}
+
 <div
-    class="emotion-0 emotion-1"
-    style="--arrow-color: #001E2B; --underline-color: #E8EDEB;"
+    class="emotion-0"
   >
-    <div
-      class="emotion-2 emotion-3"
+    <a
+      class="emotion-1"
+      href="/drivers/go/"
+      title="Previous Section"
     >
-      <span
-        class="emotion-4"
+      <div
+        class="emotion-2"
       >
-        ← 
-      </span>
-      <a
-        class="emotion-5"
-        href="/drivers/go/"
-        title="Previous Section"
-      >
-        MongoDB Go Driver
-      </a>
-    </div>
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 emotion-3"
+          data-lgid="lg-button"
+          type="button"
+        >
+          <div
+            class="emotion-4"
+          />
+          <div
+            class="emotion-5"
+          >
+            <svg
+              aria-label="Arrow Left Icon"
+              class=""
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13 6.832H6.056L7.59 5.297a1 1 0 0 0 0-1.414l-.24-.239a1 1 0 0 0-1.414 0L2.555 7.027c-.01.008-.018.017-.027.026l-.24.239a1 1 0 0 0 0 1.414l3.652 3.651a1 1 0 0 0 1.414 0l.239-.239a1 1 0 0 0 0-1.414L6.059 9.17H13a1 1 0 0 0 1-1v-.338a1 1 0 0 0-1-1Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </button>
+        <div>
+          <p
+            class="emotion-6"
+          >
+            Back
+          </p>
+          <p
+            class="emotion-7"
+          >
+            MongoDB Go Driver
+          </p>
+        </div>
+      </div>
+    </a>
   </div>
 </DocumentFragment>
 `;
@@ -245,16 +661,7 @@ exports[`renders a page with no previous link correctly 1`] = `
   }
 }
 
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-column-gap: 4px;
-  column-gap: 4px;
-}
-
-.emotion-4 {
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -267,16 +674,14 @@ exports[`renders a page with no previous link correctly 1`] = `
   line-height: 13px;
   color: #016BF8;
   font-weight: inherit;
-  line-height: 28px;
-  --hover-text-decoration-color: var(--underline-color)!important;
 }
 
-.emotion-4>code {
+.emotion-1>code {
   color: #016BF8;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-1:focus,
+.emotion-1:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -284,43 +689,227 @@ exports[`renders a page with no previous link correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-4:focus {
+.emotion-1:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-4:hover {
+.emotion-1:hover {
   text-decoration-color: #E8EDEB;
 }
 
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-column-gap: 14px;
+  column-gap: 14px;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+.emotion-3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 1px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  border-radius: 6px;
+  background-color: #F9FBFA;
+  border-color: #889397;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  height: 48px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  outline: none;
+}
+
+.emotion-3:active,
+.emotion-3[data-active="true"],
+.emotion-3:focus,
+.emotion-3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  color: #001E2B;
+}
+
+.emotion-3:hover,
+.emotion-3[data-hover="true"],
+.emotion-3:active,
+.emotion-3[data-active="true"] {
+  color: #001E2B;
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 3px #E8EDEB;
+}
+
+.emotion-3:focus-visible,
+.emotion-3[data-focus="true"] {
+  background-color: #FFFFFF;
+  box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC;
+}
+
+.emotion-4 {
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 5px;
+}
+
 .emotion-5 {
-  line-height: 28px;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  color: var(--arrow-color);
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 0;
+  -webkit-transition: all 150 ease-in-out;
+  transition: all 150 ease-in-out;
+  padding: 0 15px;
+  gap: 8px;
+}
+
+.emotion-6 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  text-align: end;
+}
+
+.emotion-6 strong,
+.emotion-6 b {
+  font-weight: 700;
+}
+
+.emotion-7 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-7 strong,
+.emotion-7 b {
+  font-weight: 700;
 }
 
 <div
-    class="emotion-0 emotion-1"
-    style="--arrow-color: #001E2B; --underline-color: #E8EDEB;"
+    class="emotion-0"
   >
-    <div
-      class="emotion-2 emotion-3"
+    <a
+      class="emotion-1"
+      href="/drivers/go/"
+      title="Next Section"
     >
-      <a
-        class="emotion-4"
-        href="/drivers/go/"
-        title="Next Section"
+      <div
+        class="emotion-2"
       >
-        MongoDB Go Driver
-      </a>
-      <span
-        class="emotion-5"
-      >
-         →
-      </span>
-    </div>
+        <button
+          aria-disabled="false"
+          class="lg-ui-button-0000 emotion-3"
+          data-lgid="lg-button"
+          type="button"
+        >
+          <div
+            class="emotion-4"
+          />
+          <div
+            class="emotion-5"
+          >
+            <svg
+              aria-label="Arrow Right Icon"
+              class=""
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 6.832h6.944L8.41 5.297a1 1 0 0 1 0-1.414l.24-.239a1 1 0 0 1 1.414 0l3.382 3.383c.01.008.018.017.027.026l.24.239a1 1 0 0 1 0 1.414l-3.652 3.651a1 1 0 0 1-1.414 0l-.239-.239a1 1 0 0 1 0-1.414L9.941 9.17H3a1 1 0 0 1-1-1v-.338a1 1 0 0 1 1-1Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </button>
+        <div>
+          <p
+            class="emotion-6"
+          >
+            Next
+          </p>
+          <p
+            class="emotion-7"
+          >
+            MongoDB Go Driver
+          </p>
+        </div>
+      </div>
+    </a>
   </div>
 </DocumentFragment>
 `;

--- a/tests/unit/__snapshots__/InternalPageNav.test.js.snap
+++ b/tests/unit/__snapshots__/InternalPageNav.test.js.snap
@@ -3,7 +3,6 @@
 exports[`renders a page with next and previous links correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  padding-top: 2em;
   padding-bottom: 2.5em;
   width: 100%;
   display: -webkit-box;
@@ -16,6 +15,16 @@ exports[`renders a page with next and previous links correctly 1`] = `
   -webkit-column-gap: 16px;
   column-gap: 16px;
   margin-top: 88px;
+}
+
+@media only screen and (max-width: 480px) {
+  .emotion-0 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    row-gap: 64px;
+    margin-top: 66px;
+  }
 }
 
 @media print {
@@ -183,22 +192,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
 }
 
 .emotion-6 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 500;
   text-align: start;
-}
-
-.emotion-6 strong,
-.emotion-6 b {
-  font-weight: 700;
 }
 
 .emotion-7 {
@@ -211,7 +205,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
   font-weight: 400;
   font-size: 13px;
   line-height: 20px;
-  color: #889397;
+  font-weight: 500;
 }
 
 .emotion-7 strong,
@@ -219,7 +213,25 @@ exports[`renders a page with next and previous links correctly 1`] = `
   font-weight: 700;
 }
 
-.emotion-9 {
+.emotion-8 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-8 strong,
+.emotion-8 b {
+  font-weight: 700;
+}
+
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -235,23 +247,8 @@ exports[`renders a page with next and previous links correctly 1`] = `
   flex-direction: row-reverse;
 }
 
-.emotion-13 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 500;
+.emotion-14 {
   text-align: end;
-}
-
-.emotion-13 strong,
-.emotion-13 b {
-  font-weight: 700;
 }
 
 <div
@@ -294,14 +291,16 @@ exports[`renders a page with next and previous links correctly 1`] = `
             </svg>
           </div>
         </button>
-        <div>
+        <div
+          class="emotion-6"
+        >
           <p
-            class="emotion-6"
+            class="emotion-7"
           >
             Back
           </p>
           <p
-            class="emotion-7"
+            class="emotion-8"
           >
             MongoDB C#/.NET Driver
           </p>
@@ -314,7 +313,7 @@ exports[`renders a page with next and previous links correctly 1`] = `
       title="Next Section"
     >
       <div
-        class="emotion-9"
+        class="emotion-10"
       >
         <button
           aria-disabled="false"
@@ -345,14 +344,16 @@ exports[`renders a page with next and previous links correctly 1`] = `
             </svg>
           </div>
         </button>
-        <div>
+        <div
+          class="emotion-14"
+        >
           <p
-            class="emotion-13"
+            class="emotion-7"
           >
             Next
           </p>
           <p
-            class="emotion-7"
+            class="emotion-8"
           >
             Java MongoDB Driver
           </p>
@@ -366,7 +367,6 @@ exports[`renders a page with next and previous links correctly 1`] = `
 exports[`renders a page with no next link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  padding-top: 2em;
   padding-bottom: 2.5em;
   width: 100%;
   display: -webkit-box;
@@ -379,6 +379,16 @@ exports[`renders a page with no next link correctly 1`] = `
   -webkit-column-gap: 16px;
   column-gap: 16px;
   margin-top: 88px;
+}
+
+@media only screen and (max-width: 480px) {
+  .emotion-0 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    row-gap: 64px;
+    margin-top: 66px;
+  }
 }
 
 @media print {
@@ -546,22 +556,7 @@ exports[`renders a page with no next link correctly 1`] = `
 }
 
 .emotion-6 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 500;
   text-align: start;
-}
-
-.emotion-6 strong,
-.emotion-6 b {
-  font-weight: 700;
 }
 
 .emotion-7 {
@@ -574,11 +569,29 @@ exports[`renders a page with no next link correctly 1`] = `
   font-weight: 400;
   font-size: 13px;
   line-height: 20px;
-  color: #889397;
+  font-weight: 500;
 }
 
 .emotion-7 strong,
 .emotion-7 b {
+  font-weight: 700;
+}
+
+.emotion-8 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-8 strong,
+.emotion-8 b {
   font-weight: 700;
 }
 
@@ -622,14 +635,16 @@ exports[`renders a page with no next link correctly 1`] = `
             </svg>
           </div>
         </button>
-        <div>
+        <div
+          class="emotion-6"
+        >
           <p
-            class="emotion-6"
+            class="emotion-7"
           >
             Back
           </p>
           <p
-            class="emotion-7"
+            class="emotion-8"
           >
             MongoDB Go Driver
           </p>
@@ -643,7 +658,6 @@ exports[`renders a page with no next link correctly 1`] = `
 exports[`renders a page with no previous link correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  padding-top: 2em;
   padding-bottom: 2.5em;
   width: 100%;
   display: -webkit-box;
@@ -656,6 +670,16 @@ exports[`renders a page with no previous link correctly 1`] = `
   -webkit-column-gap: 16px;
   column-gap: 16px;
   margin-top: 88px;
+}
+
+@media only screen and (max-width: 480px) {
+  .emotion-0 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    row-gap: 64px;
+    margin-top: 66px;
+  }
 }
 
 @media print {
@@ -823,22 +847,7 @@ exports[`renders a page with no previous link correctly 1`] = `
 }
 
 .emotion-6 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 500;
   text-align: end;
-}
-
-.emotion-6 strong,
-.emotion-6 b {
-  font-weight: 700;
 }
 
 .emotion-7 {
@@ -851,11 +860,29 @@ exports[`renders a page with no previous link correctly 1`] = `
   font-weight: 400;
   font-size: 13px;
   line-height: 20px;
-  color: #889397;
+  font-weight: 500;
 }
 
 .emotion-7 strong,
 .emotion-7 b {
+  font-weight: 700;
+}
+
+.emotion-8 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #889397;
+}
+
+.emotion-8 strong,
+.emotion-8 b {
   font-weight: 700;
 }
 
@@ -899,14 +926,16 @@ exports[`renders a page with no previous link correctly 1`] = `
             </svg>
           </div>
         </button>
-        <div>
+        <div
+          class="emotion-6"
+        >
           <p
-            class="emotion-6"
+            class="emotion-7"
           >
             Next
           </p>
           <p
-            class="emotion-7"
+            class="emotion-8"
           >
             MongoDB Go Driver
           </p>


### PR DESCRIPTION
### Stories/Links:

DOP-4791

### Current Behavior:

[MongoDB Atlas](https://www.mongodb.com/docs/atlas/getting-started/)

### Staging Links:

[Staged: MongoDB Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4791/cloud-docs/caesarbell/DOP-4791/getting-started/index.html)

[Staged MongoDB Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4791/docs/caesarbell/DOP-4791/core/databases-and-collections/index.html)

### Notes:

- Introduces the new next/prev component which is used at the bottom of the docs page to navigate to the next section.
- Proposes the use of [conditional class names](https://emotion.sh/docs/@emotion/css#cx), which I believe allows us to use static styling. It is a proposal, so please oppose if there are any opinions. I battled with myself if I should use dynamic styles aka returning the css`` via a function, but seeing one gives us static styles and the other dynamic styles, I went with the static. 

[Figma](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=3511-21322&t=K7nDZIeNjA49X2MY-0)

[Discussion with the design team](https://mongodb.slack.com/archives/C076Z47AFTL/p1720046685621589)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
