### PR TITLE
[no ticket] use white background for landing

### DIFF
--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -29,6 +29,7 @@ const StyledSkeleton = styled(Skeleton)`
 const CONTENT_MAX_WIDTH = theme.breakpoints.xxLarge;
 
 const landingTemplateStyling = css`
+  background: ${palette.white};
   position: sticky;
   top: 0px;
   box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.1);

--- a/src/components/ChatbotUi.js
+++ b/src/components/ChatbotUi.js
@@ -29,7 +29,7 @@ const StyledSkeleton = styled(Skeleton)`
 const CONTENT_MAX_WIDTH = theme.breakpoints.xxLarge;
 
 const landingTemplateStyling = css`
-  background: ${palette.white};
+  background: var(--background-color-primary);
   position: sticky;
   top: 0px;
   box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
### Stories/Links:

No ticket. This bug has been seen during release process

### Current Behavior:

[stage (qa) landing docs shows transparent background in the chatbot sticky header](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

### Staging Links:

[staged change for homepage](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/v0.17.4-fix-homepage/index.html) - used `master` branch of docs landing and v0.17.1 of parser

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
