### PR TITLE
DOP-4945: Default tab for drivers tabs

### DIFF
--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -134,8 +134,6 @@ const DocumentBody = (props) => {
     sessionStorage.setItem('pageInfo', JSON.stringify(pageInfo));
   }
 
-  console.log('page ', page?.options);
-
   return (
     <>
       <TabProvider selectors={page?.options?.selectors} defaultTabs={page?.options?.default_tabs}>

--- a/src/components/DocumentBody.js
+++ b/src/components/DocumentBody.js
@@ -134,9 +134,11 @@ const DocumentBody = (props) => {
     sessionStorage.setItem('pageInfo', JSON.stringify(pageInfo));
   }
 
+  console.log('page ', page?.options);
+
   return (
     <>
-      <TabProvider selectors={page?.options?.selectors}>
+      <TabProvider selectors={page?.options?.selectors} defaultTabs={page?.options?.default_tabs}>
         <InstruqtProvider hasLabDrawer={page?.options?.instruqt}>
           <ImageContextProvider images={props.data?.pageImage?.images ?? []}>
             <FootnoteContext.Provider value={{ footnotes }}>

--- a/src/components/Tabs/tab-context.js
+++ b/src/components/Tabs/tab-context.js
@@ -82,7 +82,6 @@ const TabProvider = ({ children, selectors = {}, defaultTabs = {} }) => {
   useEffect(() => {
     // convert selectors to tab options first here, then set init values
     // selectors are determined at build time
-    console.log('selectors ', selectors, defaultTabs);
     const choicesPerSelector = Object.keys(selectors).reduce((res, selector) => {
       res[selector] = makeChoices({
         name: selector,
@@ -91,7 +90,6 @@ const TabProvider = ({ children, selectors = {}, defaultTabs = {} }) => {
       });
       return res;
     }, {});
-    console.log('choicesPerSelector ', choicesPerSelector);
     const defaultRes = getDefaultTabs(choicesPerSelector, defaultTabs);
     // get local active tabs and set as active tabs
     // if they exist on page.

--- a/src/components/Tabs/tab-context.js
+++ b/src/components/Tabs/tab-context.js
@@ -34,7 +34,7 @@ const reducer = (prevState, newState) => {
 // Otherwise, return first choice.
 const getDefaultTabs = (choicesPerSelector, defaultTabs) =>
   Object.keys(choicesPerSelector || {}).reduce((res, selectorKey) => {
-    const defaultTabId = defaultTabs[selectorKey] ?? 'nodesjs';
+    const defaultTabId = defaultTabs[selectorKey] ?? 'nodejs';
     const defaultOptionIdx = choicesPerSelector[selectorKey].findIndex((tab) => tab.value === defaultTabId);
     // NOTE: default tabs should be specified here
     if (selectorKey === 'drivers' && defaultOptionIdx > -1) {

--- a/src/components/Tabs/tab-context.js
+++ b/src/components/Tabs/tab-context.js
@@ -28,14 +28,17 @@ const reducer = (prevState, newState) => {
 };
 
 // Helper fn to get default tabs for fallback (when no local storage found).
-// If drivers tabs, return 'nodejs' if found.
+// For drivers tabs,
+// 1. return default tab if available
+// 2. return 'nodejs' if found
 // Otherwise, return first choice.
-const getDefaultTabs = (choicesPerSelector) =>
+const getDefaultTabs = (choicesPerSelector, defaultTabs) =>
   Object.keys(choicesPerSelector || {}).reduce((res, selectorKey) => {
-    const nodeOptionIdx = choicesPerSelector[selectorKey].findIndex((tab) => tab.value === 'nodejs');
+    const defaultTabId = defaultTabs[selectorKey] ?? 'nodesjs';
+    const defaultOptionIdx = choicesPerSelector[selectorKey].findIndex((tab) => tab.value === defaultTabId);
     // NOTE: default tabs should be specified here
-    if (selectorKey === 'drivers' && nodeOptionIdx > -1) {
-      res[selectorKey] = 'nodejs';
+    if (selectorKey === 'drivers' && defaultOptionIdx > -1) {
+      res[selectorKey] = defaultTabId;
     } else {
       res[selectorKey] = choicesPerSelector[selectorKey][0].value;
     }
@@ -53,7 +56,7 @@ const getLocalTabs = (localTabs, selectors) =>
     return res;
   }, {});
 
-const TabProvider = ({ children, selectors = {} }) => {
+const TabProvider = ({ children, selectors = {}, defaultTabs = {} }) => {
   // init value to {} to match server and client side
   const [activeTabs, setActiveTab] = useReducer(reducer, {});
   const { setActiveSelectorIds } = useContext(ContentsContext);
@@ -79,6 +82,7 @@ const TabProvider = ({ children, selectors = {} }) => {
   useEffect(() => {
     // convert selectors to tab options first here, then set init values
     // selectors are determined at build time
+    console.log('selectors ', selectors, defaultTabs);
     const choicesPerSelector = Object.keys(selectors).reduce((res, selector) => {
       res[selector] = makeChoices({
         name: selector,
@@ -87,7 +91,8 @@ const TabProvider = ({ children, selectors = {} }) => {
       });
       return res;
     }, {});
-    const defaultRes = getDefaultTabs(choicesPerSelector);
+    console.log('choicesPerSelector ', choicesPerSelector);
+    const defaultRes = getDefaultTabs(choicesPerSelector, defaultTabs);
     // get local active tabs and set as active tabs
     // if they exist on page.
     // otherwise, defaults will take precedence


### PR DESCRIPTION
### Stories/Links:

DOP-4945

### Current Behavior:

[Connect to your cluster](https://www.mongodb.com/docs/atlas/tutorial/connect-to-your-cluster/)
[Autocomplete](https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/)

### Staging Links:

[Connect to your cluster](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4945-chosen-tab/tutorial/connect-to-your-cluster/index.html) (default tab is now python)
[Autocomplete](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-4945-chosen-tab/atlas-search/autocomplete/index.html) (default tab is now go)

### Notes:

Adds the ability to specify the default tab in drivers tabs.

The flow will be as follows: use localStorage activeTab if available, use a default tab if available (NEW), use nodejs if available, otherwise use the first tab.

Clear localStorage to see difference between chosen tab and default.

Sister PR in the parser [here](https://github.com/mongodb/snooty-parser/pull/629).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
