### PR TITLE
DOP-4892: Update callouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@leafygreen-ui/banner": "^8.0.1",
         "@leafygreen-ui/box": "^3.0.6",
         "@leafygreen-ui/button": "^21.2.1",
-        "@leafygreen-ui/callout": "^5.0.0",
+        "@leafygreen-ui/callout": "^10.0.0",
         "@leafygreen-ui/card": "^10.0.7",
         "@leafygreen-ui/checkbox": "^12.0.8",
         "@leafygreen-ui/code": "^14.3.3",
@@ -3972,51 +3972,78 @@
       }
     },
     "node_modules/@leafygreen-ui/callout": {
-      "version": "5.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-5.0.1.tgz",
-      "integrity": "sha512-RzoqpkvgWxEufaD2Vhg5eHSl5pdppJ5zV72W+buDZ9fgVZy1F4/LNkvtGADaYXWYTBB4bYiLgEkJw7YxTe5XNA==",
+      "version": "10.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-10.0.0.tgz",
+      "integrity": "sha512-tfhXytzFhofUTmqjXjzydoPoyn4FaflnlzgayeSnHPf2GmX4qsJMKFB883ARvVpzhdNUoZDWdOEYCK5QyCHCtg==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.0",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/typography": "^11.0.2",
-        "polished": "^4.1.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.6.0",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/typography": "^19.3.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
-    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/icon": {
-      "version": "11.29.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-      "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/lib": {
+      "version": "13.7.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.7.0.tgz",
+      "integrity": "sha512-R+2br+QrCABPefv5SD4DOAduIveoVxFtSRqk51frjLyATHLUhg7SwV783KJ0ipofCfsLdae2CZRSzT7MAVbSEA==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@storybook/csf": "^0.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/palette": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+      "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+      "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.6.0",
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/tokens": {
-      "version": "1.4.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-      "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
-      "dependencies": {
-        "@leafygreen-ui/palette": "^3.4.5"
-      }
-    },
     "node_modules/@leafygreen-ui/callout/node_modules/@leafygreen-ui/typography": {
-      "version": "11.0.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-11.0.2.tgz",
-      "integrity": "sha512-JXPpZRgwFrlIgpTWnh53i7m9OsMVLBj/jfMBCP1kpZJ+o/6Rs/OOsTbyLz8SX5WHq+HboOqlLL8PcIEk14GL3g==",
+      "version": "19.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
+      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.0.7",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/tokens": "^1.3.1"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.6.0",
+        "@leafygreen-ui/lib": "^13.6.1",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^2.2.0"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/@storybook/csf": {
+      "version": "0.1.11",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
+      "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@leafygreen-ui/callout/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/card": {
@@ -4697,9 +4724,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.5.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
-      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
+      "version": "12.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.6.0.tgz",
+      "integrity": "sha512-/+5S0aap/4NMtQlfCBQw0NH/noAkNn9A/5YOTPt86WbmDhsgoaD+BP+7TbO1GfveqZZ61vDwp5TzvP9sYLeDKg==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -32100,46 +32127,67 @@
       }
     },
     "@leafygreen-ui/callout": {
-      "version": "5.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-5.0.1.tgz",
-      "integrity": "sha512-RzoqpkvgWxEufaD2Vhg5eHSl5pdppJ5zV72W+buDZ9fgVZy1F4/LNkvtGADaYXWYTBB4bYiLgEkJw7YxTe5XNA==",
+      "version": "10.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/callout/-/callout-10.0.0.tgz",
+      "integrity": "sha512-tfhXytzFhofUTmqjXjzydoPoyn4FaflnlzgayeSnHPf2GmX4qsJMKFB883ARvVpzhdNUoZDWdOEYCK5QyCHCtg==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.0",
-        "@leafygreen-ui/icon": "^11.9.0",
-        "@leafygreen-ui/lib": "^9.3.0",
-        "@leafygreen-ui/palette": "^3.4.0",
-        "@leafygreen-ui/typography": "^11.0.2",
-        "polished": "^4.1.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.6.0",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/typography": "^19.3.0"
       },
       "dependencies": {
-        "@leafygreen-ui/icon": {
-          "version": "11.29.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-11.29.1.tgz",
-          "integrity": "sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==",
+        "@leafygreen-ui/lib": {
+          "version": "13.7.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.7.0.tgz",
+          "integrity": "sha512-R+2br+QrCABPefv5SD4DOAduIveoVxFtSRqk51frjLyATHLUhg7SwV783KJ0ipofCfsLdae2CZRSzT7MAVbSEA==",
           "requires": {
-            "@leafygreen-ui/emotion": "^4.0.7",
+            "@storybook/csf": "^0.1.0",
+            "lodash": "^4.17.21",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "4.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+          "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+        },
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+          "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.6.0",
             "lodash": "^4.17.21"
           }
         },
-        "@leafygreen-ui/tokens": {
-          "version": "1.4.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-1.4.1.tgz",
-          "integrity": "sha512-ap9IdpQy+wg8IG9rJbWZB9F9zihhixClz68UFcwJMbDqcvxcqRPBvRpkbqiJdAPwOSrbYZfrHSGEtdJk9bzZAg==",
+        "@leafygreen-ui/typography": {
+          "version": "19.3.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
+          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
           "requires": {
-            "@leafygreen-ui/palette": "^3.4.5"
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/icon": "^12.6.0",
+            "@leafygreen-ui/lib": "^13.6.1",
+            "@leafygreen-ui/palette": "^4.0.10",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
           }
         },
-        "@leafygreen-ui/typography": {
-          "version": "11.0.2",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-11.0.2.tgz",
-          "integrity": "sha512-JXPpZRgwFrlIgpTWnh53i7m9OsMVLBj/jfMBCP1kpZJ+o/6Rs/OOsTbyLz8SX5WHq+HboOqlLL8PcIEk14GL3g==",
+        "@storybook/csf": {
+          "version": "0.1.11",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
+          "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
           "requires": {
-            "@leafygreen-ui/box": "^3.0.7",
-            "@leafygreen-ui/icon": "^11.9.0",
-            "@leafygreen-ui/lib": "^9.3.0",
-            "@leafygreen-ui/palette": "^3.4.0",
-            "@leafygreen-ui/tokens": "^1.3.1"
+            "type-fest": "^2.19.0"
           }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -32713,9 +32761,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.5.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
-      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
+      "version": "12.6.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.6.0.tgz",
+      "integrity": "sha512-/+5S0aap/4NMtQlfCBQw0NH/noAkNn9A/5YOTPt86WbmDhsgoaD+BP+7TbO1GfveqZZ61vDwp5TzvP9sYLeDKg==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@leafygreen-ui/banner": "^8.0.1",
     "@leafygreen-ui/box": "^3.0.6",
     "@leafygreen-ui/button": "^21.2.1",
-    "@leafygreen-ui/callout": "^5.0.0",
+    "@leafygreen-ui/callout": "^10.0.0",
     "@leafygreen-ui/card": "^10.0.7",
     "@leafygreen-ui/checkbox": "^12.0.8",
     "@leafygreen-ui/code": "^14.3.3",


### PR DESCRIPTION
### Stories/Links:

DOP-4892

### Current Behavior:

[Atlas](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/update-callouts/getting-started/index.html)

### Notes:

Updates Callouts to new style and now can ingest dark mode.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
