### PR TITLE
DOP-4824: SiteBanner tablet breakpoint

### DIFF
--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -62,7 +62,7 @@ const SiteBanner = () => {
     <StyledBannerContainer href={bannerContent.url} title={bannerContent.altText}>
       <StyledBannerContent
         imgPath={bannerContent.imgPath}
-        tabletImgPath={bannerContent.tabletImgPath}
+        tabletImgPath={bannerContent.tabletImgPath ?? bannerContent.mobileImgPath}
         mobileImgPath={bannerContent.mobileImgPath}
       />
     </StyledBannerContainer>

--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -28,6 +28,10 @@ const StyledBannerContent = styled.div(
     height: 100%;
 
     @media ${theme.screenSize.upToMedium} {
+      background-image: url(${getBannerSource(props.tabletImgPath)});
+    }
+
+    @media ${theme.screenSize.upToSmall} {
       background-image: url(${getBannerSource(props.mobileImgPath)});
     }
   `
@@ -56,7 +60,11 @@ const SiteBanner = () => {
 
   return (
     <StyledBannerContainer href={bannerContent.url} title={bannerContent.altText}>
-      <StyledBannerContent imgPath={bannerContent.imgPath} mobileImgPath={bannerContent.mobileImgPath} />
+      <StyledBannerContent
+        imgPath={bannerContent.imgPath}
+        tabletImgPath={bannerContent.tabletImgPath}
+        mobileImgPath={bannerContent.mobileImgPath}
+      />
     </StyledBannerContainer>
   );
 };

--- a/tests/unit/SiteBanner.test.js
+++ b/tests/unit/SiteBanner.test.js
@@ -20,6 +20,7 @@ const mockSnootyEnv = (snootyEnv) => {
 const mockBannerContent = {
   altText: 'Test',
   imgPath: '/banners/test.png',
+  tabletImgPath: '/banners/test-tablet.png',
   mobileImgPath: '/banners/test-mobile.png',
   url: 'https://mongodb.com',
 };

--- a/tests/unit/__snapshots__/SiteBanner.test.js.snap
+++ b/tests/unit/__snapshots__/SiteBanner.test.js.snap
@@ -19,6 +19,12 @@ exports[`Banner component renders with a banner image 1`] = `
 
 @media only screen and (max-width: 767px) {
   .emotion-2 {
+    background-image: url(https://snooty-koueq.mongodbstitch.com/banners/test-tablet.png);
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .emotion-2 {
     background-image: url(https://snooty-koueq.mongodbstitch.com/banners/test-mobile.png);
   }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4824

### Current Behavior:

[Atlas](https://www.mongodb.com/docs/atlas/getting-started/)

### Staging Links:

[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4824-mobile-banner/index.html) (no real difference other than showing that there are breakpoints)
- the tablet image is the same as the mobile image for now, will speak to design to see if they want to add one for Vector Search

### Notes:

Adds a tablet breakpoint for SiteBanner

[Link to Atlas App Services Values](https://services.cloud.mongodb.com/groups/5bad1d3d96e82129f16c5df3/apps/5d41ef5e2de84772fc7c2de2/values)
Conversation with design (Amelia) confirmed these sized breakpoints.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
