### PR TITLE
DOP-5194: update input font size for mobile

### DIFF
--- a/src/components/ActionBar/styles.js
+++ b/src/components/ActionBar/styles.js
@@ -190,7 +190,9 @@ export const searchInputStyling = ({ mobileSearchActive }) => css`
   ${displayNone.onMedium};
 
   @media ${theme.screenSize.upToMedium} {
-    font-size: ${theme.fontSize.default};
+    input[type='search'] {
+      font-size: ${theme.fontSize.default};
+    }
   }
 
   ${mobileSearchActive &&


### PR DESCRIPTION
### Stories/Links:

DOP-5194

### Current Behavior:

https://www.mongodb.com/docs/

### Staging Links:

[staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/seung.park/DOP-5194/index.html)

### Notes:
- To reproduce the issue, check the current behavior link on a mobile phone (preferably iPhone to recreate the zoom), and open the search input. The same issue does not occur on the staging link

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
