### PR TITLE
DOP-4848: Init Callouts in dark mode

### DIFF
--- a/src/components/Admonition.js
+++ b/src/components/Admonition.js
@@ -2,9 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Callout, { Variant } from '@leafygreen-ui/callout';
 import { cx, css } from '@leafygreen-ui/emotion';
+import { Theme } from '@leafygreen-ui/lib';
+import { palette } from '@leafygreen-ui/palette';
 import { getPlaintext } from '../utils/get-plaintext';
 import { theme } from '../theme/docsTheme';
 import ComponentFactory from './ComponentFactory';
+import { sharedDarkModeOverwriteStyles } from './Link';
 
 export const admonitionMap = {
   example: Variant.Example,
@@ -16,12 +19,89 @@ export const admonitionMap = {
   warning: Variant.Warning,
 };
 
+/* Copied straight from LG Callout.styles.ts */
+const calloutColor = {
+  [Theme.Dark]: {
+    [Variant.Note]: {
+      headerText: palette.blue.light2,
+      bar: palette.blue.light1,
+    },
+    [Variant.Tip]: {
+      headerText: palette.purple.light2,
+      bar: palette.purple.base,
+    },
+    [Variant.Important]: {
+      headerText: palette.yellow.light2,
+      bar: palette.yellow.base,
+    },
+    [Variant.Warning]: {
+      headerText: palette.red.light1,
+      bar: palette.red.light1,
+    },
+    [Variant.Example]: {
+      headerText: palette.gray.light1,
+      bar: palette.gray.light1,
+    },
+  },
+  [Theme.Light]: {
+    [Variant.Note]: {
+      headerText: palette.blue.dark1,
+      bar: palette.blue.base,
+    },
+    [Variant.Tip]: {
+      headerText: palette.purple.dark2,
+      bar: palette.purple.base,
+    },
+    [Variant.Important]: {
+      headerText: palette.yellow.dark2,
+      bar: palette.yellow.base,
+    },
+    [Variant.Warning]: {
+      headerText: palette.red.dark2,
+      bar: palette.red.base,
+    },
+    [Variant.Example]: {
+      headerText: palette.gray.dark1,
+      bar: palette.gray.dark1,
+    },
+  },
+};
+
+/* Overwritten to mitigate light mode flash for dark mode preferred users */
+const colorStyles = (variant) => {
+  const { headerText: lightHeaderText, bar: lightBar } = calloutColor[Theme.Light][variant];
+  const { headerText: darkHeaderText, bar: darkBar } = calloutColor[Theme.Dark][variant];
+
+  return css`
+    h2 {
+      color: ${lightHeaderText};
+    }
+    :after {
+      background-color: ${lightBar};
+    }
+
+    .dark-theme & {
+      h2 {
+        color: ${darkHeaderText};
+      }
+      :after {
+        background-color: ${darkBar}:;
+      }
+    }
+  `;
+};
+
 const admonitionStyles = css`
   margin-top: ${theme.size.medium};
   margin-bottom: ${theme.size.medium};
 
-  p {
-    color: unset;
+  p,
+  li::marker {
+    color: var(--font-color-primary);
+  }
+  // added specificity to have precedence
+  p > a[class^='leafy'] {
+    ${sharedDarkModeOverwriteStyles}
   }
   // remove bottom margin off the final paragraph in a callout,
   // similarly remove the bottom margin off lists and list items so that
@@ -36,6 +116,7 @@ const admonitionStyles = css`
 `;
 
 const Admonition = ({ nodeData: { argument, children, name }, ...rest }) => {
+  const variant = admonitionMap[name] || Variant.Note;
   let title = getPlaintext(argument);
   if (name === 'see') {
     title = `See: ${title}`;
@@ -44,12 +125,7 @@ const Admonition = ({ nodeData: { argument, children, name }, ...rest }) => {
   }
 
   return (
-    <Callout
-      className={cx(admonitionStyles)}
-      title={title}
-      variant={admonitionMap[name] || Variant.Note}
-      baseFontSize={16}
-    >
+    <Callout className={cx([admonitionStyles, colorStyles(variant)])} title={title} variant={variant} baseFontSize={16}>
       {children.map((child, i) => (
         <ComponentFactory {...rest} key={i} nodeData={child} />
       ))}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -41,7 +41,7 @@ const THEME_STYLES = {
   },
 };
 
-const sharedDarkModeOverwriteStyles = `
+export const sharedDarkModeOverwriteStyles = `
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 `;
@@ -57,7 +57,7 @@ const gatsbyLinkStyling = (linkThemeStyle) => css`
   text-decoration: none;
   text-decoration-color: transparent;
   line-height: 13px;
-  ${sharedDarkModeOverwriteStyles};
+  ${sharedDarkModeOverwriteStyles}
 
   > code {
     ${sharedDarkModeOverwriteStyles}
@@ -82,7 +82,7 @@ const gatsbyLinkStyling = (linkThemeStyle) => css`
 // DOP-3091: LG anchors are not inline by default
 const lgLinkStyling = css`
   display: inline;
-  ${sharedDarkModeOverwriteStyles};
+  ${sharedDarkModeOverwriteStyles}
 `;
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,

--- a/tests/unit/__snapshots__/Admonition.test.js.snap
+++ b/tests/unit/__snapshots__/Admonition.test.js.snap
@@ -23,8 +23,14 @@ exports[`admonitions render correctly 1`] = `
   background-color: #016BF8;
 }
 
-.emotion-0 p {
-  color: unset;
+.emotion-0 p,
+.emotion-0 li::marker {
+  color: var(--font-color-primary);
+}
+
+.emotion-0 p>a[class^='leafy'] {
+  color: var(--link-color-primary);
+  font-weight: var(--link-font-weight);
 }
 
 .emotion-0>li:last-of-type,
@@ -33,6 +39,18 @@ exports[`admonitions render correctly 1`] = `
 .emotion-0>li:last-of-type>p,
 .emotion-0>p:last-of-type {
   margin-bottom: 0px;
+}
+
+.emotion-0 h2 {
+  color: #1254B7;
+}
+
+.emotion-0:after {
+  background-color: #016BF8;
+}
+
+.dark-theme .emotion-0 h2 {
+  color: #C3E7FE;
 }
 
 .emotion-1 {


### PR DESCRIPTION
### Stories/Links:

DOP-4848

### Current Behavior:

[Important on Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4847-init-landings/organizations-projects/index.html)
[Tip on Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4847-init-landings/production-notes/index.html)

### Staging Links:

[Atlas docs (a page I created with all variants at the top)](http://localhost:9000/master/cloud-docs/matt.meigs/DOP-4848-init-callouts/production-notes/index.html)

### Notes:

Inits Callout colors without light mode flash. 

Also, inits text within Callouts, links within Callouts and list-item markers with the correct color and weight as they seem to be very common children.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
