### PR TITLE
DOP-4922: bugfix: Use chatbot in landing in dark mode

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -18,6 +18,16 @@ export const defaultSuggestedPrompts = [
 
 const SKELETON_BORDER_RADIUS = '12px';
 
+const StyledSkeleton = styled(Skeleton)`
+  --base-color: #ebebeb;
+  --highlight-color: #f5f5f5;
+
+  .dark-theme & {
+    --base-color: var(--gray-dark2);
+    --highlight-color: var(--gray-dark1);
+  }
+`;
+
 // Match landing template max width for alignment purposes
 const CONTENT_MAX_WIDTH = theme.breakpoints.xxLarge;
 
@@ -137,7 +147,7 @@ const ChatbotUi = ({ template, darkMode }) => {
   return (
     <StyledChatBotUiContainer data-testid="chatbot-ui" template={template}>
       {/* We wrapped this in a Suspense. We can use this opportunity to render a loading state if we decided we want that */}
-      <SuspenseHelper fallback={<Skeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
+      <SuspenseHelper fallback={<StyledSkeleton borderRadius={SKELETON_BORDER_RADIUS} height={48} />}>
         <Chatbot maxInputCharacters={DEFAULT_MAX_INPUT} serverBaseUrl={CHATBOT_SERVER_BASE_URL} darkMode={darkMode}>
           <DocsChatbot suggestedPrompts={defaultSuggestedPrompts} darkMode={darkMode} />
         </Chatbot>

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -54,10 +54,8 @@ const Landing = ({ children, pageContext, useChatbot }) => {
   return (
     <>
       <div>
-        <Wrapper newChatbotLanding={process.env['GATSBY_ENABLE_DARK_MODE'] !== 'true' && useChatbot}>
-          {process.env['GATSBY_ENABLE_DARK_MODE'] !== 'true' && useChatbot && (
-            <ChatbotUi template={pageContext?.template} />
-          )}
+        <Wrapper>
+          {useChatbot && <ChatbotUi template={pageContext?.template} />}
           {children}
         </Wrapper>
       </div>

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -55,7 +55,7 @@ const Landing = ({ children, pageContext, useChatbot }) => {
     <>
       <div>
         <Wrapper>
-          {useChatbot && <ChatbotUi template={pageContext?.template} />}
+          {useChatbot && <ChatbotUi template={pageContext?.template} darkMode={darkMode} />}
           {children}
         </Wrapper>
       </div>


### PR DESCRIPTION
### Stories/Links:

DOP-4922

### Current Behavior:

[Current behavior with dark mode](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/use-local-nav/index.html)

### Staging Links:

[New behavior with dark mode](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4743-dark-hero/landing/matt.meigs/DOP-4922-chatbot-used/index.html)

### Notes:

Fixes bug where chatbot was not used on landing page when dark mode flag turned on

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
