### PR TITLE
DOP-4916: Implement SoftwareSourceCode structured data

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbContainer.js
+++ b/src/components/Breadcrumbs/BreadcrumbContainer.js
@@ -86,7 +86,7 @@ const crumbObjectShape = {
 };
 
 BreadcrumbContainer.propTypes = {
-  breadcrumbs: PropTypes.shape(crumbObjectShape).isRequired,
+  breadcrumbs: PropTypes.arrayOf(PropTypes.shape(crumbObjectShape)).isRequired,
 };
 
 export default BreadcrumbContainer;

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -86,11 +86,14 @@ const Code = ({
     reportAnalytics('CodeblockCopied', { code });
   }, [code]);
 
-  const softwareSourceCodeSd = useMemo(() => new SoftwareSourceCodeSd({ code, lang }), [code, lang]);
+  const softwareSourceCodeSd = useMemo(() => {
+    const sd = new SoftwareSourceCodeSd({ code, lang });
+    return sd.isValid() ? sd.toString() : undefined;
+  }, [code, lang]);
 
   return (
     <>
-      {softwareSourceCodeSd.isValid() && (
+      {softwareSourceCodeSd && (
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { default as CodeBlock } from '@leafygreen-ui/code';
@@ -12,6 +12,7 @@ import { TabContext } from '../Tabs/tab-context';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { getLanguage } from '../../utils/get-language';
 import { DRIVER_ICON_MAP } from '../icons/DriverIconMap';
+import { SoftwareSourceCodeSd } from '../../utils/structured-data';
 import { baseCodeStyle, borderCodeStyle, lgStyles } from './styles/codeStyle';
 import { CodeContext } from './code-context';
 
@@ -85,77 +86,89 @@ const Code = ({
     reportAnalytics('CodeblockCopied', { code });
   }, [code]);
 
+  const softwareSourceCodeSd = useMemo(() => new SoftwareSourceCodeSd({ code, lang }), [code, lang]);
+
   return (
-    <div
-      css={css`
-        ${baseCodeStyle}
-
-        // Remove whitespace when copyable false
-        > div > div {
-          display: grid;
-          grid-template-columns: ${!copyable && (languageOptions?.length === 0 || language === 'none')
-            ? 'auto 0px !important'
-            : 'code panel'};
-        }
-
-        > div {
-          border-top-left-radius: ${captionBorderRadius};
-          border-top-right-radius: ${captionBorderRadius};
-          display: grid;
-          border-color: ${palette.gray.light2};
-
-          .dark-theme & {
-            border-color: ${palette.gray.dark2};
-          }
-        }
-
-        pre {
-          background-color: ${palette.gray.light3};
-          color: ${palette.black};
-
-          .dark-theme & {
-            background-color: ${palette.black};
-            color: ${palette.gray.light3};
-          }
-        }
-
-        [data-testid='leafygreen-code-panel'] {
-          background-color: ${palette.white};
-          border-color: ${palette.gray.light2};
-
-          .dark-theme & {
-            background-color: ${palette.gray.dark2};
-            border-color: ${palette.gray.dark2};
-          }
-        }
-
-        ${lgStyles}
-      `}
-    >
-      {captionSpecified && (
-        <div>
-          <CaptionContainer style={{ '--border-color': darkMode ? palette.gray.dark2 : palette.gray.light2 }}>
-            <Caption style={{ '--color': darkMode ? palette.gray.light2 : palette.gray.dark1 }}>{caption}</Caption>
-          </CaptionContainer>
-        </div>
+    <>
+      {softwareSourceCodeSd.isValid() && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: softwareSourceCodeSd.toString(),
+          }}
+        />
       )}
-      <CodeBlock
-        copyable={copyable}
-        highlightLines={emphasizeLines}
-        language={language}
-        languageOptions={languageOptions}
-        onChange={(selectedOption) => {
-          setActiveTab({ drivers: selectedOption.id });
-        }}
-        onCopy={reportCodeCopied}
-        showLineNumbers={linenos}
-        showCustomActionButtons={sourceSpecified}
-        customActionButtons={customActionButtonList}
-        lineNumberStart={lineno_start}
+      <div
+        css={css`
+          ${baseCodeStyle}
+
+          // Remove whitespace when copyable false
+          > div > div {
+            display: grid;
+            grid-template-columns: ${!copyable && (languageOptions?.length === 0 || language === 'none')
+              ? 'auto 0px !important'
+              : 'code panel'};
+          }
+
+          > div {
+            border-top-left-radius: ${captionBorderRadius};
+            border-top-right-radius: ${captionBorderRadius};
+            display: grid;
+            border-color: ${palette.gray.light2};
+
+            .dark-theme & {
+              border-color: ${palette.gray.dark2};
+            }
+          }
+
+          pre {
+            background-color: ${palette.gray.light3};
+            color: ${palette.black};
+
+            .dark-theme & {
+              background-color: ${palette.black};
+              color: ${palette.gray.light3};
+            }
+          }
+
+          [data-testid='leafygreen-code-panel'] {
+            background-color: ${palette.white};
+            border-color: ${palette.gray.light2};
+
+            .dark-theme & {
+              background-color: ${palette.gray.dark2};
+              border-color: ${palette.gray.dark2};
+            }
+          }
+
+          ${lgStyles}
+        `}
       >
-        {code}
-      </CodeBlock>
-    </div>
+        {captionSpecified && (
+          <div>
+            <CaptionContainer style={{ '--border-color': darkMode ? palette.gray.dark2 : palette.gray.light2 }}>
+              <Caption style={{ '--color': darkMode ? palette.gray.light2 : palette.gray.dark1 }}>{caption}</Caption>
+            </CaptionContainer>
+          </div>
+        )}
+        <CodeBlock
+          copyable={copyable}
+          highlightLines={emphasizeLines}
+          language={language}
+          languageOptions={languageOptions}
+          onChange={(selectedOption) => {
+            setActiveTab({ drivers: selectedOption.id });
+          }}
+          onCopy={reportCodeCopied}
+          showLineNumbers={linenos}
+          showCustomActionButtons={sourceSpecified}
+          customActionButtons={customActionButtonList}
+          lineNumberStart={lineno_start}
+        >
+          {code}
+        </CodeBlock>
+      </div>
+    </>
   );
 };
 

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -97,7 +97,7 @@ const Code = ({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: softwareSourceCodeSd.toString(),
+            __html: softwareSourceCodeSd,
           }}
         />
       )}

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -13,6 +13,7 @@ import { reportAnalytics } from '../../utils/report-analytics';
 import { getLanguage } from '../../utils/get-language';
 import { DRIVER_ICON_MAP } from '../icons/DriverIconMap';
 import { SoftwareSourceCodeSd } from '../../utils/structured-data';
+import { usePageContext } from '../../context/page-context';
 import { baseCodeStyle, borderCodeStyle, lgStyles } from './styles/codeStyle';
 import { CodeContext } from './code-context';
 
@@ -42,6 +43,7 @@ const Code = ({
   const { setActiveTab } = useContext(TabContext);
   const { languageOptions, codeBlockLanguage } = useContext(CodeContext);
   const { darkMode } = useDarkMode();
+  const { slug } = usePageContext();
   const code = value;
   let language = (languageOptions?.length > 0 && codeBlockLanguage) || getLanguage(lang);
 
@@ -87,9 +89,9 @@ const Code = ({
   }, [code]);
 
   const softwareSourceCodeSd = useMemo(() => {
-    const sd = new SoftwareSourceCodeSd({ code, lang });
+    const sd = new SoftwareSourceCodeSd({ code, lang, slug });
     return sd.isValid() ? sd.toString() : undefined;
-  }, [code, lang]);
+  }, [code, lang, slug]);
 
   return (
     <>

--- a/src/components/Code/CodeIO.js
+++ b/src/components/Code/CodeIO.js
@@ -17,6 +17,10 @@ const outputButtonStyling = LeafyCss`
   margin: 8px;
 `;
 
+const outputContainerStyle = (showOutput) => LeafyCss`
+  ${!showOutput && 'display: none;'}
+`;
+
 const CodeIO = ({ nodeData: { children }, ...rest }) => {
   const { darkMode } = useDarkMode();
   const needsIOToggle = children.length === 2;
@@ -32,12 +36,8 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
   const outputBorderRadius = !showOutput ? '12px' : '0px';
   const singleInputBorderRadius = onlyInputSpecified ? '12px' : '0px';
 
-  const handleClick = (e) => {
-    if (showOutput) {
-      setShowOutput(false);
-    } else {
-      setShowOutput(true);
-    }
+  const handleClick = () => {
+    setShowOutput((val) => !val);
   };
 
   if (children.length === 0) {
@@ -77,7 +77,9 @@ const CodeIO = ({ nodeData: { children }, ...rest }) => {
               {buttonText}
             </Button>
           </IOToggle>
-          {showOutput && <Output nodeData={children[1]} />}
+          <div className={outputContainerStyle(showOutput)}>
+            <Output nodeData={children[1]} />
+          </div>
         </>
       )}
       {onlyInputSpecified && <Input nodeData={children[0]} />}

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -32,11 +32,14 @@ const Output = ({ nodeData: { children } }) => {
   const { darkMode } = useDarkMode();
   const { emphasize_lines, value, linenos, lang, lineno_start } = children[0];
   const language = getLanguage(lang);
-  const softwareSourceCodeSd = useMemo(() => new SoftwareSourceCodeSd({ code: value, lang }), [value, lang]);
+  const softwareSourceCodeSd = useMemo(() => {
+    const sd = new SoftwareSourceCodeSd({ code: value, lang });
+    return sd.isValid() ? sd.toString() : undefined;
+  }, [value, lang]);
 
   return (
     <>
-      {softwareSourceCodeSd.isValid() && (
+      {softwareSourceCodeSd && (
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { default as CodeBlock } from '@leafygreen-ui/code';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { getLanguage } from '../../utils/get-language';
+import { SoftwareSourceCodeSd } from '../../utils/structured-data';
 
 const OutputContainer = styled.div`
   > div > * {
@@ -27,36 +28,47 @@ const OutputContainer = styled.div`
   }
 `;
 
-const Output = ({ nodeData: { children }, ...rest }) => {
+const Output = ({ nodeData: { children } }) => {
   const { darkMode } = useDarkMode();
   const { emphasize_lines, value, linenos, lang, lineno_start } = children[0];
   const language = getLanguage(lang);
+  const softwareSourceCodeSd = useMemo(() => new SoftwareSourceCodeSd({ code: value, lang }), [value, lang]);
 
   return (
-    <OutputContainer
-      style={
-        darkMode
-          ? {
-              '--code-container-border': 'none',
-              '--code-pre-border': `1px solid ${palette.gray.dark2}`,
-            }
-          : {
-              '--code-container-border': 'initial',
-              '--code-pre-border': `none`,
-            }
-      }
-    >
-      <CodeBlock
-        highlightLines={emphasize_lines}
-        language={language}
-        showLineNumbers={linenos}
-        darkMode={true}
-        copyable={false}
-        lineNumberStart={lineno_start}
+    <>
+      {softwareSourceCodeSd.isValid() && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: softwareSourceCodeSd.toString(),
+          }}
+        />
+      )}
+      <OutputContainer
+        style={
+          darkMode
+            ? {
+                '--code-container-border': 'none',
+                '--code-pre-border': `1px solid ${palette.gray.dark2}`,
+              }
+            : {
+                '--code-container-border': 'initial',
+                '--code-pre-border': `none`,
+              }
+        }
       >
-        {value}
-      </CodeBlock>
-    </OutputContainer>
+        <CodeBlock
+          highlightLines={emphasize_lines}
+          language={language}
+          showLineNumbers={linenos}
+          darkMode={true}
+          copyable={false}
+          lineNumberStart={lineno_start}
+        >
+          {value}
+        </CodeBlock>
+      </OutputContainer>
+    </>
   );
 };
 

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -43,7 +43,7 @@ const Output = ({ nodeData: { children } }) => {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: softwareSourceCodeSd.toString(),
+            __html: softwareSourceCodeSd,
           }}
         />
       )}

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -6,6 +6,7 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { getLanguage } from '../../utils/get-language';
 import { SoftwareSourceCodeSd } from '../../utils/structured-data';
+import { usePageContext } from '../../context/page-context';
 
 const OutputContainer = styled.div`
   > div > * {
@@ -32,10 +33,11 @@ const Output = ({ nodeData: { children } }) => {
   const { darkMode } = useDarkMode();
   const { emphasize_lines, value, linenos, lang, lineno_start } = children[0];
   const language = getLanguage(lang);
+  const { slug } = usePageContext();
   const softwareSourceCodeSd = useMemo(() => {
-    const sd = new SoftwareSourceCodeSd({ code: value, lang });
+    const sd = new SoftwareSourceCodeSd({ code: value, lang, slug });
     return sd.isValid() ? sd.toString() : undefined;
-  }, [value, lang]);
+  }, [value, lang, slug]);
 
   return (
     <>

--- a/src/components/StructuredData/DocsLandingSD.js
+++ b/src/components/StructuredData/DocsLandingSD.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { baseUrl } from '../../utils/base-url';
 
 const DocsLandingSD = () => (
-  <script id="structured data" type="application/ld+json">
+  <script type="application/ld+json">
     {JSON.stringify({
       '@context': 'http://schema.org',
       '@type': 'WebSite',

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -74,10 +74,10 @@ const Video = ({ nodeData: { argument, options = {} } }) => {
   // use placeholder image for video thumbnail if invalid URL provided
   const [previewImage, setPreviewImage] = useState(withPrefix('assets/meta_generic.png'));
   const { title, description, 'upload-date': uploadDate, 'thumbnail-url': thumbnailUrl } = options;
-  const videoObjectSd = useMemo(
-    () => new VideoObjectSd({ embedUrl: url, name: title, uploadDate, thumbnailUrl, description }),
-    [url, title, uploadDate, thumbnailUrl, description]
-  );
+  const videoObjectSd = useMemo(() => {
+    const sd = new VideoObjectSd({ embedUrl: url, name: title, uploadDate, thumbnailUrl, description });
+    return sd.isValid() ? sd.toString() : undefined;
+  }, [url, title, uploadDate, thumbnailUrl, description]);
 
   useEffect(() => {
     // handles URL validity checking for well-formed YT links
@@ -111,7 +111,7 @@ const Video = ({ nodeData: { argument, options = {} } }) => {
 
   return (
     <>
-      {videoObjectSd.isValid() && (
+      {videoObjectSd && (
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -115,7 +115,7 @@ const Video = ({ nodeData: { argument, options = {} } }) => {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: videoObjectSd.toString(),
+            __html: videoObjectSd,
           }}
         />
       )}

--- a/src/utils/get-language.js
+++ b/src/utils/get-language.js
@@ -59,7 +59,7 @@ export const getLanguage = (lang) => {
  * @returns {string | undefined} The formal name of the language, if it exists
  */
 export const getFullLanguageName = (lang) => {
-  if (!lang) {
+  if (!lang || lang === 'none') {
     return undefined;
   }
 

--- a/src/utils/get-language.js
+++ b/src/utils/get-language.js
@@ -63,7 +63,7 @@ export const getFullLanguageName = (lang) => {
     return undefined;
   }
 
-  const fullLangName = LANGUAGE_NAMES[lang];
+  const fullLangName = LANGUAGE_NAMES.hasOwnProperty(lang) ? LANGUAGE_NAMES[lang] : undefined;
   if (!fullLangName) {
     console.warn(`${lang} does not have a valid language name for structured data SEO. Please contact DOP to add.`);
   }

--- a/src/utils/get-language.js
+++ b/src/utils/get-language.js
@@ -3,6 +3,44 @@
  */
 import { Language } from '@leafygreen-ui/code';
 
+// Mapping of formal language names based on loose inputs
+const LANGUAGE_NAMES = {
+  bash: 'Bash',
+  c: 'C',
+  cpp: 'C++',
+  'c#': 'C#',
+  cs: 'C#',
+  csharp: 'C#',
+  dart: 'Dart',
+  diff: 'Diff',
+  go: 'Golang',
+  graphql: 'GraphQL',
+  html: 'HTML',
+  http: 'HTTP',
+  ini: 'Ini',
+  java: 'Java',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  json: 'JSON',
+  kotlin: 'Kotlin',
+  objectivec: 'Objective-C',
+  perl: 'Perl',
+  php: 'PHP',
+  properties: 'Properties',
+  python: 'Python',
+  ruby: 'Ruby',
+  rust: 'Rust',
+  scala: 'Scala',
+  sh: 'Shell',
+  shell: 'Shell',
+  sql: 'SQL',
+  swift: 'Swift',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+  xml: 'XML',
+  yaml: 'YAML',
+};
+
 export const getLanguage = (lang) => {
   if (Object.values(Language).includes(lang)) {
     return lang;
@@ -14,4 +52,15 @@ export const getLanguage = (lang) => {
     return 'cs';
   }
   return 'none';
+};
+
+/**
+ * @param {string} lang The language passed to the code block directive
+ * @returns {string | undefined} The formal name of the language, if it exists
+ */
+export const getFullLanguageName = (lang) => {
+  if (!lang) {
+    return undefined;
+  }
+  return LANGUAGE_NAMES[lang];
 };

--- a/src/utils/get-language.js
+++ b/src/utils/get-language.js
@@ -62,5 +62,11 @@ export const getFullLanguageName = (lang) => {
   if (!lang) {
     return undefined;
   }
-  return LANGUAGE_NAMES[lang];
+
+  const fullLangName = LANGUAGE_NAMES[lang];
+  if (!fullLangName) {
+    console.warn(`${lang} does not have a valid language name for structured data SEO. Please contact DOP to add.`);
+  }
+
+  return fullLangName;
 };

--- a/src/utils/get-language.js
+++ b/src/utils/get-language.js
@@ -14,7 +14,9 @@ const LANGUAGE_NAMES = {
   dart: 'Dart',
   diff: 'Diff',
   go: 'Golang',
+  golang: 'Golang',
   graphql: 'GraphQL',
+  groovy: 'Groovy',
   html: 'HTML',
   http: 'HTTP',
   ini: 'Ini',
@@ -55,17 +57,20 @@ export const getLanguage = (lang) => {
 };
 
 /**
- * @param {string} lang The language passed to the code block directive
+ * @param {string | undefined} lang The language passed to the code block directive
  * @returns {string | undefined} The formal name of the language, if it exists
  */
-export const getFullLanguageName = (lang) => {
-  if (!lang || lang === 'none') {
+export const getFullLanguageName = (lang, slug) => {
+  const normalizedLang = lang?.toLowerCase();
+  if (!normalizedLang || ['none', 'text'].includes(normalizedLang)) {
     return undefined;
   }
 
-  const fullLangName = LANGUAGE_NAMES.hasOwnProperty(lang) ? LANGUAGE_NAMES[lang] : undefined;
+  const fullLangName = LANGUAGE_NAMES.hasOwnProperty(normalizedLang) ? LANGUAGE_NAMES[normalizedLang] : undefined;
   if (!fullLangName) {
-    console.warn(`${lang} does not have a valid language name for structured data SEO. Please contact DOP to add.`);
+    console.warn(
+      `${normalizedLang} in ${slug} does not have a valid language name for structured data SEO. Please contact DOP to add.`
+    );
   }
 
   return fullLangName;

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -55,6 +55,16 @@ export class StructuredData {
   }
 }
 
+class HowToSd extends StructuredData {
+  constructor({ steps }) {
+    super('HowTo');
+
+    this.steps = steps;
+    // TODO: DOP-5040
+    // include name and default image
+  }
+}
+
 export class SoftwareSourceCodeSd extends StructuredData {
   constructor({ code, lang }) {
     super('SoftwareSourceCode');
@@ -68,7 +78,7 @@ export class SoftwareSourceCodeSd extends StructuredData {
   }
 }
 
-export class TechArticleSd extends StructuredData {
+class TechArticleSd extends StructuredData {
   constructor({ headline, mainEntity, genre }) {
     super('TechArticle');
 
@@ -161,16 +171,6 @@ export const constructTechArticle = ({ facets, pageTitle }) => {
 
   return new TechArticleSd(techArticleProps);
 };
-
-class HowToSd extends StructuredData {
-  constructor({ steps }) {
-    super('HowTo');
-
-    this.steps = steps;
-    // TODO: DOP-5040
-    // include name and default image
-  }
-}
 
 export const constructHowToSd = ({ steps }) => {
   function getHowToSection(procedureDirective, name) {

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -1,0 +1,63 @@
+/**
+ * Classes to construct Structured Data JSON.
+ * Required props should be read in constructor function (to fail validity).
+ * Optional props can be set conditionally.
+ * Constant values should be set in the constructor function.
+ * Optional overwrites can be set in params as default values
+ */
+
+import { getFullLanguageName } from './get-language';
+
+export class StructuredData {
+  constructor(type) {
+    this['@context'] = 'https://schema.org';
+    this['@type'] = type;
+  }
+
+  isValid() {
+    function recursiveValidity(param) {
+      // array
+      if (Array.isArray(param)) {
+        return param.every((e) => recursiveValidity(e));
+      }
+      // object
+      else if (param && typeof param === 'object') {
+        return Object.keys(param).every((e) => {
+          if (param.hasOwnProperty(e)) return recursiveValidity(param[e]);
+          return true;
+        });
+      }
+
+      // string or number
+      return String(param).length > 0;
+    }
+
+    return recursiveValidity(this);
+  }
+
+  toString() {
+    return JSON.stringify(this);
+  }
+
+  static addCompanyToName(name) {
+    if (!name) {
+      return name;
+    }
+    if (Array.isArray(name)) {
+      return name.map(this.addCompanyToName);
+    }
+    if (name.toLowerCase().includes('mongodb')) {
+      return name;
+    }
+    return `MongoDB ` + name;
+  }
+}
+
+export class SoftwareSourceCodeSd extends StructuredData {
+  constructor({ code, lang }) {
+    super('SoftwareSourceCode');
+    this.codeSampleType = 'code snippet';
+    this.programmingLanguage = getFullLanguageName(lang);
+    this.text = code;
+  }
+}

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -57,7 +57,11 @@ export class SoftwareSourceCodeSd extends StructuredData {
   constructor({ code, lang }) {
     super('SoftwareSourceCode');
     this.codeSampleType = 'code snippet';
-    this.programmingLanguage = getFullLanguageName(lang);
     this.text = code;
+
+    const programmingLanguage = getFullLanguageName(lang);
+    if (programmingLanguage) {
+      this.programmingLanguage = programmingLanguage;
+    }
   }
 }

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -65,3 +65,23 @@ export class SoftwareSourceCodeSd extends StructuredData {
     }
   }
 }
+
+export class VideoObjectSd extends StructuredData {
+  constructor({ embedUrl, name, uploadDate, thumbnailUrl, description }) {
+    super('VideoObject');
+
+    this.embedUrl = embedUrl;
+    this.name = name;
+    this.uploadDate = uploadDate;
+    this.thumbnailUrl = thumbnailUrl;
+
+    if (description) {
+      this.description = description;
+    }
+  }
+
+  isValid() {
+    const hasAllReqFields = [this.embedUrl, this.name, this.uploadDate, this.thumbnailUrl].every((val) => !!val);
+    return hasAllReqFields && super.isValid();
+  }
+}

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -66,12 +66,12 @@ class HowToSd extends StructuredData {
 }
 
 export class SoftwareSourceCodeSd extends StructuredData {
-  constructor({ code, lang }) {
+  constructor({ code, lang, slug }) {
     super('SoftwareSourceCode');
     this.codeSampleType = 'code snippet';
     this.text = code;
 
-    const programmingLanguage = getFullLanguageName(lang);
+    const programmingLanguage = getFullLanguageName(lang, slug);
     if (programmingLanguage) {
       this.programmingLanguage = programmingLanguage;
     }

--- a/tests/unit/CodeIO.test.js
+++ b/tests/unit/CodeIO.test.js
@@ -15,16 +15,16 @@ describe('CodeIO', () => {
   it('closes and opens output code snippet on io button click when output is visible by default', () => {
     const wrapper = render(<CodeIO nodeData={mockData.outputVisibleByDefault} />);
     userEvent.click(wrapper.getByRole('button'));
-    expect(wrapper.queryAllByText('hello world')).toHaveLength(0);
+    expect(wrapper.getByText('hello world')).not.toBeVisible();
     userEvent.click(wrapper.getByRole('button'));
-    expect(wrapper.getByText('hello world')).toBeTruthy();
+    expect(wrapper.getByText('hello world')).toBeVisible();
   });
 
   it('opens and closes output code snippet on io button click when output is hidden by default', () => {
     const wrapper = render(<CodeIO nodeData={mockData.outputHiddenByDefault} />);
     userEvent.click(wrapper.getByRole('button'));
-    expect(wrapper.getByText('hello world')).toBeTruthy();
+    expect(wrapper.getByText('hello world')).toBeVisible();
     userEvent.click(wrapper.getByRole('button'));
-    expect(wrapper.queryAllByText('hello world')).toHaveLength(0);
+    expect(wrapper.getByText('hello world')).not.toBeVisible();
   });
 });

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"mongoimport --db test --collection inventory ^\\n          --authenticationDatabase admin --username &lt;user&gt; --password &lt;password&gt; ^\\n          --drop --file ~\\\\downloads\\\\inventory.crud.json","programmingLanguage":"JavaScript"}
+  </script>
   .emotion-0 {
   display: table;
   margin: 24px 0;
@@ -402,6 +407,11 @@ exports[`renders correctly 1`] = `
 
 exports[`renders correctly when none is passed in as a language 1`] = `
 <DocumentFragment>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"[{plot A trio of guys try and make up for missed opportunities in childhood by forming a three-player baseball team to compete against standard children baseball squads.}]"}
+  </script>
   .emotion-0 {
   display: table;
   margin: 24px 0;

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -505,33 +505,33 @@ exports[`CodeIO renders correctly 1`] = `
   justify-self: right;
 }
 
-.emotion-21>div>* {
+.emotion-22>div>* {
   display: inline!important;
 }
 
-.emotion-21 * {
+.emotion-22 * {
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;
   border-bottom-right-radius: 12px;
   border-bottom-left-radius: 12px;
 }
 
-.emotion-21>div {
+.emotion-22>div {
   border: var(--code-container-border);
 }
 
-.emotion-21>div>div>pre {
+.emotion-22>div>div>pre {
   border: var(--code-pre-border);
   border-top: none;
 }
 
-.emotion-23 {
+.emotion-24 {
   border: 1px solid #3D4F58;
   border-radius: 12px;
   overflow: hidden;
 }
 
-.emotion-24 {
+.emotion-25 {
   position: relative;
   display: grid;
   grid-template-areas: 'code panel';
@@ -541,8 +541,8 @@ exports[`CodeIO renders correctly 1`] = `
   grid-template-areas: 'code code';
 }
 
-.emotion-24:before,
-.emotion-24:after {
+.emotion-25:before,
+.emotion-25:after {
   content: '';
   display: block;
   position: absolute;
@@ -556,20 +556,20 @@ exports[`CodeIO renders correctly 1`] = `
   transition: box-shadow 100ms ease-in-out;
 }
 
-.emotion-24:before {
+.emotion-25:before {
   grid-column: 1;
   left: -40px;
 }
 
-.emotion-24:after {
+.emotion-25:after {
   grid-column: 2;
 }
 
-.emotion-24:after {
+.emotion-25:after {
   grid-column: -1;
 }
 
-.emotion-25 {
+.emotion-26 {
   grid-area: code;
   overflow-x: auto;
   border-radius: inherit;
@@ -602,45 +602,45 @@ exports[`CodeIO renders correctly 1`] = `
 }
 
 @media only screen and (max-device-width: 812px) and (-webkit-min-device-pixel-ratio: 2) {
-  .emotion-25 {
+  .emotion-26 {
     white-space: pre-wrap;
   }
 }
 
 @media only screen and (min-device-width: 813px) and (-webkit-min-device-pixel-ratio: 2) {
-  .emotion-25 {
+  .emotion-26 {
     white-space: pre;
   }
 }
 
-.emotion-25:focus-visible {
+.emotion-26:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #0498EC inset;
 }
 
-.emotion-28 {
+.emotion-29 {
   background-color: transparent;
   background-image: linear-gradient(90deg, #1C2D38, #001E2B);
   background-attachment: fixed;
 }
 
-.emotion-28>td {
+.emotion-29>td {
   border-top: 1px solid #1C2D38;
 }
 
-.emotion-28+tr>td {
+.emotion-29+tr>td {
   border-top: 1px solid #1C2D38;
 }
 
-.emotion-28+.emotion-28>td {
+.emotion-29+.emotion-29>td {
   border-top: 0;
 }
 
-.emotion-28:last-child>td {
+.emotion-29:last-child>td {
   border-bottom: 1px solid #1C2D38;
 }
 
-.emotion-29 {
+.emotion-30 {
   border-spacing: 0;
   vertical-align: top;
   padding: 0 16px;
@@ -771,44 +771,53 @@ exports[`CodeIO renders correctly 1`] = `
       </button>
     </div>
     <div
-      class="emotion-21 emotion-22"
-      style="--code-container-border: initial; --code-pre-border: none;"
+      class="emotion-21"
     >
+      <script
+        type="application/ld+json"
+      >
+        {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"hello world","programmingLanguage":"Python"}
+      </script>
       <div
-        class="emotion-23"
+        class="emotion-22 emotion-23"
+        style="--code-container-border: initial; --code-pre-border: none;"
       >
         <div
           class="emotion-24"
         >
-          <pre
+          <div
             class="emotion-25"
-            tabindex="-1"
           >
-            <code
-              class="lg-highlight-hljs-dark python emotion-9"
+            <pre
+              class="emotion-26"
+              tabindex="-1"
             >
-              <table
-                class="emotion-10"
+              <code
+                class="lg-highlight-hljs-dark python emotion-9"
               >
-                <tbody>
-                  <tr
-                    class="emotion-28"
-                  >
-                    <td
+                <table
+                  class="emotion-10"
+                >
+                  <tbody>
+                    <tr
                       class="emotion-29"
                     >
-                      1
-                    </td>
-                    <td
-                      class="emotion-13"
-                    >
-                      hello world
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </code>
-          </pre>
+                      <td
+                        class="emotion-30"
+                      >
+                        1
+                      </td>
+                      <td
+                        class="emotion-13"
+                      >
+                        hello world
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </code>
+            </pre>
+          </div>
         </div>
       </div>
     </div>

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -657,6 +657,11 @@ exports[`CodeIO renders correctly 1`] = `
 <div
     class="emotion-0"
   >
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"print('hello world')","programmingLanguage":"Python"}
+    </script>
     <div
       class="emotion-1"
     >

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -586,6 +586,11 @@ exports[`collapsible component renders all the content in the options and childr
       >
         This is collapsible content
       </p>
+      <script
+        type="application/ld+json"
+      >
+        {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"This is code within collapsible content","programmingLanguage":"JavaScript"}
+      </script>
       <div
         class="emotion-12"
       >

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"sample code","programmingLanguage":"Java"}
+  </script>
   .emotion-0 {
   display: table;
   margin: 24px 0;

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`renders correctly 1`] = `
 <DocumentFragment>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"test code"}
+  </script>
   .emotion-0 {
   display: table;
   margin: 24px 0;

--- a/tests/unit/utils/__snapshots__/structured-data.test.js.snap
+++ b/tests/unit/utils/__snapshots__/structured-data.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SoftwareSourceCode returns valid structured data with programmingLanguage 1`] = `
+SoftwareSourceCodeSd {
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeSampleType": "code snippet",
+  "text": "print("hello world")",
+}
+`;
+
+exports[`SoftwareSourceCode returns valid structured data without programmingLangauge 1`] = `
+SoftwareSourceCodeSd {
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "codeSampleType": "code snippet",
+  "text": "print("hello world")",
+}
+`;

--- a/tests/unit/utils/__snapshots__/structured-data.test.js.snap
+++ b/tests/unit/utils/__snapshots__/structured-data.test.js.snap
@@ -17,3 +17,26 @@ SoftwareSourceCodeSd {
   "text": "print("hello world")",
 }
 `;
+
+exports[`VideoObject returns valid structured data with description 1`] = `
+VideoObjectSd {
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "description": "Learn more about indexes in Atlas Search",
+  "embedUrl": "https://www.youtube.com/embed/XrJG994YxD8",
+  "name": "Mastering Indexing for Perfect Query Matching",
+  "thumbnailUrl": "https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg",
+  "uploadDate": "2023-11-08T05:00:28-08:00",
+}
+`;
+
+exports[`VideoObject returns valid structured data without description 1`] = `
+VideoObjectSd {
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "embedUrl": "https://www.youtube.com/embed/XrJG994YxD8",
+  "name": "Mastering Indexing for Perfect Query Matching",
+  "thumbnailUrl": "https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg",
+  "uploadDate": "2023-11-08T05:00:28-08:00",
+}
+`;

--- a/tests/unit/utils/structured-data.test.js
+++ b/tests/unit/utils/structured-data.test.js
@@ -1,0 +1,16 @@
+import { SoftwareSourceCodeSd } from '../../../src/utils/structured-data';
+
+describe('SoftwareSourceCode', () => {
+  it('returns valid structured data with programmingLanguage', () => {
+    const code = 'print("hello world")';
+    const lang = 'py';
+    const softwareSourceCodeSd = new SoftwareSourceCodeSd({ code, lang });
+    expect(softwareSourceCodeSd).toMatchSnapshot();
+  });
+
+  it('returns valid structured data without programmingLangauge', () => {
+    const code = 'print("hello world")';
+    const softwareSourceCodeSd = new SoftwareSourceCodeSd({ code });
+    expect(softwareSourceCodeSd).toMatchSnapshot();
+  });
+});

--- a/tests/unit/utils/structured-data.test.js
+++ b/tests/unit/utils/structured-data.test.js
@@ -1,16 +1,43 @@
-import { SoftwareSourceCodeSd } from '../../../src/utils/structured-data';
+import { SoftwareSourceCodeSd, VideoObjectSd } from '../../../src/utils/structured-data';
 
 describe('SoftwareSourceCode', () => {
   it('returns valid structured data with programmingLanguage', () => {
     const code = 'print("hello world")';
     const lang = 'py';
     const softwareSourceCodeSd = new SoftwareSourceCodeSd({ code, lang });
+    expect(softwareSourceCodeSd.isValid()).toBeTruthy();
     expect(softwareSourceCodeSd).toMatchSnapshot();
   });
 
   it('returns valid structured data without programmingLangauge', () => {
     const code = 'print("hello world")';
     const softwareSourceCodeSd = new SoftwareSourceCodeSd({ code });
+    expect(softwareSourceCodeSd.isValid()).toBeTruthy();
     expect(softwareSourceCodeSd).toMatchSnapshot();
+  });
+});
+
+describe('VideoObject', () => {
+  const embedUrl = 'https://www.youtube.com/embed/XrJG994YxD8';
+  const name = 'Mastering Indexing for Perfect Query Matching';
+  const uploadDate = '2023-11-08T05:00:28-08:00';
+  const thumbnailUrl = 'https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg';
+  const description = 'Learn more about indexes in Atlas Search';
+
+  it('returns valid structured data with description', () => {
+    const videoObjectSd = new VideoObjectSd({ embedUrl, name, uploadDate, thumbnailUrl, description });
+    expect(videoObjectSd.isValid()).toBeTruthy();
+    expect(videoObjectSd).toMatchSnapshot();
+  });
+
+  it('returns valid structured data without description', () => {
+    const videoObjectSd = new VideoObjectSd({ embedUrl, name, uploadDate, thumbnailUrl });
+    expect(videoObjectSd.isValid()).toBeTruthy();
+    expect(videoObjectSd).toMatchSnapshot();
+  });
+
+  it('returns invalid structured data with missing name field', () => {
+    const videoObjectSd = new VideoObjectSd({ embedUrl, uploadDate, thumbnailUrl, description });
+    expect(videoObjectSd.isValid()).toBeFalsy();
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-4916

### Current Behavior:

* [Different language examples](https://www.mongodb.com/docs/atlas/driver-connection/)
* [IO code block examples](https://www.mongodb.com/docs/atlas/atlas-search/compound/)
* [No language example](https://www.mongodb.com/docs/atlas/billing/)

### Staging Links:

Google doesn't care about `SoftwareSourceCode`, so they're not present in Rich Results.

* [Different language examples](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-4916-software-source-code/driver-connection/index.html)
  * [Validator](https://validator.schema.org/#url=https%3A%2F%2Fdocs-mongodb-org-stg.s3.us-east-2.amazonaws.com%2Fsandbox%2Fcloud-docs%2Fraymund.rodriguez%2FDOP-4916-software-source-code%2Fdriver-connection%2Findex.html)
* [IO code block examples](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-4916-software-source-code/atlas-search/compound/index.html)
  * [Validator](https://validator.schema.org/#url=https%3A%2F%2Fdocs-mongodb-org-stg.s3.us-east-2.amazonaws.com%2Fsandbox%2Fcloud-docs%2Fraymund.rodriguez%2FDOP-4916-software-source-code%2Fatlas-search%2Fcompound%2Findex.html)
* [No language example](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-4916-software-source-code/billing/index.html)
  * [Validator](https://validator.schema.org/#url=https%3A%2F%2Fdocs-mongodb-org-stg.s3.us-east-2.amazonaws.com%2Fsandbox%2Fcloud-docs%2Fraymund.rodriguez%2FDOP-4916-software-source-code%2Fbilling%2Findex.html)

### Notes:

* Implements `SoftwareSourceCode` structured data for code blocks, with `programmingLanguage` as optional. A new mapping of different full language names has been added here to help map languages from code blocks to more SEO-friendly names. Since we don't currently have a formal list of supported languages, I'm basing this off of what I've seen and what LeafyGreen supports.
* IO code blocks have been updated so that they're always in the HTML regardless if the output is shown on the screen or not. This allows robots to see the content, and the structured data together without needing interaction.

Ideally, these would be separate PRs, but I've added a few bonus changes based on related work. Let me know if you'd like me to create separate PRs!
* **Bonus:** Removed unnecessary IDs from structured data scripts. I originally added it to `VideoObject` because the Docs Landing SD had it, but it seems like it's not actually used for anything. Less code to worry about!
* **Bonus:** Restructured new `VideoObject` to adopt new `StructuredData` class introduced in #1249.
* **Bonus:** Fixed `BreadcrumbContainer` prop type. This reduces noisy console errors for local dev.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
