### PR TITLE
DOP-5159 Specify content repo and parser version in build script for Netlify Frontend Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage/
 .env
 .swc/
 bundle.zip
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm run build:clean:stage
 
 When a commit is pushed, this automatically triggers a Netlify build on your branch. For every push, a deploy and deploy preview will be generated. 
 
-By default, the master branch of `docs-landing` will be parsed with the parser version specified in the `Netlify.toml` and built with the frontend version of your branch. However, if you'd like to build a different site or branch, or build with a different parser version, this can be easily done by just updating the values in the Netlify.toml accordingly(don't forget to update the `ORG_NAME` to `mongodb` or `10gen` depending on which org your repo belongs to!)
+By default, the master branch of `docs-landing` will be parsed with the parser version specified in the `Netlify.toml` and built using your branch as the frontend. If you'd like to build a different site or branch or build with a different parser version, this can be easily done by just updating the values in the Netlify.toml accordingly. Don't forget to update the `ORG_NAME` to `mongodb` or `10gen` depending on which org your repo belongs to!
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm run build:clean:stage
 
 ## Staging with Netlify
 
-When a commit is pushed, this automatically triggers a Netlify build on your branch. For every push, a deploy and deploy preview will be generated. 
+When a commit is pushed, this automatically triggers a Netlify build on your branch. For every push, a deploy and deploy preview will be generated.
 
 By default, the master branch of `docs-landing` will be parsed with the parser version specified in the `Netlify.toml` and built using your branch as the frontend. If you'd like to build a different site or branch or build with a different parser version, this can be easily done by just updating the values in the Netlify.toml accordingly. Don't forget to update the `ORG_NAME` to `mongodb` or `10gen` depending on which org your repo belongs to!
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ npm run build:clean:stage
 
 :warning: Note: This will promote the contents of your local public directory. Your instance in staging may break or be outdated if you haven't run `npm run build` before `make stage`.
 
+## Staging with Netlify
+
+When a commit is pushed, this automatically triggers a Netlify build on your branch. For every push, a deploy and deploy preview will be generated. 
+
+By default, the master branch of `docs-landing` will be parsed with the parser version specified in the `Netlify.toml` and built with the frontend version of your branch. However, if you'd like to build a different site or branch, or build with a different parser version, this can be easily done by just updating the values in the Netlify.toml accordingly(don't forget to update the `ORG_NAME` to `mongodb` or `10gen` depending on which org your repo belongs to!)
+
 ## Releasing
 
 We have configured an automatic release process using [GitHub Actions](https://github.com/features/actions) that is triggered by [npm-version](https://docs.npmjs.com/cli/version). To release a version, you must have admin privileges in this repo. Then proceed as follows:

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,19 @@
 # variables that need to be changed based on the content repo you're working on -------------------------------------------
-TESTING_BRANCH=$1d
-TESTING_CONTENT_REPO=$2 # name of content repo
-ORGANIZATION=mongodb # name of org, usually mongodb or 10gen
+TESTING_ORGANIZATION=$1 # name of org, usually mongodb or 10gen
+TESTING_REPO_NAME=$2 # name of content repo
+TESTING_BRANCH_NAME=$3
 # -------------------------------------------------------------------------------------------------------------------------
-PARSER_VERSION=0.18.6
+PARSER_VERSION=$4
+echo "parser version $PARSER_VERSION"
 
 # This make command curls the examples for certain repos.
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing the repo name $1 and second arg $2"
+echo "printing the repo name $1 and args $2 $3 $4"
 # cloning the content repo
-echo "cloning content repo: ${TESTING_CONTENT_REPO}"
-git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git
+echo "Cloning content repo: ${TESTING_REPO_NAME}"
+git clone https://github.com/${TESTING_REPO_NAME}/${TESTING_REPO_NAME}.git
 
 
 # running the parser 
@@ -25,7 +26,7 @@ fi
 
 echo "======================================================================================================================================================================="
 echo "========================================================================== Running parser... =========================================================================="
-./snooty-parser/snooty/snooty build $(pwd)/${TESTING_CONTENT_REPO} --output=./bundle.zip
+./snooty-parser/snooty/snooty build $(pwd)/${TESTING_REPO_NAME} --output=./bundle.zip
 echo "========================================================================== Parser complete ============================================================================"
 echo "======================================================================================================================================================================="
 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${process.env.TESTING_REPO}"
+echo "printing process.env ${TESTING_REPO}"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 # variables that need to be changed based on the content repo you're working on -------------------------------------------
+TESTING_BRANCH=$1
 TESTING_CONTENT_REPO=$2 # name of content repo
 ORGANIZATION=mongodb # name of org, usually mongodb or 10gen
 # -------------------------------------------------------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${TESTING_REPO}, ${build.environment}"
+echo "printing process.env ${process.env.build.environment}, ${process.env.REPO_NAME}"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,9 @@
 # variables that need to be changed based on the content repo you're working on -------------------------------------------
 TESTING_ORGANIZATION=$1 # name of org, usually mongodb or 10gen
 TESTING_REPO_NAME=$2 # name of content repo
-TESTING_BRANCH_NAME=$3
+TESTING_BRANCH_NAME=$3 # name of the branch
+PARSER_VERSION=$4 # version of the parser to download
 # -------------------------------------------------------------------------------------------------------------------------
-PARSER_VERSION=$4
-echo "Parser version $PARSER_VERSION"
 
 # This make command curls the examples for certain repos.
 # If the rule doesn't exist, the error doesn't interrupt the build process.
@@ -18,7 +17,7 @@ git clone -b ${TESTING_BRANCH_NAME} https://github.com/${TESTING_ORGANIZATION}/$
 
 # running the parser 
 if [ ! -d "snooty-parser" ]; then
-  echo "snooty parser not installed, downloading..."
+  echo "Snooty parser not installed, downloading parser version $PARSER_VERSION ..."
   curl -L -o snooty-parser.zip https://github.com/mongodb/snooty-parser/releases/download/v${PARSER_VERSION}/snooty-v${PARSER_VERSION}-linux_x86_64.zip
   unzip -d ./snooty-parser snooty-parser.zip
   chmod +x ./snooty-parser/snooty

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,16 @@ TESTING_REPO_NAME=$2 # name of content repo
 TESTING_BRANCH_NAME=$3
 # -------------------------------------------------------------------------------------------------------------------------
 PARSER_VERSION=$4
-echo "parser version $PARSER_VERSION"
+echo "Parser version $PARSER_VERSION"
 
 # This make command curls the examples for certain repos.
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing the repo name $1 and args $2 $3 $4"
 # cloning the content repo
 echo "Cloning content repo: ${TESTING_REPO_NAME}"
-git clone https://github.com/${TESTING_ORGANIZATION}/${TESTING_REPO_NAME}/tree/${TESTING_BRANCH_NAME}
+git clone https://github.com/${TESTING_ORGANIZATION}/${TESTING_REPO_NAME}.git 
+cd $TESTING_REPO_NAME && git checkout $TESTING_BRANCH_NAME
 
 
 # running the parser 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 # variables that need to be changed based on the content repo you're working on -------------------------------------------
-TESTING_CONTENT_REPO=docs-landing # name of content repo
+TESTING_CONTENT_REPO=$2 # name of content repo
 ORGANIZATION=mongodb # name of org, usually mongodb or 10gen
 # -------------------------------------------------------------------------------------------------------------------------
 PARSER_VERSION=0.18.6

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
+echo "printing process.env ${process.env.TESTING_REPO}"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${build.environment}, ${REPO_NAME}"
+echo "printing process.env ${build.environment}, ${REPO_NAME}, $REPO_NAME"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing the repo name $1"
+echo "printing the repo name $1 and second arg $2"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing first arg $1"
+echo "printing the repo name $1"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${process.env.build.environment}, ${process.env.REPO_NAME}"
+echo "printing process.env ${build.environment}, ${REPO_NAME}"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ echo "parser version $PARSER_VERSION"
 echo "printing the repo name $1 and args $2 $3 $4"
 # cloning the content repo
 echo "Cloning content repo: ${TESTING_REPO_NAME}"
-git clone https://github.com/${TESTING_REPO_NAME}/${TESTING_REPO_NAME}.git
+git clone https://github.com/${TESTING_REPO_NAME}/tree/${TESTING_BRANCH_NAME}.git
 
 
 # running the parser 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${TESTING_REPO}"
+echo "printing process.env ${TESTING_REPO}, ${build.environment}"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,8 @@ echo "Parser version $PARSER_VERSION"
 
 # cloning the content repo
 echo "Cloning content repo: ${TESTING_REPO_NAME}"
-git clone https://github.com/${TESTING_ORGANIZATION}/${TESTING_REPO_NAME}.git 
-cd $TESTING_REPO_NAME && git checkout $TESTING_BRANCH_NAME
+git clone -b ${TESTING_BRANCH_NAME} https://github.com/${TESTING_ORGANIZATION}/${TESTING_REPO_NAME}.git 
+
 
 
 # running the parser 
@@ -26,7 +26,7 @@ fi
 
 echo "======================================================================================================================================================================="
 echo "========================================================================== Running parser... =========================================================================="
-./snooty-parser/snooty/snooty build $(pwd)/${TESTING_REPO_NAME} --output=./bundle.zip
+./snooty-parser/snooty/snooty build $(pwd)/${TESTING_REPO_NAME}  --output=./bundle.zip
 echo "========================================================================== Parser complete ============================================================================"
 echo "======================================================================================================================================================================="
 

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ echo "parser version $PARSER_VERSION"
 echo "printing the repo name $1 and args $2 $3 $4"
 # cloning the content repo
 echo "Cloning content repo: ${TESTING_REPO_NAME}"
-git clone https://github.com/${TESTING_REPO_NAME}/tree/${TESTING_BRANCH_NAME}.git
+git clone https://github.com/${TESTING_ORGANIZATION}/${TESTING_REPO_NAME}/tree/${TESTING_BRANCH_NAME}
 
 
 # running the parser 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PARSER_VERSION=0.18.6
 # If the rule doesn't exist, the error doesn't interrupt the build process.
 # make examples - we don't need this for docs-landing, but have it here for when we change repos
 
-echo "printing process.env ${build.environment}, ${REPO_NAME}, $REPO_NAME"
+echo "printing first arg $1"
 # cloning the content repo
 echo "cloning content repo: ${TESTING_CONTENT_REPO}"
 git clone https://github.com/${ORGANIZATION}/${TESTING_CONTENT_REPO}.git

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 # variables that need to be changed based on the content repo you're working on -------------------------------------------
-TESTING_BRANCH=$1
+TESTING_BRANCH=$1d
 TESTING_CONTENT_REPO=$2 # name of content repo
 ORGANIZATION=mongodb # name of org, usually mongodb or 10gen
 # -------------------------------------------------------------------------------------------------------------------------

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,3 @@ name = "snooty-cache-plugin"
 [build]
 publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
-
-[build.environment]
-REPO_NAME = "docs-cpp"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh $TESTING_REPO"
+command = ". ./build.sh $REPO_ENTRY.repoName"
 
 [build.environment]
 TESTING_REPO = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,7 @@ name = "snooty-cache-plugin"
 [build]
 publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
+
+[build.environment]
+REPO_NAME = "docs-cpp"
+PARSER_VERSION = 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $ORG_NAME $REPO_NAME $BRANCH_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs_landing"
+REPO_NAME = "docs-landing"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@ publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
 
 [build.environment]
-REPO_NAME = "docs-landing"
+REPO_NAME = "docs-cpp"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh"
+command = ". ./build.sh $REPO_NAME"
 
 [build.environment]
 TESTING_REPO = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $ORG_NAME $REPO_NAME $BRANCH_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-cpp"
+REPO_NAME = "docs-landing"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh $REPO_NAME"
+command = ". ./build.sh $TESTING_REPO"
 
 [build.environment]
 TESTING_REPO = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@ publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
 
 [build.environment]
-TESTING_REPO = "docs-landing"
+REPO_NAME = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,10 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
+command = ". ./build.sh $ORG_NAME $REPO_NAME $BRANCH_NAME $PARSER_VERSION"
 
 [build.environment]
-REPO_NAME = "docs-cpp"
+ORG_NAME = "mongodb"
+REPO_NAME = "docs_landing"
+BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,7 @@ name = "snooty-cache-plugin"
 [build]
 publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
+
+[build.environment]
+REPO_NAME = "docs-cpp"
+PARSER_VERSION = "0.18.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,3 @@ name = "snooty-cache-plugin"
 [build]
 publish = "public"
 command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
-
-[build.environment]
-REPO_NAME = "docs-cpp"
-PARSER_VERSION = 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $ORG_NAME $REPO_NAME $BRANCH_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-landing"
+REPO_NAME = "docs-cpp"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh $REPO_ENTRY.repoName"
+command = ". ./build.sh $build.environment.TESTING_REPO $build.environment.REPO_ENTRY"
 
 [build.environment]
 TESTING_REPO = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ name = "snooty-cache-plugin"
 
 [build]
 publish = "public"
-command = ". ./build.sh $build.environment.TESTING_REPO $build.environment.REPO_ENTRY"
+command = ". ./build.sh $BRANCH_NAME $REPO_NAME"
 
 [build.environment]
 TESTING_REPO = "docs-landing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@ name = "snooty-cache-plugin"
 [build]
 publish = "public"
 command = ". ./build.sh"
+
+[build.environment]
+TESTING_REPO = "docs-landing"


### PR DESCRIPTION
## Stories/Links:

[DOP-5159](https://jira.mongodb.org/browse/DOP-5159): Specify Content Repo and Parser version for Frontend Netlify builds

## Current Behavior:
Currently, the frontend only builds the master branch of docs-landing unless the build script itself is changed. 
[Current netlify.toml](https://github.com/mongodb/snooty/blob/main/netlify.toml)
[Current build script](https://github.com/mongodb/snooty/blob/main/build.sh)
[docs-frontend-stg build](https://app.netlify.com/sites/docs-frontend-stg/deploys/673e75a8626dc49e7ebdaec2)
[docs-frontend-dotcomstg build](https://app.netlify.com/sites/docs-frontend-dotcomstg/overview)


## Notes:
This PR updates the build script for Netlify builds, but will not have any effect on autobuilder builds. It allows for controlling the repo, repo branch, and parser version used for the Netlify build through environment variables, thus making it easier for DOP engineers to stage different repos in Netlify and laying the groundwork for fully functional Slack deploys.
 I've updated the Netlify.toml, defining environment variables for each of the four variables the build script needs, ORG_NAME REPO_NAME, BRANCH_NAME, PARSER_VERSION, and then passing those as arguments to the build script.  I then updated the build script accordingly to read in those four arguments and use them for cloning the specified content repo, checking out the specified branch, and downloading the specified parser version. 
Note: If these environment variables are set in both the Netlify.toml and the Netlify UI, the values in the Toml will override the UI values.

### README updates

- - [x] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
