### PR TITLE
DOP-4825: Hide Sitewide CTA banners on Scroll

### DIFF
--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -18,6 +18,8 @@ const StyledBannerContainer = styled.a`
   display: block;
   height: ${theme.header.bannerHeight};
   width: 100vw;
+  position: absolute;
+  z-index: 2000;
 `;
 
 const StyledBannerContent = styled.div(

--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -19,7 +19,6 @@ const StyledBannerContainer = styled.a`
   height: ${theme.header.bannerHeight};
   width: 100vw;
   position: absolute;
-  z-index: 2000;
 `;
 
 const StyledBannerContent = styled.div(

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { UnifiedNav } from '@mdb/consistent-nav';
@@ -6,13 +6,13 @@ import { SidenavMobileMenuDropdown } from '../Sidenav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
 import { AVAILABLE_LANGUAGES, getCurrLocale, onSelectLocale } from '../../utils/locale';
+import { HeaderContext } from './header-context';
 
 const StyledHeaderContainer = styled.header(
   (props) => `
   grid-area: header;
   top: 0;
-  // TODO : CHANGE THIS
-  margin-top: 40px;
+  margin-top: ${props.hasBanner ? theme.header.bannerHeight : '0px'};
   z-index: ${theme.zIndexes.header};
   ${
     props.template === 'landing' || props.template === 'errorpage' || process.env['GATSBY_ENABLE_DARK_MODE'] === 'true'
@@ -26,10 +26,12 @@ const Header = ({ sidenav, eol, template }) => {
   const unifiedNavProperty = 'DOCS';
 
   const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
+  const { bannerContent } = useContext(HeaderContext);
+
   return (
     <>
       <SiteBanner />
-      <StyledHeaderContainer template={template}>
+      <StyledHeaderContainer template={template} hasBanner={!!bannerContent}>
         <>
           {!eol && (
             <UnifiedNav

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,6 +11,8 @@ const StyledHeaderContainer = styled.header(
   (props) => `
   grid-area: header;
   top: 0;
+  // TODO : CHANGE THIS
+  margin-top: 40px;
   z-index: ${theme.zIndexes.header};
   ${
     props.template === 'landing' || props.template === 'errorpage' || process.env['GATSBY_ENABLE_DARK_MODE'] === 'true'
@@ -25,23 +27,25 @@ const Header = ({ sidenav, eol, template }) => {
 
   const enabledLocales = AVAILABLE_LANGUAGES.map((language) => language.localeCode);
   return (
-    <StyledHeaderContainer template={template}>
+    <>
       <SiteBanner />
-      <>
-        {!eol && (
-          <UnifiedNav
-            fullWidth="true"
-            position="relative"
-            property={{ name: unifiedNavProperty }}
-            showLanguageSelector={true}
-            onSelectLocale={onSelectLocale}
-            locale={getCurrLocale()}
-            enabledLocales={enabledLocales}
-          />
-        )}
-        {sidenav && <SidenavMobileMenuDropdown />}
-      </>
-    </StyledHeaderContainer>
+      <StyledHeaderContainer template={template}>
+        <>
+          {!eol && (
+            <UnifiedNav
+              fullWidth="true"
+              position="relative"
+              property={{ name: unifiedNavProperty }}
+              showLanguageSelector={true}
+              onSelectLocale={onSelectLocale}
+              locale={getCurrLocale()}
+              enabledLocales={enabledLocales}
+            />
+          )}
+          {sidenav && <SidenavMobileMenuDropdown />}
+        </>
+      </StyledHeaderContainer>
+    </>
   );
 };
 

--- a/src/hooks/useStickyTopValues.js
+++ b/src/hooks/useStickyTopValues.js
@@ -1,37 +1,25 @@
-import { useMemo, useContext } from 'react';
-import { HeaderContext } from '../components/Header/header-context';
+import { useMemo } from 'react';
 import { theme } from '../theme/docsTheme';
 
 // Returns the sum of the Header component's children's heights to give the appropriate amount of space for a component
-const getTopValue = (bannerEnabled, eol, heights) => {
+const getTopValue = (eol, heights) => {
   let topValue = 0;
   heights.forEach((height) => {
     topValue += theme.size.stripUnit(height);
   });
-
-  const bannerHeight = theme.size.stripUnit(theme.header.bannerHeight);
-  // if (bannerEnabled) {
-  //   topValue = eol ? bannerHeight : bannerHeight + topValue;
-  // } else {
   if (eol) {
     topValue = 0;
   }
-  // }
 
   return `${topValue}px`;
 };
 
 const useStickyTopValues = (eol) => {
-  const { bannerContent } = useContext(HeaderContext);
-  const bannerEnabled = bannerContent?.isEnabled;
-  const topLarge = useMemo(() => getTopValue(bannerEnabled, eol, [theme.header.navbarHeight]), [bannerEnabled, eol]);
-  const topMedium = useMemo(
-    () => getTopValue(bannerEnabled, eol, [theme.header.navbarMobileHeight]),
-    [bannerEnabled, eol]
-  );
+  const topLarge = useMemo(() => getTopValue(eol, [theme.header.navbarHeight]), [eol]);
+  const topMedium = useMemo(() => getTopValue(eol, [theme.header.navbarMobileHeight]), [eol]);
   const topSmall = useMemo(
-    () => getTopValue(bannerEnabled, eol, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
-    [bannerEnabled, eol]
+    () => getTopValue(eol, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
+    [eol]
   );
 
   return { topLarge, topMedium, topSmall };

--- a/src/hooks/useStickyTopValues.js
+++ b/src/hooks/useStickyTopValues.js
@@ -10,13 +10,13 @@ const getTopValue = (bannerEnabled, eol, heights) => {
   });
 
   const bannerHeight = theme.size.stripUnit(theme.header.bannerHeight);
-  if (bannerEnabled) {
-    topValue = eol ? bannerHeight : bannerHeight + topValue;
-  } else {
-    if (eol) {
-      topValue = 0;
-    }
+  // if (bannerEnabled) {
+  //   topValue = eol ? bannerHeight : bannerHeight + topValue;
+  // } else {
+  if (eol) {
+    topValue = 0;
   }
+  // }
 
   return `${topValue}px`;
 };

--- a/tests/unit/__snapshots__/SiteBanner.test.js.snap
+++ b/tests/unit/__snapshots__/SiteBanner.test.js.snap
@@ -6,6 +6,7 @@ exports[`Banner component renders with a banner image 1`] = `
   display: block;
   height: 40px;
   width: 100vw;
+  position: absolute;
 }
 
 .emotion-2 {

--- a/tests/unit/useStickyTopValues.test.js
+++ b/tests/unit/useStickyTopValues.test.js
@@ -41,22 +41,8 @@ describe('useStickyTopValues()', () => {
     expect(wrapper.queryByText('108px')).toBeTruthy();
   });
 
-  it('provides the correct top values with banner content and eol false', () => {
-    const wrapper = render(<TestComponent mockBannerContent={{ isEnabled: true }} HelperComponent={HelperComponent} />);
-    expect(wrapper.queryByText('135px')).toBeTruthy();
-    expect(wrapper.queryByText('96px')).toBeTruthy();
-    expect(wrapper.queryByText('148px')).toBeTruthy();
-  });
-
   it('provides the correct top values without any banner content and eol true', () => {
     const wrapper = render(<TestComponent mockBannerContent={null} HelperComponent={HelperComponentEol} />);
     expect(wrapper.queryAllByText('0px')).toBeTruthy();
-  });
-
-  it('provides the correct top values with banner content and eol false', () => {
-    const wrapper = render(
-      <TestComponent mockBannerContent={{ isEnabled: true }} HelperComponent={HelperComponentEol} />
-    );
-    expect(wrapper.queryAllByText('40px')).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-4825

### Current Behavior:

[Docs landing](https://www.mongodb.com/docs/)
[Manual](https://www.mongodb.com/docs/manual/)
[Cloud-docs](https://www.mongodb.com/docs/atlas/getting-started/)

### Staging Links:

[Docs landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/maya/DOP-4825/index.html) (behavior should be unchanged)
[Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/DOP-4825/index.html)
[Cloud docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/maya/DOP-4825/index.html)

[Example without banner](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/no-banner/v7.0/docs/maya/DOP-4825/index.html)
[Example with dark mode/action bar enabled](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/master/cloud-docs/maya/DOP-4825/index.html)

### Notes:

- Not sure how useful this PR is because the new action bar will be what automatically sticks to the top after it's released. 
- Also, I left `preview-header.js` untouched because I'm not sure how to test it and, although I could probably just copy what I did in `Header/index.js` I don't want to accidentally mess anything up, although any advice on this would be appreciated!

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
