### PR TITLE
DOP-4785: Remove MUT_CANDIDATES

### DIFF
--- a/src/components/MainColumn.js
+++ b/src/components/MainColumn.js
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { theme } from '../theme/docsTheme';
-import { MUT_CANDIDATES } from '../constants';
-import { joinClassNames } from '../utils/join-class-names';
 
 const MainColumn = ({ children, className }) => (
   <main
-    className={joinClassNames(MUT_CANDIDATES.mainColumn, className)}
+    className={className}
     css={css`
       margin: ${theme.size.default} ${theme.size.xlarge} ${theme.size.xlarge};
       max-width: 800px;

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,9 +17,3 @@ export const REF_TARGETS = {
 };
 
 export const MARIAN_URL = process.env.GATSBY_MARIAN_URL || 'https://docs-search-transport.mongodb.com/';
-
-// Class names to be used by mut for search indexing
-// https://github.com/mongodb/mut/blob/main/mut/index/Document.py#L68
-export const MUT_CANDIDATES = {
-  mainColumn: 'main-column',
-};


### PR DESCRIPTION
### Stories/Links:

DOP-4785

### Current Behavior:

[Current](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4785-remove-mut-candidates/index.html)

### Notes:

Remove old constant/classname

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
