### PR TITLE
DOP-4784: Chatbot on 404

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -108,7 +108,6 @@ const DocumentBody = (props) => {
         <InstruqtProvider hasLabDrawer={page?.options?.instruqt}>
           <Widgets
             location={location}
-            pageOptions={page?.options}
             pageTitle={pageTitle}
             slug={slug}
             isInPresentationMode={isInPresentationMode}

--- a/src/components/DocumentBodyPreview.js
+++ b/src/components/DocumentBodyPreview.js
@@ -107,7 +107,6 @@ const DocumentBody = (props) => {
         <InstruqtProvider hasLabDrawer={page?.options?.instruqt}>
           <Widgets
             location={location}
-            pageOptions={page?.options}
             pageTitle={pageTitle}
             slug={slug}
             template={template}

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -4,7 +4,7 @@ import { createNewFeedback, useRealmUser } from './realm';
 
 const FeedbackContext = createContext();
 
-export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
+export function FeedbackProvider({ page, test = {}, ...props }) {
   const hasExistingFeedback =
     !!test.feedback && typeof test.feedback === 'object' && Object.keys(test.feedback).length > 0;
   const [feedback, setFeedback] = useState((hasExistingFeedback && test.feedback) || null);
@@ -121,7 +121,6 @@ export function FeedbackProvider({ page, hideHeader, test = {}, ...props }) {
     setProgress,
     submitAllFeedback,
     abandon,
-    hideHeader,
     selectedRating,
     setSelectedRating,
     selectInitialRating,

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -56,7 +56,7 @@ const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) 
         /* Suspense at this level ensures that widgets will appear simultaneously rather than one-by-one as loaded */
         <SuspenseHelper fallback={null}>
           <WidgetsContainer className={widgetsContainer} hasOpenLabDrawer={isOpen}>
-            {hideFeedback && (
+            {!hideFeedback && (
               <>
                 <FeedbackButton />
                 <FeedbackForm />

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -37,29 +37,32 @@ const WidgetsContainer = styled.div`
   }
 `;
 
-const Widgets = ({ children, pageOptions, pageTitle, slug, isInPresentationMode, template }) => {
+const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) => {
   const { isOpen } = useContext(InstruqtContext);
   const url = isBrowser ? window.location.href : null;
-  const hideFeedbackHeader = pageOptions.hidefeedback === 'header';
   const feedbackData = useFeedbackData({
     slug,
     url,
     title: pageTitle || 'Home',
   });
 
-  // DOP-4025: hide feedback tab on homepage
-  const hideFeedback = pageOptions.hidefeedback === 'page';
+  const hideWidgets = template === 'landing';
+  const hideFeedback = template === 'errorpage';
 
   return (
-    <FeedbackProvider page={feedbackData} hideHeader={hideFeedbackHeader}>
+    <FeedbackProvider page={feedbackData}>
       {children}
-      {!isInPresentationMode && !hideFeedback && (
+      {!isInPresentationMode && !hideWidgets && (
         /* Suspense at this level ensures that widgets will appear simultaneously rather than one-by-one as loaded */
         <SuspenseHelper fallback={null}>
           <WidgetsContainer className={widgetsContainer} hasOpenLabDrawer={isOpen}>
-            <FeedbackButton />
-            <FeedbackForm />
-            {template !== 'landing' && <ChatbotFab />}
+            {hideFeedback && (
+              <>
+                <FeedbackButton />
+                <FeedbackForm />
+              </>
+            )}
+            <ChatbotFab />
           </WidgetsContainer>
         </SuspenseHelper>
       )}
@@ -69,16 +72,9 @@ const Widgets = ({ children, pageOptions, pageTitle, slug, isInPresentationMode,
 
 Widgets.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
-  pageOptions: PropTypes.shape({
-    hideFeedback: PropTypes.string,
-  }),
   pageTitle: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   isInPresentationMode: PropTypes.bool,
-};
-
-Widgets.defaultProps = {
-  pageOptions: {},
 };
 
 export const widgetsContainer = 'widgets';


### PR DESCRIPTION
### Stories/Links:

DOP-4784

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Cloud-docs](https://www.mongodb.com/docs/atlas/getting-started/)
[404](https://www.mongodb.com/docs/404/)

### Staging Links:

[Landing with no widgets](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)
[Cloud-docs with both Feedback and Chatbot](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/)
[404 with Chatbot](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/404/)

### Notes:

Chatbot now present on 404 page.

Extras: 
- Removed unused `hideHeader`/`hideFeedbackHeader `.
- Cleaned up conditionals of when to hide widgets

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
