### PR TITLE
DOP-4989: List item markers do not conform to dark mode colors

### DIFF
--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -4,6 +4,9 @@ import { cx, css } from '@leafygreen-ui/emotion';
 import ComponentFactory from '../ComponentFactory';
 
 const listParagraphStyles = css`
+  ::marker {
+    color: var(--font-color-primary);
+  }
   & > p {
     margin-bottom: 8px;
   }

--- a/src/components/Procedure/Step.js
+++ b/src/components/Procedure/Step.js
@@ -67,6 +67,7 @@ const landingStepStyles = {
     gap: ${theme.size.default};
     h2,
     h4,
+    h5,
     h6 {
       margin-top: unset;
     }

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -23,6 +23,10 @@ exports[`renders correctly 1`] = `
   margin-top: 0px;
 }
 
+.emotion-2::marker {
+  color: var(--font-color-primary);
+}
+
 .emotion-2>p {
   margin-bottom: 8px;
 }

--- a/tests/unit/__snapshots__/List.test.js.snap
+++ b/tests/unit/__snapshots__/List.test.js.snap
@@ -6,6 +6,10 @@ exports[`List renders correctly 1`] = `
   margin-top: 0px;
 }
 
+.emotion-1::marker {
+  color: var(--font-color-primary);
+}
+
 .emotion-1>p {
   margin-bottom: 8px;
 }

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -809,6 +809,7 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 
 .emotion-2 h2,
 .emotion-2 h4,
+.emotion-2 h5,
 .emotion-2 h6 {
   margin-top: unset;
 }

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -348,6 +348,7 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 
 .emotion-0 h2,
 .emotion-0 h4,
+.emotion-0 h5,
 .emotion-0 h6 {
   margin-top: unset;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4989

Updated list markers to reflect dark mode (by matching with the text color). Also updated some spacing errors with step titles (see the H5s under "Create an Atlas Search Index" in the linked page).

### Current Behavior:

[docs-qa Atlas Search Queries](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/atlas-search/tutorial/embedded-documents-tutorial/)
[docs-qa Connect to your cluster](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/tutorial/connect-to-your-cluster/)

### Staging Links:

[Atlas Search Queries](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4989/atlas-search/tutorial/embedded-documents-tutorial/index.html)
[Connect to your cluster](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4989/tutorial/connect-to-your-cluster/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
