### PR TITLE
DOP-4835: Fix meta robots not appearing due to missing page data

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -160,10 +160,15 @@ DocumentBody.propTypes = {
 
 export default DocumentBody;
 
-export const Head = ({ pageContext }) => {
-  const { slug, page, template, repoBranches } = pageContext;
+export const Head = ({ pageContext, data }) => {
+  const { slug, template, repoBranches } = pageContext;
+  const pageAst = data.page?.ast;
 
-  const pageNodes = getNestedValue(['children'], page) || [];
+  if (!pageAst) {
+    console.error('Gatsby Head is missing important page AST');
+  }
+
+  const pageNodes = getNestedValue(['children'], pageAst) || [];
 
   const meta = getMetaFromDirective('section', pageNodes, 'meta');
   const twitter = getMetaFromDirective('section', pageNodes, 'twitter');

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -165,7 +165,7 @@ export const Head = ({ pageContext, data }) => {
   const pageAst = data.page?.ast;
 
   if (!pageAst) {
-    console.error('Gatsby Head is missing important page AST');
+    throw new Error('Gatsby Head is missing important page AST');
   }
 
   const pageNodes = getNestedValue(['children'], pageAst) || [];

--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -27,7 +27,7 @@ describe('Head', () => {
       useSnootyMetadata.mockImplementation(() => mockEOLSnootyMetadata);
     });
     it('renders the canonical tag from the snooty.toml', () => {
-      render(<Head pageContext={mockCompleteEOLPageContext} />);
+      render(<Head pageContext={mockCompleteEOLPageContext.pageContext} data={mockCompleteEOLPageContext.data} />);
       const _canonical = mockEOLSnootyMetadata.canonical;
       const canonicalTag = screen.getByTestId('canonical');
       expect(canonicalTag).toBeInTheDocument();
@@ -46,9 +46,9 @@ describe('Head', () => {
       siteMetadataMock.mockImplementation(() => ({
         siteUrl: mockSiteUrl,
       }));
-      render(<Head pageContext={mockHeadPageContext} />);
+      render(<Head pageContext={mockHeadPageContext.pageContext} data={mockHeadPageContext.data} />);
       const urlSlug = 'stable';
-      const siteBasePrefix = mockHeadPageContext.repoBranches.siteBasePrefix;
+      const siteBasePrefix = mockHeadPageContext.pageContext.repoBranches.siteBasePrefix;
 
       const currentVersion = `${mockSiteUrl}/${siteBasePrefix}/${urlSlug}/`;
 
@@ -71,7 +71,7 @@ describe('Head', () => {
         siteUrl: 'https://www.mongodb.com',
         parserBranch: 'master',
       }));
-      render(<Head pageContext={mockHeadPageContext} />);
+      render(<Head pageContext={mockHeadPageContext.pageContext} data={mockHeadPageContext.data} />);
 
       const expectedCanonical = 'https://www.mongodb.com/docs/mongocli/upcoming/';
 
@@ -88,8 +88,8 @@ describe('Head', () => {
         parserBranch: 'v1.26',
       }));
 
-      const pageContext = { ...mockHeadPageContext, slug: '/introduction' };
-      render(<Head pageContext={pageContext} />);
+      const pageContext = { ...mockHeadPageContext.pageContext, slug: '/introduction' };
+      render(<Head pageContext={pageContext} data={mockHeadPageContext.data} />);
 
       const expectedCanonical = 'https://www.mongodb.com/docs/mongocli/stable/introduction/';
 
@@ -106,7 +106,7 @@ describe('Head', () => {
         siteUrl: 'https://www.mongodb.com',
         parserBranch: mockedParserBranch,
       }));
-      render(<Head pageContext={mockHeadPageContext} />);
+      render(<Head pageContext={mockHeadPageContext.pageContext} data={mockHeadPageContext.data} />);
 
       const expectedCanonical = `https://www.mongodb.com/docs/mongocli/${mockedParserBranch}/`;
 
@@ -136,14 +136,14 @@ describe('Head', () => {
         },
       ];
       const mockNonVersionedContext = {
-        ...mockHeadPageContext,
+        ...mockHeadPageContext.pageContext,
         slug: '/atlas-search/introduction',
         repoBranches: {
           branches: nonVersionedBranchArr,
           siteBasePrefix: 'docs/atlas',
         },
       };
-      render(<Head pageContext={mockNonVersionedContext} />);
+      render(<Head pageContext={mockNonVersionedContext} data={mockHeadPageContext.data} />);
 
       const expectedCanonical = 'https://www.mongodb.com/docs/atlas/atlas-search/introduction/';
 
@@ -178,19 +178,21 @@ describe('Head', () => {
       expect(canonicalTag).toHaveAttribute('href', metaCanonical.options.canonical);
     };
 
-    let mockPageContext = mockHeadPageContext;
     it('renders the canonical tag from directive rather than pulling from snooty.toml', () => {
-      mockPageContext = mockCompleteEOLPageContext;
-      mockPageContext.page.children.push(metaCanonical);
-      render(<Head pageContext={mockPageContext} />);
+      const mockPageContext = { ...mockHeadPageContext.pageContext };
+      const mockData = { ...mockCompleteEOLPageContext.data };
+      mockData.page.ast.children.push(metaCanonical);
+      render(<Head pageContext={mockPageContext} data={mockData} />);
 
       const canonicalTag = screen.getByTestId('canonical');
       expectCanonicalTagToBeCorrect(canonicalTag);
     });
 
     it("renders the canonical tag from directive rather than pulling from stable branch (version eol'd)", () => {
-      mockPageContext.page.children.push(metaCanonical);
-      render(<Head pageContext={mockPageContext} />);
+      const mockPageContext = { ...mockHeadPageContext.pageContext };
+      const mockData = { ...mockHeadPageContext.data };
+      mockData.page.ast.children.push(metaCanonical);
+      render(<Head pageContext={mockPageContext} data={mockData} />);
 
       const canonicalTag = screen.getByTestId('canonical');
       expectCanonicalTagToBeCorrect(canonicalTag);
@@ -201,8 +203,10 @@ describe('Head', () => {
       const modMockEOLSnootyMetadataToBeNotEOL = { ...mockEOLSnootyMetadata, eol: false };
       useSnootyMetadata.mockImplementation(() => modMockEOLSnootyMetadataToBeNotEOL);
 
-      mockPageContext.page.children.push(metaCanonical);
-      render(<Head pageContext={mockPageContext} />);
+      const mockPageContext = { ...mockHeadPageContext.pageContext };
+      const mockData = { ...mockHeadPageContext.data };
+      mockData.page.ast.children.push(metaCanonical);
+      render(<Head pageContext={mockPageContext} data={mockData} />);
 
       const canonicalTag = screen.getByTestId('canonical');
       expectCanonicalTagToBeCorrect(canonicalTag);
@@ -215,8 +219,9 @@ describe('Head', () => {
     });
 
     it.each([['/'], ['foo']])('renders based on slug', (slug) => {
-      const mockPageContext = { ...mockHeadPageContext, slug };
-      const { container } = render(<Head pageContext={mockPageContext} />);
+      const mockPageContext = { ...mockHeadPageContext.pageContext, slug };
+      const mockData = { ...mockHeadPageContext.data };
+      const { container } = render(<Head pageContext={mockPageContext} data={mockData} />);
       const hrefLangLinks = container.querySelectorAll('link.sl_opaque');
       expect(hrefLangLinks).toHaveLength(AVAILABLE_LANGUAGES.length);
       expect(hrefLangLinks).toMatchSnapshot();
@@ -231,13 +236,18 @@ describe('Head', () => {
       slug: mockPageId,
       repoBranches: { branches: [] },
     };
+    const mockData = {
+      page: {
+        ast: {},
+      },
+    };
     beforeEach(function () {
       metadata = { ...metadataWithoutToc };
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
     });
 
     it('correctly applies title, project name, and version', function () {
-      const { container } = render(<Head pageContext={pageContext} />);
+      const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
       expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title} ${metadata.branch}`);
     });
@@ -245,7 +255,7 @@ describe('Head', () => {
     it('defaults to project name and version if no page title', function () {
       metadata.slugToTitle = {};
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
-      const { container } = render(<Head pageContext={pageContext} />);
+      const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
       expect(title.innerHTML).toBe(`${metadata.title} ${metadata.branch}`);
     });
@@ -253,7 +263,7 @@ describe('Head', () => {
     it('only applies branch versions starting with a version number (v)', function () {
       metadata.branch = 'master';
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
-      const { container } = render(<Head pageContext={pageContext} />);
+      const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
       expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title}`);
     });
@@ -264,7 +274,7 @@ describe('Head', () => {
       delete metadata.title;
       metadata.slugToTitle = {};
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
-      const { container } = render(<Head pageContext={pageContext} />);
+      const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
       expect(title.innerHTML).toBe(`MongoDB Documentation`);
     });

--- a/tests/unit/data/CompleteEOLPageContext.json
+++ b/tests/unit/data/CompleteEOLPageContext.json
@@ -1,280 +1,286 @@
 {
-  "slug": "/",
-  "repoBranches": {
-    "branches": [{
-      "gitBranchName": "master",
-      "active": false,
-      "urlAliases": null,
-      "publishOriginalBranchName": false,
-      "urlSlug": "master",
-      "versionSelectorLabel": "master",
-      "isStableBranch": false,
-      "buildsWithSnooty": true
-    }],
-    "siteBasePrefix": "docs/atlas-open-service-broker"
+  "pageContext": {
+    "slug": "/",
+    "repoBranches": {
+      "branches": [{
+        "gitBranchName": "master",
+        "active": false,
+        "urlAliases": null,
+        "publishOriginalBranchName": false,
+        "urlSlug": "master",
+        "versionSelectorLabel": "master",
+        "isStableBranch": false,
+        "buildsWithSnooty": true
+      }],
+      "siteBasePrefix": "docs/atlas-open-service-broker"
+    },
+    "associatedReposInfo": {},
+    "isAssociatedProduct": false
   },
-  "associatedReposInfo": {},
-  "isAssociatedProduct": false,
-  "page": {
-    "type": "root",
-    "children": [{
-        "type": "target",
+  "data": {
+    "page": {
+      "ast": {
+        "type": "root",
         "children": [{
-          "type": "target_identifier",
-          "children": [],
-          "ids": [
-            "atlas-osb"
-          ]
-        }],
-        "domain": "std",
-        "name": "label",
-        "html_id": "std-label-atlas-osb"
-      },
-      {
-        "type": "directive",
-        "children": [],
-        "domain": "",
-        "name": "meta",
-        "argument": [],
-        "options": {
-          "robots": "none"
-        }
-      },
-      {
-        "type": "section",
-        "children": [{
-            "type": "heading",
+            "type": "target",
             "children": [{
-                "type": "text",
-                "value": "MongoDB Atlas Open Service Broker on "
-              },
-              {
-                "type": "substitution_reference",
-                "children": [{
-                  "type": "text",
-                  "value": "Kubernetes"
-                }],
-                "name": "k8s"
-              }
-            ],
-            "id": "mongodb-atlas-open-service-broker-on-k8s"
+              "type": "target_identifier",
+              "children": [],
+              "ids": [
+                "atlas-osb"
+              ]
+            }],
+            "domain": "std",
+            "name": "label",
+            "html_id": "std-label-atlas-osb"
           },
           {
             "type": "directive",
             "children": [],
             "domain": "",
-            "name": "default-domain",
-            "argument": [{
-              "type": "text",
-              "position": {
-                "start": {
-                  "line": 11
-                }
-              },
-              "value": "mongodb"
-            }]
-          },
-          {
-            "type": "directive",
-            "children": [{
-              "type": "root",
-              "children": [{
-                "type": "directive",
-                "children": [{
-                  "type": "paragraph",
-                  "children": [{
-                      "type": "text",
-                      "value": "Atlas Open Service Broker is deprecated. Use the "
-                    },
-                    {
-                      "type": "reference",
-                      "children": [{
-                        "type": "text",
-                        "value": "MongoDB Atlas Operator"
-                      }],
-                      "refuri": "https://github.com//mongodb/mongodb-atlas-kubernetes"
-                    },
-                    {
-                      "type": "text",
-                      "value": " instead."
-                    }
-                  ]
-                }],
-                "domain": "",
-                "name": "important",
-                "argument": []
-              }],
-              "fileid": "includes/deprecate-osb.rst"
-            }],
-            "domain": "",
-            "name": "include",
-            "argument": [{
-              "type": "text",
-              "position": {
-                "start": {
-                  "line": 13
-                }
-              },
-              "value": "/includes/deprecate-osb.rst"
-            }]
-          },
-          {
-            "type": "directive",
-            "children": [],
-            "domain": "",
-            "name": "contents",
-            "argument": [{
-              "type": "text",
-              "position": {
-                "start": {
-                  "line": 15
-                }
-              },
-              "value": "On this page"
-            }],
+            "name": "meta",
+            "argument": [],
             "options": {
-              "local": true,
-              "backlinks": "none",
-              "depth": 1,
-              "class": "singlecol"
+              "robots": "none"
             }
           },
           {
-            "type": "paragraph",
+            "type": "section",
             "children": [{
-                "type": "text",
-                "value": "The MongoDB Atlas Open Service Broker allows you to deploy\n"
-              },
-              {
-                "type": "reference",
+                "type": "heading",
                 "children": [{
+                    "type": "text",
+                    "value": "MongoDB Atlas Open Service Broker on "
+                  },
+                  {
+                    "type": "substitution_reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Kubernetes"
+                    }],
+                    "name": "k8s"
+                  }
+                ],
+                "id": "mongodb-atlas-open-service-broker-on-k8s"
+              },
+              {
+                "type": "directive",
+                "children": [],
+                "domain": "",
+                "name": "default-domain",
+                "argument": [{
                   "type": "text",
-                  "value": "MongoDB Atlas"
-                }],
-                "refuri": "https://www.mongodb.com/docs/atlas/getting-started/"
+                  "position": {
+                    "start": {
+                      "line": 11
+                    }
+                  },
+                  "value": "mongodb"
+                }]
               },
               {
-                "type": "text",
-                "value": " clusters with any platform\nthat supports the\n"
-              },
-              {
-                "type": "reference",
+                "type": "directive",
                 "children": [{
-                  "type": "text",
-                  "value": "Open Service Broker API"
+                  "type": "root",
+                  "children": [{
+                    "type": "directive",
+                    "children": [{
+                      "type": "paragraph",
+                      "children": [{
+                          "type": "text",
+                          "value": "Atlas Open Service Broker is deprecated. Use the "
+                        },
+                        {
+                          "type": "reference",
+                          "children": [{
+                            "type": "text",
+                            "value": "MongoDB Atlas Operator"
+                          }],
+                          "refuri": "https://github.com//mongodb/mongodb-atlas-kubernetes"
+                        },
+                        {
+                          "type": "text",
+                          "value": " instead."
+                        }
+                      ]
+                    }],
+                    "domain": "",
+                    "name": "important",
+                    "argument": []
+                  }],
+                  "fileid": "includes/deprecate-osb.rst"
                 }],
-                "refuri": "https://www.openservicebrokerapi.org/"
+                "domain": "",
+                "name": "include",
+                "argument": [{
+                  "type": "text",
+                  "position": {
+                    "start": {
+                      "line": 13
+                    }
+                  },
+                  "value": "/includes/deprecate-osb.rst"
+                }]
               },
               {
-                "type": "text",
-                "value": ",\nsuch as "
+                "type": "directive",
+                "children": [],
+                "domain": "",
+                "name": "contents",
+                "argument": [{
+                  "type": "text",
+                  "position": {
+                    "start": {
+                      "line": 15
+                    }
+                  },
+                  "value": "On this page"
+                }],
+                "options": {
+                  "local": true,
+                  "backlinks": "none",
+                  "depth": 1,
+                  "class": "singlecol"
+                }
               },
               {
-                "type": "reference",
+                "type": "paragraph",
                 "children": [{
-                  "type": "text",
-                  "value": "Kubernetes"
-                }],
-                "refuri": "https://kubernetes.io/docs/home"
+                    "type": "text",
+                    "value": "The MongoDB Atlas Open Service Broker allows you to deploy\n"
+                  },
+                  {
+                    "type": "reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "MongoDB Atlas"
+                    }],
+                    "refuri": "https://www.mongodb.com/docs/atlas/getting-started/"
+                  },
+                  {
+                    "type": "text",
+                    "value": " clusters with any platform\nthat supports the\n"
+                  },
+                  {
+                    "type": "reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Open Service Broker API"
+                    }],
+                    "refuri": "https://www.openservicebrokerapi.org/"
+                  },
+                  {
+                    "type": "text",
+                    "value": ",\nsuch as "
+                  },
+                  {
+                    "type": "reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Kubernetes"
+                    }],
+                    "refuri": "https://kubernetes.io/docs/home"
+                  },
+                  {
+                    "type": "text",
+                    "value": ". The broker\nuses "
+                  },
+                  {
+                    "type": "reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Atlas Public API"
+                    }],
+                    "refuri": "https://www.mongodb.com/docs/atlas/reference/api-resources/"
+                  },
+                  {
+                    "type": "text",
+                    "value": " endpoints to\ndeploy replica set and sharded cluster deployments that "
+                  },
+                  {
+                    "type": "substitution_reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Atlas"
+                    }],
+                    "name": "service"
+                  },
+                  {
+                    "type": "text",
+                    "value": "\nmanages. By integrating with the Atlas Open Service Broker, cloud-native platforms can\nfully automate the deployment and management of MongoDB "
+                  },
+                  {
+                    "type": "substitution_reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Atlas"
+                    }],
+                    "name": "service"
+                  },
+                  {
+                    "type": "text",
+                    "value": "\nclusters."
+                  }
+                ]
               },
               {
-                "type": "text",
-                "value": ". The broker\nuses "
-              },
-              {
-                "type": "reference",
+                "type": "paragraph",
                 "children": [{
-                  "type": "text",
-                  "value": "Atlas Public API"
-                }],
-                "refuri": "https://www.mongodb.com/docs/atlas/reference/api-resources/"
+                    "type": "text",
+                    "value": "You provide the Atlas Open Service Broker with the specifications for your MongoDB\ncluster. The Atlas Open Service Broker uses this information to tell "
+                  },
+                  {
+                    "type": "substitution_reference",
+                    "children": [{
+                      "type": "text",
+                      "value": "Kubernetes"
+                    }],
+                    "name": "k8s"
+                  },
+                  {
+                    "type": "text",
+                    "value": " how to\nconfigure that cluster including provisioning storage, setting up the\nnetwork connections, and configuring database users."
+                  }
+                ]
               },
               {
-                "type": "text",
-                "value": " endpoints to\ndeploy replica set and sharded cluster deployments that "
-              },
-              {
-                "type": "substitution_reference",
-                "children": [{
-                  "type": "text",
-                  "value": "Atlas"
-                }],
-                "name": "service"
-              },
-              {
-                "type": "text",
-                "value": "\nmanages. By integrating with the Atlas Open Service Broker, cloud-native platforms can\nfully automate the deployment and management of MongoDB "
-              },
-              {
-                "type": "substitution_reference",
-                "children": [{
-                  "type": "text",
-                  "value": "Atlas"
-                }],
-                "name": "service"
-              },
-              {
-                "type": "text",
-                "value": "\nclusters."
-              }
-            ]
-          },
-          {
-            "type": "paragraph",
-            "children": [{
-                "type": "text",
-                "value": "You provide the Atlas Open Service Broker with the specifications for your MongoDB\ncluster. The Atlas Open Service Broker uses this information to tell "
-              },
-              {
-                "type": "substitution_reference",
-                "children": [{
-                  "type": "text",
-                  "value": "Kubernetes"
-                }],
-                "name": "k8s"
-              },
-              {
-                "type": "text",
-                "value": " how to\nconfigure that cluster including provisioning storage, setting up the\nnetwork connections, and configuring database users."
-              }
-            ]
-          },
-          {
-            "type": "directive",
-            "children": [],
-            "domain": "",
-            "name": "toctree",
-            "argument": [],
-            "options": {
-              "titlesonly": true
-            },
-            "entries": [{
-                "title": "Installation",
-                "slug": "/installation"
-              },
-              {
-                "title": "Database Deployment",
-                "slug": "/deploy"
-              },
-              {
-                "title": "User Management",
-                "slug": "/tutorial/manage-database-users"
-              },
-              {
-                "slug": "/third-party-licenses"
-              },
-              {
-                "title": "Release Notes",
-                "slug": "/release-notes"
+                "type": "directive",
+                "children": [],
+                "domain": "",
+                "name": "toctree",
+                "argument": [],
+                "options": {
+                  "titlesonly": true
+                },
+                "entries": [{
+                    "title": "Installation",
+                    "slug": "/installation"
+                  },
+                  {
+                    "title": "Database Deployment",
+                    "slug": "/deploy"
+                  },
+                  {
+                    "title": "User Management",
+                    "slug": "/tutorial/manage-database-users"
+                  },
+                  {
+                    "slug": "/third-party-licenses"
+                  },
+                  {
+                    "title": "Release Notes",
+                    "slug": "/release-notes"
+                  }
+                ]
               }
             ]
           }
-        ]
+        ],
+        "fileid": "index.txt",
+        "options": {
+          "noprevnext": ""
+        }
       }
-    ],
-    "fileid": "index.txt",
-    "options": {
-      "noprevnext": ""
     }
   }
 }

--- a/tests/unit/data/HeadPageContext.test.json
+++ b/tests/unit/data/HeadPageContext.test.json
@@ -1,533 +1,427 @@
 {
-    "slug": "/",
-    "repoBranches": {
-        "branches": [
-            {
-                "name": "master",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "master",
-                "isStableBranch": false,
-                "urlAliases": [
-                    "upcoming",
-                    "v1.27"
-                ],
-                "urlSlug": "upcoming",
-                "versionSelectorLabel": "1.27 (upcoming)",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.26",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.26",
-                "isStableBranch": true,
-                "urlAliases": [
-                    "stable",
-                    "1.26",
-                    "1.26.0",
-                    "1.26.1"
-                ],
-                "urlSlug": "stable",
-                "versionSelectorLabel": "1.26.1 (stable)",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.25",
-                "publishOriginalBranch": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.25",
-                "isStableBranch": false,
-                "urlAliases": [],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.25",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.24",
-                "publishOriginalBranch": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.24",
-                "isStableBranch": false,
-                "urlAliases": [],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.24",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.23",
-                "publishOriginalBranch": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.23",
-                "isStableBranch": false,
-                "urlAliases": [],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.23",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.22",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.22",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.22",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.21",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.21",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.21",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.20",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.20",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.20",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.19",
-                "publishOriginalBranchName": true,
-                "active": true,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.19",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.19",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.18",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.18",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.18",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.17",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.17",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.17",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.16",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": [
-                    null
-                ],
-                "gitBranchName": "v1.16",
-                "isStableBranch": false,
-                "urlAliases": [
-                    null
-                ],
-                "urlSlug": null,
-                "versionSelectorLabel": "1.16",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.15",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.15",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.15",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.14",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.14",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.14",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.13",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.13",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.13",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.12",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.12",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.12",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.11",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.11",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.11",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.10",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.10",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.10",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.9",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.9",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.9",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.8",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.8",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.8",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.7",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.7",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.7",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.6",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.6",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.6",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.5",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.5",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.5",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.4.0",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.4.0",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.4",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.3.0",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.3.0",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.3",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.2.0",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.2.0",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.2",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.1.0",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.1.0",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.1",
-                "buildsWithSnooty": true
-            },
-            {
-                "name": "v1.0.0",
-                "publishOriginalBranchName": true,
-                "active": false,
-                "aliases": null,
-                "gitBranchName": "v1.0.0",
-                "isStableBranch": false,
-                "urlAliases": null,
-                "urlSlug": null,
-                "versionSelectorLabel": "1.0",
-                "buildsWithSnooty": true
-            },
-            {
-                "gitBranchName": "0.5",
-                "buildsWithSnooty": false,
-                "active": false
-            },
-            {
-                "gitBranchName": "0.0.4",
-                "buildsWithSnooty": false,
-                "active": false
-            },
-            {
-                "gitBranchName": "0.0.3",
-                "buildsWithSnooty": false,
-                "active": false
-            },
-            {
-                "gitBranchName": "0.2",
-                "buildsWithSnooty": false,
-                "active": false
-            },
-            {
-                "gitBranchName": "0.1",
-                "buildsWithSnooty": false,
-                "active": false
-            }
-        ],
-        "siteBasePrefix": "docs/mongocli"
+    "pageContext": {
+        "slug": "/",
+        "repoBranches": {
+            "branches": [
+                {
+                    "name": "master",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "master",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        "upcoming",
+                        "v1.27"
+                    ],
+                    "urlSlug": "upcoming",
+                    "versionSelectorLabel": "1.27 (upcoming)",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.26",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.26",
+                    "isStableBranch": true,
+                    "urlAliases": [
+                        "stable",
+                        "1.26",
+                        "1.26.0",
+                        "1.26.1"
+                    ],
+                    "urlSlug": "stable",
+                    "versionSelectorLabel": "1.26.1 (stable)",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.25",
+                    "publishOriginalBranch": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.25",
+                    "isStableBranch": false,
+                    "urlAliases": [],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.25",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.24",
+                    "publishOriginalBranch": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.24",
+                    "isStableBranch": false,
+                    "urlAliases": [],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.24",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.23",
+                    "publishOriginalBranch": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.23",
+                    "isStableBranch": false,
+                    "urlAliases": [],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.23",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.22",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.22",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.22",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.21",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.21",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.21",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.20",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.20",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.20",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.19",
+                    "publishOriginalBranchName": true,
+                    "active": true,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.19",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.19",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.18",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.18",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.18",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.17",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.17",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.17",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.16",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": [
+                        null
+                    ],
+                    "gitBranchName": "v1.16",
+                    "isStableBranch": false,
+                    "urlAliases": [
+                        null
+                    ],
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.16",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.15",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.15",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.15",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.14",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.14",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.14",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.13",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.13",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.13",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.12",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.12",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.12",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.11",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.11",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.11",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.10",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.10",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.10",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.9",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.9",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.9",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.8",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.8",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.8",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.7",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.7",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.7",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.6",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.6",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.6",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.5",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.5",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.5",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.4.0",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.4.0",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.4",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.3.0",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.3.0",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.3",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.2.0",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.2.0",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.2",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.1.0",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.1.0",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.1",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "name": "v1.0.0",
+                    "publishOriginalBranchName": true,
+                    "active": false,
+                    "aliases": null,
+                    "gitBranchName": "v1.0.0",
+                    "isStableBranch": false,
+                    "urlAliases": null,
+                    "urlSlug": null,
+                    "versionSelectorLabel": "1.0",
+                    "buildsWithSnooty": true
+                },
+                {
+                    "gitBranchName": "0.5",
+                    "buildsWithSnooty": false,
+                    "active": false
+                },
+                {
+                    "gitBranchName": "0.0.4",
+                    "buildsWithSnooty": false,
+                    "active": false
+                },
+                {
+                    "gitBranchName": "0.0.3",
+                    "buildsWithSnooty": false,
+                    "active": false
+                },
+                {
+                    "gitBranchName": "0.2",
+                    "buildsWithSnooty": false,
+                    "active": false
+                },
+                {
+                    "gitBranchName": "0.1",
+                    "buildsWithSnooty": false,
+                    "active": false
+                }
+            ],
+            "siteBasePrefix": "docs/mongocli"
+        },
+        "associatedReposInfo": {},
+        "isAssociatedProduct": false,
+        "template": "product-landing"
     },
-    "associatedReposInfo": {},
-    "isAssociatedProduct": false,
-    "template": "product-landing",
-    "page": {
-        "type": "root",
-        "children": [
-            {
-                "type": "section",
+    "data": {
+        "page": {
+            "ast": {
+                "type": "root",
                 "children": [
-                    {
-                        "type": "heading",
-                        "children": [
-                            {
-                                "type": "text",
-                                "value": "What is mongocli?"
-                            }
-                        ],
-                        "id": "what-is-mongocli-"
-                    },
-                    {
-                        "type": "directive",
-                        "children": [
-                            {
-                                "type": "paragraph",
-                                "children": [
-                                    {
-                                        "type": "text",
-                                        "value": "The MongoDB CLI is a modern command line interface that enables you to manage\nyour MongoDB services from the terminal."
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "directive",
-                                "children": [],
-                                "domain": "mongodb",
-                                "name": "button",
-                                "argument": [
-                                    {
-                                        "type": "text",
-                                        "position": {
-                                            "start": {
-                                                "line": 13
-                                            }
-                                        },
-                                        "value": "Install MongoDB CLI"
-                                    }
-                                ],
-                                "options": {
-                                    "uri": "https://www.mongodb.com/try/download/mongocli"
-                                }
-                            },
-                            {
-                                "type": "paragraph",
-                                "children": [
-                                    {
-                                        "type": "ref_role",
-                                        "children": [
-                                            {
-                                                "type": "text",
-                                                "value": "View installation instructions"
-                                            }
-                                        ],
-                                        "domain": "std",
-                                        "name": "doc",
-                                        "target": "",
-                                        "flag": "",
-                                        "fileid": [
-                                            "/install",
-                                            ""
-                                        ]
-                                    }
-                                ]
-                            }
-                        ],
-                        "domain": "mongodb",
-                        "name": "introduction",
-                        "argument": []
-                    },
-                    {
-                        "type": "directive",
-                        "children": [],
-                        "domain": "",
-                        "name": "image",
-                        "argument": [
-                            {
-                                "type": "text",
-                                "position": {
-                                    "start": {
-                                        "line": 18
-                                    }
-                                },
-                                "value": "/images/hero.png"
-                            }
-                        ],
-                        "options": {
-                            "alt": "Homepage hero image",
-                            "checksum": "dcb3ea50be8166b3807798930e9afd619d17d29e956a3bf9d7d6a78364834b47"
-                        }
-                    },
-                    {
-                        "type": "directive",
-                        "children": [],
-                        "domain": "mongodb",
-                        "name": "kicker",
-                        "argument": [
-                            {
-                                "type": "text",
-                                "position": {
-                                    "start": {
-                                        "line": 21
-                                    }
-                                },
-                                "value": "What You Can Do"
-                            }
-                        ]
-                    },
                     {
                         "type": "section",
                         "children": [
@@ -536,443 +430,90 @@
                                 "children": [
                                     {
                                         "type": "text",
-                                        "value": "Manage your Deployment from the Command Line"
+                                        "value": "What is mongocli?"
                                     }
                                 ],
-                                "id": "manage-your-deployment-from-the-command-line"
-                            },
-                            {
-                                "type": "paragraph",
-                                "children": [
-                                    {
-                                        "type": "text",
-                                        "value": "Use simple, one-line commands to interact with MongoDB "
-                                    },
-                                    {
-                                        "type": "substitution_reference",
-                                        "children": [
-                                            {
-                                                "type": "text",
-                                                "value": "Atlas"
-                                            }
-                                        ],
-                                        "name": "service"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": ",\n"
-                                    },
-                                    {
-                                        "type": "substitution_reference",
-                                        "children": [
-                                            {
-                                                "type": "text",
-                                                "value": "Cloud Manager"
-                                            }
-                                        ],
-                                        "name": "cloud-short"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": ", or "
-                                    },
-                                    {
-                                        "type": "substitution_reference",
-                                        "children": [
-                                            {
-                                                "type": "text",
-                                                "value": "Ops Manager"
-                                            }
-                                        ],
-                                        "name": "onprem"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": ", and to automate management tasks for your deployments."
-                                    }
-                                ]
+                                "id": "what-is-mongocli-"
                             },
                             {
                                 "type": "directive",
                                 "children": [
                                     {
-                                        "type": "directive",
+                                        "type": "paragraph",
                                         "children": [
                                             {
-                                                "type": "directive",
-                                                "children": [
-                                                    {
-                                                        "type": "directive",
-                                                        "children": [
-                                                            {
-                                                                "type": "section",
-                                                                "children": [
-                                                                    {
-                                                                        "type": "heading",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Create API Keys"
-                                                                            }
-                                                                        ],
-                                                                        "id": "create-api-keys"
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "In the "
-                                                                            },
-                                                                            {
-                                                                                "type": "substitution_reference",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "Atlas"
-                                                                                    }
-                                                                                ],
-                                                                                "name": "service"
-                                                                            },
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": " UI, create an API key to programmatically access\nyour organization or project."
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "ref_role",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "To learn more, see Configure Atlas API Access"
-                                                                                    }
-                                                                                ],
-                                                                                "domain": "std",
-                                                                                "name": "label",
-                                                                                "target": "atlas-prog-api-key",
-                                                                                "flag": "",
-                                                                                "url": "https://www.mongodb.com/docs/atlas/configure-api-access/#std-label-atlas-prog-api-key"
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                ]
-                                                            }
-                                                        ],
-                                                        "domain": "mongodb",
-                                                        "name": "step",
-                                                        "argument": [
-                                                            {
-                                                                "type": "text",
-                                                                "position": {
-                                                                    "start": {
-                                                                        "line": 36
-                                                                    }
-                                                                },
-                                                                "value": "Create API Keys"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "directive",
-                                                        "children": [
-                                                            {
-                                                                "type": "section",
-                                                                "children": [
-                                                                    {
-                                                                        "type": "heading",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Create a Project"
-                                                                            }
-                                                                        ],
-                                                                        "id": "create-a-project"
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "If you don't have an existing project, create one to group clusters\nthat share users, settings, or environments."
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "reference",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "To learn more, see Create a Project"
-                                                                                    }
-                                                                                ],
-                                                                                "refuri": "https://www.mongodb.com/docs/atlas/tutorial/manage-projects/#std-label-create-project"
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                ]
-                                                            }
-                                                        ],
-                                                        "domain": "mongodb",
-                                                        "name": "step",
-                                                        "argument": [
-                                                            {
-                                                                "type": "text",
-                                                                "position": {
-                                                                    "start": {
-                                                                        "line": 43
-                                                                    }
-                                                                },
-                                                                "value": "Create a Project"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "directive",
-                                                        "children": [
-                                                            {
-                                                                "type": "section",
-                                                                "children": [
-                                                                    {
-                                                                        "type": "heading",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Create a Profile"
-                                                                            }
-                                                                        ],
-                                                                        "id": "create-a-profile"
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Store your API keys, organization and project IDs, and other\nsettings in a profile to easily access your MongoDB deployments."
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "ref_role",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "To learn more, see Configure the MongoDB CLI"
-                                                                                    }
-                                                                                ],
-                                                                                "domain": "std",
-                                                                                "name": "label",
-                                                                                "target": "mcli-configure",
-                                                                                "flag": "",
-                                                                                "fileid": [
-                                                                                    "configure",
-                                                                                    "std-label-mcli-configure"
-                                                                                ]
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                ]
-                                                            }
-                                                        ],
-                                                        "domain": "mongodb",
-                                                        "name": "step",
-                                                        "argument": [
-                                                            {
-                                                                "type": "text",
-                                                                "position": {
-                                                                    "start": {
-                                                                        "line": 50
-                                                                    }
-                                                                },
-                                                                "value": "Create a Profile"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "domain": "mongodb",
-                                                "name": "procedure",
-                                                "argument": []
-                                            },
-                                            {
-                                                "type": "directive",
-                                                "children": [],
-                                                "domain": "",
-                                                "name": "image",
-                                                "argument": [
-                                                    {
-                                                        "type": "text",
-                                                        "position": {
-                                                            "start": {
-                                                                "line": 57
-                                                            }
-                                                        },
-                                                        "value": "/images/config.gif"
-                                                    }
-                                                ],
-                                                "options": {
-                                                    "alt": "MongoDB CLI config command",
-                                                    "checksum": "f89ccb09ca279e13f153aff88d50d5680a84cf202443922344569124741f40a8"
-                                                }
-                                            }
-                                        ],
-                                        "domain": "",
-                                        "name": "tab",
-                                        "argument": [
-                                            {
                                                 "type": "text",
-                                                "position": {
-                                                    "start": {
-                                                        "line": 31
-                                                    }
-                                                },
-                                                "value": "Configure the MongoDB CLI"
+                                                "value": "The MongoDB CLI is a modern command line interface that enables you to manage\nyour MongoDB services from the terminal."
                                             }
-                                        ],
-                                        "options": {
-                                            "tabid": "configure"
-                                        }
+                                        ]
                                     },
                                     {
                                         "type": "directive",
-                                        "children": [
-                                            {
-                                                "type": "directive",
-                                                "children": [
-                                                    {
-                                                        "type": "directive",
-                                                        "children": [
-                                                            {
-                                                                "type": "section",
-                                                                "children": [
-                                                                    {
-                                                                        "type": "heading",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Quick Start"
-                                                                            }
-                                                                        ],
-                                                                        "id": "quick-start"
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": "Create, configure and connect to an "
-                                                                            },
-                                                                            {
-                                                                                "type": "substitution_reference",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "Atlas"
-                                                                                    }
-                                                                                ],
-                                                                                "name": "service"
-                                                                            },
-                                                                            {
-                                                                                "type": "text",
-                                                                                "value": " cluster in one command."
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    {
-                                                                        "type": "paragraph",
-                                                                        "children": [
-                                                                            {
-                                                                                "type": "ref_role",
-                                                                                "children": [
-                                                                                    {
-                                                                                        "type": "text",
-                                                                                        "value": "To learn more, see Get Started with MongoDB Atlas"
-                                                                                    }
-                                                                                ],
-                                                                                "domain": "std",
-                                                                                "name": "label",
-                                                                                "target": "mcli-quick-start-atlas",
-                                                                                "flag": "",
-                                                                                "fileid": [
-                                                                                    "quick-start/atlas",
-                                                                                    "std-label-mcli-quick-start-atlas"
-                                                                                ]
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                ]
-                                                            }
-                                                        ],
-                                                        "domain": "mongodb",
-                                                        "name": "step",
-                                                        "argument": [
-                                                            {
-                                                                "type": "text",
-                                                                "position": {
-                                                                    "start": {
-                                                                        "line": 65
-                                                                    }
-                                                                },
-                                                                "value": "Quick Start"
-                                                            }
-                                                        ]
-                                                    }
-                                                ],
-                                                "domain": "mongodb",
-                                                "name": "procedure",
-                                                "argument": []
-                                            },
-                                            {
-                                                "type": "directive",
-                                                "children": [],
-                                                "domain": "",
-                                                "name": "image",
-                                                "argument": [
-                                                    {
-                                                        "type": "text",
-                                                        "position": {
-                                                            "start": {
-                                                                "line": 71
-                                                            }
-                                                        },
-                                                        "value": "/images/quickstart.gif"
-                                                    }
-                                                ],
-                                                "options": {
-                                                    "alt": "MongoDB CLI quickstart command",
-                                                    "checksum": "4fbcbb9f7d7f4ad061fe55491d8201bb259848b05e9d4d351bf3545991725f18"
-                                                }
-                                            }
-                                        ],
-                                        "domain": "",
-                                        "name": "tab",
+                                        "children": [],
+                                        "domain": "mongodb",
+                                        "name": "button",
                                         "argument": [
                                             {
                                                 "type": "text",
                                                 "position": {
                                                     "start": {
-                                                        "line": 60
+                                                        "line": 13
                                                     }
                                                 },
-                                                "value": "Create a Cluster with One Command"
+                                                "value": "Install MongoDB CLI"
                                             }
                                         ],
                                         "options": {
-                                            "tabid": "create-cluster"
+                                            "uri": "https://www.mongodb.com/try/download/mongocli"
                                         }
+                                    },
+                                    {
+                                        "type": "paragraph",
+                                        "children": [
+                                            {
+                                                "type": "ref_role",
+                                                "children": [
+                                                    {
+                                                        "type": "text",
+                                                        "value": "View installation instructions"
+                                                    }
+                                                ],
+                                                "domain": "std",
+                                                "name": "doc",
+                                                "target": "",
+                                                "flag": "",
+                                                "fileid": [
+                                                    "/install",
+                                                    ""
+                                                ]
+                                            }
+                                        ]
                                     }
                                 ],
-                                "domain": "",
-                                "name": "tabs",
+                                "domain": "mongodb",
+                                "name": "introduction",
                                 "argument": []
+                            },
+                            {
+                                "type": "directive",
+                                "children": [],
+                                "domain": "",
+                                "name": "image",
+                                "argument": [
+                                    {
+                                        "type": "text",
+                                        "position": {
+                                            "start": {
+                                                "line": 18
+                                            }
+                                        },
+                                        "value": "/images/hero.png"
+                                    }
+                                ],
+                                "options": {
+                                    "alt": "Homepage hero image",
+                                    "checksum": "dcb3ea50be8166b3807798930e9afd619d17d29e956a3bf9d7d6a78364834b47"
+                                }
                             },
                             {
                                 "type": "directive",
@@ -984,176 +525,641 @@
                                         "type": "text",
                                         "position": {
                                             "start": {
-                                                "line": 74
+                                                "line": 21
                                             }
                                         },
-                                        "value": "Related Products & Resources"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "type": "section",
-                        "children": [
-                            {
-                                "type": "heading",
-                                "children": [
-                                    {
-                                        "type": "text",
-                                        "value": "Go Further with the MongoDB CLI"
-                                    }
-                                ],
-                                "id": "go-further-with-the-mongodb-cli"
-                            },
-                            {
-                                "type": "paragraph",
-                                "children": [
-                                    {
-                                        "type": "text",
-                                        "value": "Explore advanced features of the MongoDB CLI and the MongoDB services you can\ninteract with."
+                                        "value": "What You Can Do"
                                     }
                                 ]
                             },
                             {
-                                "type": "directive",
+                                "type": "section",
                                 "children": [
                                     {
-                                        "type": "directive",
+                                        "type": "heading",
                                         "children": [
                                             {
-                                                "type": "paragraph",
+                                                "type": "text",
+                                                "value": "Manage your Deployment from the Command Line"
+                                            }
+                                        ],
+                                        "id": "manage-your-deployment-from-the-command-line"
+                                    },
+                                    {
+                                        "type": "paragraph",
+                                        "children": [
+                                            {
+                                                "type": "text",
+                                                "value": "Use simple, one-line commands to interact with MongoDB "
+                                            },
+                                            {
+                                                "type": "substitution_reference",
                                                 "children": [
                                                     {
                                                         "type": "text",
-                                                        "value": "Interact with your cloud deployments through a GUI"
+                                                        "value": "Atlas"
                                                     }
-                                                ]
+                                                ],
+                                                "name": "service"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "value": ",\n"
+                                            },
+                                            {
+                                                "type": "substitution_reference",
+                                                "children": [
+                                                    {
+                                                        "type": "text",
+                                                        "value": "Cloud Manager"
+                                                    }
+                                                ],
+                                                "name": "cloud-short"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "value": ", or "
+                                            },
+                                            {
+                                                "type": "substitution_reference",
+                                                "children": [
+                                                    {
+                                                        "type": "text",
+                                                        "value": "Ops Manager"
+                                                    }
+                                                ],
+                                                "name": "onprem"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "value": ", and to automate management tasks for your deployments."
                                             }
-                                        ],
-                                        "domain": "mongodb",
-                                        "name": "card",
-                                        "argument": [],
-                                        "options": {
-                                            "cta": "Read Atlas docs",
-                                            "url": "https://www.mongodb.com/docs/atlas/getting-started/",
-                                            "icon": "/images/icons/atlas.svg",
-                                            "icon-alt": "MongoDB Atlas icon",
-                                            "checksum": "19ffb0be3b701fc806c5b442aeb098cc76181ab270f3c57b108197321fecd4d0"
-                                        }
+                                        ]
                                     },
                                     {
                                         "type": "directive",
                                         "children": [
                                             {
-                                                "type": "paragraph",
+                                                "type": "directive",
                                                 "children": [
                                                     {
-                                                        "type": "text",
-                                                        "value": "Explore more advanced MongoDB CLI use cases"
+                                                        "type": "directive",
+                                                        "children": [
+                                                            {
+                                                                "type": "directive",
+                                                                "children": [
+                                                                    {
+                                                                        "type": "section",
+                                                                        "children": [
+                                                                            {
+                                                                                "type": "heading",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Create API Keys"
+                                                                                    }
+                                                                                ],
+                                                                                "id": "create-api-keys"
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "In the "
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "substitution_reference",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "Atlas"
+                                                                                            }
+                                                                                        ],
+                                                                                        "name": "service"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": " UI, create an API key to programmatically access\nyour organization or project."
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "ref_role",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "To learn more, see Configure Atlas API Access"
+                                                                                            }
+                                                                                        ],
+                                                                                        "domain": "std",
+                                                                                        "name": "label",
+                                                                                        "target": "atlas-prog-api-key",
+                                                                                        "flag": "",
+                                                                                        "url": "https://www.mongodb.com/docs/atlas/configure-api-access/#std-label-atlas-prog-api-key"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "domain": "mongodb",
+                                                                "name": "step",
+                                                                "argument": [
+                                                                    {
+                                                                        "type": "text",
+                                                                        "position": {
+                                                                            "start": {
+                                                                                "line": 36
+                                                                            }
+                                                                        },
+                                                                        "value": "Create API Keys"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "directive",
+                                                                "children": [
+                                                                    {
+                                                                        "type": "section",
+                                                                        "children": [
+                                                                            {
+                                                                                "type": "heading",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Create a Project"
+                                                                                    }
+                                                                                ],
+                                                                                "id": "create-a-project"
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "If you don't have an existing project, create one to group clusters\nthat share users, settings, or environments."
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "reference",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "To learn more, see Create a Project"
+                                                                                            }
+                                                                                        ],
+                                                                                        "refuri": "https://www.mongodb.com/docs/atlas/tutorial/manage-projects/#std-label-create-project"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "domain": "mongodb",
+                                                                "name": "step",
+                                                                "argument": [
+                                                                    {
+                                                                        "type": "text",
+                                                                        "position": {
+                                                                            "start": {
+                                                                                "line": 43
+                                                                            }
+                                                                        },
+                                                                        "value": "Create a Project"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "directive",
+                                                                "children": [
+                                                                    {
+                                                                        "type": "section",
+                                                                        "children": [
+                                                                            {
+                                                                                "type": "heading",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Create a Profile"
+                                                                                    }
+                                                                                ],
+                                                                                "id": "create-a-profile"
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Store your API keys, organization and project IDs, and other\nsettings in a profile to easily access your MongoDB deployments."
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "ref_role",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "To learn more, see Configure the MongoDB CLI"
+                                                                                            }
+                                                                                        ],
+                                                                                        "domain": "std",
+                                                                                        "name": "label",
+                                                                                        "target": "mcli-configure",
+                                                                                        "flag": "",
+                                                                                        "fileid": [
+                                                                                            "configure",
+                                                                                            "std-label-mcli-configure"
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "domain": "mongodb",
+                                                                "name": "step",
+                                                                "argument": [
+                                                                    {
+                                                                        "type": "text",
+                                                                        "position": {
+                                                                            "start": {
+                                                                                "line": 50
+                                                                            }
+                                                                        },
+                                                                        "value": "Create a Profile"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "domain": "mongodb",
+                                                        "name": "procedure",
+                                                        "argument": []
+                                                    },
+                                                    {
+                                                        "type": "directive",
+                                                        "children": [],
+                                                        "domain": "",
+                                                        "name": "image",
+                                                        "argument": [
+                                                            {
+                                                                "type": "text",
+                                                                "position": {
+                                                                    "start": {
+                                                                        "line": 57
+                                                                    }
+                                                                },
+                                                                "value": "/images/config.gif"
+                                                            }
+                                                        ],
+                                                        "options": {
+                                                            "alt": "MongoDB CLI config command",
+                                                            "checksum": "f89ccb09ca279e13f153aff88d50d5680a84cf202443922344569124741f40a8"
+                                                        }
                                                     }
-                                                ]
+                                                ],
+                                                "domain": "",
+                                                "name": "tab",
+                                                "argument": [
+                                                    {
+                                                        "type": "text",
+                                                        "position": {
+                                                            "start": {
+                                                                "line": 31
+                                                            }
+                                                        },
+                                                        "value": "Configure the MongoDB CLI"
+                                                    }
+                                                ],
+                                                "options": {
+                                                    "tabid": "configure"
+                                                }
+                                            },
+                                            {
+                                                "type": "directive",
+                                                "children": [
+                                                    {
+                                                        "type": "directive",
+                                                        "children": [
+                                                            {
+                                                                "type": "directive",
+                                                                "children": [
+                                                                    {
+                                                                        "type": "section",
+                                                                        "children": [
+                                                                            {
+                                                                                "type": "heading",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Quick Start"
+                                                                                    }
+                                                                                ],
+                                                                                "id": "quick-start"
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": "Create, configure and connect to an "
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "substitution_reference",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "Atlas"
+                                                                                            }
+                                                                                        ],
+                                                                                        "name": "service"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "text",
+                                                                                        "value": " cluster in one command."
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "paragraph",
+                                                                                "children": [
+                                                                                    {
+                                                                                        "type": "ref_role",
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "type": "text",
+                                                                                                "value": "To learn more, see Get Started with MongoDB Atlas"
+                                                                                            }
+                                                                                        ],
+                                                                                        "domain": "std",
+                                                                                        "name": "label",
+                                                                                        "target": "mcli-quick-start-atlas",
+                                                                                        "flag": "",
+                                                                                        "fileid": [
+                                                                                            "quick-start/atlas",
+                                                                                            "std-label-mcli-quick-start-atlas"
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "domain": "mongodb",
+                                                                "name": "step",
+                                                                "argument": [
+                                                                    {
+                                                                        "type": "text",
+                                                                        "position": {
+                                                                            "start": {
+                                                                                "line": 65
+                                                                            }
+                                                                        },
+                                                                        "value": "Quick Start"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "domain": "mongodb",
+                                                        "name": "procedure",
+                                                        "argument": []
+                                                    },
+                                                    {
+                                                        "type": "directive",
+                                                        "children": [],
+                                                        "domain": "",
+                                                        "name": "image",
+                                                        "argument": [
+                                                            {
+                                                                "type": "text",
+                                                                "position": {
+                                                                    "start": {
+                                                                        "line": 71
+                                                                    }
+                                                                },
+                                                                "value": "/images/quickstart.gif"
+                                                            }
+                                                        ],
+                                                        "options": {
+                                                            "alt": "MongoDB CLI quickstart command",
+                                                            "checksum": "4fbcbb9f7d7f4ad061fe55491d8201bb259848b05e9d4d351bf3545991725f18"
+                                                        }
+                                                    }
+                                                ],
+                                                "domain": "",
+                                                "name": "tab",
+                                                "argument": [
+                                                    {
+                                                        "type": "text",
+                                                        "position": {
+                                                            "start": {
+                                                                "line": 60
+                                                            }
+                                                        },
+                                                        "value": "Create a Cluster with One Command"
+                                                    }
+                                                ],
+                                                "options": {
+                                                    "tabid": "create-cluster"
+                                                }
                                             }
                                         ],
-                                        "domain": "mongodb",
-                                        "name": "card",
-                                        "argument": [],
-                                        "options": {
-                                            "cta": "Read Reference Docs",
-                                            "url": "https://www.mongodb.com/docs/mongocli/stable/command/mongocli/",
-                                            "icon": "/images/icons/reference.svg",
-                                            "icon-alt": "MongoCLI Reference icon",
-                                            "checksum": "cb759dc55c41c5850e4d42f4495e5e5a29a7ee255e14b9afb37c57486138480f"
-                                        }
+                                        "domain": "",
+                                        "name": "tabs",
+                                        "argument": []
                                     },
                                     {
                                         "type": "directive",
-                                        "children": [
-                                            {
-                                                "type": "paragraph",
-                                                "children": [
-                                                    {
-                                                        "type": "text",
-                                                        "value": "Review common error messages and issues"
-                                                    }
-                                                ]
-                                            }
-                                        ],
+                                        "children": [],
                                         "domain": "mongodb",
-                                        "name": "card",
-                                        "argument": [],
-                                        "options": {
-                                            "cta": "Read Troubleshooting Docs",
-                                            "url": "https://www.mongodb.com/docs/mongocli/stable/troubleshooting/",
-                                            "icon": "/images/icons/troubleshooting.svg",
-                                            "icon-alt": "MongoCLI Troubleshooting icon",
-                                            "checksum": "809f6b722bd532b32da74a13801fa452f1064ae6da70dc254e8a453a95b77be9"
-                                        }
+                                        "name": "kicker",
+                                        "argument": [
+                                            {
+                                                "type": "text",
+                                                "position": {
+                                                    "start": {
+                                                        "line": 74
+                                                    }
+                                                },
+                                                "value": "Related Products & Resources"
+                                            }
+                                        ]
                                     }
-                                ],
-                                "domain": "mongodb",
-                                "name": "card-group",
-                                "argument": [],
-                                "options": {
-                                    "columns": 3,
-                                    "style": "compact"
-                                }
+                                ]
                             },
                             {
-                                "type": "directive",
-                                "children": [],
-                                "domain": "",
-                                "name": "toctree",
-                                "argument": [],
-                                "options": {
-                                    "titlesonly": true
-                                },
-                                "entries": [
+                                "type": "section",
+                                "children": [
                                     {
-                                        "title": "Overview",
-                                        "slug": "/index"
+                                        "type": "heading",
+                                        "children": [
+                                            {
+                                                "type": "text",
+                                                "value": "Go Further with the MongoDB CLI"
+                                            }
+                                        ],
+                                        "id": "go-further-with-the-mongodb-cli"
                                     },
                                     {
-                                        "slug": "/install/compatibility"
+                                        "type": "paragraph",
+                                        "children": [
+                                            {
+                                                "type": "text",
+                                                "value": "Explore advanced features of the MongoDB CLI and the MongoDB services you can\ninteract with."
+                                            }
+                                        ]
                                     },
                                     {
-                                        "slug": "/install"
+                                        "type": "directive",
+                                        "children": [
+                                            {
+                                                "type": "directive",
+                                                "children": [
+                                                    {
+                                                        "type": "paragraph",
+                                                        "children": [
+                                                            {
+                                                                "type": "text",
+                                                                "value": "Interact with your cloud deployments through a GUI"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "domain": "mongodb",
+                                                "name": "card",
+                                                "argument": [],
+                                                "options": {
+                                                    "cta": "Read Atlas docs",
+                                                    "url": "https://www.mongodb.com/docs/atlas/getting-started/",
+                                                    "icon": "/images/icons/atlas.svg",
+                                                    "icon-alt": "MongoDB Atlas icon",
+                                                    "checksum": "19ffb0be3b701fc806c5b442aeb098cc76181ab270f3c57b108197321fecd4d0"
+                                                }
+                                            },
+                                            {
+                                                "type": "directive",
+                                                "children": [
+                                                    {
+                                                        "type": "paragraph",
+                                                        "children": [
+                                                            {
+                                                                "type": "text",
+                                                                "value": "Explore more advanced MongoDB CLI use cases"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "domain": "mongodb",
+                                                "name": "card",
+                                                "argument": [],
+                                                "options": {
+                                                    "cta": "Read Reference Docs",
+                                                    "url": "https://www.mongodb.com/docs/mongocli/stable/command/mongocli/",
+                                                    "icon": "/images/icons/reference.svg",
+                                                    "icon-alt": "MongoCLI Reference icon",
+                                                    "checksum": "cb759dc55c41c5850e4d42f4495e5e5a29a7ee255e14b9afb37c57486138480f"
+                                                }
+                                            },
+                                            {
+                                                "type": "directive",
+                                                "children": [
+                                                    {
+                                                        "type": "paragraph",
+                                                        "children": [
+                                                            {
+                                                                "type": "text",
+                                                                "value": "Review common error messages and issues"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "domain": "mongodb",
+                                                "name": "card",
+                                                "argument": [],
+                                                "options": {
+                                                    "cta": "Read Troubleshooting Docs",
+                                                    "url": "https://www.mongodb.com/docs/mongocli/stable/troubleshooting/",
+                                                    "icon": "/images/icons/troubleshooting.svg",
+                                                    "icon-alt": "MongoCLI Troubleshooting icon",
+                                                    "checksum": "809f6b722bd532b32da74a13801fa452f1064ae6da70dc254e8a453a95b77be9"
+                                                }
+                                            }
+                                        ],
+                                        "domain": "mongodb",
+                                        "name": "card-group",
+                                        "argument": [],
+                                        "options": {
+                                            "columns": 3,
+                                            "style": "compact"
+                                        }
                                     },
                                     {
-                                        "slug": "/configure"
-                                    },
-                                    {
-                                        "slug": "/quick-start"
-                                    },
-                                    {
-                                        "title": "MongoDB CLI Commands",
-                                        "slug": "/command/mongocli"
-                                    },
-                                    {
-                                        "slug": "/reference"
-                                    },
-                                    {
-                                        "slug": "/troubleshooting"
-                                    },
-                                    {
-                                        "title": "Release Notes",
-                                        "slug": "/release-notes"
-                                    },
-                                    {
-                                        "slug": "/third-party-licenses"
+                                        "type": "directive",
+                                        "children": [],
+                                        "domain": "",
+                                        "name": "toctree",
+                                        "argument": [],
+                                        "options": {
+                                            "titlesonly": true
+                                        },
+                                        "entries": [
+                                            {
+                                                "title": "Overview",
+                                                "slug": "/index"
+                                            },
+                                            {
+                                                "slug": "/install/compatibility"
+                                            },
+                                            {
+                                                "slug": "/install"
+                                            },
+                                            {
+                                                "slug": "/configure"
+                                            },
+                                            {
+                                                "slug": "/quick-start"
+                                            },
+                                            {
+                                                "title": "MongoDB CLI Commands",
+                                                "slug": "/command/mongocli"
+                                            },
+                                            {
+                                                "slug": "/reference"
+                                            },
+                                            {
+                                                "slug": "/troubleshooting"
+                                            },
+                                            {
+                                                "title": "Release Notes",
+                                                "slug": "/release-notes"
+                                            },
+                                            {
+                                                "slug": "/third-party-licenses"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
                         ]
                     }
-                ]
+                ],
+                "fileid": "index.txt",
+                "options": {
+                    "template": "product-landing",
+                    "hidefeedback": "header",
+                    "noprevnext": ""
+                }
             }
-        ],
-        "fileid": "index.txt",
-        "options": {
-            "template": "product-landing",
-            "hidefeedback": "header",
-            "noprevnext": ""
         }
     }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4835

### Current Behavior:

[Atlas prod](https://www.mongodb.com/docs/atlas/atlas-data-processing/) - `noindex` does not appear in a meta tag

### Staging Links:

[Atlas staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4835/atlas-data-processing/index.html) - `noindex` appears in a meta tag.

### Notes:

* Re-introduces page data into Gatsby Head. This was missing due to page context no longer having page data.
* Throws an error if page AST is missing from Gatsby Head again. This should hopefully stop the build with an error to emphasize that this is not expected.
* Adjusts existing data sources for tests for the `Head` component to split between page context and data. This should better mock how data is being passed into the component.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
