### PR TITLE
DOP-4902: Update flora to v1.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
         "@mdb/consistent-nav": "^2.2.0",
-        "@mdb/flora": "^1.5.6",
+        "@mdb/flora": "1.14.2",
         "@mdx-js/react": "^2.2.1",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.5.9",
@@ -8081,14 +8081,24 @@
       }
     },
     "node_modules/@mdb/flora": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.5.6.tgz",
-      "integrity": "sha512-+ArnKzKYC/vZHsiD44vicGlcvn+mEkvMzQPW6gD1Gtr0YCiN/1U0hCXuvyRX7Add/MrQaO1IDjWLFsWjGhJ+HA==",
+      "version": "1.14.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.14.2.tgz",
+      "integrity": "sha512-ye2aLrOGRIl4vJH47mxOWWJ/Z+CgehI4zfDCMugF3DIyttBMvUiw4+Ettecm7R/z3ljO7SIPSJJ3NEfr7JwpJQ==",
       "dependencies": {
+        "@emotion/css": "^11.11.2",
+        "@emotion/react": ">= 11.6.0",
+        "@emotion/styled": ">= 11.6.0",
         "@imgix/js-core": "3.7.1",
+        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-slot": "^1.0.2",
         "codemirror": "5.62.2",
         "codemirror-ssr": "0.0.6",
-        "lazysizes": "5.3.2"
+        "hex-rgb": "^4.3.0",
+        "lazysizes": "5.3.2",
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8",
+        "theme-ui": ">= 0.13.1",
+        "usehooks-ts": "^3.1.0"
       },
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
@@ -8097,6 +8107,14 @@
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
         "theme-ui": ">= 0.13.1"
+      }
+    },
+    "node_modules/@mdb/flora/node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -9494,6 +9512,302 @@
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@polka/url/-/url-1.0.0-next.25.tgz",
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@reach/observe-rect": {
       "version": "1.2.0",
@@ -11635,6 +11949,17 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aria-query": {
@@ -14459,6 +14784,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-port": {
       "version": "1.5.1",
@@ -17896,6 +18226,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -26732,6 +27070,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.7",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-resizable": {
       "version": "3.0.5",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-resizable/-/react-resizable-3.0.5.tgz",
@@ -26768,6 +27151,28 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-tabs": {
@@ -30485,6 +30890,26 @@
       "version": "1.3.2",
       "license": "MIT"
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -30532,6 +30957,41 @@
       "peerDependencies": {
         "react": "16.8.0 - 18",
         "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/util-deprecate": {
@@ -37303,14 +37763,31 @@
       "integrity": "sha512-cvnUm3zMXuXSzkEJk6pzuoWgfkkwfc/PdLnxRaPGzKStvWlstyXo82mbxbXaf5GKvqDgTPpc7wdxes33oHadqw=="
     },
     "@mdb/flora": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.5.6.tgz",
-      "integrity": "sha512-+ArnKzKYC/vZHsiD44vicGlcvn+mEkvMzQPW6gD1Gtr0YCiN/1U0hCXuvyRX7Add/MrQaO1IDjWLFsWjGhJ+HA==",
+      "version": "1.14.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/flora/-/@mdb/flora-1.14.2.tgz",
+      "integrity": "sha512-ye2aLrOGRIl4vJH47mxOWWJ/Z+CgehI4zfDCMugF3DIyttBMvUiw4+Ettecm7R/z3ljO7SIPSJJ3NEfr7JwpJQ==",
       "requires": {
+        "@emotion/css": "^11.11.2",
+        "@emotion/react": ">= 11.6.0",
+        "@emotion/styled": ">= 11.6.0",
         "@imgix/js-core": "3.7.1",
+        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-slot": "^1.0.2",
         "codemirror": "5.62.2",
         "codemirror-ssr": "0.0.6",
-        "lazysizes": "5.3.2"
+        "hex-rgb": "^4.3.0",
+        "lazysizes": "5.3.2",
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8",
+        "theme-ui": ">= 0.13.1",
+        "usehooks-ts": "^3.1.0"
+      },
+      "dependencies": {
+        "hex-rgb": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hex-rgb/-/hex-rgb-4.3.0.tgz",
+          "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="
+        }
       }
     },
     "@mdx-js/react": {
@@ -38139,6 +38616,137 @@
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@polka/url/-/url-1.0.0-next.25.tgz",
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
+    },
+    "@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw=="
+    },
+    "@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A=="
+    },
+    "@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      }
+    },
+    "@radix-ui/react-dismissable-layer": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      }
+    },
+    "@radix-ui/react-focus-guards": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw=="
+    },
+    "@radix-ui/react-focus-scope": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      }
+    },
+    "@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "requires": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      }
+    },
+    "@radix-ui/react-portal": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "requires": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      }
+    },
+    "@radix-ui/react-presence": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      }
+    },
+    "@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "requires": {
+        "@radix-ui/react-slot": "1.1.0"
+      }
+    },
+    "@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      }
+    },
+    "@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw=="
+    },
+    "@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "requires": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      }
+    },
+    "@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "requires": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      }
+    },
+    "@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="
     },
     "@reach/observe-rect": {
       "version": "1.2.0",
@@ -39591,6 +40199,14 @@
       "version": "1.0.10",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "aria-query": {
@@ -41414,6 +42030,11 @@
     "detect-newline": {
       "version": "3.1.0",
       "dev": true
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port": {
       "version": "1.5.1",
@@ -43680,6 +44301,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -49267,6 +49893,27 @@
     "react-refresh": {
       "version": "0.14.0"
     },
+    "react-remove-scroll": {
+      "version": "2.5.7",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.3.6",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "requires": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
     "react-resizable": {
       "version": "3.0.5",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-resizable/-/react-resizable-3.0.5.tgz",
@@ -49287,6 +49934,16 @@
         "acorn": {
           "version": "6.4.2"
         }
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
       }
     },
     "react-tabs": {
@@ -51725,6 +52382,14 @@
     "url-template": {
       "version": "2.0.8"
     },
+    "use-callback-ref": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -51749,6 +52414,23 @@
       "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "usehooks-ts": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+      "requires": {
+        "lodash.debounce": "^4.0.8"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
     "@mdb/consistent-nav": "^2.2.0",
-    "@mdb/flora": "^1.5.6",
+    "@mdb/flora": "1.14.2",
     "@mdx-js/react": "^2.2.1",
     "abort-controller": "^3.0.0",
     "adm-zip": "^0.5.9",

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -188,7 +188,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 .emotion-10 {
-  font-family: Akzidenz-Grotesk Std;
+  font-family: Akzidenz-Grotesk Std,Noto Sans KR,Noto Sans SC,Noto Sans JP;
   font-size: 16px;
   line-height: 16px;
   color: #ffffff;
@@ -233,7 +233,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   line-height: 16px;
   font-size: 16px;
   color: #ffffff;
-  font-family: Akzidenz-Grotesk Std;
+  font-family: Akzidenz-Grotesk Std,Noto Sans KR,Noto Sans SC,Noto Sans JP;
   background-color: #21313c;
   border: 1px solid #b8c4c2;
   border-radius: 8px;
@@ -390,7 +390,9 @@ exports[`DocumentBody renders the necessary elements 1`] = `
               <img
                 alt="MongoDB logo"
                 class="emotion-6"
+                height="38"
                 src="https://webimages.mongodb.com/_com_assets/cms/kuyj3d95v5vbmm2f4-horizontal_white.svg?auto=format%252Ccompress"
+                width="150"
               />
             </a>
           </div>
@@ -722,6 +724,8 @@ exports[`DocumentBody renders the necessary elements 2`] = `
 <img
   alt="MongoDB logo"
   class="emotion-0"
+  height="38"
   src="https://webimages.mongodb.com/_com_assets/cms/kuyj3d95v5vbmm2f4-horizontal_white.svg?auto=format%252Ccompress"
+  width="150"
 />
 `;


### PR DESCRIPTION
### Stories/Links:

DOP-4902

### Current Behavior:

[Prod](https://www.mongodb.com/docs/)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-4902-update-flora/index.html)

### Notes:

Needed to update Flora to take advantage of inline style change from [this PR](https://github.com/10gen/flora/pull/313/files).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
