### PR TITLE
DOP-5016: Links in footnote can have inconsistent font size

### DIFF
--- a/src/components/Footnote/index.js
+++ b/src/components/Footnote/index.js
@@ -12,8 +12,12 @@ const tableStyling = (darkMode) => css`
   border: 0;
   border-collapse: collapse;
   margin: 24px 0;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 24px;
+
+  tbody tr td a {
+    font-size: 13px;
+  }
 
   tbody tr td div.highlight pre {
     background-color: inherit;

--- a/src/components/Footnote/index.js
+++ b/src/components/Footnote/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
+import { theme } from '../../theme/docsTheme';
 import ComponentFactory from '../ComponentFactory';
 import { getNestedValue } from '../../utils/get-nested-value';
 import { intersperse } from '../../utils/intersperse';
@@ -12,11 +13,11 @@ const tableStyling = (darkMode) => css`
   border: 0;
   border-collapse: collapse;
   margin: 24px 0;
-  font-size: 13px;
+  font-size: ${theme.fontSize.small};
   line-height: 24px;
 
   tbody tr td a {
-    font-size: 13px;
+    font-size: ${theme.fontSize.small};
   }
 
   tbody tr td div.highlight pre {

--- a/tests/unit/__snapshots__/Footnote.test.js.snap
+++ b/tests/unit/__snapshots__/Footnote.test.js.snap
@@ -6,8 +6,12 @@ exports[`renders correctly 1`] = `
   border: 0;
   border-collapse: collapse;
   margin: 24px 0;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 24px;
+}
+
+.emotion-0 tbody tr td a {
+  font-size: 13px;
 }
 
 .emotion-0 tbody tr td div.highlight pre {


### PR DESCRIPTION
### Stories/Links:

DOP-5016

Updating font size for both text and links to be 13px; see [Slack thread here](https://mongodb.slack.com/archives/C04L4BVFEM9/p1728051297579989)

### Current Behavior:

[Example 1](https://www.mongodb.com/docs/atlas/reference/microsoft-azure/#footnote-azure-disk-docs)
[Example 2](https://www.mongodb.com/docs/atlas/unsupported-commands/#ref-1-id4)

### Staging Links:

[Example 1](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4973-example/cloud-docs/maya/DOP-5016/reference/microsoft-azure/index.html#footnote-azure-disk-docs)
[Example 2](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4973-example/cloud-docs/maya/DOP-5016/unsupported-commands/index.html#ref-1-id4)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
