### PR TITLE
DOP-4918: Add VideoObject structured data to Video component

### DIFF
--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -72,15 +72,15 @@ const Video = ({ nodeData: { argument, options } }) => {
   const url = `${argument[0]['refuri']}`;
   // use placeholder image for video thumbnail if invalid URL provided
   const [previewImage, setPreviewImage] = useState(withPrefix('assets/meta_generic.png'));
-  const { name, description, 'upload-date': uploadDate, 'thumbnail-url': thumbnailUrl } = options;
+  const { title, description, 'upload-date': uploadDate, 'thumbnail-url': thumbnailUrl } = options;
   // Required fields based on https://developers.google.com/search/docs/appearance/structured-data/video#video-object
-  const hasAllReqFields = [url, name, uploadDate, thumbnailUrl].every((val) => !!val);
+  const hasAllReqFields = [url, title, uploadDate, thumbnailUrl].every((val) => !!val);
 
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
     embedUrl: url,
-    name,
+    name: title,
     uploadDate,
     thumbnailUrl,
   };
@@ -122,7 +122,7 @@ const Video = ({ nodeData: { argument, options } }) => {
   return (
     <>
       {hasAllReqFields && (
-        <script id="video-object-sd" type="application/ld+json">
+        <script id={`video-object-sd-${url}`} type="application/ld+json">
           {JSON.stringify(structuredData)}
         </script>
       )}

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -68,7 +68,7 @@ const getTheSupportedMedia = (url) => {
   return REACT_PLAYERS[supportedType];
 };
 
-const Video = ({ nodeData: { argument, options } }) => {
+const Video = ({ nodeData: { argument, options = {} } }) => {
   const url = `${argument[0]['refuri']}`;
   // use placeholder image for video thumbnail if invalid URL provided
   const [previewImage, setPreviewImage] = useState(withPrefix('assets/meta_generic.png'));

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -146,6 +146,12 @@ const Video = ({ nodeData: { argument, options = {} } }) => {
 Video.propTypes = {
   nodeData: PropTypes.shape({
     argument: PropTypes.array.isRequired,
+    options: PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      'upload-date': PropTypes.string,
+      'thumbnail-url': PropTypes.string,
+    }),
   }).isRequired,
 };
 

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -68,10 +68,26 @@ const getTheSupportedMedia = (url) => {
   return REACT_PLAYERS[supportedType];
 };
 
-const Video = ({ nodeData: { argument }, ...rest }) => {
+const Video = ({ nodeData: { argument, options } }) => {
   const url = `${argument[0]['refuri']}`;
   // use placeholder image for video thumbnail if invalid URL provided
   const [previewImage, setPreviewImage] = useState(withPrefix('assets/meta_generic.png'));
+  const { name, description, 'upload-date': uploadDate, 'thumbnail-url': thumbnailUrl } = options;
+  // Required fields based on https://developers.google.com/search/docs/appearance/structured-data/video#video-object
+  const hasAllReqFields = [url, name, uploadDate, thumbnailUrl].every((val) => !!val);
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'VideoObject',
+    embedUrl: url,
+    name,
+    uploadDate,
+    thumbnailUrl,
+  };
+
+  if (description) {
+    structuredData['description'] = description;
+  }
 
   useEffect(() => {
     // handles URL validity checking for well-formed YT links
@@ -104,19 +120,26 @@ const Video = ({ nodeData: { argument }, ...rest }) => {
   }
 
   return (
-    <ReactPlayerWrapper>
-      <ReactPlayer
-        css={videoStyling(ReactSupportedMedia)}
-        config={ReactSupportedMedia.config}
-        controls
-        url={url}
-        width="100%"
-        height="100%"
-        playing
-        playIcon={<VideoPlayButton />}
-        light={previewImage}
-      />
-    </ReactPlayerWrapper>
+    <>
+      {hasAllReqFields && (
+        <script id="video-object-sd" type="application/ld+json">
+          {JSON.stringify(structuredData)}
+        </script>
+      )}
+      <ReactPlayerWrapper>
+        <ReactPlayer
+          css={videoStyling(ReactSupportedMedia)}
+          config={ReactSupportedMedia.config}
+          controls
+          url={url}
+          width="100%"
+          height="100%"
+          playing
+          playIcon={<VideoPlayButton />}
+          light={previewImage}
+        />
+      </ReactPlayerWrapper>
+    </>
   );
 };
 

--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -5,12 +5,15 @@ import Video from '../../src/components/Video';
 // data for this component
 import mockData from './data/Video.test.json';
 
+const REACT_PLAYER_QUERY = 'div.react-player__preview';
+const SD_SCRIPT_QUERY = 'script[type="application/ld+json"]';
+
 it('YouTube video renders correctly', () => {
   const tree = render(<Video nodeData={mockData.validYouTubeURL} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
 
-it('Vimeo video renders correctly', () => {
+it('Vimeo video renders null', () => {
   const tree = render(<Video nodeData={mockData.validVimeoURL} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
@@ -20,7 +23,7 @@ it('Wistia video renders correctly', () => {
   expect(tree.asFragment()).toMatchSnapshot();
 });
 
-it('DailyMotion video renders correctly', () => {
+it('DailyMotion video renders null', () => {
   const tree = render(<Video nodeData={mockData.validDailyMotionURL} />);
   expect(tree.asFragment()).toMatchSnapshot();
 });
@@ -38,5 +41,55 @@ describe('Console warning messages', () => {
       'Media Not Found: A video player could not be found for the following https://docs.mongodb.com/realm/',
       'Invalid URL: https://www.youtube.com/ has been passed into the Video component',
     ]);
+  });
+});
+
+describe('Structured data', () => {
+  it('is defined when all fields required by Google are present', () => {
+    const mockNodeData = { ...mockData.validYouTubeURL };
+    mockNodeData['options'] = {
+      title: 'Test Video',
+      'upload-date': '2023-11-08T05:00:28-08:00',
+      'thumbnail-url': 'https://i.ytimg.com/vi/o2ss2LJNZVE/maxresdefault.jpg',
+    };
+
+    const { container } = render(<Video nodeData={mockNodeData} />);
+    const videoPlayer = container.querySelector(REACT_PLAYER_QUERY);
+    const sdScript = container.querySelector(SD_SCRIPT_QUERY);
+
+    expect(videoPlayer).toBeInTheDocument();
+    expect(sdScript).toBeInTheDocument();
+    expect(sdScript.textContent).toEqual(
+      '{"@context":"https://schema.org","@type":"VideoObject","embedUrl":"https://www.youtube.com/watch?v=YBOiX8DwinE&ab_channel=MongoDB","name":"Test Video","uploadDate":"2023-11-08T05:00:28-08:00","thumbnailUrl":"https://i.ytimg.com/vi/o2ss2LJNZVE/maxresdefault.jpg"}'
+    );
+  });
+
+  it('is defined with optional fields', () => {
+    const mockNodeData = { ...mockData.validYouTubeURL };
+    mockNodeData['options'] = {
+      title: 'Test Video',
+      'upload-date': '2023-11-08T05:00:28-08:00',
+      'thumbnail-url': 'https://i.ytimg.com/vi/o2ss2LJNZVE/maxresdefault.jpg',
+      description: 'Optional description field',
+    };
+
+    const { container } = render(<Video nodeData={mockNodeData} />);
+    const videoPlayer = container.querySelector(REACT_PLAYER_QUERY);
+    const sdScript = container.querySelector(SD_SCRIPT_QUERY);
+
+    expect(videoPlayer).toBeInTheDocument();
+    expect(sdScript).toBeInTheDocument();
+    expect(sdScript.textContent).toEqual(
+      '{"@context":"https://schema.org","@type":"VideoObject","embedUrl":"https://www.youtube.com/watch?v=YBOiX8DwinE&ab_channel=MongoDB","name":"Test Video","uploadDate":"2023-11-08T05:00:28-08:00","thumbnailUrl":"https://i.ytimg.com/vi/o2ss2LJNZVE/maxresdefault.jpg","description":"Optional description field"}'
+    );
+  });
+
+  it('is not defined when missing one or more field(s) required by Google', () => {
+    const mockNodeData = { ...mockData.validYouTubeURL };
+    const { container } = render(<Video nodeData={mockNodeData} />);
+    const videoPlayer = container.querySelector(REACT_PLAYER_QUERY);
+    const sdScript = container.querySelector(SD_SCRIPT_QUERY);
+    expect(videoPlayer).toBeInTheDocument();
+    expect(sdScript).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/__snapshots__/Video.test.js.snap
+++ b/tests/unit/__snapshots__/Video.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DailyMotion video renders correctly 1`] = `<DocumentFragment />`;
+exports[`DailyMotion video renders null 1`] = `<DocumentFragment />`;
 
-exports[`Vimeo video renders correctly 1`] = `<DocumentFragment />`;
+exports[`Vimeo video renders null 1`] = `<DocumentFragment />`;
 
 exports[`Wistia video renders correctly 1`] = `
 <DocumentFragment>


### PR DESCRIPTION
### Stories/Links:

DOP-4918
[Related parser PR](https://github.com/mongodb/snooty-parser/pull/619)
[Example rST](https://github.com/rayangler/cloud-docs/commit/93ab9b1cc34c1a461e8266da44f07687acc49c49)

### Current Behavior:

Examples of pages with videos. They're in the same order as the staging links below
* https://www.mongodb.com/docs/atlas/atlas-search/create-index/ - Video is under the "Atlas UI" language/tab
* https://www.mongodb.com/docs/atlas/atlas-search/manage-indexes/
* https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/
* https://www.mongodb.com/docs/atlas/atlas-search/searching/

### Staging Links:

* [Video with all options](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/test-video-object/cloud-docs/raymund.rodriguez/DOP-4918-video-object/atlas-search/create-index/index.html) - Video is under the "Atlas UI" language/tab
  * [Rich results](https://search.google.com/test/rich-results/result?id=qeY4Q_3wkeQ7dRlgFTlKfw) - VideoObject should be found with no errors or warnings
* [Video with all required options, but no description](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/test-video-object/cloud-docs/raymund.rodriguez/DOP-4918-video-object/atlas-search/manage-indexes/index.html)
  * [Rich results](https://search.google.com/test/rich-results/result?id=NWG835UY5-cwJQ_1l8KR-A) - The VideoObject is still valid despite the warning. The warning is only seen as an optimization.
* [Video with only optional description](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/test-video-object/cloud-docs/raymund.rodriguez/DOP-4918-video-object/atlas-search/operators-and-collectors/index.html)
  * [Rich results](https://search.google.com/test/rich-results/result?id=L2Z3zJFH4AyX3m2xFaqkzA) - No VideoObject is expected
* [Video with no options defined](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/test-video-object/cloud-docs/raymund.rodriguez/DOP-4918-video-object/atlas-search/searching/index.html) (default)
  * [Rich results](https://search.google.com/test/rich-results/result?id=AlOcrnf81jpI-leAPkZ2dg) - No VideoObject is expected

### Notes:

* To test, go to the staging links and inspect the page for a `VideoObject` structured data script next to each video.
* Sharing this [Google page](https://developers.google.com/search/docs/appearance/structured-data/video#video-object) on VideoObject for general reference, in case it helps provide more context on the required fields.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
