### PR TITLE
DOP-5189: Create Netlify function to proxy URL fetch

### DIFF
--- a/netlify/functions/fetch-url.js
+++ b/netlify/functions/fetch-url.js
@@ -39,7 +39,8 @@ async function handler(req, context) {
     return handleURL({ url });
   }
 
-  return new Response('', { status: 200 });
+  // Expected to only work when a url query param is defined
+  return new Response(null, { status: 400 });
 }
 
 export default handler;

--- a/netlify/functions/fetch-url.js
+++ b/netlify/functions/fetch-url.js
@@ -1,15 +1,8 @@
 import axios from 'axios';
 
-async function handleURL({ url, ifModifiedSince }) {
+async function handleURL({ url }) {
   try {
-    const reqHeaders = {};
-
-    if (ifModifiedSince) {
-      reqHeaders['If-Modified-Since'] = ifModifiedSince;
-    }
-
-    const { data, status } = await axios.get(url, {
-      headers: reqHeaders,
+    const { data } = await axios.get(url, {
       // Throw error whenever response status >= 400
       validateStatus: (status) => {
         console.log(`Returning status ${status} for ${url}`);
@@ -18,7 +11,7 @@ async function handleURL({ url, ifModifiedSince }) {
     });
 
     return new Response(data, {
-      status,
+      status: 200,
       headers: {
         'Cache-Control': 'public, durable, max-age=300',
       },
@@ -36,15 +29,12 @@ async function handleURL({ url, ifModifiedSince }) {
 async function handler(req, context) {
   const params = context.url.searchParams;
   const url = params.get('url');
-  // Netlify does not seem to allow If-Modified-Since header, so we have to receive it differently
-  // https://docs.netlify.com/platform/caching/#vary-by-header
-  const ifModifiedSince = params.get('ifModifiedSince');
 
   // Log to help keep track of requests
   console.log({ req, context });
 
   if (url) {
-    return handleURL({ url, ifModifiedSince });
+    return handleURL({ url });
   }
 
   return new Response('', { status: 200 });

--- a/netlify/functions/fetch-url.js
+++ b/netlify/functions/fetch-url.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 async function handleURL({ url }) {
   try {
     const { data } = await axios.get(url, {
-      // Throw error whenever response status >= 400
+      // Throws error whenever response status >= 400
       validateStatus: (status) => {
         console.log(`Returning status ${status} for ${url}`);
         return status < 400;
@@ -26,6 +26,8 @@ async function handleURL({ url }) {
   }
 }
 
+// This function exists only to help proxy URLs that were originally causing 403 errors, potentially due
+// to IP addresses. (DOP-5189)
 async function handler(req, context) {
   const params = context.url.searchParams;
   const url = params.get('url');

--- a/netlify/functions/fetch-url.js
+++ b/netlify/functions/fetch-url.js
@@ -1,0 +1,53 @@
+import axios from 'axios';
+
+async function handleURL({ url, ifModifiedSince }) {
+  try {
+    const reqHeaders = {};
+
+    if (ifModifiedSince) {
+      reqHeaders['If-Modified-Since'] = ifModifiedSince;
+    }
+
+    const { data, status } = await axios.get(url, {
+      headers: reqHeaders,
+      // Throw error whenever response status >= 400
+      validateStatus: (status) => {
+        console.log(`Returning status ${status} for ${url}`);
+        return status < 400;
+      },
+    });
+
+    return new Response(data, {
+      status,
+      headers: {
+        'Cache-Control': 'public, durable, max-age=300',
+      },
+    });
+  } catch (err) {
+    console.log({ err });
+
+    if (axios.isAxiosError(err) && err.response) {
+      return new Response(null, { status: err.response.status });
+    }
+    return new Response(null, { status: 500 });
+  }
+}
+
+async function handler(req, context) {
+  const params = context.url.searchParams;
+  const url = params.get('url');
+  // Netlify does not seem to allow If-Modified-Since header, so we have to receive it differently
+  // https://docs.netlify.com/platform/caching/#vary-by-header
+  const ifModifiedSince = params.get('ifModifiedSince');
+
+  // Log to help keep track of requests
+  console.log({ req, context });
+
+  if (url) {
+    return handleURL({ url, ifModifiedSince });
+  }
+
+  return new Response('', { status: 200 });
+}
+
+export default handler;


### PR DESCRIPTION
### Stories/Links:

DOP-5189

### Current Behavior:

N/A - Function does not exist yet

### Staging Links:

https://deploy-preview-1310--docs-frontend-stg.netlify.app/.netlify/functions/fetch-url?url=https://raw.githubusercontent.com/10gen/docs-shared/main/dbx/encrypt-fields.rst

https://deploy-preview-1310--docs-frontend-stg.netlify.app/.netlify/functions/fetch-url?url=https://raw.githubusercontent.com/10gen/docs-shared/main/dbx/compatibility-table-legend.rst

https://deploy-preview-1310--docs-frontend-stg.netlify.app/.netlify/functions/fetch-url?url=https://raw.githubusercontent.com/10gen/docs-shared/main/dbx/lifecycle-schedule-callout.rst

### Notes:

* The function currently relies on the `url` query param to fetch the content from said URLs. The function is currently as minimal as possible and leverages basic cache headers.
* This function is intended to only be a temporary solution for 403 errors from `sharedinclude` files in both Netlify builders and the Autobuilder. This function will ideally be removed once we no longer need to support `sharedinclude` after the monorepo is all set up (will file a new ticket for this once this ticket is complete).
* This function will be used by the parser to conditionally get content from `raw.githubusercontent.com` URLs. See the [parser PR](https://github.com/mongodb/snooty-parser/pull/635) for more information.
* Netlify builders examples: [With 403 errors](https://app.netlify.com/sites/docs-csharp-rayangler/deploys/673f66bf64be3a2ebf1c8215) vs. [No 403 errors](https://app.netlify.com/sites/docs-csharp-rayangler/deploys/673f542912d27e0c4de659a3)
* Autobuilder examples: [With 403 errors](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=673f7dac82937ce272d30b5f) vs. [No 403 errors](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=673f6bcf51440a366f7d851d)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
