### PR TITLE
DOP-4797: address action bar's z-index in relation to nav and sidebar

### DIFF
--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -16,7 +16,7 @@ const ActionBarContainer = styled('div')`
   position: sticky;
   top: 0;
   flex-wrap: wrap;
-  z-index: ${theme.zIndexes.header};
+  z-index: ${theme.zIndexes.header - 100};
   background-color: ${(props) => (props.darkMode ? palette.black : palette.white)};
   border-bottom: 1px solid ${(props) => (props.darkMode ? palette.gray.dark2 : palette.gray.light2)};
 

--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -16,7 +16,7 @@ const ActionBarContainer = styled('div')`
   position: sticky;
   top: 0;
   flex-wrap: wrap;
-  z-index: ${theme.zIndexes.header - 100};
+  z-index: ${theme.zIndexes.actionBar};
   background-color: ${(props) => (props.darkMode ? palette.black : palette.white)};
   border-bottom: 1px solid ${(props) => (props.darkMode ? palette.gray.dark2 : palette.gray.light2)};
 

--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -19,6 +19,7 @@ const StyledBannerContainer = styled.a`
   height: ${theme.header.bannerHeight};
   width: 100vw;
   position: absolute;
+  z-index: ${theme.zIndexes.header};
 `;
 
 const StyledBannerContent = styled.div(

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -100,7 +100,7 @@ const SidenavContainer = styled.div(
   ({ topLarge, topMedium, topSmall, template }) => css`
     grid-area: sidenav;
     position: sticky;
-    z-index: 2;
+    z-index: ${theme.zIndexes.header - 5};
     ${getTopAndHeight(topLarge, template)};
 
     @media ${theme.screenSize.upToLarge} {

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -100,7 +100,7 @@ const SidenavContainer = styled.div(
   ({ topLarge, topMedium, topSmall, template }) => css`
     grid-area: sidenav;
     position: sticky;
-    z-index: ${theme.zIndexes.header - 5};
+    z-index: ${theme.zIndexes.sidenav};
     ${getTopAndHeight(topLarge, template)};
 
     @media ${theme.screenSize.upToLarge} {

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -60,7 +60,7 @@ const FeedbackCard = ({ isOpen, children }) => {
   const onClose = () => {
     abandon();
     // reset the z-index set by the screenshot button in ScreenshotButton.js
-    elementZIndex.setZIndex('.widgets', 1000);
+    elementZIndex.setZIndex('.widgets', theme.zIndexes.header);
   };
 
   return (

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
@@ -9,6 +9,7 @@ import useScreenSize from '../../../hooks/useScreenSize';
 import useStickyTopValues from '../../../hooks/useStickyTopValues';
 import { InstruqtContext } from '../../Instruqt/instruqt-context';
 import { elementZIndex } from '../../../utils/dynamically-set-z-index';
+import { HeaderContext } from '../../Header/header-context';
 import ProgressBar from './components/PageIndicators';
 import CloseButton from './components/CloseButton';
 import { useFeedbackContext } from './context';
@@ -56,6 +57,11 @@ const FeedbackCard = ({ isOpen, children }) => {
   const { darkMode } = useDarkMode();
   const { topSmall } = useStickyTopValues(false, process.env['GATSBY_ENABLE_DARK_MODE'] && isMobile);
   useNoScroll(isMobile);
+  const { bannerContent } = useContext(HeaderContext);
+  const topBuffer = useMemo(
+    () => parseInt(topSmall, 10) + (!!bannerContent ? parseInt(theme.header.bannerHeight, 10) : 0) + 'px',
+    [bannerContent, topSmall]
+  );
 
   const onClose = () => {
     abandon();
@@ -65,8 +71,8 @@ const FeedbackCard = ({ isOpen, children }) => {
 
   return (
     isOpen && (
-      <FloatingContainer darkMode={darkMode} top={topSmall} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
-        <Card top={topSmall}>
+      <FloatingContainer darkMode={darkMode} top={topBuffer} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
+        <Card>
           <CloseButton onClick={onClose} />
           <ProgressBar />
           <div>{children}</div>

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { palette } from '@leafygreen-ui/palette';
 import { feedbackId } from '../FeedbackWidget/FeedbackForm';
 import { theme } from '../../../../src/theme/docsTheme';
 import useScreenSize from '../../../hooks/useScreenSize';
@@ -19,9 +21,11 @@ const FloatingContainer = styled.div`
   right: ${theme.size.large};
 
   @media ${theme.screenSize.upToSmall} {
-    position: fixed;
+    padding-top: ${({ top }) => `${top}`};
     right: 0;
-    top: ${({ top }) => top};
+    top: 0;
+    bottom: 60px;
+    background-color: ${({ darkMode }) => (darkMode ? palette.black : palette.white)};
   }
 `;
 
@@ -37,11 +41,10 @@ const Card = styled(LeafygreenCard)`
   }
 
   @media ${theme.screenSize.upToSmall} {
-    height: calc(100vh - ${({ top }) => top});
     width: 100vw;
     border-radius: 0;
     border-width: 0px;
-    padding-top: 40px;
+    box-shadow: none;
   }
 `;
 
@@ -50,18 +53,19 @@ const FeedbackCard = ({ isOpen, children }) => {
   const { isOpen: isLabOpen } = useContext(InstruqtContext);
   // Ensure FeedbackCard can be fullscreen size
   const { isMobile } = useScreenSize();
-  const { topSmall } = useStickyTopValues();
+  const { darkMode } = useDarkMode();
+  const { topSmall } = useStickyTopValues(false, process.env['GATSBY_ENABLE_DARK_MODE'] && isMobile);
   useNoScroll(isMobile);
 
   const onClose = () => {
     abandon();
     // reset the z-index set by the screenshot button in ScreenshotButton.js
-    elementZIndex.resetZIndex('.widgets');
+    elementZIndex.setZIndex('.widgets', 1000);
   };
 
   return (
     isOpen && (
-      <FloatingContainer top={topSmall} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
+      <FloatingContainer darkMode={darkMode} top={topSmall} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
         <Card top={topSmall}>
           <CloseButton onClick={onClose} />
           <ProgressBar />

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -17,7 +17,7 @@ const WidgetsContainer = styled.div`
   position: fixed;
   right: ${theme.size.large};
   bottom: ${({ hasOpenLabDrawer }) => (hasOpenLabDrawer ? '70px' : theme.size.large)};
-  z-index: 1000;
+  z-index: ${theme.zIndexes.header};
 
   @media ${theme.screenSize.upToSmall} {
     background-color: white;

--- a/src/hooks/useStickyTopValues.js
+++ b/src/hooks/useStickyTopValues.js
@@ -32,22 +32,23 @@ const useStickyTopValues = (eol, includeActionBar = false) => {
       ]),
     [bannerEnabled, eol, includeActionBar]
   );
+
+  const actionBarHeight = useMemo(
+    () => (includeActionBar ? [theme.header.actionBarMobileHeight] : []),
+    [includeActionBar]
+  );
   const topMedium = useMemo(
-    () =>
-      getTopValue(bannerEnabled, eol, [
-        theme.header.navbarMobileHeight,
-        ...(includeActionBar ? [theme.header.actionBarMobileHeight] : []),
-      ]),
-    [bannerEnabled, eol, includeActionBar]
+    () => getTopValue(bannerEnabled, eol, [theme.header.navbarMobileHeight, ...actionBarHeight]),
+    [actionBarHeight, bannerEnabled, eol]
   );
   const topSmall = useMemo(
     () =>
       getTopValue(bannerEnabled, eol, [
         theme.header.navbarMobileHeight,
         theme.header.docsMobileMenuHeight,
-        ...(includeActionBar ? [theme.header.actionBarMobileHeight] : []),
+        ...actionBarHeight,
       ]),
-    [bannerEnabled, eol, includeActionBar]
+    [actionBarHeight, bannerEnabled, eol]
   );
 
   return { topLarge, topMedium, topSmall };

--- a/src/hooks/useStickyTopValues.js
+++ b/src/hooks/useStickyTopValues.js
@@ -21,17 +21,33 @@ const getTopValue = (bannerEnabled, eol, heights) => {
   return `${topValue}px`;
 };
 
-const useStickyTopValues = (eol) => {
+const useStickyTopValues = (eol, includeActionBar = false) => {
   const { bannerContent } = useContext(HeaderContext);
   const bannerEnabled = bannerContent?.isEnabled;
-  const topLarge = useMemo(() => getTopValue(bannerEnabled, eol, [theme.header.navbarHeight]), [bannerEnabled, eol]);
+  const topLarge = useMemo(
+    () =>
+      getTopValue(bannerEnabled, eol, [
+        theme.header.navbarHeight,
+        ...(includeActionBar ? [theme.header.actionBarHeight] : []),
+      ]),
+    [bannerEnabled, eol, includeActionBar]
+  );
   const topMedium = useMemo(
-    () => getTopValue(bannerEnabled, eol, [theme.header.navbarMobileHeight]),
-    [bannerEnabled, eol]
+    () =>
+      getTopValue(bannerEnabled, eol, [
+        theme.header.navbarMobileHeight,
+        ...(includeActionBar ? [theme.header.actionBarMobileHeight] : []),
+      ]),
+    [bannerEnabled, eol, includeActionBar]
   );
   const topSmall = useMemo(
-    () => getTopValue(bannerEnabled, eol, [theme.header.navbarMobileHeight, theme.header.docsMobileMenuHeight]),
-    [bannerEnabled, eol]
+    () =>
+      getTopValue(bannerEnabled, eol, [
+        theme.header.navbarMobileHeight,
+        theme.header.docsMobileMenuHeight,
+        ...(includeActionBar ? [theme.header.actionBarMobileHeight] : []),
+      ]),
+    [bannerEnabled, eol, includeActionBar]
   );
 
   return { topLarge, topMedium, topSmall };

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -91,6 +91,8 @@ const transitionSpeed = {
 
 // z-indexes for topmost major elements on the site. Subcomponents should have their own z-indexes set
 const zIndexes = {
+  actionBar: 800,
+  sidenav: 900,
   header: 1000,
   widgets: 2000,
 };

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -75,6 +75,8 @@ const header = {
   docsMobileMenuHeight: '52px',
   // used for scrolling elements into place, considering sticky header
   navbarScrollOffset: '175px',
+  actionBarHeight: '115px',
+  actionBarMobileHeight: '185px', // TODO: update after mobile designs are finalized
 };
 
 const widgets = {

--- a/tests/unit/__snapshots__/SiteBanner.test.js.snap
+++ b/tests/unit/__snapshots__/SiteBanner.test.js.snap
@@ -7,6 +7,7 @@ exports[`Banner component renders with a banner image 1`] = `
   height: 40px;
   width: 100vw;
   position: absolute;
+  z-index: 1000;
 }
 
 .emotion-2 {

--- a/tests/unit/useStickyTopValues.test.js
+++ b/tests/unit/useStickyTopValues.test.js
@@ -25,6 +25,17 @@ const HelperComponentEol = () => {
   );
 };
 
+const HelperComponentActionBar = () => {
+  const { topLarge, topMedium, topSmall } = useStickyTopValues(false, true);
+  return (
+    <>
+      <div className="topLarge">{topLarge}</div>
+      <div className="topMedium">{topMedium}</div>
+      <div className="topSmall">{topSmall}</div>
+    </>
+  );
+};
+
 const TestComponent = ({ mockBannerContent, HelperComponent }) => {
   return (
     <HeaderContext.Provider value={{ bannerContent: mockBannerContent }}>
@@ -58,5 +69,13 @@ describe('useStickyTopValues()', () => {
       <TestComponent mockBannerContent={{ isEnabled: true }} HelperComponent={HelperComponentEol} />
     );
     expect(wrapper.queryAllByText('40px')).toBeTruthy();
+  });
+
+  it('provides the correct top values with just the action bar', () => {
+    const wrapper = render(<TestComponent mockBannerContent={null} HelperComponent={HelperComponentActionBar} />);
+    expect(wrapper.queryAllByText('210px')).toBeTruthy();
+    expect(wrapper.queryAllByText('241px')).toBeTruthy();
+    expect(wrapper.queryAllByText('293px')).toBeTruthy();
+    wrapper.debug();
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-4797

### Current Behavior:

[Current behavior on recent staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/maya/upgrade-callout/index.html)
In mobile views, above staging link shows Action Bar taking precedence over ConsistentNav and Docs Mobile Nav Menu. Also the feedback widget in mobile view is hidden behind the new Action Bar.

### Staging Links:

[Staging link with Action Bar enabled](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/HEAD/cloud-docs/seung.park/DOP-4797/index.html)
[Regression check with existing Nav Bar only](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/e30f3798c918e2ceea07829aed9dd431b02df7f7/HEAD/cloud-docs/seung.park/DOP-4797/atlas-search/atlas-search-overview/index.html)

### Notes:
- May have some conflicts with @mayaraman19 's [PR for non-sticky banner](https://github.com/mongodb/snooty/pull/1175)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
