### PR TITLE
No ticket: Realm landing page hero text fix (dark mode)

### DIFF
--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -41,12 +41,15 @@ const Wrapper = styled('main')`
   ${({ isRealm }) =>
     isRealm &&
     `
-    h1 {
-      color: ${palette.black};
-    }
 
-    .introduction > p:first-of-type {
-      color: ${palette.black};
+    @media ${theme.screenSize.mediumAndUp} {
+      h1 {
+        color: ${palette.black};
+      }
+
+      .introduction > p:first-of-type {
+        color: ${palette.black};
+      }
     }
 
     section > p {

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -41,6 +41,14 @@ const Wrapper = styled('main')`
   ${({ isRealm }) =>
     isRealm &&
     `
+    h1 {
+      color: ${palette.black};
+    }
+
+    .introduction > p:first-of-type {
+      color: ${palette.black};
+    }
+
     section > p {
       grid-column: 2/-2;
       max-width: 775px;


### PR DESCRIPTION
### Current Behavior:

Don't have a good link, but the title and the introduction paragraph on the hero image were turning light gray in dark mode and could not be seen on top of this light hero image.

### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4942-dark-icons-realm-master/realm/matt.meigs/realm-dark-mode-hero-text/index.html

### Notes:

Color now stays black on realm landing page in desktop size.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
