### PR TITLE
DOP-4691: add tracking to collapsible

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@leafygreen-ui/box';
 import Icon from '@leafygreen-ui/icon';
@@ -6,6 +6,7 @@ import IconButton from '@leafygreen-ui/icon-button';
 import { cx } from '@leafygreen-ui/emotion';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { Body } from '@leafygreen-ui/typography';
+import { reportAnalytics } from '../../utils/report-analytics';
 import ComponentFactory from '../ComponentFactory';
 import Heading from '../Heading';
 import { collapsibleStyle, headerContainerStyle, headerStyle, iconStyle, innerContentStyle } from './styles';
@@ -23,6 +24,14 @@ const Collapsible = ({ nodeData: { children, options }, ...rest }) => {
     [heading, id]
   );
 
+  const onIconClick = useCallback(() => {
+    reportAnalytics('CollapsibleClicked', {
+      action: open ? 'collapsed' : 'expanded',
+      heading,
+    });
+    setOpen(!open);
+  }, [heading, open]);
+
   return (
     <Box className={cx('collapsible', collapsibleStyle)}>
       <Box className={cx(headerContainerStyle)}>
@@ -35,7 +44,7 @@ const Collapsible = ({ nodeData: { children, options }, ...rest }) => {
         <IconButton
           className={iconStyle(darkMode)}
           aria-labelledby={'Expand the collapsed content'}
-          onClick={() => setOpen(!open)}
+          onClick={onIconClick}
         >
           <Icon glyph={open ? 'ChevronDown' : 'ChevronRight'} />
         </IconButton>


### PR DESCRIPTION
### Stories/Links:

[DOP-4691](https://jira.mongodb.org/browse/DOP-4691?focusedCommentId=6547966&focusedId=6547966&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6547966)

[Previous PR](https://github.com/mongodb/snooty/pull/1171)

### Staging Links:

[Staging link with Segment action added](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4690/docs-test-spark/seung.park/DOP-4691-tracking/dop-4690/index.html) (clicking on the collapsible icon should still work as designed)


### Notes:

Segment does not work on above staging link, but when testing this locally:

```
{
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
    "url": "http://localhost:9000/DOP-4690/docs-test-spark/seung.park/DOP-4691-tracking/dop-4690/",
    "adblock_enabled": "false",
    "anonymousId": "51723da6-70c2-4789-a41a-3614ad12ba8d",
    "clientId": "886506957.1716918121",
    "landing_page": "http://localhost:8000/",
    "sessionId": "seid-1721671014306-a60417df4808dd1ee150c01fb",
    "ga_client_id": "886506957.1716918121",
    "action": "collapsed",
    "heading": "This collapsible has no subheader",
    "category": "all",
    "label": "collapsibleclicked"
}
```



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
