### PR TITLE
Update build.sh parser version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 TESTING_CONTENT_REPO=docs-landing # name of content repo
 ORGANIZATION=mongodb # name of org, usually mongodb or 10gen
 # -------------------------------------------------------------------------------------------------------------------------
-PARSER_VERSION=0.18.0
+PARSER_VERSION=0.18.4
 
 # This make command curls the examples for certain repos.
 # If the rule doesn't exist, the error doesn't interrupt the build process.


### PR DESCRIPTION
### Notes:

Update `build.sh` to parser version v0.18.4

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
