### PR TITLE
DOP-4601: Unhide Japanese locale

### DIFF
--- a/src/utils/head-scripts/redirect-based-on-lang.js
+++ b/src/utils/head-scripts/redirect-based-on-lang.js
@@ -10,7 +10,7 @@ function redirectBasedOnLang() {
 
     // Based on locale utils; couldn't figure out how to use imports due to how webpack attempts to resolve them
     // PLEASE make sure this matches the AVAILABLE_LANGUAGES object, excluding English and other hidden languages
-    const supportedLocaleCodes = ['zh-cn', 'ko-kr', 'pt-br'];
+    const supportedLocaleCodes = ['zh-cn', 'ko-kr', 'pt-br', 'ja-jp'];
     const isEnglishSite = !supportedLocaleCodes.find((localeCode) =>
       window.location.pathname.startsWith('/' + localeCode)
     );

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -23,10 +23,11 @@ const AVAILABLE_LANGUAGES = [
   { language: '简体中文', localeCode: 'zh-cn', fontFamily: 'Noto Sans SC' },
   { language: '한국어', localeCode: 'ko-kr', fontFamily: 'Noto Sans KR' },
   { language: 'Português', localeCode: 'pt-br' },
+  { language: '日本語', localeCode: 'ja-jp', fontFamily: 'Noto Sans JP' },
 ];
 
 // Languages in current development that we do not want displayed publicly yet
-const HIDDEN_LANGUAGES = [{ language: '日本語', localeCode: 'ja-jp', fontFamily: 'Noto Sans JP' }];
+const HIDDEN_LANGUAGES = [];
 
 /**
  * @param {boolean} forceAll - Bypasses feature flag requirements if necessary
@@ -43,7 +44,8 @@ export const getAvailableLanguages = (forceAll = false) => {
 };
 
 const validateLocaleCode = (potentialCode) =>
-  !!getAvailableLanguages().find(({ localeCode }) => potentialCode === localeCode);
+  // Include hidden languages in validation to ensure current locale of hidden sites can still be captured correctly
+  !!getAvailableLanguages(true).find(({ localeCode }) => potentialCode === localeCode);
 
 /**
  * Strips the first locale code found in the slug. This function should be used to determine the original un-localized path of a page.

--- a/tests/unit/__snapshots__/Head.test.js.snap
+++ b/tests/unit/__snapshots__/Head.test.js.snap
@@ -26,6 +26,12 @@ NodeList [
     hreflang="pt-br"
     rel="alternate"
   />,
+  <link
+    class="sl_opaque"
+    href="https://www.mongodb.com/ja-jp/"
+    hreflang="ja-jp"
+    rel="alternate"
+  />,
 ]
 `;
 
@@ -53,6 +59,12 @@ NodeList [
     class="sl_opaque"
     href="https://www.mongodb.com/pt-br/foo/"
     hreflang="pt-br"
+    rel="alternate"
+  />,
+  <link
+    class="sl_opaque"
+    href="https://www.mongodb.com/ja-jp/foo/"
+    hreflang="ja-jp"
     rel="alternate"
   />,
 ]

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -262,7 +262,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   color: #0ad05b;
 }
 
-.emotion-20 {
+.emotion-21 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -274,12 +274,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-20 {
+  .emotion-21 {
     display: block;
   }
 }
 
-.emotion-21 {
+.emotion-22 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -290,12 +290,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-21 {
+  .emotion-22 {
     margin-top: 0px;
   }
 }
 
-.emotion-22 {
+.emotion-23 {
   font-family: Akzidenz-Grotesk Std;
   font-weight: 500;
   font-size: 16px;
@@ -305,12 +305,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-22 {
+  .emotion-23 {
     margin-top: initial;
   }
 }
 
-.emotion-23 {
+.emotion-24 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -319,16 +319,16 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-23 {
+  .emotion-24 {
     display: block;
   }
 }
 
-.emotion-24 {
+.emotion-25 {
   margin-bottom: 24px;
 }
 
-.emotion-25 {
+.emotion-26 {
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -346,7 +346,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   align-items: center;
 }
 
-.emotion-58 {
+.emotion-59 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -359,7 +359,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-58 {
+  .emotion-59 {
     display: none;
   }
 }
@@ -473,6 +473,13 @@ exports[`DocumentBody renders the necessary elements 1`] = `
                     role="option"
                     tabindex="0"
                   >
+                    日本語
+                  </li>
+                  <li
+                    class="emotion-16"
+                    role="option"
+                    tabindex="0"
+                  >
                     简体中文
                   </li>
                 </ul>
@@ -481,27 +488,27 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           </div>
         </div>
         <div
-          class="emotion-20"
+          class="emotion-21"
         >
           © 2024 MongoDB, Inc.
         </div>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-22"
       >
         <p
-          class="emotion-22"
+          class="emotion-23"
         >
           About
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-24"
         >
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/careers"
               rel="noreferrer noopener"
               target="_self"
@@ -510,10 +517,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://investors.mongodb.com"
               rel="noreferrer noopener"
               target="_self"
@@ -522,10 +529,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/legal"
               rel="noreferrer noopener"
               target="_self"
@@ -534,10 +541,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://github.com/mongodb"
               rel="noreferrer noopener"
               target="_self"
@@ -546,10 +553,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/company/contact/mongodb-vulnerability-disclosure-policy"
               rel="noreferrer noopener"
               target="_self"
@@ -558,10 +565,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/products/platform/trust"
               rel="noreferrer noopener"
               target="_self"
@@ -570,10 +577,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/company/contact/social-media-hub"
               rel="noreferrer noopener"
               target="_self"
@@ -584,21 +591,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-22"
       >
         <p
-          class="emotion-22"
+          class="emotion-23"
         >
           Support
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-24"
         >
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/company/contact"
               rel="noreferrer noopener"
               target="_self"
@@ -607,10 +614,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://support.mongodb.com/welcome"
               rel="noreferrer noopener"
               target="_self"
@@ -619,10 +626,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://status.mongodb.com/"
               rel="noreferrer noopener"
               target="_self"
@@ -631,10 +638,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/services/support"
               rel="noreferrer noopener"
               target="_self"
@@ -645,21 +652,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-21"
+        class="emotion-22"
       >
         <p
-          class="emotion-22"
+          class="emotion-23"
         >
           Deployment Options
         </p>
         <ul
-          class="emotion-23"
+          class="emotion-24"
         >
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/cloud/atlas/register"
               rel="noreferrer noopener"
               target="_self"
@@ -668,10 +675,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href="https://www.mongodb.com/try/download/enterprise"
               rel="noreferrer noopener"
               target="_self"
@@ -680,10 +687,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-24"
+            class="emotion-25"
           >
             <a
-              class=" emotion-25"
+              class=" emotion-26"
               href=" https://www.mongodb.com/try/download/community"
               rel="noreferrer noopener"
               target="_self"
@@ -694,7 +701,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-58"
+        class="emotion-59"
       >
         © 2024 MongoDB, Inc.
       </div>

--- a/tests/unit/utils/__snapshots__/locale.test.js.snap
+++ b/tests/unit/utils/__snapshots__/locale.test.js.snap
@@ -3,6 +3,7 @@
 exports[`getLocaleMapping returns a valid mapping of URLs 1`] = `
 {
   "en-us": "https://www.mongodb.com/docs/",
+  "ja-jp": "https://www.mongodb.com/docs/ja-jp/",
   "ko-kr": "https://www.mongodb.com/docs/ko-kr/",
   "pt-br": "https://www.mongodb.com/docs/pt-br/",
   "zh-cn": "https://www.mongodb.com/docs/zh-cn/",
@@ -12,6 +13,7 @@ exports[`getLocaleMapping returns a valid mapping of URLs 1`] = `
 exports[`getLocaleMapping returns a valid mapping of URLs 2`] = `
 {
   "en-us": "https://www.mongodb.com/docs/about/page/",
+  "ja-jp": "https://www.mongodb.com/docs/ja-jp/about/page/",
   "ko-kr": "https://www.mongodb.com/docs/ko-kr/about/page/",
   "pt-br": "https://www.mongodb.com/docs/pt-br/about/page/",
   "zh-cn": "https://www.mongodb.com/docs/zh-cn/about/page/",
@@ -21,6 +23,7 @@ exports[`getLocaleMapping returns a valid mapping of URLs 2`] = `
 exports[`getLocaleMapping returns a valid mapping of URLs 3`] = `
 {
   "en-us": "https://www.mongodb.com/introduction/",
+  "ja-jp": "https://www.mongodb.com/ja-jp/introduction/",
   "ko-kr": "https://www.mongodb.com/ko-kr/introduction/",
   "pt-br": "https://www.mongodb.com/pt-br/introduction/",
   "zh-cn": "https://www.mongodb.com/zh-cn/introduction/",


### PR DESCRIPTION
### Stories/Links:

DOP-4601

### Current Behavior:

* [Japanese](https://www.mongodb.com/ja-jp/docs/atlas/)
* [English](https://www.mongodb.com/docs/atlas/)
* [Chinese](https://www.mongodb.com/zh-cn/docs/atlas/)
* [Korean](https://www.mongodb.com/ko-kr/docs/atlas/)
* [Portuguese](https://www.mongodb.com/pt-br/docs/atlas/)

### Staging Links:

All links were built without the `GATSBY_FEATURE_SHOW_HIDDEN_LOCALES` feature flag, to mimic prod.

* [Japanese](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ja-jp/sandbox/cloud-docs/raymund.rodriguez/DOP-4601-jp-live/index.html)
* [English](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-4601-jp-live/index.html)
* [Chinese](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/sandbox/cloud-docs/raymund.rodriguez/DOP-4601-jp-live/index.html)
* [Korean](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/ko-kr/sandbox/cloud-docs/raymund.rodriguez/DOP-4601-jp-live/index.html)
* [Portuguese](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/pt-br/sandbox/cloud-docs/raymund.rodriguez/DOP-4601-jp-live/index.html)

### Notes:

* Japanese should now be present in consistent nav language dropdowns (top nav and footer)
* Users with a browser language set to Japanese (without previously selecting the English language) will now be redirected to the Japanese site.
* Small change to include hidden sites in locale validation. This is irrelevant now, but it would've been useful so that any locale-specific logic on a hidden site like `ja-jp` would've seen `ja-jp` as valid. If done previously, this would've helped prevent bugs where hreflang links on the [Japanese docs site](https://www.mongodb.com/ja-jp/docs/) were showing `ja-jp` in the URLs, or showing the chatbot as an option.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
