### PR TITLE
DOP-4847: Landing pages init in Dark Mode

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -12,7 +12,7 @@ import { TabContext } from '../Tabs/tab-context';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { getLanguage } from '../../utils/get-language';
 import { DRIVER_ICON_MAP } from '../icons/DriverIconMap';
-import { baseCodeStyle, borderCodeStyle } from './styles/codeStyle';
+import { baseCodeStyle, borderCodeStyle, lgStyles } from './styles/codeStyle';
 import { CodeContext } from './code-context';
 
 const sourceCodeStyle = css`
@@ -37,7 +37,6 @@ const getDriverImage = (driver, driverIconMap) => {
 
 const Code = ({
   nodeData: { caption, copyable, emphasize_lines: emphasizeLines, lang, linenos, value, source, lineno_start },
-  darkMode: darkModeProp,
 }) => {
   const { setActiveTab } = useContext(TabContext);
   const { languageOptions, codeBlockLanguage } = useContext(CodeContext);
@@ -103,7 +102,43 @@ const Code = ({
           border-top-left-radius: ${captionBorderRadius};
           border-top-right-radius: ${captionBorderRadius};
           display: grid;
+
+          border-color: ${palette.gray.light2};
+
+          .dark-theme & {
+            border-color: ${palette.gray.dark2};
+          }
         }
+
+        pre {
+          background-color: ${palette.gray.light3};
+          color: ${palette.black};
+
+          .dark-theme & {
+            background-color: ${palette.black};
+            color: ${palette.gray.light3};
+          }
+        }
+
+        [data-testid='leafygreen-code-panel'] {
+          background-color: ${palette.white};
+          border-color: ${palette.gray.light2};
+
+          .dark-theme & {
+            background-color: ${palette.gray.dark2};
+            border-color: ${palette.gray.dark2};
+          }
+
+          > button {
+            color: ${palette.gray.base};
+
+            .dark-theme & {
+              color: ${palette.gray.light1};
+            }
+          }
+        }
+
+        ${lgStyles}
       `}
     >
       {captionSpecified && (
@@ -118,7 +153,6 @@ const Code = ({
         highlightLines={emphasizeLines}
         language={language}
         languageOptions={languageOptions}
-        darkMode={darkModeProp ?? darkMode}
         onChange={(selectedOption) => {
           setActiveTab({ drivers: selectedOption.id });
         }}

--- a/src/components/Code/styles/codeStyle.js
+++ b/src/components/Code/styles/codeStyle.js
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../../theme/docsTheme';
 
 export const baseCodeStyle = css`
@@ -17,4 +18,155 @@ export const baseCodeStyle = css`
 export const borderCodeStyle = css`
   border-width: 1px;
   border-style: solid;
+`;
+
+/* Explanatory interface copied from LG for clarity */
+/**
+ * interface Base16Palette {
+  0: string; // Background
+  1: string; // Borders / non-text graphical accents
+  2: string; // Comments, Doctags, Formulas
+  3: string; // Default Text
+  4: string; // Highlights
+  5: string; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+  6: string; // Classes, Markup Bold, Search Text Background
+  7: string; // Strings, Inherited Class, Markup Code, Diff Inserted
+  8: string; // Support, Regular Expressions, Escape Characters, Markup Quotes
+  9: string; // Functions, Methods, Classes, Names, Sections, Literals
+  10: string; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+ */
+
+export const variantColors = {
+  light: {
+    0: palette.gray.light3,
+    1: palette.gray.light2,
+    2: palette.gray.dark2,
+    3: palette.black,
+    4: palette.white,
+    5: '#D83713',
+    6: '#956d00',
+    7: '#12824D',
+    8: '#007ab8',
+    9: '#016ee9',
+    10: '#CC3887',
+  },
+
+  dark: {
+    0: palette.black,
+    1: palette.gray.dark2,
+    2: palette.gray.light1,
+    3: palette.gray.light3,
+    4: palette.gray.dark2,
+    5: '#FF6F44',
+    6: '#EDB210',
+    7: '#35DE7B',
+    8: '#a5e3ff',
+    9: '#2dc4ff',
+    10: '#FF7DC3',
+  },
+};
+
+export const lgStyles = `
+  [class*="lg-highlight-hljs-"] {
+    
+    .lg-highlight-keyword,
+    .lg-highlight-keyword.lg-highlight-function,
+    .lg-highlight-keyword.lg-highlight-class,
+    .lg-highlight-selector-tag,
+    .lg-highlight-selector-attr,
+    .lg-highlight-selector-pseudo,
+    .lg-highlight-selector-id,
+    .lg-highlight-selector-class {
+      color: ${variantColors.light[10]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[10]};
+      }
+    }
+
+    .lg-highlight-regexp,
+    .lg-highlight-number,
+    .lg-highlight-literal,
+    .lg-highlight-function.lg-highlight-title {
+      color: ${variantColors.light[9]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[9]};
+      }
+    }
+
+    .lg-highlight-quote,
+    .lg-highlight-section,
+    .lg-highlight-name {
+      color: ${variantColors.light[8]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[8]};
+      }
+    }
+
+    .lg-highlight-string,
+    .lg-highlight-addition {
+      color: ${variantColors.light[7]};
+
+      .dark-theme & {
+       color: ${variantColors.dark[7]};
+      }
+    }
+
+    .lg-highlight-meta,
+    .lg-highlight-meta-string {
+      color: ${variantColors.light[6]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[6]};
+      }
+    }
+
+    .lg-highlight-variable,
+    .lg-highlight-deletion,
+    .lg-highlight-symbol,
+    .lg-highlight-bullet,
+    .lg-highlight-meta,
+    .lg-highlight-link,
+    .lg-highlight-attr,
+    .lg-highlight-attribute,
+    .lg-highlight-language,
+    .lg-highlight-template-variable,
+    .lg-highlight-built_in,
+    .lg-highlight-type,
+    .lg-highlight-params {
+      color: ${variantColors.light[5]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[5]};
+      }
+    }
+
+    .lg-highlight-title,
+    .lg-highlight-class.lg-highlight-title {
+      color: ${variantColors.light[3]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[3]};
+      }
+    }
+
+    .lg-highlight-doctag,
+    .lg-highlight-formula {
+      color: ${variantColors.light[3]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[3]};
+      }
+    }
+  
+    .lg-highlight-comment {
+      color: ${variantColors.light[2]};
+
+      .dark-theme & {
+        color: ${variantColors.dark[2]};
+      }
+    }
+  }
 `;

--- a/src/components/Procedure/Step.js
+++ b/src/components/Procedure/Step.js
@@ -7,21 +7,26 @@ import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
 
 const circleIndividualStyles = {
-  connected: (darkMode) => css`
+  connected: css`
     position: relative;
     font-weight: bold;
-    background-color: ${darkMode ? palette.green.dark2 : palette.green.light3};
-    color: ${darkMode ? palette.gray.light2 : palette.green.dark2};
+    background-color: ${palette.green.light3};
+    color: ${palette.green.dark2};
     height: 34px;
     width: 34px;
+
+    .dark-theme & {
+      background-color: ${palette.green.dark2};
+      color: ${palette.gray.light2};
+    }
   `,
-  normal: (darkMode) => css`
+  normal: css`
     border: 1px solid ${palette.gray.light1};
     font-weight: 400;
     font-size: 16px;
     line-height: 28px;
     background-color: inherit;
-    color: ${darkMode ? palette.white : palette.black};
+    color: var(--opposite-color);
     height: 27px;
     width: 27px;
   `,
@@ -35,7 +40,7 @@ const Circle = styled('div')`
 `;
 
 const landingStepStyles = {
-  connected: (darkMode) => css`
+  connected: css`
     position: relative;
     gap: 33px;
 
@@ -47,14 +52,18 @@ const landingStepStyles = {
 
     :not(:last-child):before {
       content: '';
-      border-left: 2px dashed ${darkMode ? palette.gray.dark1 : palette.gray.light2};
+      border-left: 2px dashed ${palette.gray.light2};
       bottom: 0;
       left: 16px;
       position: absolute;
       top: 0;
+
+      .dark-theme & {
+        border-left-color: ${palette.gray.dark1};
+      }
     }
   `,
-  normal: (darkMode) => css`
+  normal: css`
     gap: ${theme.size.large};
     h2,
     h4 {
@@ -98,11 +107,11 @@ const contentStyles = {
   `,
 };
 
-const Step = ({ nodeData: { children }, stepNumber, stepStyle = 'connected', darkMode, template, ...rest }) => {
+const Step = ({ nodeData: { children }, stepNumber, stepStyle = 'connected', template, ...rest }) => {
   return (
-    <StyledStep css={landingStepStyles[stepStyle](darkMode)}>
+    <StyledStep css={landingStepStyles[stepStyle]}>
       <StepBlock>
-        <Circle css={circleIndividualStyles[stepStyle](darkMode)}>{stepNumber}</Circle>
+        <Circle css={circleIndividualStyles[stepStyle]}>{stepNumber}</Circle>
       </StepBlock>
       <Content css={contentStyles[stepStyle]}>
         {children.map((child, i) => (

--- a/src/components/Procedure/index.js
+++ b/src/components/Procedure/index.js
@@ -19,10 +19,9 @@ const StyledProcedure = styled('div')`
     }
  
   `}
-  ${({ darkMode }) =>
-    `
-    background-color: ${darkMode ? palette.gray.dark4 : 'initial'};
-    color: ${darkMode ? palette.gray.light2 : 'initial'};`}
+  .dark-theme & {
+    color: ${palette.gray.light2};
+  }
 `;
 
 // Returns an array of all "step" nodes nested within the "procedure" node and nested "include" nodes
@@ -58,7 +57,7 @@ const Procedure = ({ nodeData: { children, options }, ...rest }) => {
   return (
     <StyledProcedure procedureStyle={style} darkMode={darkMode}>
       {steps.map((child, i) => (
-        <Step {...rest} nodeData={child} stepNumber={i + 1} stepStyle={style} key={i} darkMode={darkMode} />
+        <Step {...rest} nodeData={child} stepNumber={i + 1} stepStyle={style} key={i} />
       ))}
     </StyledProcedure>
   );

--- a/src/components/Sidenav/ProductsList.js
+++ b/src/components/Sidenav/ProductsList.js
@@ -47,7 +47,7 @@ const HeadingTitle = styled('span')`
 
 const Products = styled(`ul`)`
   display: none;
-  background-color: var(--background-color);
+  background-color: var(--sidenav-bg-color);
   list-style-type: none;
   padding: 0;
   li > a {
@@ -61,9 +61,16 @@ const ProductsListContainer = styled('div')`
 `;
 
 const ProductsListHeading = styled('div')`
+  --all-products-color-open: ${palette.gray.dark3};
+  --all-products-color-closed: ${palette.gray.dark1};
+  .dark-theme & {
+    --all-products-color-open: ${palette.gray.light2};
+    --all-products-color-closed: ${palette.gray.light1};
+  }
+
   align-items: center;
-  background-color: var(--background-color);
-  color: var(--color);
+  background-color: var(--sidenav-bg-color);
+  color: ${({ open }) => (open ? 'var(--all-products-color-open)' : 'var(--all-products-color-closed)')};
   cursor: pointer;
   display: flex;
   padding: ${theme.size.default} ${theme.size.medium} 12px;
@@ -72,11 +79,18 @@ const ProductsListHeading = styled('div')`
   z-index: 1;
 
   :hover {
-    color: var(--hover-color);
+    color: var(--all-products-color-open);
   }
 `;
 
 const ProductLink = styled(Link)`
+  --color: ${palette.black};
+  --on-hover: ${palette.gray.dark2};
+  .dark-theme & {
+    --color: ${palette.gray.light1};
+    --on-hover: ${palette.gray.light2};
+  }
+
   color: var(--color);
   display: inline-block;
   font-size: ${theme.fontSize.small};
@@ -85,7 +99,7 @@ const ProductLink = styled(Link)`
   width: 100%;
 
   :hover {
-    color: var(--hover-color);
+    color: var(--on-hover);
     font-weight: bold;
     text-decoration: none;
   }
@@ -107,16 +121,6 @@ const iconStyle = ({ isOpen }) => LeafyCSS`
   transition: transform ${chevronRotationDuration};
 `;
 
-const getProductListHeadingDynamicStyles = (darkMode, isOpen) => {
-  const darkThemeColor = isOpen ? palette.gray.light2 : palette.gray.light1;
-  const lightThemeColor = isOpen ? palette.gray.dark3 : palette.gray.dark1;
-  return {
-    '--color': darkMode ? darkThemeColor : lightThemeColor,
-    '--background-color': darkMode ? palette.gray.dark4 : palette.gray.light3,
-    '--hover-color': darkMode ? palette.gray.light2 : palette.gray.dark3,
-  };
-};
-
 const ProductsList = ({ darkMode }) => {
   const products = useAllProducts();
   const [isOpen, setOpen] = useState(false);
@@ -125,10 +129,7 @@ const ProductsList = ({ darkMode }) => {
     <>
       <Global styles={transitionClasses} />
       <ProductsListContainer>
-        <ProductsListHeading
-          style={getProductListHeadingDynamicStyles(darkMode, isOpen)}
-          onClick={() => setOpen(!isOpen)}
-        >
+        <ProductsListHeading open={isOpen} onClick={() => setOpen(!isOpen)}>
           <Icon className={cx(iconStyle({ isOpen }))} glyph="ChevronUp" />
           <HeadingTitle>View all products</HeadingTitle>
         </ProductsListHeading>
@@ -142,15 +143,7 @@ const ProductsList = ({ darkMode }) => {
           {products.map(({ title, url }, index) => {
             return (
               <li key={index}>
-                <ProductLink
-                  style={{
-                    '--color': darkMode ? palette.gray.light1 : palette.black,
-                    '--hover-color': darkMode ? palette.gray.light2 : palette.gray.dark2,
-                  }}
-                  to={url}
-                >
-                  {title}
-                </ProductLink>
+                <ProductLink to={url}>{title}</ProductLink>
               </li>
             );
           })}

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useRef, useState } from 'rea
 import PropTypes from 'prop-types';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { Tabs as LeafyTabs, Tab as LeafyTab } from '@leafygreen-ui/tabs';
+import { palette } from '@leafygreen-ui/palette';
 import { CodeProvider } from '../Code/code-context';
 import ComponentFactory from '../ComponentFactory';
 import { theme } from '../../theme/docsTheme';
@@ -66,6 +67,16 @@ const getTabsStyling = ({ isHidden, isProductLanding }) => css`
   ${defaultTabsStyling};
   ${isHidden && hiddenTabsStyling};
   ${isProductLanding && landingTabsStyling};
+
+  [aria-label*='Tabs to describe usage of'] {
+    /* Using a background allows the "border" to appear underneath the individual tab color */
+    background: linear-gradient(0deg, ${palette.gray.light2} 1px, rgb(255 255 255 / 0%) 1px);
+
+    .dark-theme & {
+      /* Using a background allows the "border" to appear underneath the individual tab color */
+      background: linear-gradient(0deg, ${palette.gray.dark2} 1px, rgb(255 255 255 / 0%) 1px);
+    }
+  }
 `;
 
 const tabContentStyling = css`

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -12,6 +12,7 @@ body {
   --font-color-primary: var(--black);
   --font-color-light: var(--gray-base);
   --heading-color-primary: var(--green-dark2);
+  --opposite-color: var(--black);
 
   --link-color-primary: var(--blue-base);
   --link-font-weight: 500;
@@ -47,6 +48,7 @@ body {
   --font-color-primary: var(--gray-light2);
   --font-color-light: var(--gray-light2);
   --heading-color-primary: var(--gray-light2);
+  --opposite-color: var(--white);
 
   --link-color-primary: var(--blue-light1);
   --link-font-weight: 700;

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../theme/docsTheme.js';
 import { findKeyValuePair } from '../utils/find-key-value-pair.js';
@@ -14,7 +13,7 @@ const Wrapper = styled('main')`
   width: 100%;
 
   h1 {
-    color: var(--color);
+    color: var(--font-color-primary);
   }
 
   h2 {
@@ -190,7 +189,6 @@ const ProductLanding = ({ children, data: { page } }) => {
   }, []);
 
   const bannerNode = findKeyValuePair([{ children: shallowChildren }], 'name', 'banner');
-  const { darkMode } = useDarkMode();
 
   return (
     <Wrapper
@@ -199,7 +197,6 @@ const ProductLanding = ({ children, data: { page } }) => {
       useHero={useHero}
       hasBanner={!!bannerNode}
       hasMaxWidthParagraphs={hasMaxWidthParagraphs}
-      style={{ '--color': darkMode ? palette.gray.light2 : palette.black }}
     >
       {children}
     </Wrapper>

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -23,6 +23,167 @@ exports[`renders correctly 1`] = `
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0>div {
+  border-color: #3D4F58;
+}
+
+.emotion-0 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-1 {
@@ -270,6 +431,167 @@ exports[`renders correctly when none is passed in as a language 1`] = `
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0>div {
+  border-color: #3D4F58;
+}
+
+.emotion-0 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -46,6 +46,167 @@ exports[`CodeIO renders correctly 1`] = `
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-1>div {
+  border-color: #3D4F58;
+}
+
+.emotion-1 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-1 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-1 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-1 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-1 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-1 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-1 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-2 {

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -218,6 +218,167 @@ exports[`collapsible component renders all the content in the options and childr
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-12>div {
+  border-color: #3D4F58;
+}
+
+.emotion-12 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-12 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-12 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-12 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-12 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-12 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-12 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-13 {

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -23,6 +23,167 @@ exports[`renders correctly 1`] = `
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0>div {
+  border-color: #3D4F58;
+}
+
+.emotion-0 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -4,8 +4,6 @@ exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -18,6 +16,10 @@ exports[`renders correctly 1`] = `
   .emotion-0 {
     padding-bottom: 24px;
   }
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
 }
 
 .emotion-2 {
@@ -42,6 +44,10 @@ exports[`renders correctly 1`] = `
   left: 16px;
   position: absolute;
   top: 0;
+}
+
+.dark-theme .emotion-2:not(:last-child):before {
+  border-left-color: #5C6C75;
 }
 
 .emotion-4 {
@@ -69,6 +75,11 @@ exports[`renders correctly 1`] = `
   color: #00684A;
   height: 34px;
   width: 34px;
+}
+
+.dark-theme .emotion-6 {
+  background-color: #00684A;
+  color: #E8EDEB;
 }
 
 .emotion-8 {
@@ -217,8 +228,6 @@ exports[`renders steps nested in include nodes 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -231,6 +240,10 @@ exports[`renders steps nested in include nodes 1`] = `
   .emotion-0 {
     padding-bottom: 24px;
   }
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
 }
 
 .emotion-2 {
@@ -255,6 +268,10 @@ exports[`renders steps nested in include nodes 1`] = `
   left: 16px;
   position: absolute;
   top: 0;
+}
+
+.dark-theme .emotion-2:not(:last-child):before {
+  border-left-color: #5C6C75;
 }
 
 .emotion-4 {
@@ -282,6 +299,11 @@ exports[`renders steps nested in include nodes 1`] = `
   color: #00684A;
   height: 34px;
   width: 34px;
+}
+
+.dark-theme .emotion-6 {
+  background-color: #00684A;
+  color: #E8EDEB;
 }
 
 .emotion-8 {
@@ -777,8 +799,10 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
 }
 
 .emotion-2 {
@@ -822,7 +846,7 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   font-size: 16px;
   line-height: 28px;
   background-color: inherit;
-  color: #001E2B;
+  color: var(--opposite-color);
   height: 27px;
   width: 27px;
 }

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -23,6 +23,167 @@ exports[`renders correctly 1`] = `
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   display: grid;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0>div {
+  border-color: #3D4F58;
+}
+
+.emotion-0 pre {
+  background-color: #F9FBFA;
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 pre {
+  background-color: #001E2B;
+  color: #F9FBFA;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #FFFFFF;
+  border-color: #E8EDEB;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel'] {
+  background-color: #3D4F58;
+  border-color: #3D4F58;
+}
+
+.emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #889397;
+}
+
+.dark-theme .emotion-0 [data-testid='leafygreen-code-panel']>button {
+  color: #C1C7C6;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #CC3887;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-function,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-keyword.lg-highlight-class,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-tag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-pseudo,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-id,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-selector-class {
+  color: #FF7DC3;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #016ee9;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-regexp,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-number,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-literal,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-function.lg-highlight-title {
+  color: #2dc4ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #007ab8;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-quote,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-section,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-name {
+  color: #a5e3ff;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #12824D;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-string,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-addition {
+  color: #35DE7B;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #956d00;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta-string {
+  color: #EDB210;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #D83713;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-deletion,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-symbol,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-bullet,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-meta,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-link,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attr,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-attribute,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-language,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-template-variable,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-built_in,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-type,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-params {
+  color: #FF6F44;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-title,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-class.lg-highlight-title {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #001E2B;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-doctag,
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-formula {
+  color: #F9FBFA;
+}
+
+.emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #3D4F58;
+}
+
+.dark-theme .emotion-0 [class*="lg-highlight-hljs-"] .lg-highlight-comment {
+  color: #C1C7C6;
 }
 
 .emotion-1 {

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -26,6 +26,10 @@ exports[`renders with "connected" styling 1`] = `
   top: 0;
 }
 
+.dark-theme .emotion-0:not(:last-child):before {
+  border-left-color: #5C6C75;
+}
+
 .emotion-2 {
   position: relative;
   min-height: 59px;
@@ -51,6 +55,11 @@ exports[`renders with "connected" styling 1`] = `
   color: #00684A;
   height: 34px;
   width: 34px;
+}
+
+.dark-theme .emotion-4 {
+  background-color: #00684A;
+  color: #E8EDEB;
 }
 
 .emotion-6 {
@@ -185,6 +194,10 @@ exports[`renders with "connected" styling by default 1`] = `
   top: 0;
 }
 
+.dark-theme .emotion-0:not(:last-child):before {
+  border-left-color: #5C6C75;
+}
+
 .emotion-2 {
   position: relative;
   min-height: 59px;
@@ -210,6 +223,11 @@ exports[`renders with "connected" styling by default 1`] = `
   color: #00684A;
   height: 34px;
   width: 34px;
+}
+
+.dark-theme .emotion-4 {
+  background-color: #00684A;
+  color: #E8EDEB;
 }
 
 .emotion-6 {
@@ -361,7 +379,7 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   font-size: 16px;
   line-height: 28px;
   background-color: inherit;
-  color: #001E2B;
+  color: var(--opposite-color);
   height: 27px;
   width: 27px;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4847

### Current Behavior:

[docs-c](https://www.mongodb.com/docs/languages/c/c-driver/current/)
[docs-landing](https://www.mongodb.com/docs/)
[java landing](https://www.mongodb.com/docs/languages/java/)
[Atlas](https://www.mongodb.com/docs/atlas/)
[Manual](https://www.mongodb.com/docs/manual/)

### Staging Links:

[docs-c](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/c/matt.meigs/DOP-4847-init-landings/index.html)
[Docs-landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/DOP-4847-init-landings/index.html)
[Java landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/DOP-4847-init-landings/languages/java/index.html)
[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4847-init-landings/index.html)
[Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/v7.0/docs/matt.meigs/DOP-4847-init-landings/index.html)

### Notes:

This PR tries to init in dark mode most large pieces that usually occur above the fold on landing pages. This includes `Codeblocks`, `Headers`, `Procedures`, `ProductList`, and also changes the headers in `IA` sidenavs to match the rest of our normal ones.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
