### PR TITLE
No ticket: Realm product-landing template headers - more specific

### DIFF
--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -38,18 +38,22 @@ const Wrapper = styled('main')`
   }
 
   // realm PLP has full width p
-  ${({ isRealm }) =>
+  ${({ isRealm, hasLightHero }) =>
     isRealm &&
     `
+    ${
+      hasLightHero &&
+      `
+      @media ${theme.screenSize.mediumAndUp} {
+        h1 {
+          color: ${palette.black};
+        }
 
-    @media ${theme.screenSize.mediumAndUp} {
-      h1 {
-        color: ${palette.black};
+        .introduction > p:first-of-type {
+          color: ${palette.black};
+        }
       }
-
-      .introduction > p:first-of-type {
-        color: ${palette.black};
-      }
+    `
     }
 
     section > p {
@@ -176,6 +180,8 @@ const Wrapper = styled('main')`
   }
 `;
 
+const LIGHT_HERO_PAGES = ['index.txt'];
+
 const ProductLanding = ({ children, data: { page } }) => {
   const { project } = useSnootyMetadata();
   const useHero = ['guides', 'realm'].includes(project);
@@ -183,6 +189,7 @@ const ProductLanding = ({ children, data: { page } }) => {
   const isRealm = project === 'realm';
   const pageOptions = page?.ast?.options;
   const hasMaxWidthParagraphs = ['', 'true'].includes(pageOptions?.['pl-max-width-paragraphs']);
+  const hasLightHero = LIGHT_HERO_PAGES.includes(page?.ast?.fileid);
 
   // shallow copy children, and search for existence of banner
   const shallowChildren = children.reduce((res, child) => {
@@ -207,6 +214,7 @@ const ProductLanding = ({ children, data: { page } }) => {
       isRealm={isRealm}
       useHero={useHero}
       hasBanner={!!bannerNode}
+      hasLightHero={hasLightHero}
       hasMaxWidthParagraphs={hasMaxWidthParagraphs}
     >
       {children}

--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -38,24 +38,9 @@ const Wrapper = styled('main')`
   }
 
   // realm PLP has full width p
-  ${({ isRealm, hasLightHero }) =>
+  ${({ isRealm }) =>
     isRealm &&
     `
-    ${
-      hasLightHero &&
-      `
-      @media ${theme.screenSize.mediumAndUp} {
-        h1 {
-          color: ${palette.black};
-        }
-
-        .introduction > p:first-of-type {
-          color: ${palette.black};
-        }
-      }
-    `
-    }
-
     section > p {
       grid-column: 2/-2;
       max-width: 775px;
@@ -64,6 +49,21 @@ const Wrapper = styled('main')`
     section ul  {
       grid-column: 2;
       max-width: 500px;
+    }
+  `}
+
+  // Light-colored hero styling
+  ${({ hasLightHero }) =>
+    hasLightHero &&
+    `
+    @media ${theme.screenSize.mediumAndUp} {
+      h1 {
+        color: ${palette.black};
+      }
+
+      .introduction > p:first-of-type {
+        color: ${palette.black};
+      }
     }
   `}
 
@@ -180,7 +180,7 @@ const Wrapper = styled('main')`
   }
 `;
 
-const LIGHT_HERO_PAGES = ['index.txt'];
+const REALM_LIGHT_HERO_PAGES = ['index.txt'];
 
 const ProductLanding = ({ children, data: { page } }) => {
   const { project } = useSnootyMetadata();
@@ -189,7 +189,7 @@ const ProductLanding = ({ children, data: { page } }) => {
   const isRealm = project === 'realm';
   const pageOptions = page?.ast?.options;
   const hasMaxWidthParagraphs = ['', 'true'].includes(pageOptions?.['pl-max-width-paragraphs']);
-  const hasLightHero = LIGHT_HERO_PAGES.includes(page?.ast?.fileid);
+  const hasLightHero = isRealm && REALM_LIGHT_HERO_PAGES.includes(page?.ast?.fileid);
 
   // shallow copy children, and search for existence of banner
   const shallowChildren = children.reduce((res, child) => {


### PR DESCRIPTION
### Context

After fixing the header text color on the Realm landing page, I realized that there are many uses of the `product-landing` template within the Realm repo. This means that it was changing all the text colors in those pages rather than just the one with the light color hero on it. 

This PR makes this change more specific than just being in the Realm repo and product-landing template. It requires a hard-coded fileid to identify which page has the light color hero image.

In the future, if we have the time maybe we add an option to the image directive in the parser to specify which hero images are light colored? This is not a wide-spread problem, but I also hate the hard-coded solution long-term. 

### Current Behavior:

[Old staging with issue (check any of the sdk pages to see the issue)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4942-dark-icons-realm-master/realm/matt.meigs/realm-dark-mode-hero-text/index.html)

### Staging Links:

[Fixed staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4942-dark-icons-realm-master/realm/matt.meigs/fix-realm-headers/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
