### PR TITLE
DOP-4584: Add bottom margin for last "community built" link in list

### DIFF
--- a/src/components/CommunityPillLink.js
+++ b/src/components/CommunityPillLink.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { css, cx } from '@leafygreen-ui/emotion';
 import PropTypes from 'prop-types';
 import Badge, { Variant } from '@leafygreen-ui/badge';
 import { getPlaintext } from '../utils/get-plaintext';
+import { theme } from '../theme/docsTheme';
 import Link from './Link';
 
 const communityPillVariants = {
@@ -13,11 +15,17 @@ const communityPillVariants = {
   green: Variant.Green,
 };
 
+const pillLinkStyle = css`
+  :last-of-type {
+    margin-bottom: ${theme.size.default};
+  }
+`;
+
 const CommunityPillLink = ({ nodeData, variant = 'lightGray', text = 'community built' }) => {
   const { argument, options: { url } = {} } = nodeData || {};
 
   return (
-    <div>
+    <div className={cx(pillLinkStyle)}>
       {nodeData && argument && url && <Link to={url}>{getPlaintext(argument)}</Link>}
       <Badge variant={communityPillVariants[variant]}>{text}</Badge>
     </div>

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -49,7 +49,11 @@ exports[`renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.emotion-1 {
+.emotion-1:last-of-type {
+  margin-bottom: 16px;
+}
+
+.emotion-2 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -74,7 +78,7 @@ exports[`renders correctly 1`] = `
   color: #00684A;
 }
 
-.emotion-2 {
+.emotion-3 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -85,22 +89,6 @@ exports[`renders correctly 1`] = `
   font-weight: 500;
   letter-spacing: normal;
   margin: 16px 0 8px 0;
-}
-
-.emotion-2 strong,
-.emotion-2 b {
-  font-weight: 700;
-}
-
-.emotion-3 {
-  margin: unset;
-  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
-  color: #001E2B;
-  font-size: 13px;
-  line-height: 20px;
-  color: #001E2B;
-  font-weight: 400;
-  margin-bottom: 16px;
 }
 
 .emotion-3 strong,
@@ -116,6 +104,7 @@ exports[`renders correctly 1`] = `
   line-height: 20px;
   color: #001E2B;
   font-weight: 400;
+  margin-bottom: 16px;
 }
 
 .emotion-4 strong,
@@ -123,11 +112,26 @@ exports[`renders correctly 1`] = `
   font-weight: 700;
 }
 
-.emotion-4 a {
+.emotion-5 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+}
+
+.emotion-5 strong,
+.emotion-5 b {
+  font-weight: 700;
+}
+
+.emotion-5 a {
   line-height: unset;
 }
 
-.emotion-5 {
+.emotion-6 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -157,8 +161,8 @@ exports[`renders correctly 1`] = `
   display: inline;
 }
 
-.emotion-5:hover,
-.emotion-5:focus {
+.emotion-6:hover,
+.emotion-6:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
@@ -167,15 +171,15 @@ exports[`renders correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   outline: none;
 }
 
-.emotion-5:hover {
+.emotion-6:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-5:focus {
+.emotion-6:focus {
   text-decoration-color: #016BF8;
 }
 
@@ -193,29 +197,31 @@ exports[`renders correctly 1`] = `
       src="/images/icons/university.svg"
       width="24px"
     />
-    <div>
+    <div
+      class="emotion-1"
+    >
       <div
-        class="emotion-1"
+        class="emotion-2"
       >
         Test card tag
       </div>
     </div>
     <div>
       <p
-        class="emotion-2"
+        class="emotion-3"
       >
         Test card headline
       </p>
       <p
-        class="emotion-3"
+        class="emotion-4"
       >
         Test card paragraph
       </p>
       <p
-        class="emotion-4"
+        class="emotion-5"
       >
         <a
-          class="lg-ui-0001 emotion-5"
+          class="lg-ui-0001 emotion-6"
           href="https://university.mongodb.com/courses/M001/about"
           target="_self"
         >

--- a/tests/unit/__snapshots__/CommunityPillLink.test.js.snap
+++ b/tests/unit/__snapshots__/CommunityPillLink.test.js.snap
@@ -2,7 +2,11 @@
 
 exports[`community drivers directives render correctly 1`] = `
 <DocumentFragment>
-  .emotion-0 {
+  .emotion-0:last-of-type {
+  margin-bottom: 16px;
+}
+
+.emotion-1 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -32,8 +36,8 @@ exports[`community drivers directives render correctly 1`] = `
   display: inline;
 }
 
-.emotion-0:hover,
-.emotion-0:focus {
+.emotion-1:hover,
+.emotion-1:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
@@ -42,19 +46,19 @@ exports[`community drivers directives render correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   outline: none;
 }
 
-.emotion-0:hover {
+.emotion-1:hover {
   text-decoration-color: #E8EDEB;
 }
 
-.emotion-0:focus {
+.emotion-1:focus {
   text-decoration-color: #016BF8;
 }
 
-.emotion-1 {
+.emotion-2 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -64,7 +68,7 @@ exports[`community drivers directives render correctly 1`] = `
   height: 12px;
 }
 
-.emotion-2 {
+.emotion-3 {
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -89,9 +93,11 @@ exports[`community drivers directives render correctly 1`] = `
   color: #5C6C75;
 }
 
-<div>
+<div
+    class="emotion-0"
+  >
     <a
-      class="lg-ui-0001 emotion-0"
+      class="lg-ui-0001 emotion-1"
       href="https://example.com"
       rel="noopener noreferrer"
     >
@@ -101,7 +107,7 @@ exports[`community drivers directives render correctly 1`] = `
       <svg
         alt=""
         aria-hidden="true"
-        class="emotion-1"
+        class="emotion-2"
         height="16"
         role="presentation"
         viewBox="0 0 16 16"
@@ -118,7 +124,7 @@ exports[`community drivers directives render correctly 1`] = `
       </svg>
     </a>
     <div
-      class="emotion-2"
+      class="emotion-3"
     >
       community built
     </div>


### PR DESCRIPTION
### Stories/Links:

DOP-4584

### Current Behavior:

https://www.mongodb.com/docs/languages/python/#frameworks

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/master/landing/maya/DOP-4584/languages/python/index.html#frameworks)

[Using tags in Card](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4641/landing/maya/DOP-4584/index.html) - to ensure no changes/extra margins here

[Only one community built link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4641/landing/maya/DOP-4584/languages/python/index.html#frameworks)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
