### PR TITLE
add width/height to svg and make button a block

### DIFF
--- a/src/components/ActionBar/DarkModeDropdown.js
+++ b/src/components/ActionBar/DarkModeDropdown.js
@@ -9,6 +9,7 @@ import { theme } from '../../theme/docsTheme';
 import IconDarkmode from '../icons/Computer';
 
 const iconStyling = css`
+  display: block;
   align-content: center;
   cursor: pointer;
 

--- a/src/components/icons/Computer.js
+++ b/src/components/icons/Computer.js
@@ -2,7 +2,15 @@ import React from 'react';
 
 const IconDarkmode = ({ styles, className }) => {
   return (
-    <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 24 24`} {...styles} className={className}>
+    <svg
+      id="Layer_1"
+      width="24"
+      height="24"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={`0 0 24 24`}
+      {...styles}
+      className={className}
+    >
       <g fill="currentColor">
         <path d="M12,18.92c-.29,0-.55.11-.76.32-.21.21-.32.46-.32.76v2c0,.29.11.55.32.76.21.21.46.32.76.32s.55-.11.76-.32c.21-.21.32-.46.32-.76v-2c0-.29-.11-.55-.32-.76-.21-.21-.46-.32-.76-.32Z" />
         <path d="M5.59,7.1c.22.21.48.31.77.32.29,0,.54-.1.74-.32.21-.22.31-.47.31-.76,0-.29-.1-.54-.31-.76l-1.06-1.07c-.21-.22-.46-.33-.76-.32-.3,0-.55.12-.76.34-.21.22-.32.48-.33.78,0,.29.1.54.32.75l1.08,1.05Z" />

--- a/tests/unit/__snapshots__/DarkModeDropdown.test.js.snap
+++ b/tests/unit/__snapshots__/DarkModeDropdown.test.js.snap
@@ -20,6 +20,7 @@ exports[`DarkMode Dropdown component renders dark mode dropdown 1`] = `
   height: 28px;
   width: 28px;
   color: #5C6C75;
+  display: block;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -150,6 +151,7 @@ exports[`DarkMode Dropdown component renders dark mode dropdown 2`] = `
   height: 28px;
   width: 28px;
   color: #5C6C75;
+  display: block;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -787,6 +789,7 @@ exports[`DarkMode Dropdown component updates dark mode when selecting a differen
   height: 28px;
   width: 28px;
   color: #C1C7C6;
+  display: block;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;


### PR DESCRIPTION
### Stories/Links:

DOP-4999

Safari does not show the icon for sun/moon combo when selected:


### Current Behavior:

[current QA does not show system icon when selected](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

### Staging Links:

[Test this page in safari](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-4999/index.html)

### Notes:
- QA (preprd) should be available for now. Will update PR description if the current link changes

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
