### PR TITLE
DOP-4810: All Products dropdown docs-qa links

### DIFF
--- a/plugins/utils/products.js
+++ b/plugins/utils/products.js
@@ -1,13 +1,7 @@
-const { siteMetadata } = require('../../gatsby-config');
-const { baseUrl } = require('../../src/utils/base-url');
-
 const createProductNodes = async ({ db, createNode, createNodeId, createContentDigest }) => {
   // Get all MongoDB products for the sidenav
   const products = await db.fetchAllProducts();
   products.forEach((product) => {
-    let url = baseUrl(product.baseUrl + product.slug);
-    if (siteMetadata.snootyEnv === 'dotcomstg') url = product.baseUrl + product.slug;
-
     createNode({
       children: [],
       id: createNodeId(`Product-${product.title}`),
@@ -17,7 +11,7 @@ const createProductNodes = async ({ db, createNode, createNodeId, createContentD
       },
       parent: null,
       title: product.title,
-      url,
+      url: product.baseUrl + product.slug,
     });
   });
 };

--- a/plugins/utils/products.js
+++ b/plugins/utils/products.js
@@ -1,10 +1,12 @@
+const { siteMetadata } = require('../../gatsby-config');
 const { baseUrl } = require('../../src/utils/base-url');
 
 const createProductNodes = async ({ db, createNode, createNodeId, createContentDigest }) => {
   // Get all MongoDB products for the sidenav
   const products = await db.fetchAllProducts();
   products.forEach((product) => {
-    const url = baseUrl(product.baseUrl + product.slug);
+    let url = baseUrl(product.baseUrl + product.slug);
+    if (siteMetadata.snootyEnv === 'dotcomstg') url = product.baseUrl + product.slug;
 
     createNode({
       children: [],


### PR DESCRIPTION
### Stories/Links:

DOP-4810

### Current Behavior:

I just staged this branch... but clicking on any of the products would take you to something like `www.mongodb.com.website/atlas`

### Staging Links:

[Preprd landing](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/)
Might be staged back by someone else to how it used to be (buggy)

Pictures of hovered urls
<img width="466" alt="Screenshot 2024-10-31 at 4 21 18 PM" src="https://github.com/user-attachments/assets/93595172-f613-4296-a89b-6a7024c84362">
<img width="584" alt="Screenshot 2024-10-31 at 4 21 27 PM" src="https://github.com/user-attachments/assets/d9b83e82-8079-4fae-86ec-77a12b1f44a6">


### Notes:

Went for the simplest approach. Modifying `baseUrl` util would have had wider ranging consequences.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
