### PR TITLE
DOP-4920: Add SearchAction structured data

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -223,7 +223,7 @@ export const Head = ({ pageContext, data }) => {
   const pageTitle = getPlaintext(getNestedValue(['slugToTitle', lookup], metadata));
   const siteTitle = getSiteTitle(metadata);
 
-  const isDocsLandingHomepage = metadata.project === 'landing' && template === 'landing';
+  const isDocsLandingHomepage = metadata.project === 'landing' && template === 'landing' && slug === '/';
   const needsBreadcrumbs = template === 'document' || template === undefined;
 
   // Retrieves the canonical URL based on certain situations

--- a/src/components/StructuredData/DocsLandingSD.js
+++ b/src/components/StructuredData/DocsLandingSD.js
@@ -18,6 +18,14 @@ const DocsLandingSD = () => (
       },
       author: 'MongoDB Documentation Team',
       inLanguage: 'English',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: 'https://mongodb.com/docs/search/?q={search_term_string}&page=1',
+        },
+        'query-input': 'required name=search_term_string',
+      },
     })}
   </script>
 );


### PR DESCRIPTION
### Stories/Links:

DOP-4920
[Google Rich Results test](https://search.google.com/test/rich-results/result/r%2Fsitelinks-searchbox?id=O19qyQs_m8tHGiL3zp-ZTg) - No errors found; new SearchAction is present.
[schema.org validator](https://validator.schema.org/#url=https%3A%2F%2Fdocs-mongodb-org-stg.s3.us-east-2.amazonaws.com%2Fmaster%2Flanding%2Fraymund.rodriguez%2FDOP-4920-search-action%2Findex.html) - No errors found

### Current Behavior:

[Landing](https://mongodb.com/docs)
[Atlas](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-4920-search-action/index.html)
[Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/DOP-4920-search-action/index.html) - control; no `SearchAction` structured data found on any page

### Notes:

* Adds only to docs landing homepage.
* Please see validator links above to ensure that structured data has no errors.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
