### PR TITLE
DOP-4839: use same buffer for target links

### DIFF
--- a/src/components/Target.js
+++ b/src/components/Target.js
@@ -20,7 +20,7 @@ const DescriptionTerm = ({ children, html_id, ...rest }) => {
       {children.map((child, j) => (
         <ComponentFactory key={j} {...rest} nodeData={child} />
       ))}
-      <Permalink id={html_id} description="definition" buffer="-150px" />
+      <Permalink id={html_id} description="definition" />
     </dt>
   );
 };

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -53,7 +53,7 @@ a .emotion-0 {
 }
 
 .emotion-3 {
-  margin-top: -150px;
+  margin-top: -175px;
   position: absolute;
   padding-bottom: 2px;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4839

This is a real quick fix (follow up to https://github.com/mongodb/snooty/pull/1163) to remove custom buffer space and use default for Target components
Less prominent now with the banner being hidden, but for consistency sake.

### Current Behavior:

[Heading Permalink](https://www.mongodb.com/docs/v7.3/reference/write-concern/#write-concern-specification)
[Example of Target using Permalink](https://www.mongodb.com/docs/v7.3/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-)


### Staging Links:

[Heading Permalink](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/8f161c3c0788eed8c351e2f19031c33149385317/v7.3/docs/seung.park/DOP-4839/reference/write-concern/index.html#write-concern-specification)
[Example of Target using Permalink](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/8f161c3c0788eed8c351e2f19031c33149385317/v7.3/docs/seung.park/DOP-4839/reference/write-concern/index.html#mongodb-writeconcern-writeconcern.-majority-)


### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
