### PR TITLE
DOP-4947: Add Gold role component

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -79,6 +79,7 @@ import RoleHighlight from './Roles/Highlight';
 import RoleIcon from './Roles/Icon';
 import RoleKbd from './Roles/Kbd';
 import RoleRed from './Roles/Red';
+import RoleGold from './Roles/Gold';
 import RoleRequired from './Roles/Required';
 
 const IGNORED_NAMES = new Set([
@@ -115,6 +116,7 @@ const roleMap = {
   'icon-lg': RoleIcon,
   kbd: RoleKbd,
   red: RoleRed,
+  gold: RoleGold,
   required: RoleRequired,
   sub: Subscript,
   subscript: Subscript,

--- a/src/components/Roles/Gold.js
+++ b/src/components/Roles/Gold.js
@@ -4,13 +4,13 @@ import { css } from '@emotion/react';
 import { palette } from '@leafygreen-ui/palette';
 import ComponentFactory from '../ComponentFactory';
 
-const Red = ({ nodeData: { children } }) => (
+const Gold = ({ nodeData: { children } }) => (
   <strong
     css={css`
-      color: ${palette.red.dark2};
+      color: ${palette.yellow.dark2};
 
       .dark-theme & {
-        color: ${palette.red.light1};
+        color: ${palette.yellow.light2};
       }
     `}
   >
@@ -20,10 +20,10 @@ const Red = ({ nodeData: { children } }) => (
   </strong>
 );
 
-Red.propTypes = {
+Gold.propTypes = {
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
 };
 
-export default Red;
+export default Gold;


### PR DESCRIPTION
### Stories/Links:

DOP-4947

### Current Behavior:

N/A

### Staging Links:

[Staging link using parser branch with new role](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/gold-role/mongodb-shell/matt.meigs/DOP-4947-gold-role/run-commands/index.html)

### Notes:

Creates a Gold role component. Also, adds the correct dark mode color for the Red role component color.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
