### PR TITLE
DOP-4562: new LinkNewTab role

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -81,6 +81,7 @@ import RoleKbd from './Roles/Kbd';
 import RoleRed from './Roles/Red';
 import RoleGold from './Roles/Gold';
 import RoleRequired from './Roles/Required';
+import LinkNewTab from './Roles/LinkNewTab';
 
 const IGNORED_NAMES = new Set([
   'contents',
@@ -122,6 +123,7 @@ const roleMap = {
   subscript: Subscript,
   sup: Superscript,
   superscript: Superscript,
+  'link-new-tab': LinkNewTab,
 };
 
 const componentMap = {

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -78,10 +78,10 @@ import RoleGUILabel from './Roles/GUILabel';
 import RoleHighlight from './Roles/Highlight';
 import RoleIcon from './Roles/Icon';
 import RoleKbd from './Roles/Kbd';
+import RoleLinkNewTab from './Roles/LinkNewTab';
 import RoleRed from './Roles/Red';
 import RoleGold from './Roles/Gold';
 import RoleRequired from './Roles/Required';
-import LinkNewTab from './Roles/LinkNewTab';
 
 const IGNORED_NAMES = new Set([
   'contents',
@@ -123,7 +123,7 @@ const roleMap = {
   subscript: Subscript,
   sup: Superscript,
   superscript: Superscript,
-  'link-new-tab': LinkNewTab,
+  'link-new-tab': RoleLinkNewTab,
 };
 
 const componentMap = {

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -93,6 +93,7 @@ const Link = ({
   showLinkArrow,
   hideExternalIcon: hideExternalIconProp,
   showExternalIcon,
+  openInNewTab,
   ...other
 }) => {
   if (!to) to = '';
@@ -142,7 +143,7 @@ const Link = ({
       className={joinClassNames(lgLinkStyling, className)}
       href={to}
       hideExternalIcon={!showExtIcon}
-      target={target}
+      target={openInNewTab ? '_blank' : target}
       {...anchorProps}
     >
       {children}

--- a/src/components/Roles/LinkNewTab.js
+++ b/src/components/Roles/LinkNewTab.js
@@ -14,6 +14,7 @@ const LinkNewTab = ({ nodeData: { children, target } }) => (
 LinkNewTab.propTypes = {
   nodeData: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.object).isRequired,
+    target: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/Roles/LinkNewTab.js
+++ b/src/components/Roles/LinkNewTab.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from '../ComponentFactory';
+import Link from '../Link';
+
+const LinkNewTab = ({ nodeData: { children, target } }) => (
+  <Link to={target} openInNewTab={true}>
+    {children.map((node, i) => (
+      <ComponentFactory key={i} nodeData={node} />
+    ))}
+  </Link>
+);
+
+LinkNewTab.propTypes = {
+  nodeData: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};
+
+export default LinkNewTab;


### PR DESCRIPTION
### Stories/Links:

DOP-4562

### Current Behavior:

Current links all use same tab

### Staging Links:

[Staged](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/collapse-expanded/landing/matt.meigs/DOP-4562-new-tab/launch-manage/index.html) (the **Atlas Playground** link)
From [this rst](https://github.com/mongodb/docs-landing/blob/ec04305be221313abece37a4fd14f96a093cb240/source/launch-manage.txt#L47)

### Notes:

New role to open links in new tab.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
