### PR TITLE
Upgrade Callout/Admonition so we can use Dark Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@leafygreen-ui/banner": "^8.0.1",
         "@leafygreen-ui/box": "^3.0.6",
         "@leafygreen-ui/button": "^21.2.1",
-        "@leafygreen-ui/callout": "^5.0.0",
+        "@leafygreen-ui/callout": "^9.0.22",
         "@leafygreen-ui/card": "^10.0.7",
         "@leafygreen-ui/checkbox": "^12.0.8",
         "@leafygreen-ui/code": "^14.3.3",
@@ -3972,49 +3972,78 @@
       }
     },
     "node_modules/@leafygreen-ui/callout": {
-      "version": "5.0.1",
-      "license": "Apache-2.0",
+      "version": "9.0.22",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-9.0.22.tgz",
+      "integrity": "sha512-xFxNGUOUTlCLVSDTTR92u67RRJrWMzJAj0TH220Zt0zhUgqBNpydMpAOTT6e+UtOq6UH8WzceasdmWxbQIu29g==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.0",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/typography": "^11.0.2",
-        "polished": "^4.1.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.0.1",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/typography": "^19.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
-    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/icon": {
-      "version": "11.29.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/lib": {
+      "version": "13.6.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.1.tgz",
+      "integrity": "sha512-NaA0qmbY3QUg0GMpbaK0cdif2lRnGrzXMadi3ETRXHgMRljHi4y5I+v02bjggQ7vOW9VWhSooCF5HTtNd5j3fw==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/palette": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+      "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+      "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.6.0",
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/tokens": {
-      "version": "1.4.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-      "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
-      "dependencies": {
-        "@leafygreen-ui/palette": "^3.4.5"
-      }
-    },
     "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/typography": {
-      "version": "11.0.2",
-      "license": "Apache-2.0",
+      "version": "19.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+      "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.0.7",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/tokens": "^1.3.1"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/lib": "^13.6.1",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@storybook/csf": {
+      "version": "0.1.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
+      "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/card": {
@@ -32098,42 +32127,67 @@
       }
     },
     "@leafygreen-ui/callout": {
-      "version": "5.0.1",
+      "version": "9.0.22",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-9.0.22.tgz",
+      "integrity": "sha512-xFxNGUOUTlCLVSDTTR92u67RRJrWMzJAj0TH220Zt0zhUgqBNpydMpAOTT6e+UtOq6UH8WzceasdmWxbQIu29g==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.0",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/typography": "^11.0.2",
-        "polished": "^4.1.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.0.1",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/typography": "^19.0.0"
       },
       "dependencies": {
-        "@leafygreen-ui/icon": {
-          "version": "11.29.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-          "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+        "@leafygreen-ui/lib": {
+          "version": "13.6.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.1.tgz",
+          "integrity": "sha512-NaA0qmbY3QUg0GMpbaK0cdif2lRnGrzXMadi3ETRXHgMRljHi4y5I+v02bjggQ7vOW9VWhSooCF5HTtNd5j3fw==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "4.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+          "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+        },
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+          "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.6.0",
             "lodash": "^4.17.21"
           }
         },
-        "@leafygreen-ui/tokens": {
-          "version": "1.4.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-          "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
+        "@leafygreen-ui/typography": {
+          "version": "19.2.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+          "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
           "requires": {
-            "@leafygreen-ui/palette": "^3.4.5"
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/icon": "^12.5.4",
+            "@leafygreen-ui/lib": "^13.6.1",
+            "@leafygreen-ui/palette": "^4.0.10",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
           }
         },
-        "@leafygreen-ui/typography": {
-          "version": "11.0.2",
+        "@storybook/csf": {
+          "version": "0.1.11",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
+          "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
           "requires": {
-            "@leafygreen-ui/box": "^3.0.7",
-            "@leafygreen-ui/icon": "^11.9.0",
-            "@leafygreen-ui/lib": "^9.3.0",
-            "@leafygreen-ui/palette": "^3.4.0",
-            "@leafygreen-ui/tokens": "^1.3.1"
+            "type-fest": "^2.19.0"
           }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@leafygreen-ui/banner": "^8.0.1",
     "@leafygreen-ui/box": "^3.0.6",
     "@leafygreen-ui/button": "^21.2.1",
-    "@leafygreen-ui/callout": "^5.0.0",
+    "@leafygreen-ui/callout": "^9.0.22",
     "@leafygreen-ui/card": "^10.0.7",
     "@leafygreen-ui/checkbox": "^12.0.8",
     "@leafygreen-ui/code": "^14.3.3",

--- a/tests/unit/__snapshots__/Admonition.test.js.snap
+++ b/tests/unit/__snapshots__/Admonition.test.js.snap
@@ -3,10 +3,10 @@
 exports[`admonitions render correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  font-family: Euclid Circular A,‘Helvetica Neue’,Helvetica,Arial,sans-serif;
-  background-color: #FFFFFF;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   border-radius: 16px;
   position: relative;
+  background-color: #FFFFFF;
   color: #0C2657;
   border: 2px solid #C3E7FE;
   box-shadow: inset 0px 2px 0px 0px #E1F7FF;
@@ -60,19 +60,25 @@ exports[`admonitions render correctly 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  left: 20px;
   position: absolute;
+  left: 20px;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 .emotion-3 {
   margin: unset;
-  font-family: 'Euclid Circular A',Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
   font-size: 12px;
-  font-weight: bold;
+  font-weight: 700;
   text-transform: uppercase;
-  line-height: 16px;
-  letter-spacing: 0.3px;
+  line-height: 20px;
+  letter-spacing: 0.4px;
+  color: #001E2B;
   color: inherit;
   letter-spacing: 0.6px;
 }
@@ -92,6 +98,60 @@ exports[`admonitions render correctly 1`] = `
 .emotion-5 {
   font-size: 16px;
   line-height: 28px;
+}
+
+.emotion-5 .lg-ui-0001,
+.emotion-5 a {
+  font-size: inherit;
+  line-height: inherit;
+  font-weight: 700;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 2px;
+  border-radius: 2px;
+}
+
+.emotion-5 .lg-ui-0001:hover,
+.emotion-5 a:hover,
+.emotion-5 .lg-ui-0001:focus,
+.emotion-5 a:focus,
+.emotion-5 .lg-ui-0001:focus-visible,
+.emotion-5 a:focus-visible {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 2px;
+}
+
+.emotion-5 .lg-ui-0001:hover span::after,
+.emotion-5 a:hover span::after,
+.emotion-5 .lg-ui-0001:focus span::after,
+.emotion-5 a:focus span::after,
+.emotion-5 .lg-ui-0001:focus-visible span::after,
+.emotion-5 a:focus-visible span::after {
+  display: none;
+}
+
+.emotion-5 .lg-ui-0001:focus-visible,
+.emotion-5 a:focus-visible {
+  position: relative;
+}
+
+.emotion-5 .lg-ui-0001,
+.emotion-5 a {
+  color: #0C2657;
+}
+
+.emotion-5 .lg-ui-0001:hover,
+.emotion-5 a:hover {
+  color: #083C90;
+}
+
+.emotion-5 .lg-ui-0001:focus-visible,
+.emotion-5 a:focus-visible {
+  box-shadow: 0 0 0 3px #FFFFFF,0 0 0 5px #0498EC;
 }
 
 <div


### PR DESCRIPTION
I think we're waiting on design for this but I got bored so I upgraded Callout

## Staging Links

[Note](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/aggregation/index.html#aggregation-pipelines)
[Tip](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/sharding/index.html#shard-key-strategy)
[Important](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/reference/method/db.collection.find/index.html)
[Warning](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/reference/method/KeyVault.rewrapManyDataKey/index.html) (scroll down)
[Example](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/core/security-ldap/index.html#managing-ldap-users-on-the-mongodb-server)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
