### PR TITLE
DOP-4893: List Table bugs in dark mode

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -66,7 +66,9 @@ const bodyCellStyle = css`
   overflow-wrap: anywhere;
   word-break: break-word;
 
-  * {
+  *,
+  p,
+  a {
     line-height: 20px;
   }
 

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -55,7 +55,9 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   min-height: unset;
 }
 
-.emotion-3 * {
+.emotion-3 *,
+.emotion-3 p,
+.emotion-3 a {
   line-height: 20px;
 }
 
@@ -335,7 +337,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   min-height: unset;
 }
 
-.emotion-16 * {
+.emotion-16 *,
+.emotion-16 p,
+.emotion-16 a {
   line-height: 20px;
 }
 
@@ -399,7 +403,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   min-height: unset;
 }
 
-.emotion-18 * {
+.emotion-18 *,
+.emotion-18 p,
+.emotion-18 a {
   line-height: 20px;
 }
 


### PR DESCRIPTION
### Stories/Links:

DOP-4893

Table has weird shift in spacing in dark mode in cells with nested content because leafygreen paragraph styles overwrite table styles.

### Current Behavior:

[Global clusters on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/main/global-clusters/index.html#global-write-zones-and-zone-mapping)
[Unsupported commands on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/main/unsupported-commands/index.html)
[Table testing on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/main/tables/index.html)

### Staging Links:

[Global clusters](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4893/global-clusters/index.html#global-write-zones-and-zone-mapping)
[Unsupported commands](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4893/unsupported-commands/index.html)
[Table testing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4893/tables/index.html)

### Notes:

When nested components are rendered in tables, content is rendered as `<p>`/`<Body>` tags/LG components (as opposed to `<div>`s with text inside them). For some reason, when we switch to dark mode LG styling overwrites (overrides?) our styling. This over-overwrites the LG styling by using ever-so-slightly more specific selectors...?

Also confirmed [here](https://mongodb.slack.com/archives/C076Z47AFTL/p1725379692623219) that we want the table header background to be the same as the rest of the page.

Thank you to @rayangler for the super helpful table-testing page!

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
