### PR TITLE
DOP-4879: use feedback widget in action bar (desktop)

### DIFF
--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -8,7 +8,13 @@ import { getPlaintext } from '../../utils/get-plaintext';
 import { getNestedValue } from '../../utils/get-nested-value';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import ChatbotUi from '../ChatbotUi';
-import { FeedbackProvider, FeedbackForm, FeedbackButton, useFeedbackData } from '../Widgets/FeedbackWidget';
+import {
+  FeedbackProvider,
+  FeedbackForm,
+  FeedbackButton,
+  useFeedbackData,
+  FeedbackContainer,
+} from '../Widgets/FeedbackWidget';
 import DarkModeDropdown from './DarkModeDropdown';
 
 const ActionBarContainer = styled('div')`
@@ -71,10 +77,6 @@ const ActionsBox = styled('div')`
   @media ${theme.screenSize.upToSmall} {
     padding-left: 2rem;
   }
-`;
-
-const FeedbackContainer = styled.div`
-  position: relative;
 `;
 
 // Note: When working on this component further, please check with design on how it should look in the errorpage template (404) as well!

--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -3,7 +3,9 @@ import styled from '@emotion/styled';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
+import { isBrowser } from '../../utils/is-browser';
 import ChatbotUi from '../ChatbotUi';
+import { FeedbackProvider, FeedbackForm, FeedbackButton, useFeedbackData } from '../Widgets/FeedbackWidget';
 import DarkModeDropdown from './DarkModeDropdown';
 
 const ActionBarContainer = styled('div')`
@@ -62,9 +64,19 @@ const ActionsBox = styled('div')`
   }
 `;
 
+const FeedbackContainer = styled.div`
+  position: relative;
+`;
+
 // Note: When working on this component further, please check with design on how it should look in the errorpage template (404) as well!
-const ActionBar = ({ template, ...props }) => {
+const ActionBar = ({ template, pageTitle, slug, ...props }) => {
   const { darkMode } = useDarkMode();
+  const url = isBrowser ? window.location.href : null;
+  const feedbackData = useFeedbackData({
+    slug,
+    url,
+    title: pageTitle || 'Home',
+  });
   return (
     <ActionBarContainer className={props.className} darkMode={darkMode}>
       <ActionBarSearchContainer>
@@ -73,9 +85,12 @@ const ActionBar = ({ template, ...props }) => {
       <ActionsBox>
         <DarkModeDropdown></DarkModeDropdown>
         {template !== 'errorpage' && (
-          <div>
-            <button>Feedback</button>
-          </div>
+          <FeedbackProvider page={feedbackData}>
+            <FeedbackContainer>
+              <FeedbackButton />
+              <FeedbackForm />
+            </FeedbackContainer>
+          </FeedbackProvider>
         )}
       </ActionsBox>
     </ActionBarContainer>

--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -4,6 +4,9 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 import { isBrowser } from '../../utils/is-browser';
+import { getPlaintext } from '../../utils/get-plaintext';
+import { getNestedValue } from '../../utils/get-nested-value';
+import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import ChatbotUi from '../ChatbotUi';
 import { FeedbackProvider, FeedbackForm, FeedbackButton, useFeedbackData } from '../Widgets/FeedbackWidget';
 import DarkModeDropdown from './DarkModeDropdown';
@@ -75,13 +78,15 @@ const FeedbackContainer = styled.div`
 `;
 
 // Note: When working on this component further, please check with design on how it should look in the errorpage template (404) as well!
-const ActionBar = ({ template, pageTitle, slug, ...props }) => {
+const ActionBar = ({ template, slug, ...props }) => {
   const { darkMode } = useDarkMode();
   const url = isBrowser ? window.location.href : null;
+  const metadata = useSnootyMetadata();
   const feedbackData = useFeedbackData({
     slug,
     url,
-    title: pageTitle || 'Home',
+    title:
+      getPlaintext(getNestedValue(['slugToTitle', slug === '/' ? 'index' : slug], metadata)) || 'MongoDB Documentation',
   });
   return (
     <ActionBarContainer className={props.className}>

--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -19,8 +19,14 @@ const ActionBarContainer = styled('div')`
   top: 0;
   flex-wrap: wrap;
   z-index: ${theme.zIndexes.actionBar};
-  background-color: ${(props) => (props.darkMode ? palette.black : palette.white)};
-  border-bottom: 1px solid ${(props) => (props.darkMode ? palette.gray.dark2 : palette.gray.light2)};
+  background-color: var(--background-color-primary);
+  border-bottom: 1px solid var(--border-color);
+
+  --border-color: ${palette.gray.light2};
+
+  .dark-theme & {
+    --border-color: ${palette.gray.dark2};
+  }
 
   @media ${theme.screenSize.mediumAndUp} {
     & > div {
@@ -78,7 +84,7 @@ const ActionBar = ({ template, pageTitle, slug, ...props }) => {
     title: pageTitle || 'Home',
   });
   return (
-    <ActionBarContainer className={props.className} darkMode={darkMode}>
+    <ActionBarContainer className={props.className}>
       <ActionBarSearchContainer>
         <ChatbotUi darkMode={darkMode} />
       </ActionBarSearchContainer>

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -14,7 +14,6 @@ import useSnootyMetadata from '../utils/use-snooty-metadata';
 import { getCurrentLocaleFontFamilyValue } from '../utils/locale';
 import { getSiteTitle } from '../utils/get-site-title';
 import { PageContext } from '../context/page-context';
-import Widgets from './Widgets';
 import SEO from './SEO';
 import FootnoteContext from './Footnote/footnote-context';
 import ComponentFactory from './ComponentFactory';
@@ -81,7 +80,7 @@ const getAnonymousFootnoteReferences = (index, numAnonRefs) => {
 const fontFamily = getCurrentLocaleFontFamilyValue();
 
 const DocumentBody = (props) => {
-  const { location, data, pageContext } = props;
+  const { data, pageContext } = props;
   const page = data?.page?.ast;
   const { slug, template } = pageContext;
 
@@ -96,9 +95,6 @@ const DocumentBody = (props) => {
 
   const metadata = useSnootyMetadata();
 
-  const lookup = slug === '/' ? 'index' : slug;
-  const pageTitle = getPlaintext(getNestedValue(['slugToTitle', lookup], metadata)) || 'MongoDB Documentation';
-
   const { Template, useChatbot } = getTemplate(template);
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
@@ -107,34 +103,26 @@ const DocumentBody = (props) => {
     <>
       <TabProvider selectors={page?.options?.selectors}>
         <InstruqtProvider hasLabDrawer={page?.options?.instruqt}>
-          <Widgets
-            location={location}
-            pageTitle={pageTitle}
-            slug={slug}
-            isInPresentationMode={isInPresentationMode}
-            template={template}
-          >
-            <ImageContextProvider images={props.data?.pageImage?.images ?? []}>
-              <FootnoteContext.Provider value={{ footnotes }}>
-                <PageContext.Provider value={{ page, template, slug }}>
-                  <div id="template-container">
-                    <Template {...props} useChatbot={useChatbot}>
-                      {pageNodes.map((child, index) => (
-                        <ComponentFactory
-                          key={index}
-                          metadata={metadata}
-                          nodeData={child}
-                          page={page}
-                          template={template}
-                          slug={slug}
-                        />
-                      ))}
-                    </Template>
-                  </div>
-                </PageContext.Provider>
-              </FootnoteContext.Provider>
-            </ImageContextProvider>
-          </Widgets>
+          <ImageContextProvider images={props.data?.pageImage?.images ?? []}>
+            <FootnoteContext.Provider value={{ footnotes }}>
+              <PageContext.Provider value={{ page, template, slug }}>
+                <div id="template-container">
+                  <Template {...props} useChatbot={useChatbot}>
+                    {pageNodes.map((child, index) => (
+                      <ComponentFactory
+                        key={index}
+                        metadata={metadata}
+                        nodeData={child}
+                        page={page}
+                        template={template}
+                        slug={slug}
+                      />
+                    ))}
+                  </Template>
+                </div>
+              </PageContext.Provider>
+            </FootnoteContext.Provider>
+          </ImageContextProvider>
         </InstruqtProvider>
       </TabProvider>
       {!isInPresentationMode && (

--- a/src/components/DocumentBodyPreview.js
+++ b/src/components/DocumentBodyPreview.js
@@ -6,9 +6,7 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { getPlaintext } from '../utils/get-plaintext';
 import { getTemplate } from '../utils/get-template';
 import Layout from '../layouts/preview-layout';
-import { usePresentationMode } from '../hooks/use-presentation-mode';
 import { PageContext } from '../context/page-context';
-import Widgets from './Widgets';
 import SEO from './SEO';
 import FootnoteContext from './Footnote/footnote-context';
 import ComponentFactory from './ComponentFactory';
@@ -66,7 +64,6 @@ const getAnonymousFootnoteReferences = (index, numAnonRefs) => {
 
 const DocumentBody = (props) => {
   const {
-    location,
     pageContext: { slug },
     data,
   } = props;
@@ -90,8 +87,6 @@ const DocumentBody = (props) => {
   const siteTitle = getNestedValue(['title'], metadata) || '';
   const { Template, useChatbot } = getTemplate(template);
 
-  const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
-
   return (
     <Layout
       pageContext={{
@@ -106,23 +101,15 @@ const DocumentBody = (props) => {
       <SEO pageTitle={pageTitle} siteTitle={siteTitle} />
       <TabProvider selectors={page?.options?.selectors}>
         <InstruqtProvider hasLabDrawer={page?.options?.instruqt}>
-          <Widgets
-            location={location}
-            pageTitle={pageTitle}
-            slug={slug}
-            template={template}
-            isInPresentationMode={isInPresentationMode}
-          >
-            <FootnoteContext.Provider value={{ footnotes }}>
-              <PageContext.Provider value={{ page, template, slug }}>
-                <Template {...props} useChatbot={useChatbot}>
-                  {pageNodes.map((child, index) => (
-                    <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
-                  ))}
-                </Template>
-              </PageContext.Provider>
-            </FootnoteContext.Provider>
-          </Widgets>
+          <FootnoteContext.Provider value={{ footnotes }}>
+            <PageContext.Provider value={{ page, template, slug }}>
+              <Template {...props} useChatbot={useChatbot}>
+                {pageNodes.map((child, index) => (
+                  <ComponentFactory key={index} metadata={metadata} nodeData={child} page={page} slug={slug} />
+                ))}
+              </Template>
+            </PageContext.Provider>
+          </FootnoteContext.Provider>
         </InstruqtProvider>
       </TabProvider>
       <footer style={{ width: '100%', height: '568px', backgroundColor: '#061621' }}></footer>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -14,7 +14,6 @@ const StyledHeaderContainer = styled.header(
   top: 0;
   margin-top: ${props.hasBanner ? theme.header.bannerHeight : '0px'};
   z-index: ${theme.zIndexes.header};
-  ${props.template === 'landing' || props.template === 'errorpage' ? '' : 'position: sticky;'}
   `
 );
 

--- a/src/components/Sidenav/DocsHomeButton.js
+++ b/src/components/Sidenav/DocsHomeButton.js
@@ -8,7 +8,6 @@ import { Link } from '@leafygreen-ui/typography';
 import { baseUrl } from '../../utils/base-url';
 import { sideNavItemBasePadding } from './styles/sideNavItem';
 import { titleStyle } from './styles/sideNavItem';
-import DarkModeToggle from './DarkModeToggle';
 
 const homeLinkStyle = LeafyCSS`
   span {
@@ -40,7 +39,6 @@ const DocsHomeButton = ({ darkMode }) => {
         <Icon glyph="Home"></Icon>
         Docs Home
       </SideNavItem>
-      {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && <DarkModeToggle />}
     </div>
   );
 };

--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -4,8 +4,8 @@ import { useFeedbackContext } from './context';
 import { FEEDBACK_BUTTON_TEXT } from './constants';
 
 const FeedbackButton = () => {
-  const { initializeFeedback } = useFeedbackContext();
-  return <Button onClick={() => initializeFeedback()}>{FEEDBACK_BUTTON_TEXT}</Button>;
+  const { initializeFeedback, abandon, feedback } = useFeedbackContext();
+  return <Button onClick={() => (!feedback ? initializeFeedback() : abandon())}>{FEEDBACK_BUTTON_TEXT}</Button>;
 };
 
 export default FeedbackButton;

--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -1,69 +1,11 @@
 import React from 'react';
-import { css, cx } from '@leafygreen-ui/emotion';
-import { palette } from '@leafygreen-ui/palette';
-import Icon from '@leafygreen-ui/icon';
-import { Theme } from '@leafygreen-ui/lib';
-import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
-import { theme } from '../../../../src/theme/docsTheme';
+import Button from '@leafygreen-ui/button';
 import { useFeedbackContext } from './context';
 import { FEEDBACK_BUTTON_TEXT } from './constants';
 
-const FEEDBACK_FAB_COLORS = {
-  [Theme.Light]: {
-    color: palette.blue.dark1,
-    bgColor: palette.white,
-    boxShadow: `0px 4px 10px -4px ${palette.gray.light2}`,
-    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.light2}`,
-  },
-  [Theme.Dark]: {
-    color: palette.blue.light1,
-    bgColor: palette.gray.dark4,
-    boxShadow: 'none',
-    boxShadowOnHover: `0px 0px 0px 3px ${palette.blue.dark2}`,
-  },
-};
-
-const containerStyle = (siteTheme) => css`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  padding: 12px ${theme.size.default};
-  background-color: ${FEEDBACK_FAB_COLORS[siteTheme].bgColor};
-  border: 1px solid ${palette.blue.light1};
-  border-radius: 40px;
-  box-shadow: ${FEEDBACK_FAB_COLORS[siteTheme].boxShadow};
-  z-index: 9;
-  color: ${FEEDBACK_FAB_COLORS[siteTheme].color};
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 20px;
-
-  :hover {
-    box-shadow: ${FEEDBACK_FAB_COLORS[siteTheme].boxShadowOnHover};
-  }
-
-  @media ${theme.screenSize.upToSmall} {
-    bottom: ${theme.size.medium};
-    right: ${theme.size.medium};
-  }
-`;
-
-const starIconStyle = css`
-  color: ${palette.blue.light1};
-`;
-
 const FeedbackButton = () => {
-  const { theme } = useDarkMode();
-  const { feedback, initializeFeedback } = useFeedbackContext();
-  return (
-    !feedback && (
-      <button className={cx(containerStyle(theme))} onClick={() => initializeFeedback()}>
-        <Icon className={starIconStyle} glyph="Favorite" />
-        {FEEDBACK_BUTTON_TEXT}
-      </button>
-    )
-  );
+  const { initializeFeedback } = useFeedbackContext();
+  return <Button onClick={() => initializeFeedback()}>{FEEDBACK_BUTTON_TEXT}</Button>;
 };
 
 export default FeedbackButton;

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -16,11 +16,6 @@ import { useFeedbackContext } from './context';
 import useNoScroll from './hooks/useNoScroll';
 
 const FloatingContainer = styled.div`
-  position: fixed;
-  z-index: 14;
-  bottom: ${({ hasOpenLabDrawer }) => (hasOpenLabDrawer ? '70px' : theme.size.large)};
-  right: ${theme.size.large};
-
   @media ${theme.screenSize.upToSmall} {
     padding-top: ${({ top }) => `${top}`};
     right: 0;

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -27,7 +27,8 @@ const FloatingContainer = styled.div`
 
 const Card = styled(LeafygreenCard)`
   /* Card Size */
-  width: 234px;
+  width: 290px;
+  padding: ${theme.size.medium} ${theme.size.default};
   display: flex;
   flex-direction: column;
   position: relative;

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
-import { feedbackId } from '../FeedbackWidget/FeedbackForm';
 import { theme } from '../../../../src/theme/docsTheme';
 import useScreenSize from '../../../hooks/useScreenSize';
 import useStickyTopValues from '../../../hooks/useStickyTopValues';
 import { InstruqtContext } from '../../Instruqt/instruqt-context';
-import { elementZIndex } from '../../../utils/dynamically-set-z-index';
 import { HeaderContext } from '../../Header/header-context';
 import ProgressBar from './components/PageIndicators';
 import CloseButton from './components/CloseButton';
@@ -61,13 +59,11 @@ const FeedbackCard = ({ isOpen, children }) => {
 
   const onClose = () => {
     abandon();
-    // reset the z-index set by the screenshot button in ScreenshotButton.js
-    elementZIndex.setZIndex('.widgets', theme.zIndexes.header);
   };
 
   return (
     isOpen && (
-      <FloatingContainer darkMode={darkMode} top={topBuffer} id={feedbackId} hasOpenLabDrawer={isLabOpen}>
+      <FloatingContainer darkMode={darkMode} top={topBuffer} hasOpenLabDrawer={isLabOpen}>
         <Card>
           <CloseButton onClick={onClose} />
           <ProgressBar />

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useContext, useMemo } from 'react';
 import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
@@ -61,27 +61,9 @@ const FeedbackCard = ({ isOpen, children }) => {
     abandon();
   };
 
-  const ref = useRef(null);
-
-  // Effect to detect click outside of FeedbackCard
-  useEffect(() => {
-    // close feedback if clicked somewhere outside
-    function handleClickOutside(event) {
-      if (ref.current && !ref.current.contains(event.target)) {
-        abandon();
-      }
-    }
-    // Bind the event listener
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      // Unbind the event listener on clean up
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [abandon, ref]);
-
   return (
     isOpen && (
-      <CardContainer ref={ref} darkMode={darkMode} top={topBuffer} hasOpenLabDrawer={isLabOpen}>
+      <CardContainer darkMode={darkMode} top={topBuffer} hasOpenLabDrawer={isLabOpen}>
         <Card>
           <CloseButton onClick={onClose} />
           <ProgressBar />

--- a/src/components/Widgets/FeedbackWidget/FeedbackCard.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackCard.js
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import styled from '@emotion/styled';
 import LeafygreenCard from '@leafygreen-ui/card';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
@@ -13,7 +13,7 @@ import CloseButton from './components/CloseButton';
 import { useFeedbackContext } from './context';
 import useNoScroll from './hooks/useNoScroll';
 
-const FloatingContainer = styled.div`
+const CardContainer = styled.div`
   @media ${theme.screenSize.upToSmall} {
     padding-top: ${({ top }) => `${top}`};
     right: 0;
@@ -61,15 +61,33 @@ const FeedbackCard = ({ isOpen, children }) => {
     abandon();
   };
 
+  const ref = useRef(null);
+
+  // Effect to detect click outside of FeedbackCard
+  useEffect(() => {
+    // close feedback if clicked somewhere outside
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        abandon();
+      }
+    }
+    // Bind the event listener
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [abandon, ref]);
+
   return (
     isOpen && (
-      <FloatingContainer darkMode={darkMode} top={topBuffer} hasOpenLabDrawer={isLabOpen}>
+      <CardContainer ref={ref} darkMode={darkMode} top={topBuffer} hasOpenLabDrawer={isLabOpen}>
         <Card>
           <CloseButton onClick={onClose} />
           <ProgressBar />
           <div>{children}</div>
         </Card>
-      </FloatingContainer>
+      </CardContainer>
     )
   );
 };

--- a/src/components/Widgets/FeedbackWidget/FeedbackContainer.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackContainer.js
@@ -9,9 +9,11 @@ const Container = styled.div`
 
 const FeedbackContainer = ({ children }) => {
   const ref = useRef(null);
-  const { abandon } = useFeedbackContext();
+  const { abandon, isScreenshotButtonClicked } = useFeedbackContext();
 
-  useClickOutside(ref, abandon);
+  useClickOutside(ref, () => {
+    !isScreenshotButtonClicked && abandon();
+  });
 
   return <Container ref={ref}>{children}</Container>;
 };

--- a/src/components/Widgets/FeedbackWidget/FeedbackContainer.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackContainer.js
@@ -1,0 +1,19 @@
+import React, { useRef } from 'react';
+import styled from '@emotion/styled';
+import { useClickOutside } from '../../../hooks/use-click-outside';
+import { useFeedbackContext } from './context';
+
+const Container = styled.div`
+  position: relative;
+`;
+
+const FeedbackContainer = ({ children }) => {
+  const ref = useRef(null);
+  const { abandon } = useFeedbackContext();
+
+  useClickOutside(ref, abandon);
+
+  return <Container ref={ref}>{children}</Container>;
+};
+
+export default FeedbackContainer;

--- a/src/components/Widgets/FeedbackWidget/FeedbackForm.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackForm.js
@@ -3,6 +3,7 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import Loadable from '@loadable/component';
 import { createPortal } from 'react-dom';
 import useScreenSize from '../../../hooks/useScreenSize';
+import { theme } from '../../../theme/docsTheme';
 import { useFeedbackContext } from './context';
 import FeedbackCard from './FeedbackCard';
 import RatingView from './views/RatingView';
@@ -19,7 +20,9 @@ export const FeedbackContent = ({ view }) => {
 };
 
 const formStyle = css`
-  position: relative;
+  position: absolute;
+  right: 0;
+  margin-top: ${theme.size.tiny};
 `;
 
 const FeedbackForm = () => {

--- a/src/components/Widgets/FeedbackWidget/FeedbackForm.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackForm.js
@@ -25,13 +25,16 @@ const formStyle = css`
   margin-top: ${theme.size.tiny};
 `;
 
+export const feedbackId = 'feedback-card';
+export const fwFormId = 'feedback-form';
+
 const FeedbackForm = () => {
   const { view } = useFeedbackContext();
   const { isMobile } = useScreenSize();
   const isOpen = view !== 'waiting';
 
   const renderedComponent = isOpen && (
-    <div className={cx(fwFormId, formStyle)} hidden={!isOpen}>
+    <div className={cx(fwFormId, formStyle)} id={feedbackId} hidden={!isOpen}>
       <FeedbackCard isOpen={isOpen}>
         <FeedbackContent view={view} />
       </FeedbackCard>
@@ -40,8 +43,5 @@ const FeedbackForm = () => {
 
   return isMobile ? createPortal(renderedComponent, document.body) : renderedComponent;
 };
-
-export const feedbackId = 'feedback-card';
-export const fwFormId = 'feedback-form';
 
 export default FeedbackForm;

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -12,7 +12,6 @@ import { isBrowser } from '../../../../utils/is-browser';
 import useNoScroll from '../hooks/useNoScroll';
 import { theme } from '../../../../theme/docsTheme';
 import { SCREENSHOT_BUTTON_TEXT, SCREENSHOT_BUTTON_TEXT_LOW, SCREENSHOT_OVERLAY_ALT_TEXT } from '../constants';
-import { elementZIndex } from '../../../../utils/dynamically-set-z-index';
 
 const HIGHLIGHT_BORDER_SIZE = 5;
 
@@ -183,12 +182,11 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
     setIsScreenshotButtonClicked(true);
     domElementClickedRef.current = 'dashed';
     setSelectedElementBorderStyle('dashed');
-    elementZIndex.resetZIndex('.widgets');
   }, []);
 
   // close out the instructions panel
   const handleInstructionClick = () => {
-    document.getElementById(feedbackId).style.left = 'initial';
+    document.getElementById(feedbackId).style.right = null;
     resetProperties();
   };
 
@@ -199,20 +197,18 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
     setIsScreenshotButtonClicked(false);
     setCurrElemState(null);
     setScreenshotTaken(false);
-    elementZIndex.resetZIndex('.widgets');
   };
 
   const handleDOMElementClick = (e) => {
     e.preventDefault();
 
     //conditionally set the z-index on the widget card when the screenshot is clicked
-    elementZIndex.setZIndex('.widgets', 14);
 
     domElementClickedRef.current = 'solid';
     setSelectedElementBorderStyle(domElementClickedRef.current);
     setScreenshotTaken(true);
 
-    document.getElementById(feedbackId).style.left = 'initial';
+    document.getElementById(feedbackId).style.right = null;
   };
 
   const handleExitButtonClick = (e) => {
@@ -227,7 +223,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
 
   if (isScreenshotButtonClicked) {
     if (isBrowser && domElementClickedRef.current === 'dashed') {
-      document.getElementById(feedbackId).style.left = '-9000px';
+      document.getElementById(feedbackId).style.right = '-9000px';
       // highlight elements based on mouse movement
       document.addEventListener('mousemove', handleElementHighlight);
     }

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -202,8 +202,6 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
   const handleDOMElementClick = (e) => {
     e.preventDefault();
 
-    //conditionally set the z-index on the widget card when the screenshot is clicked
-
     domElementClickedRef.current = 'solid';
     setSelectedElementBorderStyle(domElementClickedRef.current);
     setScreenshotTaken(true);

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -11,7 +11,7 @@ import { feedbackId } from '../FeedbackForm';
 import { isBrowser } from '../../../../utils/is-browser';
 import useNoScroll from '../hooks/useNoScroll';
 import { theme } from '../../../../theme/docsTheme';
-import { SCREENSHOT_BUTTON_TEXT, SCREENSHOT_OVERLAY_ALT_TEXT } from '../constants';
+import { SCREENSHOT_BUTTON_TEXT, SCREENSHOT_BUTTON_TEXT_LOW, SCREENSHOT_OVERLAY_ALT_TEXT } from '../constants';
 import { elementZIndex } from '../../../../utils/dynamically-set-z-index';
 
 const HIGHLIGHT_BORDER_SIZE = 5;
@@ -79,11 +79,10 @@ const ScreenshotSelect = styled(Button)`
   height: 28px;
   margin: 0 auto ${theme.size.small} 0;
   z-index: 5;
-  width: 158px !important;
 `;
 
 const ScreenshotButton = ({ size = 'default', ...props }) => {
-  const { setScreenshotTaken } = useFeedbackContext();
+  const { setScreenshotTaken, selectedRating } = useFeedbackContext();
   const [isScreenshotButtonClicked, setIsScreenshotButtonClicked] = useState(false);
   const [currElemState, setCurrElemState] = useState(null);
 
@@ -335,7 +334,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
         leftGlyph={<img src={withPrefix(glyphImage)} alt="Screenshot Button" />}
         {...props}
       >
-        {SCREENSHOT_BUTTON_TEXT}
+        {selectedRating < 4 ? SCREENSHOT_BUTTON_TEXT_LOW : SCREENSHOT_BUTTON_TEXT}
       </ScreenshotSelect>
     </>
   );

--- a/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
+++ b/src/components/Widgets/FeedbackWidget/components/ScreenshotButton.js
@@ -81,8 +81,8 @@ const ScreenshotSelect = styled(Button)`
 `;
 
 const ScreenshotButton = ({ size = 'default', ...props }) => {
-  const { setScreenshotTaken, selectedRating } = useFeedbackContext();
-  const [isScreenshotButtonClicked, setIsScreenshotButtonClicked] = useState(false);
+  const { setScreenshotTaken, selectedRating, isScreenshotButtonClicked, setIsScreenshotButtonClicked } =
+    useFeedbackContext();
   const [currElemState, setCurrElemState] = useState(null);
 
   // border around highlighted element
@@ -182,7 +182,7 @@ const ScreenshotButton = ({ size = 'default', ...props }) => {
     setIsScreenshotButtonClicked(true);
     domElementClickedRef.current = 'dashed';
     setSelectedElementBorderStyle('dashed');
-  }, []);
+  }, [setIsScreenshotButtonClicked]);
 
   // close out the instructions panel
   const handleInstructionClick = () => {

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -133,7 +133,7 @@ const StarRating = ({ className, handleRatingSelection = () => {}, editable = tr
               }
             : {};
 
-          return <Star key={ratingValue} isHighlighted={isHighlighted} triggerEnabled={editable} {...eventProps} />;
+          return <Star key={ratingValue} isHighlighted={isHighlighted} {...eventProps} />;
         })}
       </Layout>
       {showCaption && (

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
-import loadable from '@loadable/component';
 import { palette } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Body } from '@leafygreen-ui/typography';
@@ -8,13 +7,6 @@ import Icon from '@leafygreen-ui/icon';
 import { useFeedbackContext } from '../context';
 import useScreenSize from '../../../../hooks/useScreenSize';
 import { theme } from '../../../../theme/docsTheme';
-const Tooltip = loadable(() => import('./LeafygreenTooltip'));
-
-// Given a string, convert all regular space characters to non-breaking spaces
-const convertSpacesToNbsp = (someString) => {
-  const nbsp = '\xa0';
-  return someString.replace(/\s/g, nbsp);
-};
 
 const FILLED_STAR_COLOR = palette.green.light1;
 const UNFILLED_STAR_COLOR = palette.white;
@@ -73,56 +65,27 @@ export const StarRatingLabel = styled.div`
   margin-top: 12px;
 `;
 
-export const RATING_TOOLTIPS = {
-  1: 'Very Poor',
-  2: 'Poor',
-  3: 'Neutral',
-  4: 'Good',
-  5: 'Very Good',
-};
-
-const Star = ({
-  ratingValue,
-  isHighlighted,
-  onClick,
-  onMouseEnter,
-  onMouseLeave,
-  onFocus,
-  onKeyDown,
-  onBlur,
-  triggerEnabled,
-}) => {
+const Star = ({ isHighlighted, onClick, onMouseEnter, onMouseLeave, onFocus, onKeyDown, onBlur }) => {
   const { isTabletOrMobile } = useScreenSize();
   const starSize = isTabletOrMobile ? 32 : 24;
 
   return (
     <div onClick={onClick} onMouseLeave={onMouseLeave}>
-      <Tooltip
-        key={`star-${ratingValue}`}
-        justify="middle"
-        triggerEvent="hover"
-        enabled={triggerEnabled}
-        usePortal={false}
-        trigger={
-          <StarContainer>
-            <Icon
-              data-testid={`rating-star${isHighlighted ? '-highlighted' : ''}`}
-              className={starIconStyle(isHighlighted)}
-              glyph="Favorite"
-              size={starSize}
-              // Change default viewbox to allow focus outline to be more centered
-              viewBox="0 -0.5 16 16"
-              onMouseEnter={onMouseEnter}
-              tabIndex={0}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              onKeyDown={onKeyDown}
-            />
-          </StarContainer>
-        }
-      >
-        {convertSpacesToNbsp(RATING_TOOLTIPS[ratingValue])}
-      </Tooltip>
+      <StarContainer>
+        <Icon
+          data-testid={`rating-star${isHighlighted ? '-highlighted' : ''}`}
+          className={starIconStyle(isHighlighted)}
+          glyph="Favorite"
+          size={starSize}
+          // Change default viewbox to allow focus outline to be more centered
+          viewBox="0 -0.5 16 16"
+          onMouseEnter={onMouseEnter}
+          tabIndex={0}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+        />
+      </StarContainer>
     </div>
   );
 };
@@ -170,15 +133,7 @@ const StarRating = ({ className, handleRatingSelection = () => {}, editable = tr
               }
             : {};
 
-          return (
-            <Star
-              key={ratingValue}
-              ratingValue={ratingValue}
-              isHighlighted={isHighlighted}
-              triggerEnabled={editable}
-              {...eventProps}
-            />
-          );
+          return <Star key={ratingValue} isHighlighted={isHighlighted} triggerEnabled={editable} {...eventProps} />;
         })}
       </Layout>
       {showCaption && (

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -5,7 +5,6 @@ import { palette } from '@leafygreen-ui/palette';
 import { css } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import { useFeedbackContext } from '../context';
-import { isBrowser } from '../../../../utils/is-browser';
 import useScreenSize from '../../../../hooks/useScreenSize';
 import { theme } from '../../../../theme/docsTheme';
 const Tooltip = loadable(() => import('./LeafygreenTooltip'));
@@ -52,6 +51,14 @@ const Layout = styled.div`
 
 const StarContainer = styled.div`
   cursor: pointer;
+`;
+
+const CaptionContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 16px;
+  align-items: center;
 `;
 
 export const StarRatingLabel = styled.div`
@@ -140,7 +147,7 @@ const StarRating = ({ className, handleRatingSelection = () => {}, editable = tr
   };
 
   return (
-    isBrowser && (
+    <>
       <Layout className={className} onMouseLeave={resetHoverStates}>
         {[1, 2, 3, 4, 5].map((ratingValue) => {
           const isHighlighted = hoveredRating ? hoveredRating >= ratingValue : selectedRating >= ratingValue;
@@ -166,7 +173,12 @@ const StarRating = ({ className, handleRatingSelection = () => {}, editable = tr
           );
         })}
       </Layout>
-    )
+      <CaptionContainer>
+        Poor
+        <Icon glyph="ArrowRight" />
+        Excellent
+      </CaptionContainer>
+    </>
   );
 };
 

--- a/src/components/Widgets/FeedbackWidget/components/StarRating.js
+++ b/src/components/Widgets/FeedbackWidget/components/StarRating.js
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import loadable from '@loadable/component';
 import { palette } from '@leafygreen-ui/palette';
-import { css } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
+import { Body } from '@leafygreen-ui/typography';
 import Icon from '@leafygreen-ui/icon';
 import { useFeedbackContext } from '../context';
 import useScreenSize from '../../../../hooks/useScreenSize';
@@ -42,7 +43,7 @@ const Layout = styled.div`
   display: flex;
   gap: ${theme.size.small};
   justify-content: center;
-  margin: ${theme.size.default} 0 ${theme.size.small};
+  margin: ${theme.size.default} 0 10px;
 
   @media ${theme.screenSize.upToLarge} {
     gap: 12px;
@@ -53,12 +54,19 @@ const StarContainer = styled.div`
   cursor: pointer;
 `;
 
-const CaptionContainer = styled.div`
+const captionStyling = css`
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   width: 100%;
-  padding: 0 16px;
-  align-items: center;
+  padding: 0 ${theme.size.default};
+  color: var(--tab-color-primary);
+  column-gap: ${theme.size.medium};
+  margin-left: ${theme.size.small};
+`;
+
+const StyledArrow = styled.span`
+  line-height: ${theme.fontSize.tiny};
+  font-size: ${theme.fontSize.h2};
 `;
 
 export const StarRatingLabel = styled.div`
@@ -119,7 +127,7 @@ const Star = ({
   );
 };
 
-const StarRating = ({ className, handleRatingSelection = () => {}, editable = true }) => {
+const StarRating = ({ className, handleRatingSelection = () => {}, editable = true, showCaption = true }) => {
   const [hoveredRating, setHoveredRating] = useState(null);
   const [lastHoveredRating, setLastHoveredRating] = useState(null);
   const { selectedRating } = useFeedbackContext();
@@ -173,11 +181,13 @@ const StarRating = ({ className, handleRatingSelection = () => {}, editable = tr
           );
         })}
       </Layout>
-      <CaptionContainer>
-        Poor
-        <Icon glyph="ArrowRight" />
-        Excellent
-      </CaptionContainer>
+      {showCaption && (
+        <Body baseFontSize={13} className={cx(captionStyling)}>
+          Poor
+          <StyledArrow>&#10230;</StyledArrow>
+          Excellent
+        </Body>
+      )}
     </>
   );
 };

--- a/src/components/Widgets/FeedbackWidget/constants.js
+++ b/src/components/Widgets/FeedbackWidget/constants.js
@@ -8,9 +8,11 @@ export const SCREENSHOT_OVERLAY_ALT_TEXT = 'Screenshot';
 export const FEEDBACK_BUTTON_TEXT = 'Feedback';
 export const RATING_QUESTION_TEXT = 'How would you rate this page?';
 export const COMMENT_PLACEHOLDER_TEXT = 'Tell us more about your experience';
+export const COMMENT_PLACEHOLDER_TEXT_LOW = 'Tell us how we can improve';
 export const EMAIL_PLACEHOLDER_TEXT = 'Email Address';
 export const EMAIL_ERROR_TEXT = 'Please enter a valid email.';
-export const SCREENSHOT_BUTTON_TEXT = 'Take a screenshot';
+export const SCREENSHOT_BUTTON_TEXT = 'Show us a screenshot';
+export const SCREENSHOT_BUTTON_TEXT_LOW = 'Show us where the problem is';
 export const FEEDBACK_SUBMIT_BUTTON_TEXT = 'Send';
 
 export const SUBMITTED_VIEW_TEXT = {

--- a/src/components/Widgets/FeedbackWidget/constants.js
+++ b/src/components/Widgets/FeedbackWidget/constants.js
@@ -5,7 +5,7 @@ export const CLOSE_BUTTON_ALT_TEXT = 'Close Feedback Form';
 export const SCREENSHOT_OVERLAY_ALT_TEXT = 'Screenshot';
 
 // TEXT
-export const FEEDBACK_BUTTON_TEXT = 'Rate this page';
+export const FEEDBACK_BUTTON_TEXT = 'Feedback';
 export const RATING_QUESTION_TEXT = 'How would you rate this page?';
 export const COMMENT_PLACEHOLDER_TEXT = 'Tell us more about your experience';
 export const EMAIL_PLACEHOLDER_TEXT = 'Email Address';

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useContext, useEffect, createContext, useTransition } from 'react';
-import { globalHistory } from '@gatsbyjs/reach-router';
+import { useLocation } from '@gatsbyjs/reach-router';
 import { getViewport } from '../../../hooks/useViewport';
 import { createNewFeedback, useRealmUser } from './realm';
 
@@ -15,6 +15,7 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
   const [progress, setProgress] = useState([true, false, false]);
   const [, startTransition] = useTransition();
   const { user, reassignCurrentUser } = useRealmUser();
+  const { href } = useLocation();
 
   // Create a new feedback document
   const initializeFeedback = (nextView = 'rating') => {
@@ -128,10 +129,11 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
 
   // reset feedback when route changes
   useEffect(() => {
-    return globalHistory.listen((location, action) => {
-      abandon();
-    });
-  }, [abandon]);
+    // disable effect for testing views
+    if (test?.view) return;
+    abandon();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [href]);
 
   return <FeedbackContext.Provider value={value}>{props.children}</FeedbackContext.Provider>;
 }

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -1,4 +1,5 @@
-import React, { useState, useContext, createContext, useTransition } from 'react';
+import React, { useState, useCallback, useContext, useEffect, createContext, useTransition } from 'react';
+import { globalHistory } from '@gatsbyjs/reach-router';
 import { getViewport } from '../../../hooks/useViewport';
 import { createNewFeedback, useRealmUser } from './realm';
 
@@ -101,15 +102,14 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
 
   // Stop giving feedback (if in progress) and reset the widget to the
   // initial state.
-  const abandon = () => {
-    // Reset to the initial state
+  const abandon = useCallback(() => {
     setView('waiting');
     if (feedback) {
       // set the rating and feedback to null
       setFeedback(null);
       setSelectedRating(null);
     }
-  };
+  }, [feedback]);
 
   const value = {
     feedback,
@@ -125,6 +125,13 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
     setSelectedRating,
     selectInitialRating,
   };
+
+  // reset feedback when route changes
+  useEffect(() => {
+    return globalHistory.listen((location, action) => {
+      abandon();
+    });
+  }, [abandon]);
 
   return <FeedbackContext.Provider value={value}>{props.children}</FeedbackContext.Provider>;
 }

--- a/src/components/Widgets/FeedbackWidget/context.js
+++ b/src/components/Widgets/FeedbackWidget/context.js
@@ -13,6 +13,7 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
   const [view, setView] = useState(test.view || 'waiting');
   const [screenshotTaken, setScreenshotTaken] = useState(test.screenshotTaken || false);
   const [progress, setProgress] = useState([true, false, false]);
+  const [isScreenshotButtonClicked, setIsScreenshotButtonClicked] = useState(false);
   const [, startTransition] = useTransition();
   const { user, reassignCurrentUser } = useRealmUser();
   const { href } = useLocation();
@@ -110,6 +111,7 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
       setFeedback(null);
       setSelectedRating(null);
     }
+    setIsScreenshotButtonClicked(false);
   }, [feedback]);
 
   const value = {
@@ -125,6 +127,8 @@ export function FeedbackProvider({ page, test = {}, ...props }) {
     selectedRating,
     setSelectedRating,
     selectInitialRating,
+    isScreenshotButtonClicked,
+    setIsScreenshotButtonClicked,
   };
 
   // reset feedback when route changes

--- a/src/components/Widgets/FeedbackWidget/index.js
+++ b/src/components/Widgets/FeedbackWidget/index.js
@@ -2,5 +2,6 @@ import { FeedbackProvider, useFeedbackContext } from './context';
 import useFeedbackData from './useFeedbackData';
 import FeedbackForm from './FeedbackForm';
 import FeedbackButton from './FeedbackButton';
+import FeedbackContainer from './FeedbackContainer';
 
-export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackButton };
+export { FeedbackProvider, useFeedbackContext, useFeedbackData, FeedbackForm, FeedbackButton, FeedbackContainer };

--- a/src/components/Widgets/FeedbackWidget/views/CommentView.js
+++ b/src/components/Widgets/FeedbackWidget/views/CommentView.js
@@ -21,7 +21,6 @@ import {
   EMAIL_PLACEHOLDER_TEXT,
   FEEDBACK_SUBMIT_BUTTON_TEXT,
 } from '../constants';
-import { elementZIndex } from '../../../../utils/dynamically-set-z-index';
 const ScreenshotButton = Loadable(() => import('../components/ScreenshotButton'));
 
 const SubmitButton = styled(Button)`
@@ -108,8 +107,6 @@ const CommentView = () => {
   const { isMobile } = useScreenSize();
 
   const handleSubmit = async () => {
-    elementZIndex.resetZIndex('.widgets');
-
     if (isValidEmail) {
       if (screenshotTaken) {
         const dataUri = await retrieveDataUri();

--- a/src/components/Widgets/FeedbackWidget/views/CommentView.js
+++ b/src/components/Widgets/FeedbackWidget/views/CommentView.js
@@ -16,6 +16,7 @@ import StarRating from '../components/StarRating';
 import { theme } from '../../../../theme/docsTheme';
 import {
   COMMENT_PLACEHOLDER_TEXT,
+  COMMENT_PLACEHOLDER_TEXT_LOW,
   EMAIL_ERROR_TEXT,
   EMAIL_PLACEHOLDER_TEXT,
   FEEDBACK_SUBMIT_BUTTON_TEXT,
@@ -96,7 +97,7 @@ const useValidation = (inputValue, validator) => {
 };
 
 const CommentView = () => {
-  const { submitAllFeedback, screenshotTaken, setSelectedRating } = useFeedbackContext();
+  const { submitAllFeedback, screenshotTaken, setSelectedRating, selectedRating } = useFeedbackContext();
 
   const [comment, setComment] = useState('');
   const [email, setEmail] = useState('');
@@ -123,12 +124,12 @@ const CommentView = () => {
 
   return (
     <Layout>
-      <StyledStarRating handleRatingSelection={setSelectedRating} />
+      <StyledStarRating handleRatingSelection={setSelectedRating} showCaption={false} />
       <StyledCommentInput
         type="text"
         id="feedback-comment"
         aria-labelledby="Comment Text Box"
-        placeholder={COMMENT_PLACEHOLDER_TEXT}
+        placeholder={selectedRating < 4 ? COMMENT_PLACEHOLDER_TEXT_LOW : COMMENT_PLACEHOLDER_TEXT}
         value={comment}
         onChange={(e) => setComment(e.target.value)}
         baseFontSize={13}

--- a/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
+++ b/src/components/Widgets/FeedbackWidget/views/SubmittedView.js
@@ -19,6 +19,10 @@ const StyledHeading = styled(Subtitle)`
   text-align: center;
 `;
 
+const Container = styled(Layout)`
+  padding: 0 ${theme.size.default};
+`;
+
 const SubmittedView = () => {
   const { abandon } = useFeedbackContext();
   const { isMobile } = useScreenSize();
@@ -26,9 +30,9 @@ const SubmittedView = () => {
   const shouldShowSupportLink = selectedRating <= 3;
 
   return (
-    <Layout>
+    <Container>
       <StyledHeading>{SUBMITTED_VIEW_TEXT.HEADING}</StyledHeading>
-      <StarRating editable={false} />
+      <StarRating editable={false} showCaption={false} />
       <Subheading>{SUBMITTED_VIEW_TEXT.SUB_HEADING}</Subheading>
       <Subheading>
         <span>{SUBMITTED_VIEW_TEXT.RESOURCES_CTA}</span>
@@ -50,7 +54,7 @@ const SubmittedView = () => {
         )}
       </Subheading>
       {isMobile && <Button onClick={() => abandon()}>Return to the Documentation</Button>}
-    </Layout>
+    </Container>
   );
 };
 

--- a/src/hooks/use-canonical-url.js
+++ b/src/hooks/use-canonical-url.js
@@ -8,8 +8,8 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
   const { siteUrl, parserBranch } = siteMetadata;
   // Use parserBranch by default to avoid undefined slugs when testing
   const urlSlug =
-    repoBranches.branches.find((branch) => branch.gitBranchName === parserBranch)?.urlSlug ?? parserBranch;
-  const siteBasePrefix = repoBranches.siteBasePrefix;
+    repoBranches?.branches.find((branch) => branch.gitBranchName === parserBranch)?.urlSlug ?? parserBranch;
+  const siteBasePrefix = repoBranches?.siteBasePrefix;
   const pathPrefix = generateVersionedPrefix(urlSlug, siteBasePrefix);
 
   // Use default logic assuming there is no canonical provided from the meta directive
@@ -36,7 +36,7 @@ export const useCanonicalUrl = (meta, metadata, slug, repoBranches) => {
 
   // else we check for EOL
   if (metadata.eol) {
-    const stableBranch = repoBranches.branches.find((branch) => {
+    const stableBranch = repoBranches?.branches.find((branch) => {
       return branch.active && branch.isStableBranch;
     });
 

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
+import ActionBar from '../components/ActionBar/ActionBar';
 import ContentTransition from '../components/ContentTransition';
 import Header from '../components/Header';
 import { Sidenav } from '../components/Sidenav';
@@ -130,6 +131,7 @@ const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBran
             <div />
           )}
           <StyledContentContainer>
+            <ActionBar template={template} />
             <ContentTransition slug={slug}>{children}</ContentTransition>
           </StyledContentContainer>
         </GlobalGrid>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -131,7 +131,7 @@ const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBran
             <div />
           )}
           <StyledContentContainer>
-            <ActionBar template={template} />
+            <ActionBar template={template} slug={slug} />
             <ContentTransition slug={slug}>{children}</ContentTransition>
           </StyledContentContainer>
         </GlobalGrid>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -84,7 +84,7 @@ const GlobalGrid = styled('div')`
   overflow: clip;
 `;
 
-const StyledContentContainer = styled('div')`
+export const StyledContentContainer = styled('div')`
   grid-area: contents;
   margin: 0px;
 `;

--- a/src/layouts/preview-layout.js
+++ b/src/layouts/preview-layout.js
@@ -10,6 +10,8 @@ import { getTemplate } from '../utils/get-template';
 import { useDelightedSurvey } from '../hooks/useDelightedSurvey';
 import { theme } from '../theme/docsTheme';
 import { MetadataProvider } from '../utils/use-snooty-metadata';
+import ActionBar from '../components/ActionBar/ActionBar';
+import { StyledContentContainer } from '.';
 
 // These fonts are ported over from @mdb/flora design system repo
 // They are used on the content areas and are not included in Snooty itself
@@ -170,7 +172,10 @@ const DefaultLayout = ({
                 eol={eol}
               />
             )}
-            <ContentTransition slug={slug}>{children}</ContentTransition>
+            <StyledContentContainer>
+              <ActionBar template={template} slug={slug} />
+              <ContentTransition slug={slug}>{children}</ContentTransition>
+            </StyledContentContainer>
           </GlobalGrid>
         </RootProvider>
       </MetadataProvider>

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -21,7 +21,6 @@ body {
   --link-color-primary: var(--blue-light1);
   --link-font-weight: 700;
 
-  /* TODO: check this is correct color */
   --background-color-primary: var(--black);
   --background-color-secondary: transparent;
 

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -1,14 +1,4 @@
 body {
-  background-color: initial;
-  color: initial;
-}
-
-.dark-theme body {
-  background-color: var(--lg-bg-dark-mode);
-  color: var(--lg-color-dark-mode);
-}
-
-body {
   --font-color-primary: var(--black);
   --font-color-light: var(--gray-base);
   --heading-color-primary: var(--green-dark2);
@@ -31,9 +21,20 @@ body {
   --link-color-primary: var(--blue-light1);
   --link-font-weight: 700;
 
-  --background-color-primary: var(--gray-dark3);
+  /* TODO: check this is correct color */
+  --background-color-primary: var(--black);
   --background-color-secondary: transparent;
 
   --tab-color-primary: var(--gray-light1);
   --tab-color-secondary: var(--gray-light2);
+}
+
+body {
+  background-color: initial;
+  color: initial;
+}
+
+.dark-theme body {
+  background-color: var(--background-color-primary);
+  color: var(--font-color-primary);
 }

--- a/tests/testSetup.js
+++ b/tests/testSetup.js
@@ -8,6 +8,9 @@ jest.mock('@gatsbyjs/reach-router', () => ({
     hash: '',
   })),
   navigate: jest.fn(),
+  globalHistory: {
+    listen: jest.fn(),
+  },
 }));
 
 export const mockLocation = (search, pathname) => useLocation.mockImplementation(() => ({ search, pathname }));

--- a/tests/unit/Chatbot.test.js
+++ b/tests/unit/Chatbot.test.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import * as snootyMetadata from '../../src/utils/use-snooty-metadata';
 import ActionBar from '../../src/components/ActionBar/ActionBar';
 
 jest.mock('../../src/hooks/use-site-metadata', () => ({
   useSiteMetadata: () => ({ reposDatabase: 'pool_test' }),
+}));
+jest.spyOn(snootyMetadata, 'default').mockImplementation(() => ({
+  branch: 'master',
+  project: '',
 }));
 
 describe('Chatbot Ui', () => {

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -16,6 +16,7 @@ import {
   mockScreenshotFunctions,
   clearMockScreenshotFunctions,
 } from '../utils/data/feedbackWidgetScreenshotFunctions';
+import { mockLocation } from '../utils/mock-location';
 import {
   CLOSE_BUTTON_ALT_TEXT,
   COMMENT_PLACEHOLDER_TEXT,
@@ -91,6 +92,7 @@ describe('FeedbackWidget', () => {
   afterEach(clearMockStitchFunctions);
   beforeEach(mockScreenshotFunctions);
   afterEach(clearMockScreenshotFunctions);
+  beforeEach(() => mockLocation('', '', '', 'https://mongodb.com/docs/atlas'));
 
   describe('FeedbackButton', () => {
     it('shows the rating view when clicked', async () => {
@@ -132,6 +134,20 @@ describe('FeedbackWidget', () => {
       userEvent.click(wrapper.getByLabelText(CLOSE_BUTTON_ALT_TEXT));
       await tick();
       expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(0);
+    });
+
+    it('closes when navigating to a different page', async () => {
+      wrapper = await mountFormWithFeedbackState({});
+      // Click the button
+      userEvent.click(wrapper.getByText(FEEDBACK_BUTTON_TEXT));
+      await tick();
+      // Expect rating question to be on screen
+      expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(1);
+
+      mockLocation('', '', '', 'https://mongodb.com/docs/atlas/getting-started');
+      await tick();
+      // Form is closed when navigating to new page
+      expect(wrapper.queryAllByTestId(RATING_QUESTION_TEXT)).toHaveLength(0);
     });
 
     describe('RatingView', () => {

--- a/tests/unit/FeedbackWidget.test.js
+++ b/tests/unit/FeedbackWidget.test.js
@@ -110,12 +110,10 @@ describe('FeedbackWidget', () => {
       expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(0);
 
       // Focus and simulate keyboard interaction
-      const fwButon = wrapper.getByText(FEEDBACK_BUTTON_TEXT);
+      const fwButon = wrapper.getByRole('button');
       fwButon.focus();
       userEvent.keyboard('{Enter}');
       await tick();
-
-      // Ensure rating view appears
       expect(wrapper.queryAllByText(RATING_QUESTION_TEXT)).toHaveLength(1);
     });
 
@@ -198,6 +196,7 @@ describe('FeedbackWidget', () => {
             view: 'comment',
             comment: 'This is a test comment.',
             user: { email: 'test@example.com' },
+            rating: 5,
           });
 
           // click on screenshot button; use closest() because of LG implementation of `"pointer-events": "none"`

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -3,8 +3,6 @@ import { render, screen, act } from '@testing-library/react';
 import * as Gatsby from 'gatsby';
 import { mockLocation } from '../utils/mock-location';
 import DocumentBody from '../../src/components/DocumentBody';
-import { FEEDBACK_BUTTON_TEXT } from '../../src/components/Widgets/FeedbackWidget/constants';
-import { CHATBOT_WIDGET_TEXT } from '../../src/components/Widgets/ChatbotWidget/ChatbotFab';
 import mockPageContext from './data/PageContext.test.json';
 import mockSnootyMetadata from './data/SnootyMetadata.json';
 
@@ -33,10 +31,12 @@ describe('DocumentBody', () => {
   });
 
   it('renders the necessary elements', async () => {
+    let renderRes;
     await act(async () => {
       mockLocation(null);
-      render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
+      renderRes = render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
     });
+    renderRes.debug();
     const footer = await screen.findByTestId('consistent-footer');
     expect(footer).toBeVisible();
     expect(footer).toMatchSnapshot();
@@ -47,23 +47,14 @@ describe('DocumentBody', () => {
     const mainNav = await screen.findByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).toBeVisible();
     expect(mainNav).toMatchSnapshot();
-
-    const feedbackWidget = await screen.findByText(FEEDBACK_BUTTON_TEXT, {}, { timeout: 15000 });
-    expect(feedbackWidget).toBeVisible();
-
-    const chatbotWidget = await screen.findByText(CHATBOT_WIDGET_TEXT, {}, { timeout: 15000 });
-    expect(chatbotWidget).toBeVisible();
   });
 
-  it('does not render the following elements, footer, feedback widget, navigation', async () => {
+  it('does not render the following elements, footer, navigation', async () => {
     mockLocation('?presentation=true');
     render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
     // use `queryBy` to avoid throwing an error with `getBy`
     const footer = screen.queryByTestId('consistent-footer');
     expect(footer).not.toBeInTheDocument();
-
-    const feedbackWidget = screen.queryByText(FEEDBACK_BUTTON_TEXT);
-    expect(feedbackWidget).not.toBeInTheDocument();
 
     const mainNav = screen.queryByRole('img', { name: 'MongoDB logo' });
     expect(mainNav).not.toBeInTheDocument();

--- a/tests/unit/Presentation.test.js
+++ b/tests/unit/Presentation.test.js
@@ -31,12 +31,10 @@ describe('DocumentBody', () => {
   });
 
   it('renders the necessary elements', async () => {
-    let renderRes;
     await act(async () => {
       mockLocation(null);
-      renderRes = render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
+      render(<DocumentBody location={window.location} pageContext={mockPageContext} />);
     });
-    renderRes.debug();
     const footer = await screen.findByTestId('consistent-footer');
     expect(footer).toBeVisible();
     expect(footer).toMatchSnapshot();

--- a/tests/utils/mock-location.js
+++ b/tests/utils/mock-location.js
@@ -4,5 +4,5 @@ jest.mock('@gatsbyjs/reach-router', () => ({
   useLocation: jest.fn(),
 }));
 
-export const mockLocation = (search, pathname, hash) =>
-  useLocation.mockImplementation(() => ({ search, pathname, hash }));
+export const mockLocation = (search, pathname, hash, href) =>
+  useLocation.mockImplementation(() => ({ search, pathname, hash, href }));


### PR DESCRIPTION
### Stories/Links:

DOP-4879

### Current Behavior:

[Current prod feedback uses FAB for feedback](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Staging link with feedback enabled in action bar](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4879/index.html)
[Gatsby preview build test](https://preview-mongodbseungpark.gatsbyjs.io/drivers/DOP-4817/)

### Notes:
- This PR updates the Feedback Module to be in the Action Bar (for Desktop)
- Feedback behavior should not change as existing, but there are small design changes that are noticeable 
    - caption to indicate rating
    - update padding and sizing of feedback card
    - update copy based on selected feedback rating

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
