### PR TITLE
0px if not browser

### DIFF
--- a/src/hooks/useViewport.js
+++ b/src/hooks/useViewport.js
@@ -10,7 +10,10 @@ export function getViewport() {
         scrollY: Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop || 0),
         scrollX: Math.max(window.pageXOffset, document.documentElement.scrollLeft, document.body.scrollLeft || 0),
       }
-    : {};
+    : {
+        scrollY: 0,
+        scrollX: 0,
+      };
 
   return viewport;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-5000

Unfortunately I can't really replicate this behavior in local dev, but in preprd you see that `scrollY = undefined` on initial load which causes the bottom 3 links to not show up until you scroll. This PR sets it to 0 when it's being built so it is not undefined on initial load. Check out the `<div>` with id `docs-side-nav-container`. 

### Current Behavior:

[Landing prod](https://www.mongodb.com/docs/)
[Landing preprd](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)

### Staging Links:

[Landing Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4683/landing/maya/DOP-5000/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
