### PR TITLE
DOP-5095: Add structured_data class name to script tags

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -12,7 +12,7 @@ import { TabContext } from '../Tabs/tab-context';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { getLanguage } from '../../utils/get-language';
 import { DRIVER_ICON_MAP } from '../icons/DriverIconMap';
-import { SoftwareSourceCodeSd } from '../../utils/structured-data';
+import { STRUCTURED_DATA_CLASSNAME, SoftwareSourceCodeSd } from '../../utils/structured-data';
 import { usePageContext } from '../../context/page-context';
 import { baseCodeStyle, borderCodeStyle, lgStyles } from './styles/codeStyle';
 import { CodeContext } from './code-context';
@@ -97,6 +97,7 @@ const Code = ({
     <>
       {softwareSourceCodeSd && (
         <script
+          className={STRUCTURED_DATA_CLASSNAME}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: softwareSourceCodeSd,

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -5,7 +5,7 @@ import { default as CodeBlock } from '@leafygreen-ui/code';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import { getLanguage } from '../../utils/get-language';
-import { SoftwareSourceCodeSd } from '../../utils/structured-data';
+import { STRUCTURED_DATA_CLASSNAME, SoftwareSourceCodeSd } from '../../utils/structured-data';
 import { usePageContext } from '../../context/page-context';
 
 const OutputContainer = styled.div`
@@ -43,6 +43,7 @@ const Output = ({ nodeData: { children } }) => {
     <>
       {softwareSourceCodeSd && (
         <script
+          className={STRUCTURED_DATA_CLASSNAME}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: softwareSourceCodeSd,

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -11,7 +11,7 @@ import { getPlaintext } from '../utils/get-plaintext';
 import { getTemplate } from '../utils/get-template';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
 import { getSiteTitle } from '../utils/get-site-title';
-import { constructTechArticle } from '../utils/structured-data';
+import { STRUCTURED_DATA_CLASSNAME, constructTechArticle } from '../utils/structured-data';
 import { PageContext } from '../context/page-context';
 import { useBreadcrumbs } from '../hooks/use-breadcrumbs';
 import { isBrowser } from '../utils/is-browser';
@@ -237,7 +237,7 @@ export const Head = ({ pageContext, data }) => {
       {isDocsLandingHomepage && <DocsLandingSD />}
       {needsBreadcrumbs && <BreadcrumbSchema slug={slug} />}
       {techArticleSd && (
-        <script id={'tech-article-sd'} type="application/ld+json">
+        <script className={STRUCTURED_DATA_CLASSNAME} id={'tech-article-sd'} type="application/ld+json">
           {techArticleSd.toString()}
         </script>
       )}

--- a/src/components/Procedure/index.js
+++ b/src/components/Procedure/index.js
@@ -7,7 +7,7 @@ import {
   useAncestorComponentContext,
 } from '../../context/ancestor-components-context';
 import { theme } from '../../theme/docsTheme';
-import { constructHowToSd } from '../../utils/structured-data';
+import { STRUCTURED_DATA_CLASSNAME, constructHowToSd } from '../../utils/structured-data';
 import { useHeadingContext } from '../../context/heading-context';
 import Step from './Step';
 
@@ -76,7 +76,11 @@ const Procedure = ({ nodeData, ...rest }) => {
       {howToSd && (
         // using dangerouslySetInnerHTML as JSON is rendered with
         // encoded quotes at build time
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: howToSd }} />
+        <script
+          className={STRUCTURED_DATA_CLASSNAME}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: howToSd }}
+        />
       )}
       <StyledProcedure procedureStyle={style}>
         {steps.map((child, i) => (

--- a/src/components/StructuredData/BreadcrumbSchema.js
+++ b/src/components/StructuredData/BreadcrumbSchema.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { getCompleteBreadcrumbData, getFullBreadcrumbPath } from '../../utils/get-complete-breadcrumb-data.js';
 import { useBreadcrumbs } from '../../hooks/use-breadcrumbs';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
+import { STRUCTURED_DATA_CLASSNAME } from '../../utils/structured-data.js';
 
 const getBreadcrumbList = (breadcrumbs) =>
   breadcrumbs.map(({ path, title }, index) => {
@@ -34,7 +35,7 @@ const BreadcrumbSchema = ({ slug }) => {
   return (
     <>
       {Array.isArray(queriedCrumbs.breadcrumbs) && (
-        <script type="application/ld+json">
+        <script className={STRUCTURED_DATA_CLASSNAME} type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'BreadcrumbList',

--- a/src/components/StructuredData/DocsLandingSD.js
+++ b/src/components/StructuredData/DocsLandingSD.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { baseUrl } from '../../utils/base-url';
+import { STRUCTURED_DATA_CLASSNAME } from '../../utils/structured-data';
 
 const DocsLandingSD = () => (
-  <script type="application/ld+json">
+  <script className={STRUCTURED_DATA_CLASSNAME} type="application/ld+json">
     {JSON.stringify({
       '@context': 'http://schema.org',
       '@type': 'WebSite',

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -7,7 +7,7 @@ import { css } from '@emotion/react';
 import { palette } from '@leafygreen-ui/palette';
 import { withPrefix } from 'gatsby';
 import { theme } from '../../theme/docsTheme';
-import { VideoObjectSd } from '../../utils/structured-data';
+import { STRUCTURED_DATA_CLASSNAME, VideoObjectSd } from '../../utils/structured-data';
 import VideoPlayButton from './VideoPlayButton';
 
 // Imported both players to keep bundle size low and rendering the one associated to the URL being passed in
@@ -113,6 +113,7 @@ const Video = ({ nodeData: { argument, options = {} } }) => {
     <>
       {videoObjectSd && (
         <script
+          className={STRUCTURED_DATA_CLASSNAME}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: videoObjectSd,

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -10,6 +10,7 @@ import { getFullLanguageName } from './get-language';
 import { findKeyValuePair } from './find-key-value-pair';
 import { getPlaintext } from './get-plaintext';
 
+// Class name to help Smartling identify all structured data, if needed
 export const STRUCTURED_DATA_CLASSNAME = 'structured_data';
 
 export class StructuredData {

--- a/src/utils/structured-data.js
+++ b/src/utils/structured-data.js
@@ -10,6 +10,8 @@ import { getFullLanguageName } from './get-language';
 import { findKeyValuePair } from './find-key-value-pair';
 import { getPlaintext } from './get-plaintext';
 
+export const STRUCTURED_DATA_CLASSNAME = 'structured_data';
+
 export class StructuredData {
   constructor(type) {
     this['@context'] = 'https://schema.org';

--- a/tests/unit/__snapshots__/Code.test.js.snap
+++ b/tests/unit/__snapshots__/Code.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <script
+    class="structured_data"
     type="application/ld+json"
   >
     {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"mongoimport --db test --collection inventory ^\\n          --authenticationDatabase admin --username &lt;user&gt; --password &lt;password&gt; ^\\n          --drop --file ~\\\\downloads\\\\inventory.crud.json","programmingLanguage":"JavaScript"}
@@ -408,6 +409,7 @@ exports[`renders correctly 1`] = `
 exports[`renders correctly when none is passed in as a language 1`] = `
 <DocumentFragment>
   <script
+    class="structured_data"
     type="application/ld+json"
   >
     {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"[{plot A trio of guys try and make up for missed opportunities in childhood by forming a three-player baseball team to compete against standard children baseball squads.}]"}

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -658,6 +658,7 @@ exports[`CodeIO renders correctly 1`] = `
     class="emotion-0"
   >
     <script
+      class="structured_data"
       type="application/ld+json"
     >
       {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"print('hello world')","programmingLanguage":"Python"}
@@ -774,6 +775,7 @@ exports[`CodeIO renders correctly 1`] = `
       class="emotion-21"
     >
       <script
+        class="structured_data"
         type="application/ld+json"
       >
         {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"hello world","programmingLanguage":"Python"}

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -590,6 +590,7 @@ exports[`collapsible component renders all the content in the options and childr
         This is collapsible content
       </p>
       <script
+        class="structured_data"
         type="application/ld+json"
       >
         {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"This is code within collapsible content","programmingLanguage":"JavaScript"}

--- a/tests/unit/__snapshots__/LiteralInclude.test.js.snap
+++ b/tests/unit/__snapshots__/LiteralInclude.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <script
+    class="structured_data"
     type="application/ld+json"
   >
     {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"sample code","programmingLanguage":"Java"}

--- a/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
+++ b/tests/unit/__snapshots__/ReleaseSpecification.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <script
+    class="structured_data"
     type="application/ld+json"
   >
     {"@context":"https://schema.org","@type":"SoftwareSourceCode","codeSampleType":"code snippet","text":"test code"}


### PR DESCRIPTION
### Stories/Links:

DOP-5095

### Current Behavior:

[Atlas prod](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Atlas staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-5095-sd-class-name/index.html)

### Notes:

* No behavior change is expected. This should solely be an additive change recommended by the Smartling team, in case we need to target them in the future for whatever reason.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
