### PR TITLE
DOP-5059: Default expanded Collapsibles

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -16,7 +16,7 @@ import { collapsibleStyle, headerContainerStyle, headerStyle, iconStyle, innerCo
 import './styles.css';
 
 const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest }) => {
-  const { id, heading, sub_heading: subHeading } = options;
+  const { id, heading, expanded, sub_heading: subHeading } = options;
   const { hash } = useLocation();
 
   // get a list of all ids in collapsible content
@@ -25,7 +25,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(!!options.expanded);
+  const [open, setOpen] = useState(!!expanded);
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -25,7 +25,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(!!options.expanded);
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],

--- a/tests/unit/Collapsible.test.js
+++ b/tests/unit/Collapsible.test.js
@@ -4,6 +4,7 @@ import { render, act } from '@testing-library/react';
 import { mockLocation } from '../utils/mock-location';
 import Collapsible from '../../src/components/Collapsible';
 import mockData from './data/Collapsible.test.json';
+import expandedMockData from './data/CollapsibleExpanded.test.json';
 
 describe('collapsible component', () => {
   it('renders all the content in the options and children', () => {
@@ -37,6 +38,14 @@ describe('collapsible component', () => {
   it('opens the collapsible content if hash is found in the URL', async () => {
     mockLocation(null, '/', '#this-is-a-heading');
     let renderResult = render(<Collapsible nodeData={mockData}></Collapsible>),
+      button = renderResult.getByRole('button'),
+      icon = button.querySelector('[role=img]');
+    expect(icon.getAttribute('aria-label')).toContain('Chevron');
+    expect(icon.getAttribute('aria-label')).toContain('Down');
+  });
+
+  it('is default expanded if expanded option is truthy', async () => {
+    const renderResult = render(<Collapsible nodeData={expandedMockData} />),
       button = renderResult.getByRole('button'),
       icon = button.querySelector('[role=img]');
     expect(icon.getAttribute('aria-label')).toContain('Chevron');

--- a/tests/unit/data/CollapsibleExpanded.test.json
+++ b/tests/unit/data/CollapsibleExpanded.test.json
@@ -1,0 +1,59 @@
+{
+    "type": "directive",
+    "position": {
+       "start": {
+          "line": {
+             "$numberInt": "13"
+          }
+       }
+    },
+    "children": [
+       {
+          "type": "paragraph",
+          "position": {
+             "start": {
+                "line": {
+                   "$numberInt": "17"
+                }
+             }
+          },
+          "children": [
+             {
+                "type": "text",
+                "position": {
+                   "start": {
+                      "line": {
+                         "$numberInt": "17"
+                      }
+                   }
+                },
+                "value": "This is collapsible content"
+             }
+          ]
+       },
+       {
+          "type": "code",
+          "position": {
+             "start": {
+                "line": {
+                   "$numberInt": "19"
+                }
+             }
+          },
+          "lang": "javascript",
+          "copyable": true,
+          "emphasize_lines": [],
+          "value": "This is code within collapsible content",
+          "linenos": false
+       }
+    ],
+    "domain": "mongodb",
+    "name": "collapsible",
+    "argument": [],
+    "options": {
+       "heading": "This is a heading",
+       "sub_heading": "This is a subheading",
+       "expanded": true,
+       "id": "this-is-a-heading"
+    }
+ }


### PR DESCRIPTION
### Stories/Links:

DOP-5059

### Current Behavior:

No current collapsibles in prod, I don't thiiiiink?
[Staging with collapsibles in old build](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4690/docs-test-spark/seung.park/DOP-4691/dop-4690/index.html)

### Staging Links:

[New staging with three collapsibles](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-5059-expanded/launch-manage/index.html) (first and third are expanded by default)

### Notes:

Partner PR in parser [here](https://github.com/mongodb/snooty-parser/pull/626)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
