### PR TITLE
DOP-4813: address React warnings for hydration for tabs

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -120,8 +120,7 @@ const Code = ({
         languageOptions={languageOptions}
         darkMode={darkModeProp ?? darkMode}
         onChange={(selectedOption) => {
-          const tabsetName = 'drivers';
-          setActiveTab({ name: tabsetName, value: selectedOption.id });
+          setActiveTab({ drivers: selectedOption.id });
         }}
         onCopy={reportCodeCopied}
         showLineNumbers={linenos}

--- a/src/components/Tabs/TabSelectors.js
+++ b/src/components/Tabs/TabSelectors.js
@@ -50,7 +50,7 @@ const TabSelector = ({ activeTab, handleClick, iconMapping, name, options }) => 
       label={getLabel(name)}
       usePortal={false}
       onChange={({ value }) => {
-        handleClick({ name, value });
+        handleClick({ [name]: value });
         reportAnalytics('LanguageSelection', {
           areaFrom: 'LanguageSelector',
           languageInitial: activeTab,

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -112,10 +112,7 @@ const Tabs = ({ nodeData: { children, options = {} }, page, ...rest }) => {
       const tabId = tabIds[index];
       const priorAnchorOffset = getPosition(scrollAnchorRef.current).y;
 
-      setActiveTab({
-        name: tabsetName,
-        value: tabId,
-      });
+      setActiveTab({ [tabsetName]: tabId });
       reportAnalytics('Tab Selected', {
         tabId,
         tabSet: tabsetName,

--- a/src/components/Tabs/tab-context.js
+++ b/src/components/Tabs/tab-context.js
@@ -5,7 +5,7 @@
  * child components to read and update
  */
 
-import React, { useEffect, useMemo, useReducer, useRef } from 'react';
+import React, { useEffect, useReducer, useRef } from 'react';
 import { getLocalValue, setLocalValue } from '../../utils/browser-storage';
 import { DRIVER_ICON_MAP } from '../icons/DriverIconMap';
 import { makeChoices } from './TabSelectors';
@@ -55,19 +55,6 @@ const TabProvider = ({ children, selectors = {} }) => {
   // init value to {} to match server and client side
   const [activeTabs, setActiveTab] = useReducer(reducer, {});
 
-  // convert selectors to tab options first here, then set init values
-  // selectors are determined at build time
-  const choicesPerSelector = useMemo(() => {
-    return Object.keys(selectors).reduce((res, selector) => {
-      res[selector] = makeChoices({
-        name: selector,
-        options: selectors[selector],
-        ...(selector === 'drivers' && { iconMapping: DRIVER_ICON_MAP }),
-      });
-      return res;
-    }, {});
-  }, [selectors]);
-
   const initLoaded = useRef(false);
 
   useEffect(() => {
@@ -76,7 +63,19 @@ const TabProvider = ({ children, selectors = {} }) => {
     setLocalValue('activeTabs', activeTabs);
   }, [activeTabs]);
 
+  // initial effect to read from local storage
+  // used in an effect to keep SSG HTML consistent
   useEffect(() => {
+    // convert selectors to tab options first here, then set init values
+    // selectors are determined at build time
+    const choicesPerSelector = Object.keys(selectors).reduce((res, selector) => {
+      res[selector] = makeChoices({
+        name: selector,
+        options: selectors[selector],
+        ...(selector === 'drivers' && { iconMapping: DRIVER_ICON_MAP }),
+      });
+      return res;
+    }, {});
     const defaultRes = getDefaultTabs(choicesPerSelector);
     // get local active tabs and set as active tabs
     // if they exist on page.


### PR DESCRIPTION
### Stories/Links:

DOP-4813

### Current Behavior:

[Visiting this page in incognito leads to hydration error in console](https://www.mongodb.com/docs/manual/core/indexes/create-index/)

- Addresses the problem of hydration errors by having consistent initial values in server and client side (either nodejs in language dropdown, or first option for each set of tabs)

[Visiting this page in incognito, and selecting C++, ](https://www.mongodb.com/docs/manual/core/transactions/) then in a new tab [visiting this page results in no tab selection (since no C++)](https://www.mongodb.com/docs/manual/core/indexes/create-index/)

- Addresses problem of preserving a non-existent tab by checking for its existence before setting it as the current tab

### Staging Links:

[No hydration errors. First init in nodejs, and then update to local storage (if it exists)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.3/docs/seung.park/DOP-4813/core/indexes/create-index/index.html)

Visiting [this page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.3/docs/seung.park/DOP-4813/core/transactions/index.html) and selecting C++ and consequently opening [this page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.3/docs/seung.park/DOP-4813/core/indexes/create-index/index.html) in a new tab works as desired (with node as first option since C++ is not available)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
