### PR TITLE
DOP-4978: mobile search filters page in dark mode

### DIFF
--- a/src/components/SearchResults/MobileFilters.js
+++ b/src/components/SearchResults/MobileFilters.js
@@ -18,7 +18,7 @@ const disableBodyScroll = css`
 `;
 
 const Container = styled('div')`
-  background-color: ${palette.white};
+  background-color: var(--background-color-primary);
   position: fixed;
   left: 0;
   top: ${({ topValue }) => topValue};

--- a/src/components/SearchResults/MobileFilters.js
+++ b/src/components/SearchResults/MobileFilters.js
@@ -37,6 +37,10 @@ const BackButton = styled('div')`
   cursor: pointer;
   display: flex;
   gap: 0 ${theme.size.small};
+
+  .dark-theme & {
+    color: ${palette.gray.light1};
+  }
 `;
 
 const Label = styled('div')`


### PR DESCRIPTION
### Stories/Links:

DOP-4978

### Current Behavior:

Current dark mode mobile search filters page:
<img width="660" alt="Screenshot 2024-09-03 at 2 38 04 PM" src="https://github.com/user-attachments/assets/9911846d-e150-4175-9f2b-f597db4446c3">

### Staging Links:

[Staging Link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-4978-search-mobile-dark/search/index.html)

To see: use mobile viewport and click "Refine your search"

### Notes:

Mobile Search filters "page" background and button text were not ingesting dark mode.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
