### PR TITLE
DOP-5083: Bugfix. Procedure text color in Dark Mode

### DIFF
--- a/src/components/Procedure/index.js
+++ b/src/components/Procedure/index.js
@@ -13,6 +13,12 @@ import Step from './Step';
 
 const StyledProcedure = styled('div')`
   margin-top: ${theme.size.default};
+
+  .dark-theme & {
+    color: ${palette.gray.light2};
+    background-color: ${palette.black};
+  }
+
   ${({ procedureStyle }) =>
     procedureStyle === 'connected' &&
     `
@@ -24,10 +30,6 @@ const StyledProcedure = styled('div')`
     }
  
   `}
-  ${({ darkMode }) =>
-    `
-    background-color: ${darkMode ? palette.black : 'initial'};
-    color: ${darkMode ? palette.gray.light2 : 'initial'};`}
 `;
 
 // Returns an array of all "step" nodes nested within the "procedure" node and nested "include" nodes

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -4,8 +4,11 @@ exports[`renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
+  background-color: #001E2B;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -226,8 +229,11 @@ exports[`renders steps nested in include nodes 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
+  background-color: #001E2B;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -795,8 +801,11 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin-top: 16px;
-  background-color: initial;
-  color: initial;
+}
+
+.dark-theme .emotion-0 {
+  color: #E8EDEB;
+  background-color: #001E2B;
 }
 
 .emotion-2 {


### PR DESCRIPTION
### Stories/Links:

DOP-5083

### Current Behavior:

[Current bug](https://www.mongodb.com/docs/atlas/tutorial/create-serverless-instance/#select-the-serverless-type) (be in dark mode, click Atlas UI tab, scroll down til text is unreadable)

### Staging Links:

[Staged Atlas](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5020-dark-mode-images/cloud-docs/matt.meigs/DOP-5083-dark-text/tutorial/create-serverless-instance/index.html)

### Notes:

darkMode was not being passed to component.

I reconfigured to use our newer approach anyway! No light mode flash.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
