### PR TITLE
DOP-4874: Dark Mode: FABs

### DIFF
--- a/src/components/Widgets/ChatbotWidget/ChatbotFab.js
+++ b/src/components/Widgets/ChatbotWidget/ChatbotFab.js
@@ -2,6 +2,7 @@ import { lazy, Fragment } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@leafygreen-ui/emotion';
 
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { useSiteMetadata } from '../../../hooks/use-site-metadata';
 import { DEFAULT_MAX_INPUT, defaultSuggestedPrompts } from '../../ChatbotUi';
 import { MongoDbLegalDisclosure } from './MongoDBLegal';
@@ -21,6 +22,7 @@ const StyledChatBotFabContainer = styled.div`
 `;
 
 const ChatbotFab = () => {
+  const { darkMode } = useDarkMode();
   const { snootyEnv } = useSiteMetadata();
   const CHATBOT_SERVER_BASE_URL =
     snootyEnv === 'dotcomprd'
@@ -31,7 +33,12 @@ const ChatbotFab = () => {
       // Classname below to help ignore element for screenshots
       className={fabChatbot}
     >
-      <Chatbot name="MongoDB AI" maxInputCharacters={DEFAULT_MAX_INPUT} serverBaseUrl={CHATBOT_SERVER_BASE_URL}>
+      <Chatbot
+        name="MongoDB AI"
+        maxInputCharacters={DEFAULT_MAX_INPUT}
+        serverBaseUrl={CHATBOT_SERVER_BASE_URL}
+        darkMode={darkMode}
+      >
         <FloatingActionButtonTrigger text={CHATBOT_WIDGET_TEXT} />
         <ModalView
           disclaimer={

--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -2,28 +2,45 @@ import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import Icon from '@leafygreen-ui/icon';
+import { Theme } from '@leafygreen-ui/lib';
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { theme } from '../../../../src/theme/docsTheme';
 import { useFeedbackContext } from './context';
 import { FEEDBACK_BUTTON_TEXT } from './constants';
 
-const containerStyle = css`
+const FEEDBACK_FAB_COLORS = {
+  [Theme.Light]: {
+    color: palette.blue.dark1,
+    bgColor: palette.white,
+    boxShadow: `0px 4px 10px -4px ${palette.gray.light2}`,
+    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.light2}`,
+  },
+  [Theme.Dark]: {
+    color: palette.blue.light1,
+    bgColor: palette.gray.dark4,
+    boxShadow: 'none',
+    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.dark2}`,
+  },
+};
+
+const containerStyle = (darkTheme) => css`
   display: flex;
   align-items: center;
   gap: 4px;
   cursor: pointer;
   padding: 12px ${theme.size.default};
-  background-color: ${palette.white};
+  background-color: ${FEEDBACK_FAB_COLORS[darkTheme].bgColor};
   border: 1px solid ${palette.blue.light1};
   border-radius: 40px;
-  box-shadow: 0px 4px 10px -4px ${palette.gray.light2};
+  box-shadow: ${FEEDBACK_FAB_COLORS[darkTheme].boxShadow};
   z-index: 9;
-  color: ${palette.blue.dark1};
+  color: ${FEEDBACK_FAB_COLORS[darkTheme].color};
   font-weight: 600;
   font-size: 13px;
   line-height: 20px;
 
   :hover {
-    box-shadow: 0px 0px 0px 3px ${palette.blue.light2};
+    box-shadow: ${FEEDBACK_FAB_COLORS[darkTheme].boxShadowOnHover};
   }
 
   @media ${theme.screenSize.upToSmall} {
@@ -37,10 +54,11 @@ const starIconStyle = css`
 `;
 
 const FeedbackButton = () => {
+  const { theme } = useDarkMode();
   const { feedback, initializeFeedback } = useFeedbackContext();
   return (
     !feedback && (
-      <button className={cx(containerStyle)} onClick={() => initializeFeedback()}>
+      <button className={cx(containerStyle(theme))} onClick={() => initializeFeedback()}>
         <Icon className={starIconStyle} glyph="Favorite" />
         {FEEDBACK_BUTTON_TEXT}
       </button>

--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -19,7 +19,7 @@ const FEEDBACK_FAB_COLORS = {
     color: palette.blue.light1,
     bgColor: palette.gray.dark4,
     boxShadow: 'none',
-    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.dark2}`,
+    boxShadowOnHover: `0px 0px 0px 3px #083C90`,
   },
 };
 

--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -19,28 +19,28 @@ const FEEDBACK_FAB_COLORS = {
     color: palette.blue.light1,
     bgColor: palette.gray.dark4,
     boxShadow: 'none',
-    boxShadowOnHover: `0px 0px 0px 3px #083C90`,
+    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.dark2}`,
   },
 };
 
-const containerStyle = (darkTheme) => css`
+const containerStyle = (siteTheme) => css`
   display: flex;
   align-items: center;
   gap: 4px;
   cursor: pointer;
   padding: 12px ${theme.size.default};
-  background-color: ${FEEDBACK_FAB_COLORS[darkTheme].bgColor};
+  background-color: ${FEEDBACK_FAB_COLORS[siteTheme].bgColor};
   border: 1px solid ${palette.blue.light1};
   border-radius: 40px;
-  box-shadow: ${FEEDBACK_FAB_COLORS[darkTheme].boxShadow};
+  box-shadow: ${FEEDBACK_FAB_COLORS[siteTheme].boxShadow};
   z-index: 9;
-  color: ${FEEDBACK_FAB_COLORS[darkTheme].color};
+  color: ${FEEDBACK_FAB_COLORS[siteTheme].color};
   font-weight: 600;
   font-size: 13px;
   line-height: 20px;
 
   :hover {
-    box-shadow: ${FEEDBACK_FAB_COLORS[darkTheme].boxShadowOnHover};
+    box-shadow: ${FEEDBACK_FAB_COLORS[siteTheme].boxShadowOnHover};
   }
 
   @media ${theme.screenSize.upToSmall} {


### PR DESCRIPTION
### Stories/Links:

DOP-4874

### Current Behavior:

[Atlas](https://www.mongodb.com/docs/atlas/)
[Landing](https://www.mongodb.com/docs/legacy/)

### Staging Links:

[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4874-dark-mode-fabs/index.html)
[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/matt.meigs/DOP-4874-dark-mode-fabs/legacy/index.html)

### Notes:

This allows the chatbot to ingest the darkmode state. It also matches the Feedback FAB to the dark mode styles.

[FIgma](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=2560-7626&t=bnSXpL7I3dsa6zw2-4)
And offline discussions for some colors with Amelia in design.

I've let the chatbot team know that the sparkle AI icon is the wrong color and they're working with LG on it.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
