### PR TITLE
DOP-4846: initialize tabs in dark mode

### DIFF
--- a/src/components/Procedure/index.js
+++ b/src/components/Procedure/index.js
@@ -21,7 +21,7 @@ const StyledProcedure = styled('div')`
   `}
   ${({ darkMode }) =>
     `
-    background-color: ${darkMode ? palette.black : 'initial'};
+    background-color: ${darkMode ? palette.gray.dark4 : 'initial'};
     color: ${darkMode ? palette.gray.light2 : 'initial'};`}
 `;
 

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -26,8 +26,13 @@ const getPosition = (element) => {
 const defaultTabsStyling = css`
   margin-bottom: ${theme.size.medium};
   ${TAB_BUTTON_SELECTOR} {
+    color: var(--tab-color-primary);
     font-size: ${theme.size.default};
     align-items: center;
+
+    &[aria-selected='true'] {
+      color: var(--tab-color-secondary);
+    }
   }
 
   @media ${theme.screenSize.upTo2XLarge} {

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -17,6 +17,9 @@ body {
 
   --background-color-primary: var(--white);
   --background-color-secondary: var(--gray-light3);
+
+  --tab-color-primary: var(--gray-dark1);
+  --tab-color-secondary: var(--green-dark2);
 }
 
 .dark-theme body {
@@ -28,4 +31,7 @@ body {
 
   --background-color-primary: var(--gray-dark3);
   --background-color-secondary: transparent;
+
+  --tab-color-primary: var(--gray-light1);
+  --tab-color-secondary: var(--gray-light2);
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4846
This was a lot smaller than I anticipated due to work done in [DOP-4843](https://github.com/mongodb/snooty/pull/1183)
Ensures tab buttons are initialized in light/dark mode (reducing flicker)

### Current Behavior:

[This is an example of tabs flickering - open with dark mode already enabled](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4767/docs-test-spark/seung.park/DOP-4767-css-vars/index.html). You can see the tabs change from light -> dark mode

### Staging Links:

[Staging link shows Tab buttons initializing in preferred mode (light/dark both)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4690/docs-test-spark/seung.park/DOP-4846/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
