### PR TITLE
DOP-5053: Fix client-side fetch refresh - legacy page

### DIFF
--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -151,7 +151,7 @@ const DeprecatedVersionSelector = () => {
             resp.filter((project) => project.hasEolVersions),
             'project'
           );
-          if (reposBranchesMap.size > 0) setReposMap(reposBranchesMap);
+          if (!isEmpty(reposBranchesMap)) setReposMap(reposBranchesMap);
         })
         .catch((error) => {
           console.error(`ERROR: could not access ${reposDatabase} for dropdown data.`);

--- a/tests/unit/DeprecatedVersionSelector.test.js
+++ b/tests/unit/DeprecatedVersionSelector.test.js
@@ -121,8 +121,8 @@ describe('DeprecatedVersionSelector when rendered', () => {
       const productDropdown = wrapper.container.querySelectorAll('button')[0];
       userEvent.click(productDropdown);
 
-      expect(wrapper.findByText('MongoDB Manual')).toBeTruthy();
-      expect(wrapper.findByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
+      expect(wrapper.getByText('MongoDB Manual')).toBeTruthy();
+      expect(wrapper.getByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
     });
 
     it('version dropdown text is correct', () => {
@@ -209,7 +209,7 @@ describe('DeprecatedVersionSelector when rendered', () => {
   });
 
   it('populates the dropdown using build-time data if atlas fails', () => {
-    mockFetchDocuments = jest.spyOn(realm, 'fetchDocsets').mockImplementation(async (dbName) => {
+    mockFetchDocuments.mockImplementation(async (dbName) => {
       return Promise.reject();
     });
 
@@ -218,18 +218,19 @@ describe('DeprecatedVersionSelector when rendered', () => {
     const productDropdown = wrapper.container.querySelectorAll('button')[0];
     userEvent.click(productDropdown);
 
-    expect(wrapper.findByText('MongoDB Manual')).toBeTruthy();
-    expect(wrapper.findByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
+    expect(wrapper.getByText('MongoDB Manual')).toBeTruthy();
+    expect(wrapper.getByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
   });
 
-  it('client-side fetchDocsets overwrites build-time data', () => {
+  it('client-side fetchDocsets overwrites build-time data', async () => {
     useAllDocsets.mockImplementation(() => []);
     wrapper = render(<DeprecatedVersionSelector />);
+    await waitFor(() => expect(mockFetchDocuments).toBeCalled());
 
     const productDropdown = wrapper.container.querySelectorAll('button')[0];
     userEvent.click(productDropdown);
 
-    expect(wrapper.findByText('MongoDB Manual')).toBeTruthy();
-    expect(wrapper.findByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
+    expect(wrapper.getByText('MongoDB Manual')).toBeTruthy();
+    expect(wrapper.getByText('MongoDB Atlas Open Service Broker on Kubernetes')).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-5053

### Current Behavior:

[Current](https://www.mongodb.com/docs/legacy/)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4873-dark-icons/landing/matt.meigs/DOP-5053-legacy-fetch/legacy/index.html)

### Notes:

Fixes error in checking for empty fetch result. Fixes and adds a test.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
