### PR TITLE
DOP-4956: Hovering over sidenav results in light mode while loading

### DIFF
--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -118,10 +118,7 @@ const SidenavContainer = styled.div(
     a[class*='lg-ui-side-nav-item'] {
       color: var(--sidenav-item-color);
       :hover {
-        background-color: ${palette.gray.light2};
-        .dark-theme & {
-          background-color: ${palette.gray.dark3};
-        }
+        background-color: var(--sidenav-hover-bg-color);
       }
     }
 

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -117,10 +117,8 @@ const SidenavContainer = styled.div(
 
     a[class*='lg-ui-side-nav-item'] {
       color: var(--sidenav-item-color);
-      :not([aria-current='page']) {
-        :hover {
-          background-color: var(--sidenav-hover-bg-color);
-        }
+      :not([aria-current='page']):hover {
+        background-color: var(--sidenav-hover-bg-color);
       }
     }
 

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -117,6 +117,12 @@ const SidenavContainer = styled.div(
 
     a[class*='lg-ui-side-nav-item'] {
       color: var(--sidenav-item-color);
+      :hover {
+        background-color: ${palette.gray.light2};
+        .dark-theme & {
+          background-color: ${palette.gray.dark3};
+        }
+      }
     }
 
     [data-testid='side-nav-collapse-toggle'] {

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -117,8 +117,10 @@ const SidenavContainer = styled.div(
 
     a[class*='lg-ui-side-nav-item'] {
       color: var(--sidenav-item-color);
-      :hover {
-        background-color: var(--sidenav-hover-bg-color);
+      :not([aria-current='page']) {
+        :hover {
+          background-color: var(--sidenav-hover-bg-color);
+        }
       }
     }
 

--- a/src/styles/global-dark-mode.css
+++ b/src/styles/global-dark-mode.css
@@ -28,6 +28,7 @@ body {
 
   --sidenav-item-title: var(--gray-dark3);
   --sidenav-item-color: var(--black);
+  --sidenav-hover-bg-color: var(--gray-light2);
   --sidenav-active-bg-color: var(--green-light3);
   --sidenav-active-color: var(--green-dark2);
   --sidenav-active-before-color: var(--green-dark1);
@@ -64,6 +65,7 @@ body {
 
   --sidenav-item-title: var(--gray-light2);
   --sidenav-item-color: var(--gray-light2);
+  --sidenav-hover-bg-color: var(--gray-dark3);
   --sidenav-active-bg-color: var(--green-dark3);
   --sidenav-active-color: var(--white);
   --sidenav-active-before-color: var(--green-base);


### PR DESCRIPTION
### Stories/Links:

DOP-4956

Initializes sidenav items for dark mode on hover as well.

To test, reload the page and hover over sidenav items.

### Current Behavior:

[Dark Mode Docs pre-this change](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/docs/maya/main/index.html)

### Staging Links:

[Docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/docs/maya/DOP-4956/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
