### PR TITLE
DOP-5032: Site Banner width

### DIFF
--- a/src/components/Banner/SiteBanner.js
+++ b/src/components/Banner/SiteBanner.js
@@ -17,7 +17,7 @@ const getBannerSource = (src) => {
 const StyledBannerContainer = styled.a`
   display: block;
   height: ${theme.header.bannerHeight};
-  width: 100vw;
+  width: 100%;
   position: absolute;
   z-index: ${theme.zIndexes.header};
 `;

--- a/tests/unit/__snapshots__/SiteBanner.test.js.snap
+++ b/tests/unit/__snapshots__/SiteBanner.test.js.snap
@@ -5,7 +5,7 @@ exports[`Banner component renders with a banner image 1`] = `
   .emotion-0 {
   display: block;
   height: 40px;
-  width: 100vw;
+  width: 100%;
   position: absolute;
   z-index: 1000;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-5032

### Current Behavior:

[Current prod with banner](https://www.mongodb.com/docs/)

### Staging Links:

[Staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-5032-banner-width/index.html)

### Notes:

NOTE: to see the issue in prod, you must have your user settings to ALWAYS show scrollbar.

Simply needed to be `100%` vs `100vw`.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
