### PR TITLE
DOP-5028: Mobile Search filters page not scrollable and adjusts for banner

### DIFF
--- a/src/components/SearchResults/MobileFilters.js
+++ b/src/components/SearchResults/MobileFilters.js
@@ -5,6 +5,7 @@ import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
 import useStickyTopValues from '../../hooks/useStickyTopValues';
 import { theme } from '../../theme/docsTheme';
+import { HeaderContext } from '../Header/header-context';
 import SearchContext from './SearchContext';
 import SearchFilters from './SearchFilters';
 import { Facets } from './Facets';
@@ -13,7 +14,7 @@ import { Facets } from './Facets';
 // this component is mounted.
 const disableBodyScroll = css`
   body {
-    overflow: hidden;
+    overflow: hidden !important;
   }
 `;
 
@@ -50,7 +51,8 @@ const Label = styled('div')`
 `;
 
 const MobileFilters = ({ facets }) => {
-  const { topSmall } = useStickyTopValues(false, true);
+  const { bannerContent } = useContext(HeaderContext);
+  const { topSmall } = useStickyTopValues(false, true, !!bannerContent);
   const { setShowMobileFilters, showFacets } = useContext(SearchContext);
 
   const closeMobileFilters = useCallback(() => {


### PR DESCRIPTION
### Stories/Links:

DOP-5028

### Current Behavior:

[Prod Search](https://www.mongodb.com/docs/search/?q=find)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

In links above use a mobile viewport, click on Refine Your Search, and scroll.

In prod, the spacing is off because of the banner, and on scroll the user can see all search results oddly scrolling by at the top of the page.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
