### PR TITLE
DOP-5142: Remove border radius one dark mode images

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,7 +7,6 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import ImageContext from '../context/image-context';
 import { getNestedValue } from '../utils/get-nested-value';
-import { getPageSlug } from '../utils/get-page-slug';
 import { removeLeadingSlash } from '../utils/remove-leading-slash';
 import { theme } from '../theme/docsTheme';
 
@@ -38,8 +37,6 @@ const gatsbyContainerStyle = css`
 function getImageProps({
   altText,
   userOptionStyle,
-  slug,
-  sectionDepth,
   width,
   height,
   gatsbyImage,
@@ -63,7 +60,6 @@ function getImageProps({
     imageProps['height'] = height;
   }
 
-  const applyBorder = hasBorder || (darkMode && getPageSlug(slug) !== '/' && sectionDepth > 1);
   const borderColor = darkMode && hasBorder ? palette.gray.dark2 : darkMode ? 'transparent' : palette.gray.light1;
 
   if (gatsbyImage && loading === 'lazy') {
@@ -73,7 +69,7 @@ function getImageProps({
       directiveClass,
       customAlign,
       className,
-      applyBorder ? borderContainerStyling : ''
+      hasBorder ? borderContainerStyling : ''
     );
     imageProps['imgStyle'] = {
       '--border-color': borderColor,
@@ -83,7 +79,7 @@ function getImageProps({
     imageProps['srcSet'] = srcSet;
     imageProps['className'] = cx(
       defaultImageStyling,
-      applyBorder ? borderStyling : '',
+      hasBorder ? borderStyling : '',
       directiveClass,
       customAlign,
       className
@@ -96,7 +92,7 @@ function getImageProps({
   return imageProps;
 }
 
-const Image = ({ nodeData, className, slug, sectionDepth }) => {
+const Image = ({ nodeData, className }) => {
   const scale = (parseInt(getNestedValue(['options', 'scale'], nodeData), 10) || 100) / 100;
   const widthOption = getNestedValue(['options', 'width'], nodeData);
   let height = getNestedValue(['options', 'height'], nodeData);
@@ -138,8 +134,6 @@ const Image = ({ nodeData, className, slug, sectionDepth }) => {
     width,
     height,
     gatsbyImage,
-    slug,
-    sectionDepth,
     hasBorder,
     darkMode,
     customAlign,


### PR DESCRIPTION
### Stories/Links:

DOP-5142

### Current Behavior:

[ReadWriteConcern photo for example](https://www.mongodb.com/docs/v8.0/reference/read-concern-majority/#example)

### Staging Links:

[ReadWriteConcern in staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5106-redirects/docs/matt.meigs/DOP-5142-img-corners/reference/read-concern-majority/index.html#example)

### Notes:

All dark mode images that were not hero images or on landing pages were being given a large border-radius style which could obscure some content. This removes that.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
