### PR TITLE
DOP-5130: Collapsible default expanded

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -25,7 +25,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(!!expanded);
+  const [open, setOpen] = useState(expanded ?? true);
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],


### PR DESCRIPTION
### Stories/Links:

DOP-5130

### Current Behavior:

No current uses that I know of.

### Staging Links:

Staging with three dummy collapsibles. 
Here's rst (first true, second false, third unspecified)

### Notes:

Content wants collapsibles to be expanded by default. We now will use the expanded option in rst as a boolean. 
Parser PR here.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
