### PR TITLE
DOP-4908: remove search icon from top nav

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -32,6 +32,7 @@ const Header = ({ eol, template }) => {
             <>
               <UnifiedNav
                 fullWidth="true"
+                hideSearch="true"
                 position="relative"
                 property={{ name: unifiedNavProperty }}
                 showLanguageSelector={true}
@@ -43,6 +44,7 @@ const Header = ({ eol, template }) => {
               />
               <UnifiedNav
                 fullWidth="true"
+                hideSearch="true"
                 position="relative"
                 property={{ name: unifiedNavProperty }}
                 showLanguageSelector={true}


### PR DESCRIPTION
### Stories/Links:

DOP-4908

Note: this [has been done before](https://github.com/mongodb/snooty/pull/1204/files#diff-a89ac12c8ec97364db532676bd572c7e552dcb933901a3d3358fa0285fabe445R32), but got undone when addressing [merge conflicts on the feature branch](https://github.com/mongodb/snooty/commit/632c79eb22f83a04c16c32a956d63b0e9d3e0cee#diff-a89ac12c8ec97364db532676bd572c7e552dcb933901a3d3358fa0285fabe445)

### Current Behavior:

[current QA docs show search icon in top nav](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/)

### Staging Links:

[staged cloud docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/remove-search-from-topnav/index.html)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
