### PR TITLE
DOP-5001: Accessibility shortcuts for dark mode should work

### DIFF
--- a/src/components/ActionBar/DarkModeDropdown.js
+++ b/src/components/ActionBar/DarkModeDropdown.js
@@ -1,12 +1,12 @@
 import React, { useCallback, useContext, useRef, useState } from 'react';
 import { cx, css } from '@leafygreen-ui/emotion';
-import Box from '@leafygreen-ui/box';
 import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 import { Menu, MenuItem } from '@leafygreen-ui/menu';
 import { DarkModeContext } from '../../context/dark-mode-context';
 import { theme } from '../../theme/docsTheme';
 import IconDarkmode from '../icons/DarkMode';
+import useScreenSize from '../../hooks/useScreenSize';
 import DarkModeGuideCue from './DarkModeGuideCue';
 
 const iconStyling = css`
@@ -35,7 +35,7 @@ const darkModeSvgStyle = {
 };
 
 const DarkModeDropdown = () => {
-  const guideCueRef = useRef();
+  const dropdownRef = useRef();
 
   // not using dark mode from LG/provider here to account for case of 'system' dark theme
   const { setDarkModePref, darkModePref } = useContext(DarkModeContext);
@@ -50,20 +50,21 @@ const DarkModeDropdown = () => {
     [setDarkModePref, setOpen]
   );
 
+  const { isTabletOrMobile } = useScreenSize();
+  const justify = isTabletOrMobile ? 'start' : 'end';
+
   return (
-    // Remove Fragment and div when Dark Mode Guide Cue is removed - only used for guide cue placement
     <>
-      <div ref={guideCueRef}>
+      <div ref={dropdownRef}>
         <Menu
           className={cx(menuStyling)}
-          usePortal={false}
-          justify={'start'}
+          portalContainer={dropdownRef.current}
+          scrollContainer={dropdownRef.current}
+          justify={justify}
           align={'bottom'}
           open={open}
           setOpen={setOpen}
           trigger={
-            // using Box here to prevent warning of Button within Button
-            // since we are using usePortal=false to mitigate sticky header
             <IconButton className={cx(iconStyling)} aria-label="Dark Mode Menu" aria-labelledby="Dark Mode Menu">
               {darkModePref === 'system' ? (
                 <IconDarkmode />
@@ -76,9 +77,7 @@ const DarkModeDropdown = () => {
           <MenuItem
             active={darkModePref === 'light-theme'}
             onClick={() => select('light-theme')}
-            onKeyDown={() => select('light-theme')}
             glyph={<Icon size={DROPDOWN_ICON_SIZE} glyph={'Sun'} />}
-            as={Box}
             className={menuItemStyling}
           >
             Light
@@ -86,9 +85,7 @@ const DarkModeDropdown = () => {
           <MenuItem
             active={darkModePref === 'dark-theme'}
             onClick={() => select('dark-theme')}
-            onKeyDown={() => select('dark-theme')}
             glyph={<Icon size={DROPDOWN_ICON_SIZE} glyph={'Moon'} />}
-            as={Box}
             className={menuItemStyling}
           >
             Dark
@@ -96,7 +93,6 @@ const DarkModeDropdown = () => {
           <MenuItem
             active={darkModePref === 'system'}
             onClick={() => select('system')}
-            onKeyDown={() => select('system')}
             glyph={
               <IconDarkmode
                 className={css`
@@ -107,14 +103,13 @@ const DarkModeDropdown = () => {
                 styles={darkModeSvgStyle}
               />
             }
-            as={Box}
             className={menuItemStyling}
           >
             System
           </MenuItem>
         </Menu>
       </div>
-      <DarkModeGuideCue guideCueRef={guideCueRef} dropdownIsOpen={open} />
+      <DarkModeGuideCue guideCueRef={dropdownRef} dropdownIsOpen={open} />
     </>
   );
 };

--- a/src/components/ActionBar/DarkModeDropdown.js
+++ b/src/components/ActionBar/DarkModeDropdown.js
@@ -24,6 +24,10 @@ const menuStyling = css`
   margin-top: ${theme.size.small};
 `;
 
+const menuItemStyling = css`
+  tabindex: 0;
+`;
+
 const DROPDOWN_ICON_SIZE = 20;
 const darkModeSvgStyle = {
   width: DROPDOWN_ICON_SIZE,
@@ -60,12 +64,7 @@ const DarkModeDropdown = () => {
           trigger={
             // using Box here to prevent warning of Button within Button
             // since we are using usePortal=false to mitigate sticky header
-            <IconButton
-              as={Box}
-              className={cx(iconStyling)}
-              aria-label="Dark Mode Menu"
-              aria-labelledby="Dark Mode Menu"
-            >
+            <IconButton className={cx(iconStyling)} aria-label="Dark Mode Menu" aria-labelledby="Dark Mode Menu">
               {darkModePref === 'system' ? (
                 <IconDarkmode />
               ) : (
@@ -77,20 +76,27 @@ const DarkModeDropdown = () => {
           <MenuItem
             active={darkModePref === 'light-theme'}
             onClick={() => select('light-theme')}
+            onKeyDown={() => select('light-theme')}
             glyph={<Icon size={DROPDOWN_ICON_SIZE} glyph={'Sun'} />}
+            as={Box}
+            className={menuItemStyling}
           >
             Light
           </MenuItem>
           <MenuItem
             active={darkModePref === 'dark-theme'}
             onClick={() => select('dark-theme')}
+            onKeyDown={() => select('dark-theme')}
             glyph={<Icon size={DROPDOWN_ICON_SIZE} glyph={'Moon'} />}
+            as={Box}
+            className={menuItemStyling}
           >
             Dark
           </MenuItem>
           <MenuItem
             active={darkModePref === 'system'}
             onClick={() => select('system')}
+            onKeyDown={() => select('system')}
             glyph={
               <IconDarkmode
                 className={css`
@@ -101,6 +107,8 @@ const DarkModeDropdown = () => {
                 styles={darkModeSvgStyle}
               />
             }
+            as={Box}
+            className={menuItemStyling}
           >
             System
           </MenuItem>


### PR DESCRIPTION
### Stories/Links:

DOP-5001

Updates so you can focus on + select options from Dark Mode dropdown. Navigate to the Dark mode dropdown icon using the `tab` key, then use the up+down arrow keys and Enter to select a dark mode preference.

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4683/landing/maya/DOP-5001/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
