### PR TITLE
DOP-4784-B: Remove chatbot FAB from 404, use ChatbotUi bar

### DIFF
--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -62,7 +62,8 @@ const ActionsBox = styled('div')`
   }
 `;
 
-const ActionBar = ({ ...props }) => {
+// Note: When working on this component further, please check with design on how it should look in the errorpage template (404) as well!
+const ActionBar = ({ template, ...props }) => {
   const { darkMode } = useDarkMode();
   return (
     <ActionBarContainer className={props.className} darkMode={darkMode}>
@@ -71,9 +72,11 @@ const ActionBar = ({ ...props }) => {
       </ActionBarSearchContainer>
       <ActionsBox>
         <DarkModeDropdown></DarkModeDropdown>
-        <div>
-          <button>Feedback</button>
-        </div>
+        {template !== 'errorpage' && (
+          <div>
+            <button>Feedback</button>
+          </div>
+        )}
       </ActionsBox>
     </ActionBarContainer>
   );

--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -47,13 +47,62 @@ const landingTemplateStyling = css`
     grid-template-columns: ${theme.size.medium} 1fr ${theme.size.medium};
   }
 
+  > div {
+    max-width: 862px;
+
+    @media ${theme.screenSize.upToLarge} {
+      max-width: unset;
+    }
+  }
+
   // Ensure direct children (Chatbot and Loading Skeleton) of the container are
   // in the correct column
   > div,
   span {
     grid-column: 2 / -2;
   }
+
+  // Styling the chatbot's loading skeleton
+  > span {
+    display: flex;
+    height: 48px;
+    align-items: self-end;
+  }
 `;
+
+const errorPageTemplateStyling = css`
+  position: sticky;
+  top: 0px;
+  box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.1);
+  padding: 16px 0px 0px 0px;
+
+  > div {
+    max-width: 910px;
+    margin: auto;
+
+    @media only screen and (max-width: 1038px) {
+      margin: 0 64px;
+    }
+  }
+
+  // Styling the chatbot's loading skeleton
+  > span {
+    max-width: 910px;
+    margin: auto;
+    display: flex;
+    height: 48px;
+    align-items: self-end;
+
+    @media only screen and (max-width: 1038px) {
+      margin: 0 64px;
+    }
+  }
+`;
+
+const templateStylingMap = {
+  errorpage: errorPageTemplateStyling,
+  landing: landingTemplateStyling,
+};
 
 const StyledChatBotUiContainer = styled.div`
   padding: ${theme.size.default} 50px;
@@ -63,23 +112,10 @@ const StyledChatBotUiContainer = styled.div`
   min-height: 96px;
   align-items: center;
 
-  > div {
-    max-width: 862px;
-
-    @media ${theme.screenSize.upToLarge} {
-      max-width: unset;
-    }
-  }
-
-  // Styling the chatbot's loading skeleton
-  > span {
-    display: flex;
-    height: 48px;
-    align-items: self-end;
-  }
-
   ${({ template }) =>
-    template === 'landing' && process.env['GATSBY_ENABLE_DARK_MODE'] !== 'true' && landingTemplateStyling};
+    template in templateStylingMap &&
+    process.env['GATSBY_ENABLE_DARK_MODE'] !== 'true' &&
+    templateStylingMap[template]};
 `;
 
 const DocsChatbot = lazy(() =>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -12,7 +12,11 @@ const StyledHeaderContainer = styled.header(
   grid-area: header;
   top: 0;
   z-index: ${theme.zIndexes.header};
-  ${props.template === 'landing' || process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' ? '' : 'position: sticky;'}
+  ${
+    props.template === 'landing' || props.template === 'errorpage' || process.env['GATSBY_ENABLE_DARK_MODE'] === 'true'
+      ? ''
+      : 'position: sticky;'
+  }
   `
 );
 

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -46,8 +46,7 @@ const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) 
     title: pageTitle || 'Home',
   });
 
-  const hideWidgets = template === 'landing';
-  const hideFeedback = template === 'errorpage';
+  const hideWidgets = ['landing', 'errorpage'].includes(template);
 
   return (
     <FeedbackProvider page={feedbackData}>
@@ -56,12 +55,8 @@ const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) 
         /* Suspense at this level ensures that widgets will appear simultaneously rather than one-by-one as loaded */
         <SuspenseHelper fallback={null}>
           <WidgetsContainer className={widgetsContainer} hasOpenLabDrawer={isOpen}>
-            {!hideFeedback && (
-              <>
-                <FeedbackButton />
-                <FeedbackForm />
-              </>
-            )}
+            <FeedbackButton />
+            <FeedbackForm />
             <ChatbotFab />
           </WidgetsContainer>
         </SuspenseHelper>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -131,7 +131,7 @@ const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBran
             <div />
           )}
           <StyledContentContainer>
-            {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && <ActionBar />}
+            {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && <ActionBar template={template} />}
             <ContentTransition slug={slug}>{children}</ContentTransition>
           </StyledContentContainer>
         </GlobalGrid>

--- a/src/templates/NotFound.js
+++ b/src/templates/NotFound.js
@@ -7,12 +7,15 @@ import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme';
 import { baseUrl } from '../utils/base-url';
 import Link from '../components/Link';
+import ChatbotUi from '../components/ChatbotUi';
 
 const ErrorBox = styled('div')`
-  padding: 0px ${theme.size.default};
+  padding: 0 0 0 ${theme.size.default};
+  max-width: 455px;
 
   @media ${theme.screenSize.upToSmall} {
     padding: 0px ${theme.size.default};
+    width: unset;
   }
 `;
 
@@ -33,11 +36,22 @@ const SupportLink = styled(Link)`
   }
 `;
 
+const ImageContainer = styled.div`
+  width: 455px;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+`;
+
 const NotFoundImage = () => {
   const altText = 'Page not found';
   const imgPath = 'assets/404.png';
 
-  return <img src={withPrefix(imgPath)} alt={altText} height={444} width={444} />;
+  return (
+    <ImageContainer>
+      <img src={withPrefix(imgPath)} alt={altText} height={444} width={444} />
+    </ImageContainer>
+  );
 };
 
 const ErrorBoxContainer = () => {
@@ -96,6 +110,7 @@ const ErrorBoxContainer = () => {
 const NotFound = () => {
   return (
     <main>
+      {process.env['GATSBY_ENABLE_DARK_MODE'] !== 'true' && <ChatbotUi template="errorpage" />}
       <div
         css={css`
           align-items: center;


### PR DESCRIPTION
### Stories/Links:

DOP-4784 (b)

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Cloud-docs](https://www.mongodb.com/docs/atlas/getting-started/)
[404](https://www.mongodb.com/docs/404/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/matt.meigs/DOP-4784-fix-404-chatbot/index.html)
[Cloud-docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4784-fix-404-chatbot/index.html)
[404](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/add-title/docs-404/matt.meigs/DOP-4784-fix-404-chatbot/index.html)

### Notes:

This is a re-do of DOP-4784.

I had previously added the Chatbot FAB to the 404 page. What is actually needed is the ChatbotUI bar.

This PR removes the FAB from the 404. It also adds the ChatbotUi component to the 404 page.

In doing so, there were styling differences between the landing template and the errorpage template that needed to be addressed to match the design requirements listed in the ticket's comments. The chatbot bar needed to match the width of the page elements which currently are simply justified to center no matter the width of the div. The changes in this PR cement the widths of the divs in the main section so that the chatbot bar can match their widths in all screensizes.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
