### PR TITLE
DOP-4990: remove fab from depreacted projects

### DIFF
--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { isBrowser } from '../../utils/is-browser';
+import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import { theme } from '../../theme/docsTheme';
 import { InstruqtContext } from '../Instruqt/instruqt-context';
 import { SuspenseHelper } from '../SuspenseHelper';
@@ -38,7 +39,10 @@ const WidgetsContainer = styled.div`
   }
 `;
 
+const DEPRECATED_PROJECTS = ['atlas-app-services', 'datalake', 'realm'];
+
 const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) => {
+  const { project } = useSnootyMetadata();
   const { isOpen } = useContext(InstruqtContext);
   const url = isBrowser ? window.location.href : null;
   const feedbackData = useFeedbackData({
@@ -47,7 +51,7 @@ const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) 
     title: pageTitle || 'Home',
   });
 
-  const hideWidgets = ['landing', 'errorpage'].includes(template);
+  const hideWidgets = ['landing', 'errorpage'].includes(template) || DEPRECATED_PROJECTS.includes(project);
   const hideFeedback = template === 'openapi';
 
   return (

--- a/src/components/Widgets/index.js
+++ b/src/components/Widgets/index.js
@@ -51,8 +51,8 @@ const Widgets = ({ children, pageTitle, slug, isInPresentationMode, template }) 
     title: pageTitle || 'Home',
   });
 
-  const hideWidgets = ['landing', 'errorpage'].includes(template) || DEPRECATED_PROJECTS.includes(project);
-  const hideFeedback = template === 'openapi';
+  const hideWidgets = ['landing', 'errorpage'].includes(template);
+  const hideFeedback = template === 'openapi' || DEPRECATED_PROJECTS.includes(project);
 
   return (
     <FeedbackProvider page={feedbackData}>


### PR DESCRIPTION
### Stories/Links:

DOP-4990
Removing feedback FAB from docs outlined in ticket

### Current Behavior:

[atlas data lake](https://www.mongodb.com/docs/datalake/)
[atlas app services](https://www.mongodb.com/docs/atlas/app-services/)

### Staging Links:

[atlas data lake](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/datalake/seung.park/DOP-4990/index.html)
[realm](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/realm/seung.park/DOP-4990/index.html)
[atlas app services](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-app-services/seung.park/DOP-4990/index.html)
[regression check for cloud docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-4990/index.html)

### Notes:
- Incoming separate PR for removing feedback button from action bar, targeting feature branch

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
