### PR TITLE
DOP-4875: Dark Mode - Breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbContainer.js
+++ b/src/components/Breadcrumbs/BreadcrumbContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { palette } from '@leafygreen-ui/palette';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { theme } from '../../theme/docsTheme';
 import { getFullBreadcrumbPath } from '../../utils/get-complete-breadcrumb-data';
@@ -16,12 +18,18 @@ const StyledSlash = styled('span')`
 const Flexbox = styled('div')`
   display: flex;
   align-items: center;
+
+  a,
+  span {
+    color: ${({ darkMode }) => (darkMode ? palette.gray.light1 : '#5C6C75')};
+  }
 `;
 
 const MIN_BREADCRUMBS = 3;
 const initialMaxCrumbs = (breadcrumbs) => breadcrumbs.length + 1;
 
 const BreadcrumbContainer = ({ breadcrumbs }) => {
+  const { darkMode } = useDarkMode();
   const [maxCrumbs, setMaxCrumbs] = React.useState(initialMaxCrumbs(breadcrumbs));
 
   React.useEffect(() => {
@@ -53,7 +61,7 @@ const BreadcrumbContainer = ({ breadcrumbs }) => {
   };
 
   return (
-    <Flexbox>
+    <Flexbox darkMode={darkMode}>
       {processedBreadcrumbs.map((crumb, index) => {
         const isFirst = index === 0;
         return (

--- a/src/components/Breadcrumbs/BreadcrumbContainer.js
+++ b/src/components/Breadcrumbs/BreadcrumbContainer.js
@@ -21,7 +21,7 @@ const Flexbox = styled('div')`
 
   a,
   span {
-    color: ${({ darkMode }) => (darkMode ? palette.gray.light1 : '#5C6C75')};
+    color: ${({ darkMode }) => (darkMode ? palette.gray.light1 : palette.gray.dark1)};
   }
 `;
 

--- a/src/components/Breadcrumbs/IndividualBreadcrumb.js
+++ b/src/components/Breadcrumbs/IndividualBreadcrumb.js
@@ -10,6 +10,8 @@ const linkStyling = LeafyCss`
   font-size: ${theme.fontSize.small};
   vertical-align: middle;
   line-height: unset;
+  // Important to overwrite GatsbyLink dark-theme font-weight
+  font-weight: 400;
 
   :hover,
   :focus {

--- a/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbContainer.test.js.snap
@@ -13,6 +13,11 @@ exports[`BreadcrumbContainer renders a driver site correctly with intermediate b
   align-items: center;
 }
 
+.emotion-0 a,
+.emotion-0 span {
+  color: #5C6C75;
+}
+
 .emotion-2 {
   overflow: hidden;
   white-space: nowrap;
@@ -63,6 +68,7 @@ exports[`BreadcrumbContainer renders a driver site correctly with intermediate b
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-3:hover,
@@ -204,6 +210,11 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
   align-items: center;
 }
 
+.emotion-0 a,
+.emotion-0 span {
+  color: #5C6C75;
+}
+
 .emotion-2 {
   overflow: hidden;
   white-space: nowrap;
@@ -254,6 +265,7 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-3:hover,
@@ -326,6 +338,7 @@ exports[`BreadcrumbContainer renders correctly as a docs homepage 1`] = `
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-11>code {
@@ -437,6 +450,11 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
   align-items: center;
 }
 
+.emotion-0 a,
+.emotion-0 span {
+  color: #5C6C75;
+}
+
 .emotion-2 {
   overflow: hidden;
   white-space: nowrap;
@@ -487,6 +505,7 @@ exports[`BreadcrumbContainer renders correctly with intermediate breadcrumb, no 
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-3:hover,
@@ -612,6 +631,11 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
   align-items: center;
 }
 
+.emotion-0 a,
+.emotion-0 span {
+  color: #5C6C75;
+}
+
 .emotion-2 {
   overflow: hidden;
   white-space: nowrap;
@@ -662,6 +686,7 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-3:hover,
@@ -734,6 +759,7 @@ exports[`BreadcrumbContainer renders correctly with no intermediate breadcrumbs,
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-11>code {

--- a/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
+++ b/tests/unit/__snapshots__/Breadcrumbs.test.js.snap
@@ -21,6 +21,11 @@ exports[`renders correctly as a homepage 1`] = `
   align-items: center;
 }
 
+.emotion-1 a,
+.emotion-1 span {
+  color: #5C6C75;
+}
+
 .emotion-3 {
   overflow: hidden;
   white-space: nowrap;
@@ -71,6 +76,7 @@ exports[`renders correctly as a homepage 1`] = `
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-4:hover,
@@ -170,6 +176,11 @@ exports[`renders correctly with siteTitle 1`] = `
   align-items: center;
 }
 
+.emotion-1 a,
+.emotion-1 span {
+  color: #5C6C75;
+}
+
 .emotion-3 {
   overflow: hidden;
   white-space: nowrap;
@@ -220,6 +231,7 @@ exports[`renders correctly with siteTitle 1`] = `
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-4:hover,
@@ -272,6 +284,7 @@ exports[`renders correctly with siteTitle 1`] = `
   font-size: 13px;
   vertical-align: middle;
   line-height: unset;
+  font-weight: 400;
 }
 
 .emotion-12>code {


### PR DESCRIPTION
### Stories/Links:

DOP-4875

### Current Behavior:

[Atlas](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4875-dark-mode-breadcrumbs/index.html)

### Notes:

This PR updates the color of breadcrumbs in dark mode.

[Figma](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=2560-7626&t=bnSXpL7I3dsa6zw2-4)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
