### PR TITLE
DOP-5048: Ensure inline definition popover is visible

### DIFF
--- a/src/components/Roles/Abbr.js
+++ b/src/components/Roles/Abbr.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import InlineDefinition from '@leafygreen-ui/inline-definition';
+import { theme } from '../../theme/docsTheme';
 
 const Abbr = ({
   nodeData: {
@@ -17,7 +18,11 @@ const Abbr = ({
     expansion = expansion.split(')')[0];
     abbr = abbr.trim();
   }
-  return <InlineDefinition definition={expansion}>{abbr}</InlineDefinition>;
+  return (
+    <InlineDefinition popoverZIndex={theme.zIndexes.popovers} definition={expansion}>
+      {abbr}
+    </InlineDefinition>
+  );
 };
 
 Abbr.propTypes = {

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -94,7 +94,7 @@ const zIndexes = {
   sidenav: 900,
   header: 1000,
   widgets: 2000,
-  popovers: 9999,
+  popovers: 10000,
 };
 
 // media queries that define system color preference

--- a/src/theme/docsTheme.js
+++ b/src/theme/docsTheme.js
@@ -94,6 +94,7 @@ const zIndexes = {
   sidenav: 900,
   header: 1000,
   widgets: 2000,
+  popovers: 9999,
 };
 
 // media queries that define system color preference


### PR DESCRIPTION
### Stories/Links:

DOP-5048

### Current Behavior:

* [Atlas prod](https://mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/index.html#atlas-vector-search-queries)

### Staging Links:

* [Atlas staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-5048-inline-def-visibility/atlas-vector-search/vector-search-overview/index.html#atlas-vector-search-queries)

### Notes:

* Just a simple z-index fix. Created a new `popovers` field for z-indexes in our themes file. I chose a high number that could potentially serve as our maximum, if needed, but happy to tone it down if it seems too much.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
