### PR TITLE
DOP-4806: Correct Document template data ingestion to fix noprevnext

### DIFF
--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -26,9 +26,9 @@ const StyledRightColumn = styled(RightColumn)`
   grid-area: right;
 `;
 
-const Document = ({ children, pageContext: { slug, page, isAssociatedProduct } }) => {
+const Document = ({ children, data: { page }, pageContext: { slug, isAssociatedProduct } }) => {
   const { slugToBreadcrumbLabel, title, toctreeOrder } = useSnootyMetadata();
-  const pageOptions = page?.options;
+  const pageOptions = page?.ast.options;
   const showPrevNext = !(pageOptions?.noprevnext === '' || pageOptions?.template === 'guide');
 
   return (
@@ -57,8 +57,10 @@ Document.propTypes = {
   }).isRequired,
   data: PropTypes.shape({
     page: PropTypes.shape({
-      children: PropTypes.array,
-      options: PropTypes.object,
+      ast: PropTypes.shape({
+        children: PropTypes.array,
+        options: PropTypes.object,
+      }).isRequired,
     }).isRequired,
   }),
 };


### PR DESCRIPTION
### Stories/Links:

DOP-4806

### Notes:

I tried adding a test, but this template is kind of tricky and requires an oodle-load of stuff to be mocked. I can try and get a test going if desired, however!!

### Current Behavior:

* https://www.mongodb.com/docs/atlas/security-serverless-private-endpoint/

### Staging Links:
![image](https://github.com/user-attachments/assets/0fef2831-3869-4aa6-b123-f2d803377cf1)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
