### PR TITLE
DOP-5013: Upgrade chatbot UI to version `0.9.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "lodash": "^4.6.0",
         "minimist": "^1.2.6",
         "mobx": "^6.1.5",
-        "mongodb-chatbot-ui": "^0.8.1",
+        "mongodb-chatbot-ui": "^0.9.0",
         "no-scroll": "^2.1.1",
         "node-fetch": "^3.3.2",
         "node-gyp": "^10.1.0",
@@ -23433,9 +23433,9 @@
       }
     },
     "node_modules/mongodb-chatbot-ui": {
-      "version": "0.8.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.8.1.tgz",
-      "integrity": "sha512-znvBMmXcW1bxk2YOehGW8q+X5zQ1ztmIXVsy+MxL9oa1exJg2BCh5QuqRtTynBTWpOzDtJddfdmSg/2TTFv90g==",
+      "version": "0.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.9.0.tgz",
+      "integrity": "sha512-IV3ltrTwfYVcy6Oj7ZXJ4aHIC/vZY4sOLRaKlPoAiU2oHuIKtUlHkVxfxyvwS+Uwk1pEpv/+jAC6EEKdn2wlBA==",
       "bundleDependencies": [
         "mongodb-rag-core"
       ],
@@ -47650,9 +47650,9 @@
       "version": "2.29.4"
     },
     "mongodb-chatbot-ui": {
-      "version": "0.8.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.8.1.tgz",
-      "integrity": "sha512-znvBMmXcW1bxk2YOehGW8q+X5zQ1ztmIXVsy+MxL9oa1exJg2BCh5QuqRtTynBTWpOzDtJddfdmSg/2TTFv90g==",
+      "version": "0.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.9.0.tgz",
+      "integrity": "sha512-IV3ltrTwfYVcy6Oj7ZXJ4aHIC/vZY4sOLRaKlPoAiU2oHuIKtUlHkVxfxyvwS+Uwk1pEpv/+jAC6EEKdn2wlBA==",
       "requires": {
         "@emotion/css": "^11.11.2",
         "@leafygreen-ui/badge": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lodash": "^4.6.0",
     "minimist": "^1.2.6",
     "mobx": "^6.1.5",
-    "mongodb-chatbot-ui": "^0.8.1",
+    "mongodb-chatbot-ui": "^0.9.0",
     "no-scroll": "^2.1.1",
     "node-fetch": "^3.3.2",
     "node-gyp": "^10.1.0",


### PR DESCRIPTION
### Stories/Links:

DOP-5013

### Current Behavior:

[Landing](https://www.mongodb.com/docs/)
[Cloud-docs](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4683/landing/maya/DOP-5013/index.html)
[Cloud-docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4973-example/cloud-docs/maya/DOP-5013/index.html)

As it says in the ticket - to test, ensure that the input character limit is 3000 instead of 300. There should be no other changes.

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
