### PR TITLE
DOP-4994: Feedback Button horizontal text in all languages

### DIFF
--- a/src/components/Widgets/FeedbackWidget/FeedbackButton.js
+++ b/src/components/Widgets/FeedbackWidget/FeedbackButton.js
@@ -38,6 +38,8 @@ const FeedbackButton = () => {
           darkModePrestyling,
           css`
             ${displayNone.onMobileAndTablet}
+            // For vertical languages (chinese, korean, japanese)
+            text-wrap: nowrap;
           `
         )}
         onClick={() => (!feedback ? initializeFeedback() : abandon())}


### PR DESCRIPTION
### Stories/Links:

DOP-4616

### Current Behavior:

![Screenshot 2024-09-09 at 11 28 50 AM](https://github.com/user-attachments/assets/258270f8-2339-41f9-90da-5c96fe685823)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-4994-feedback-btn/index.html)

### Notes:

Wraps text to keep in line when in other languages.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
