### PR TITLE
DOP-4881: Z-index issue with left nav and language dropdown

### DIFF
--- a/src/components/Contents/ContentsListItem.js
+++ b/src/components/Contents/ContentsListItem.js
@@ -59,6 +59,9 @@ const linkStyling = ({ depth, isActive }) => css`
     color: currentColor;
     text-decoration: none;
   }
+  span > span {
+    position: unset;
+  }
 `;
 
 const ContentsListItem = ({ children, depth = 0, id, isActive = false }) => {

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -83,6 +83,9 @@ const gatsbyLinkStyling = (linkThemeStyle) => css`
 const lgLinkStyling = css`
   display: inline;
   ${sharedDarkModeOverwriteStyles}
+  span > span {
+    position: unset;
+  }
 `;
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -83,9 +83,6 @@ const gatsbyLinkStyling = (linkThemeStyle) => css`
 const lgLinkStyling = css`
   display: inline;
   ${sharedDarkModeOverwriteStyles}
-  span > span {
-    position: unset;
-  }
 `;
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,


### PR DESCRIPTION
### Stories/Links:

DOP-4881

### Current Behavior:

[Manage Connections with AWS Lambda](https://www.mongodb.com/docs/atlas/manage-connections-aws-lambda/)
[Configure Cluster Authentication](https://www.mongodb.com/docs/atlas/security/config-db-auth/)

### Staging Links:

[Manage Connections with AWS Lambda](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4881/manage-connections-aws-lambda/index.html)
[Configure Cluster Authentication](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4881/security/config-db-auth/index.html) (just to make sure underline still looks okay)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
