### PR TITLE
DOP-5038: add segment tracking to dark mode controls

### DIFF
--- a/src/components/ActionBar/DarkModeDropdown.js
+++ b/src/components/ActionBar/DarkModeDropdown.js
@@ -8,6 +8,7 @@ import { theme } from '../../theme/docsTheme';
 import IconDarkmode from '../icons/DarkMode';
 import useScreenSize from '../../hooks/useScreenSize';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
+import { reportAnalytics } from '../../utils/report-analytics';
 import DarkModeGuideCue from './DarkModeGuideCue';
 import { DEPRECATED_PROJECTS } from './ActionBar';
 
@@ -43,6 +44,9 @@ const DarkModeDropdown = () => {
 
   const select = useCallback(
     (selectedPref) => {
+      reportAnalytics('DarkModeSelection', {
+        value: selectedPref,
+      });
       setDarkModePref(selectedPref);
       setOpen(false);
     },
@@ -62,7 +66,12 @@ const DarkModeDropdown = () => {
           justify={justify}
           align={'bottom'}
           open={open}
-          setOpen={setOpen}
+          setOpen={() => {
+            reportAnalytics('DarkModeMenu', {
+              action: open ? 'closed' : 'opened',
+            });
+            setOpen((e) => !e);
+          }}
           trigger={
             <IconButton className={cx(iconStyling)} aria-label="Dark Mode Menu" aria-labelledby="Dark Mode Menu">
               {darkModePref === 'system' ? (


### PR DESCRIPTION
### Stories/Links:

DOP-5038

### Current Behavior:

[docs landing without tracking](https://www.mongodb.com/docs/)

### Staging Links:

[staging link with user tracking](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-5038/index.html)

### Notes:
- To test, you can visit the live debugger for [segment actions](https://app.segment.com/mongodb/sources/docs/debugger) and visit the above staging link to test the analytics:

![image](https://github.com/user-attachments/assets/fb516fe5-b5b7-48ec-9b03-a976d59d69b3)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
