### PR TITLE
DOP-4955: OpenAPI Preview page - disable Dark Mode

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -72,6 +72,8 @@ export const onRenderBody = ({ setHeadComponents }) => {
               try {
                 var d = document.documentElement.classList;
                 d.remove("light-theme", "dark-theme");
+                var h = window.location.href;
+                if (h.includes('/openapi/preview')) return;
                 var e = JSON.parse(localStorage.getItem("mongodb-docs"))?.["theme"];
                 if ("system" === e || (!e)) {
                   var t = "(prefers-color-scheme: dark)",

--- a/src/components/ActionBar/ActionBar.js
+++ b/src/components/ActionBar/ActionBar.js
@@ -71,7 +71,7 @@ const ActionBar = ({ template, ...props }) => {
         <ChatbotUi darkMode={darkMode} />
       </ActionBarSearchContainer>
       <ActionsBox>
-        <DarkModeDropdown></DarkModeDropdown>
+        {template !== 'openapi' && <DarkModeDropdown />}
         {template !== 'errorpage' && (
           <div>
             <button>Feedback</button>

--- a/src/components/OpenAPI/index.js
+++ b/src/components/OpenAPI/index.js
@@ -128,7 +128,7 @@ const LoadingWidget = ({ className }) => (
 const MenuTitleContainer = ({ pageTitle }) => {
   return (
     <>
-      <DocsHomeButton />
+      <DocsHomeButton hideDarkModeToggle={true} />
       <Border />
       <MenuTitle>{pageTitle}</MenuTitle>
     </>

--- a/src/components/RootProvider.js
+++ b/src/components/RootProvider.js
@@ -9,7 +9,7 @@ import { ContentsProvider } from './Contents/contents-context';
 
 const RootProvider = ({ children, headingNodes, slug, repoBranches, remoteMetadata }) => {
   return (
-    <DarkModeContextProvider>
+    <DarkModeContextProvider slug={slug}>
       <ContentsProvider headingNodes={headingNodes}>
         <HeaderContextProvider>
           <VersionContextProvider repoBranches={repoBranches} slug={slug}>

--- a/src/components/Sidenav/DocsHomeButton.js
+++ b/src/components/Sidenav/DocsHomeButton.js
@@ -26,7 +26,7 @@ const containerStyle = LeafyCSS`
   align-items: center;
 `;
 
-const DocsHomeButton = ({ darkMode }) => {
+const DocsHomeButton = ({ hideDarkModeToggle }) => {
   return (
     <div className={cx(containerStyle)}>
       <SideNavItem
@@ -38,13 +38,13 @@ const DocsHomeButton = ({ darkMode }) => {
         <Icon glyph="Home"></Icon>
         Docs Home
       </SideNavItem>
-      {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && <DarkModeToggle />}
+      {process.env['GATSBY_ENABLE_DARK_MODE'] === 'true' && !hideDarkModeToggle && <DarkModeToggle />}
     </div>
   );
 };
 
 DocsHomeButton.propTypes = {
-  darkMode: PropTypes.bool,
+  hideDarkModeToggle: PropTypes.bool,
 };
 
 export default DocsHomeButton;

--- a/src/components/Sidenav/ProductsList.js
+++ b/src/components/Sidenav/ProductsList.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -121,7 +120,7 @@ const iconStyle = ({ isOpen }) => LeafyCSS`
   transition: transform ${chevronRotationDuration};
 `;
 
-const ProductsList = ({ darkMode }) => {
+const ProductsList = () => {
   const products = useAllProducts();
   const [isOpen, setOpen] = useState(false);
 
@@ -151,10 +150,6 @@ const ProductsList = ({ darkMode }) => {
       </CSSTransition>
     </>
   );
-};
-
-ProductsList.propTypes = {
-  darkMode: PropTypes.bool,
 };
 
 export default ProductsList;

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -2,7 +2,6 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { css as LeafyCSS, cx } from '@leafygreen-ui/emotion';
 import { useViewportSize } from '@leafygreen-ui/hooks';
 import Icon from '@leafygreen-ui/icon';
@@ -177,14 +176,12 @@ const additionalLinks = [
   { glyph: 'University', title: 'Register for Courses', url: 'https://learn.mongodb.com/' },
 ];
 
-const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, slug, eol }) => {
+const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, slug, eol }) => {
   const { hideMobile, isCollapsed, setCollapsed, setHideMobile } = useContext(SidenavContext);
   const { project } = useSnootyMetadata();
   const isDocsLanding = project === 'landing';
   const viewportSize = useViewportSize();
   const isMobile = viewportSize?.width <= theme.breakpoints.large;
-
-  const { darkMode } = useDarkMode();
 
   // CSS top property values for sticky side nav based on header height
   const topValues = useStickyTopValues(eol);
@@ -266,7 +263,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
             <IATransition back={back} hasIA={!!ia} slug={slug} isMobile={isMobile}>
               <NavTopContainer>
                 <ArtificialPadding />
-                <DocsHomeButton darkMode={darkMode} />
+                <DocsHomeButton />
                 <Border />
                 {ia && (
                   <IA
@@ -286,7 +283,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, siteTitle, s
                   />
                 )}
               </NavTopContainer>
-              {showAllProducts && <ProductsList darkMode={darkMode} />}
+              {showAllProducts && <ProductsList />}
             </IATransition>
 
             {!ia && !showAllProducts && (
@@ -335,7 +332,6 @@ Sidenav.propTypes = {
     options: PropTypes.object,
   }).isRequired,
   repoBranches: PropTypes.object,
-  siteTitle: PropTypes.string,
   slug: PropTypes.string.isRequired,
   eol: PropTypes.bool.isRequired,
 };

--- a/src/context/dark-mode-context.js
+++ b/src/context/dark-mode-context.js
@@ -21,7 +21,9 @@ export const DARK_THEME_CLASSNAME = 'dark-theme';
 export const LIGHT_THEME_CLASSNAME = 'light-theme';
 export const SYSTEM_THEME_CLASSNAME = 'system';
 
-const DarkModeContextProvider = ({ children }) => {
+const LIGHT_MODE_ONLY_PAGE_SLUGS = ['openapi/preview'];
+
+const DarkModeContextProvider = ({ children, slug }) => {
   const docClassList = useMemo(() => isBrowser && window?.document?.documentElement?.classList, []);
 
   // darkModePref   {str}   'light-theme' || 'dark-theme' || 'system';
@@ -53,12 +55,15 @@ const DarkModeContextProvider = ({ children }) => {
       loaded.current = true;
       return;
     }
-    setLocalValue('theme', darkModePref);
     updateDocumentClasslist(darkModePref, darkPref);
-  }, [darkModePref, updateDocumentClasslist, darkPref]);
+
+    // Do not save light mode preference to localStorage if on light-mode-only page
+    if (LIGHT_MODE_ONLY_PAGE_SLUGS.includes(slug)) return;
+    setLocalValue('theme', darkModePref);
+  }, [darkModePref, updateDocumentClasslist, darkPref, slug]);
 
   useEffect(() => {
-    if (!isBrowser || !docClassList) return;
+    if (!isBrowser || !docClassList || LIGHT_MODE_ONLY_PAGE_SLUGS.includes(slug)) return;
 
     // NOTE: client side read of darkmode from document classnames
     // which is derived from local storage (see gatsby-ssr script).

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -90,7 +90,7 @@ const StyledContentContainer = styled('div')`
 
 const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBranches, template } }) => {
   const { sidenav } = getTemplate(template);
-  const { chapters, guides, slugToTitle, title, toctree, eol, project } = useSnootyMetadata();
+  const { chapters, guides, slugToTitle, toctree, eol, project } = useSnootyMetadata();
   const remoteMetadata = useRemoteMetadata();
 
   const isInPresentationMode = usePresentationMode()?.toLocaleLowerCase() === 'true';
@@ -120,7 +120,6 @@ const DefaultLayout = ({ children, data: { page }, pageContext: { slug, repoBran
               page={page.ast}
               pageTitle={pageTitle}
               repoBranches={repoBranches}
-              siteTitle={title}
               slug={slug}
               toctree={toctree}
               eol={eol}

--- a/src/layouts/preview-layout.js
+++ b/src/layouts/preview-layout.js
@@ -139,7 +139,7 @@ const DefaultLayout = ({
   metadata,
 }) => {
   const { sidenav } = getTemplate(template);
-  const { chapters, guides, slugToTitle, title, toctree, eol } = metadata;
+  const { chapters, guides, slugToTitle, toctree, eol } = metadata;
 
   const pageTitle = React.useMemo(() => page?.options?.title || slugToTitle?.[slug === '/' ? 'index' : slug], [slug]); // eslint-disable-line react-hooks/exhaustive-deps
   useDelightedSurvey(slug, metadata.project);
@@ -164,7 +164,6 @@ const DefaultLayout = ({
                 page={page}
                 pageTitle={pageTitle}
                 repoBranches={repoBranches}
-                siteTitle={title}
                 slug={slug}
                 toctree={toctree}
                 eol={eol}


### PR DESCRIPTION
### Stories/Links:

DOP-4955

### Current Behavior:

[Preview Page](https://www.mongodb.com/docs/openapi/preview/)

### Staging Links:

[Preview Page](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-4955-dark-openapi-preview/openapi/preview/index.html)

### Notes:

This PR disables Dark Mode on the OpenAPI preview page. It does it in such a way that it does not affect localStorage or the user's saved preference at all so that when navigating between the preview page and any other docs page, the user's dark mode preference will not be affected by the switch. 

Also, I have cleaned up some unused props.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
