### PR TITLE
DOP-4844: Init Cards in dark mode

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -6,6 +6,7 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import LeafyGreenCard from '@leafygreen-ui/card';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Body } from '@leafygreen-ui/typography';
+import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -18,7 +19,11 @@ const cardBaseStyles = css`
   display: flex;
   height: 100%;
   background-color: var(--background-color-primary);
-  border-color: var(--wayfinding-border-color);
+  border-color: ${palette.gray.light2};
+
+  .dark-theme & {
+    border-color: ${palette.gray.dark2};
+  }
 `;
 
 const landingStyles = css`

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -17,6 +17,8 @@ import { getSuitableIcon } from '../../utils/get-suitable-icon';
 const cardBaseStyles = css`
   display: flex;
   height: 100%;
+  background-color: var(--background-color-primary);
+  border-color: var(--wayfinding-border-color);
 `;
 
 const landingStyles = css`
@@ -88,6 +90,7 @@ const compactIconStyle = `
 const headingStyling = ({ isCompact, isExtraCompact, isLargeIconStyle }) => css`
   font-weight: 500;
   letter-spacing: normal;
+  color: var(--font-color-primary);
   margin: ${isCompact || isExtraCompact ? `0 0 ${theme.size.small}` : `${theme.size.default} 0 ${theme.size.small} 0`};
   ${isLargeIconStyle && 'margin-bottom: 36px;'}
 `;

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -23,7 +23,6 @@ body {
   --tab-color-secondary: var(--green-dark2);
 
   --wayfinding-bg-color: var(--gray-light3);
-  /* --wayfinding-border-color also covers Card border color */
   --wayfinding-border-color: var(--gray-light2);
 }
 

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -23,6 +23,7 @@ body {
   --tab-color-secondary: var(--green-dark2);
 
   --wayfinding-bg-color: var(--gray-light3);
+  /* --wayfinding-border-color also covers Card border color */
   --wayfinding-border-color: var(--gray-light2);
 }
 

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -24,7 +24,7 @@ exports[`renders correctly 1`] = `
   display: flex;
   height: 100%;
   background-color: var(--background-color-primary);
-  border-color: var(--wayfinding-border-color);
+  border-color: #E8EDEB;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -45,6 +45,10 @@ exports[`renders correctly 1`] = `
 .emotion-0:hover:focus,
 .emotion-0:active:focus {
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 20px -4px rgba(0,30,43,0.2);
+}
+
+.dark-theme .emotion-0 {
+  border-color: #3D4F58;
 }
 
 .emotion-0 p:last-of-type {

--- a/tests/unit/__snapshots__/Card.test.js.snap
+++ b/tests/unit/__snapshots__/Card.test.js.snap
@@ -23,6 +23,8 @@ exports[`renders correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  background-color: var(--background-color-primary);
+  border-color: var(--wayfinding-border-color);
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -88,6 +90,7 @@ exports[`renders correctly 1`] = `
   font-weight: 500;
   font-weight: 500;
   letter-spacing: normal;
+  color: var(--font-color-primary);
   margin: 16px 0 8px 0;
 }
 

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -72,7 +72,7 @@ exports[`renders correctly 1`] = `
   display: flex;
   height: 100%;
   background-color: var(--background-color-primary);
-  border-color: var(--wayfinding-border-color);
+  border-color: #E8EDEB;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -101,6 +101,10 @@ exports[`renders correctly 1`] = `
 .emotion-2:hover:focus,
 .emotion-2:active:focus {
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 20px -4px rgba(0,30,43,0.2);
+}
+
+.dark-theme .emotion-2 {
+  border-color: #3D4F58;
 }
 
 .emotion-2 p:last-of-type {

--- a/tests/unit/__snapshots__/CardGroup.test.js.snap
+++ b/tests/unit/__snapshots__/CardGroup.test.js.snap
@@ -71,6 +71,8 @@ exports[`renders correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  background-color: var(--background-color-primary);
+  border-color: var(--wayfinding-border-color);
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -69,7 +69,7 @@ exports[`card correctly with and without url 1`] = `
   display: flex;
   height: 100%;
   background-color: var(--background-color-primary);
-  border-color: var(--wayfinding-border-color);
+  border-color: #E8EDEB;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -82,6 +82,10 @@ exports[`card correctly with and without url 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   padding: 32px 24px;
+}
+
+.dark-theme .emotion-2 {
+  border-color: #3D4F58;
 }
 
 .emotion-2 p:last-of-type {
@@ -220,7 +224,7 @@ exports[`card correctly with and without url 1`] = `
   display: flex;
   height: 100%;
   background-color: var(--background-color-primary);
-  border-color: var(--wayfinding-border-color);
+  border-color: #E8EDEB;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -249,6 +253,10 @@ exports[`card correctly with and without url 1`] = `
 .emotion-14:hover:focus,
 .emotion-14:active:focus {
   box-shadow: 0 0 0 2px #FFFFFF,0 0 0 4px #0498EC,0 4px 20px -4px rgba(0,30,43,0.2);
+}
+
+.dark-theme .emotion-14 {
+  border-color: #3D4F58;
 }
 
 .emotion-14 p:last-of-type {

--- a/tests/unit/__snapshots__/CardRef.test.js.snap
+++ b/tests/unit/__snapshots__/CardRef.test.js.snap
@@ -68,6 +68,8 @@ exports[`card correctly with and without url 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  background-color: var(--background-color-primary);
+  border-color: var(--wayfinding-border-color);
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -118,6 +120,7 @@ exports[`card correctly with and without url 1`] = `
   font-weight: 500;
   font-weight: 500;
   letter-spacing: normal;
+  color: var(--font-color-primary);
   margin: 0 0 8px;
 }
 
@@ -216,6 +219,8 @@ exports[`card correctly with and without url 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  background-color: var(--background-color-primary);
+  border-color: var(--wayfinding-border-color);
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;


### PR DESCRIPTION
### Stories/Links:

DOP-4844

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Tools & Connectors](https://www.mongodb.com/docs/tools-and-connectors/)
[Atlas](https://www.mongodb.com/docs/atlas/api)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/DOP-4844-init-cards/index.html)
[Tools & Connectors](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/DOP-4844-init-cards/tools-and-connectors/index.html)
[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4844-init-cards/api/index.html)

### Notes:

This PR simply makes Cards initialize in Dark Mode (if user preferred) without light mode flash. The icons are sometimes (usually) still in light mode. That will be taken care of in [this ticket](https://jira.mongodb.org/browse/DOP-4942). (that is an rst change)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
