### PR TITLE
Easiest solution: disallow option and hotkey in locale not en-us

### DIFF
--- a/src/components/ActionBar/SearchInput.js
+++ b/src/components/ActionBar/SearchInput.js
@@ -14,6 +14,7 @@ import debounce from '../../utils/debounce';
 import { isBrowser } from '../../utils/is-browser';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import { SuspenseHelper } from '../SuspenseHelper';
+import { getCurrLocale } from '../../utils/locale';
 import { searchIconStyling, searchInputStyling, StyledInputContainer } from './styles';
 import { ShortcutIcon, SparkleIcon } from './SparkIcon';
 const Chatbot = lazy(() => import('mongodb-chatbot-ui'));
@@ -60,6 +61,7 @@ const SearchInput = ({ className, slug }) => {
   const [selectedOption, setSelectedOption] = useState(0);
   const [mobileSearchActive, setMobileSearchActive] = useState(false);
   const { search } = useLocation();
+  const locale = getCurrLocale();
 
   useBackdropClick(
     () => {
@@ -80,24 +82,27 @@ const SearchInput = ({ className, slug }) => {
     return () => debounced();
   }, [searchValue]);
 
-  const keyPressHandler = useCallback(async (event) => {
-    // cmd+k or ctrl+k focuses search bar,
-    // unless already focused on an input field
-    const holdingCtrlCmd = (navigator.userAgent.includes('Mac') && event.metaKey) || event.ctrlKey;
-    if (holdingCtrlCmd && event.key === 'k' && document.activeElement.tagName.toLowerCase() !== 'input') {
-      event.preventDefault();
-      inputRef.current?.focus();
-      return;
-    }
+  const keyPressHandler = useCallback(
+    async (event) => {
+      // cmd+k or ctrl+k focuses search bar,
+      // unless already focused on an input field
+      const holdingCtrlCmd = (navigator.userAgent.includes('Mac') && event.metaKey) || event.ctrlKey;
+      if (holdingCtrlCmd && event.key === 'k' && document.activeElement.tagName.toLowerCase() !== 'input') {
+        event.preventDefault();
+        inputRef.current?.focus();
+        return;
+      }
 
-    // if currently focused on search input,
-    // activates the chatbot modal
-    if (event.target.isSameNode(inputRef.current) && event.key === '/') {
-      event.preventDefault();
-      setIsOpen(false);
-      return menuRef.current?.select(1);
-    }
-  }, []);
+      // if currently focused on search input,
+      // activates the chatbot modal
+      if (event.target.isSameNode(inputRef.current) && event.key === '/' && locale === 'en-us') {
+        event.preventDefault();
+        setIsOpen(false);
+        return menuRef.current?.select(1);
+      }
+    },
+    [locale]
+  );
 
   // adding keyboard shortcuts document wide
   useEffect(() => {

--- a/src/components/ActionBar/SearchInput.js
+++ b/src/components/ActionBar/SearchInput.js
@@ -94,7 +94,7 @@ const SearchInput = ({ className, slug }) => {
         return;
       }
 
-      // if currently focused on search input,
+      // if currently focused on search input and on English site (therefore, chatbot is an option),
       // activates the chatbot modal
       if (event.target.isSameNode(inputRef.current) && event.key === '/' && isEnglish) {
         event.preventDefault();

--- a/src/components/ActionBar/SearchInput.js
+++ b/src/components/ActionBar/SearchInput.js
@@ -62,6 +62,7 @@ const SearchInput = ({ className, slug }) => {
   const [mobileSearchActive, setMobileSearchActive] = useState(false);
   const { search } = useLocation();
   const locale = getCurrLocale();
+  const isEnglish = locale === 'en-us';
 
   useBackdropClick(
     () => {
@@ -95,13 +96,13 @@ const SearchInput = ({ className, slug }) => {
 
       // if currently focused on search input,
       // activates the chatbot modal
-      if (event.target.isSameNode(inputRef.current) && event.key === '/' && locale === 'en-us') {
+      if (event.target.isSameNode(inputRef.current) && event.key === '/' && isEnglish) {
         event.preventDefault();
         setIsOpen(false);
         return menuRef.current?.select(1);
       }
     },
-    [locale]
+    [isEnglish]
   );
 
   // adding keyboard shortcuts document wide
@@ -169,7 +170,7 @@ const SearchInput = ({ className, slug }) => {
       }
 
       case keyMap.ArrowDown: {
-        if (isOpen) {
+        if (isOpen && isEnglish) {
           setSelectedOption((selectedOption + 1) % 2);
           inputRef.current?.focus();
           e.preventDefault();
@@ -178,7 +179,7 @@ const SearchInput = ({ className, slug }) => {
       }
 
       case keyMap.ArrowUp: {
-        if (isOpen) {
+        if (isOpen && isEnglish) {
           setSelectedOption(Math.abs(selectedOption - (1 % 2)));
           inputRef.current?.focus();
           e.preventDefault();


### PR DESCRIPTION
### Stories/Links:

DOP-5002

### Current Behavior:

[Old cloud-docs](https://mongodbcom-cdn.website.staging.corp.mongodb.com/pt-br/docs-qa/atlas/)
- be on VPN!

### Staging Links:

[New docs-landing](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/) (check other languages)
- make sure to be on VPN!

### Notes:

We need to only have chatbot functionality on English sites.

Went with the simplest solution. 

Disallowed chatbot search option and disallowed chatbot hotkey when the locale is anything other than `en-us`.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
