### PR TITLE
DOP-5161: Banner color is wrong

### DIFF
--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -85,7 +85,7 @@ const bannerStyle = ({ variant }) => css`
   border-color: ${styleMapLight[variant].borderColor};
   // copied from LG
   ::before {
-    background: linear-gradient(to left, transparent 6px, ${styleMapLight[variant].beforeColor}} 6px);
+    background: linear-gradient(to left, transparent 6px, ${styleMapLight[variant].beforeColor} 6px);
   }
   a {
     color: ${styleMapLight[variant].linkColor};

--- a/tests/unit/__snapshots__/Banner.test.js.snap
+++ b/tests/unit/__snapshots__/Banner.test.js.snap
@@ -80,7 +80,7 @@ exports[`renders a Banner correctly 1`] = `
 }
 
 .emotion-0::before {
-  background: linear-gradient(to left, transparent 6px, #016BF8} 6px);
+  background: linear-gradient(to left, transparent 6px, #016BF8 6px);
 }
 
 .emotion-0 a {


### PR DESCRIPTION
### Stories/Links:

DOP-5161

### Current Behavior:

[current behavior](https://www.mongodb.com/docs/atlas/app-services/)

### Staging Links:

[staging behavior](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/atlas-app-services/bianca.laube/DOP-5161/index.html)

### Notes:
* simple fix, there was just an extra `}`

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
