### PR TITLE
DOP-5014: allow chatbot option consecutively

### DIFF
--- a/src/components/ActionBar/SearchMenu.js
+++ b/src/components/ActionBar/SearchMenu.js
@@ -52,6 +52,7 @@ const SearchMenu = forwardRef(function SearchMenu(
       type: isChatbotRes ? 'chatbot' : 'docs-search',
       query: searchValue,
     });
+    setSelectedResult(undefined);
     if (isChatbotRes) {
       return handleSubmit(searchValue).catch((e) => console.error(e));
     }


### PR DESCRIPTION
### Stories/Links:

DOP-5014

### Current Behavior:

[Current behavior on docs shows that you cannot choose chatbot twice in a row](https://www.mongodb.com/docs/)

https://github.com/user-attachments/assets/d5fe32fb-deb9-4ab5-8ccc-969d93e86ad9

### Staging Links:

[Staging link with minimal changes](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/seung.park/DOP-5014/index.html)
Above link works with multiple times of selecting the chatbot option

### Notes:
- This was due not triggering the useEffect watching for changes on selectedOption, because selectedOption was persisted as the same option. This small PR resets the selectedOption when any option is selected, to enable the trigger.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
