### PR TITLE
DOP-5124: reconstruct table data using tanstack tables

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -234,22 +234,14 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
   const headerRowCount = parseInt(options?.['header-rows'], 10) || 0;
   const stubColumnCount = parseInt(options?.['stub-columns'], 10) || 0;
   const bodyRows = children[0].children.slice(headerRowCount);
-  const columnCount = bodyRows[0].children[0].children.length;
 
   // Check if :header-rows: 0 is specified or :header-rows: is omitted
-  const [headerRows] = useState(() =>
-    headerRowCount > 0 ? children[0].children[0].children.slice(0, headerRowCount) : []
-  );
-
-  let widths = null;
-  const customWidths = options?.widths;
-  if (customWidths && customWidths !== 'auto') {
-    widths = customWidths.split(/[ ,]+/);
-    if (columnCount !== widths.length) {
-      // If custom width specification does not match number of columns, do not apply
-      widths = null;
-    }
-  }
+  const [headerRows] = useState(() => {
+    const MAX_HEADER_ROW = 1;
+    return headerRowCount > 0
+      ? children[0].children[0].children.slice(0, Math.min(MAX_HEADER_ROW, headerRowCount))
+      : [];
+  });
 
   // get all ID's for elements within header, or first two rows of body
   const firstHeaderRowChildren = headerRows[0]?.children ?? [];
@@ -268,6 +260,18 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
     data: data,
   });
   const { rows } = table.getRowModel();
+
+  const columnCount = columns.length;
+
+  let widths = null;
+  const customWidths = options?.widths;
+  if (customWidths && customWidths !== 'auto') {
+    widths = customWidths.split(/[ ,]+/);
+    if (columnCount !== widths.length) {
+      // If custom width specification does not match number of columns, do not apply
+      widths = null;
+    }
+  }
 
   return (
     <AncestorComponentContextProvider component={'table'}>

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -13,7 +13,6 @@ import {
 } from '@leafygreen-ui/table';
 import { palette } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
-// import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { theme } from '../theme/docsTheme';
 import { AncestorComponentContextProvider, useAncestorComponentContext } from '../context/ancestor-components-context';
 import ComponentFactory from './ComponentFactory';
@@ -33,6 +32,7 @@ const styleTable = ({ customAlign, customWidth }) => css`
   ${customAlign && `text-align: ${align(customAlign)}`};
   ${customWidth && `width: ${customWidth}`};
   margin: ${theme.size.medium} 0;
+  table-layout: fixed;
 `;
 
 const theadStyle = css`
@@ -180,11 +180,18 @@ const includesNestedTable = (rows) => {
 
 const generateColumns = (headerRow, bodyRows) => {
   if (!headerRow?.children) {
-    return bodyRows.map((_bodyRow, index) => ({
-      id: `column-${index}`,
-      accessorKey: `column-${index}`,
-      header: '',
-    }));
+    // generate columns from bodyRows
+    const flattenedRows = bodyRows.map((bodyRow) => bodyRow.children[0].children);
+    const maxColumns = Math.max(...flattenedRows.map((row) => row.length));
+    const res = [];
+    for (let colIndex = 0; colIndex < maxColumns; colIndex++) {
+      res.push({
+        id: `column-${colIndex}`,
+        accessorKey: `column-${colIndex}`,
+        header: '',
+      });
+    }
+    return res;
   }
 
   return headerRow.children.map((listItemNode, index) => {

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Cell,
@@ -32,7 +32,9 @@ const styleTable = ({ customAlign, customWidth }) => css`
   ${customAlign && `text-align: ${align(customAlign)}`};
   ${customWidth && `width: ${customWidth}`};
   margin: ${theme.size.medium} 0;
-  table-layout: fixed;
+  > table {
+    table-layout: fixed;
+  }
 `;
 
 const theadStyle = css`
@@ -230,7 +232,6 @@ const generateRowsData = (bodyRowNodes, columns) => {
 
 const ListTable = ({ nodeData: { children, options }, ...rest }) => {
   const ancestors = useAncestorComponentContext();
-  // const { theme: siteTheme } = useDarkMode();
   // TODO: header row count should not be more than 1
   // need a warning in parser
   const headerRowCount = parseInt(options?.['header-rows'], 10) || 0;
@@ -239,9 +240,8 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
   const columnCount = bodyRows[0].children[0].children.length;
 
   // Check if :header-rows: 0 is specified or :header-rows: is omitted
-  const headerRows = useMemo(
-    () => (headerRowCount > 0 ? children[0].children[0].children.slice(0, headerRowCount) : []),
-    [children, headerRowCount]
+  const [headerRows] = useState(() =>
+    headerRowCount > 0 ? children[0].children[0].children.slice(0, headerRowCount) : []
   );
 
   let widths = null;
@@ -263,8 +263,8 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
   const shouldAlternateRowColor = noTableNesting && bodyRows.length > 4;
 
   const tableRef = useRef();
-  const columns = useMemo(() => generateColumns(headerRows[0], bodyRows), [headerRows, bodyRows]);
-  const data = useMemo(() => generateRowsData(bodyRows, columns), [bodyRows, columns]);
+  const [columns] = useState(() => generateColumns(headerRows[0], bodyRows));
+  const [data] = useState(() => generateRowsData(bodyRows, columns));
   const table = useLeafyGreenTable({
     containerRef: tableRef,
     columns: columns,

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -32,9 +32,6 @@ const styleTable = ({ customAlign, customWidth }) => css`
   ${customAlign && `text-align: ${align(customAlign)}`};
   ${customWidth && `width: ${customWidth}`};
   margin: ${theme.size.medium} 0;
-  > table {
-    table-layout: fixed;
-  }
 `;
 
 const theadStyle = css`

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -317,11 +317,7 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
                 const isStub = colIndex <= stubColumnCount - 1;
                 const role = isStub ? 'rowheader' : null;
                 return (
-                  <Cell
-                    key={cell.id}
-                    className={cx(baseCellStyle, bodyCellStyle, 'body-cell', isStub && stubCellStyle)}
-                    role={role}
-                  >
+                  <Cell key={cell.id} className={cx(baseCellStyle, bodyCellStyle, isStub && stubCellStyle)} role={role}>
                     {cell.renderValue()}
                   </Cell>
                 );

--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -297,7 +297,7 @@ const ListTable = ({ nodeData: { children, options }, ...rest }) => {
         <TableHead className={cx(theadStyle)}>
           {headerRowCount > 0 &&
             table.getHeaderGroups().map((headerGroup) => (
-              <HeaderRow key={headerGroup.id}>
+              <HeaderRow key={headerGroup.id} data-testid="leafygreen-ui-header-row">
                 {headerGroup.headers.map((header) => {
                   return (
                     <HeaderCell className={cx(baseCellStyle, headerCellStyle)} key={header.id} header={header}>

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -7,6 +7,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 100%;
   position: relative;
   margin: 24px 0;
+  table-layout: fixed;
 }
 
 .emotion-1 {
@@ -35,11 +36,15 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 .emotion-3 {
   padding: 0 8px;
   overflow: hidden;
+  padding-left: 32px;
   padding: 10px 8px!important;
   vertical-align: top;
   color: var(--font-color-primary);
   overflow-wrap: anywhere;
   word-break: break-word;
+  -webkit-align-content: flex-start;
+  -ms-flex-line-pack: flex-start;
+  align-content: flex-start;
 }
 
 .emotion-3:focus-visible {
@@ -48,10 +53,6 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 
 .emotion-3:last-child {
   padding-right: 24px;
-}
-
-.emotion-3:first-child {
-  padding-left: 32px;
 }
 
 .emotion-3 * {
@@ -64,18 +65,31 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   min-height: unset;
 }
 
+.emotion-3>div {
+  min-height: unset;
+  max-height: unset;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 .emotion-3 *,
 .emotion-3 p,
 .emotion-3 a {
   line-height: 20px;
 }
 
-.emotion-3>div>div>*,
+.emotion-3>div>*,
 .emotion-3>div>div p {
   margin: 0 0 12px;
 }
 
-.emotion-3>div>div>*:last-child {
+.emotion-3>div>div *:last-child,
+.emotion-3>div>*:last-child {
   margin-bottom: 0;
 }
 
@@ -92,11 +106,90 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   transition-property: min-height,max-height,opacity,padding,transform;
   transition-duration: 150ms;
   transition-timing-function: ease;
+  opacity: 1;
+  min-height: 40px;
+  max-height: 40px;
   -webkit-box-pack: left;
   -ms-flex-pack: left;
   -webkit-justify-content: left;
   justify-content: left;
   text-align: left;
+}
+
+.emotion-5 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  margin-bottom: 16px;
+  color: var(--font-color-primary);
+}
+
+.emotion-5 strong,
+.emotion-5 b {
+  font-weight: 700;
+}
+
+.emotion-6 {
+  padding: 0 8px;
+  overflow: hidden;
+  padding: 10px 8px!important;
+  vertical-align: top;
+  color: var(--font-color-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  -webkit-align-content: flex-start;
+  -ms-flex-line-pack: flex-start;
+  align-content: flex-start;
+}
+
+.emotion-6:focus-visible {
+  box-shadow: inset;
+}
+
+.emotion-6:last-child {
+  padding-right: 24px;
+}
+
+.emotion-6 * {
+  font-size: 13px!important;
+  line-height: inherit;
+}
+
+.emotion-6>div {
+  height: unset;
+  min-height: unset;
+}
+
+.emotion-6>div {
+  min-height: unset;
+  max-height: unset;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.emotion-6 *,
+.emotion-6 p,
+.emotion-6 a {
+  line-height: 20px;
+}
+
+.emotion-6>div>*,
+.emotion-6>div>div p {
+  margin: 0 0 12px;
+}
+
+.emotion-6>div>div *:last-child,
+.emotion-6>div>*:last-child {
+  margin-bottom: 0;
 }
 
 <div
@@ -131,72 +224,93 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
       />
       <tbody>
         <tr
+          aria-hidden="false"
           class=""
+          data-selected="false"
+          id="lg-table-row-0"
         >
           <td
-            class="emotion-3"
+            class="body-cell emotion-3"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 notebook
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-3"
+            class="body-cell emotion-6"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 50
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-3"
+            class="body-cell emotion-6"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 8.5x11,in
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-3"
+            class="body-cell emotion-6"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 A
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-3"
+            class="body-cell emotion-6"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 college-ruled,perforated
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-3"
+            class="body-cell emotion-6"
           >
             <div
               class="emotion-4"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-5"
+              >
                 8
-              </div>
+              </p>
             </div>
           </td>
         </tr>
@@ -213,6 +327,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   width: 100%;
   position: relative;
   margin: 24px 0;
+  table-layout: fixed;
 }
 
 .emotion-1 {
@@ -242,12 +357,14 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   padding: 0 8px;
   overflow: hidden;
   padding-left: 32px;
+  width: 150px;
   padding: 10px 8px!important;
   vertical-align: top;
   color: var(--font-color-primary);
   line-height: 24px;
   font-weight: 600;
   font-size: 13px;
+  width: auto;
 }
 
 .emotion-3:focus-visible {
@@ -292,12 +409,14 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 .emotion-5 {
   padding: 0 8px;
   overflow: hidden;
+  width: 150px;
   padding: 10px 8px!important;
   vertical-align: top;
   color: var(--font-color-primary);
   line-height: 24px;
   font-weight: 600;
   font-size: 13px;
+  width: auto;
 }
 
 .emotion-5:focus-visible {
@@ -333,11 +452,15 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 .emotion-16 {
   padding: 0 8px;
   overflow: hidden;
+  padding-left: 32px;
   padding: 10px 8px!important;
   vertical-align: top;
   color: var(--font-color-primary);
   overflow-wrap: anywhere;
   word-break: break-word;
+  -webkit-align-content: flex-start;
+  -ms-flex-line-pack: flex-start;
+  align-content: flex-start;
   background-color: #F9FBFA;
   border-right: 3px solid #E8EDEB;
   font-weight: 600;
@@ -351,10 +474,6 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   padding-right: 24px;
 }
 
-.emotion-16:first-child {
-  padding-left: 32px;
-}
-
 .emotion-16 * {
   font-size: 13px!important;
   line-height: inherit;
@@ -365,18 +484,31 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   min-height: unset;
 }
 
+.emotion-16>div {
+  min-height: unset;
+  max-height: unset;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 .emotion-16 *,
 .emotion-16 p,
 .emotion-16 a {
   line-height: 20px;
 }
 
-.emotion-16>div>div>*,
+.emotion-16>div>*,
 .emotion-16>div>div p {
   margin: 0 0 12px;
 }
 
-.emotion-16>div>div>*:last-child {
+.emotion-16>div>div *:last-child,
+.emotion-16>div>*:last-child {
   margin-bottom: 0;
 }
 
@@ -398,6 +530,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   transition-property: min-height,max-height,opacity,padding,transform;
   transition-duration: 150ms;
   transition-timing-function: ease;
+  opacity: 1;
+  min-height: 40px;
+  max-height: 40px;
   -webkit-box-pack: left;
   -ms-flex-pack: left;
   -webkit-justify-content: left;
@@ -406,6 +541,23 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
 }
 
 .emotion-18 {
+  margin: unset;
+  font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #001E2B;
+  font-size: 13px;
+  line-height: 20px;
+  color: #001E2B;
+  font-weight: 400;
+  margin-bottom: 16px;
+  color: var(--font-color-primary);
+}
+
+.emotion-18 strong,
+.emotion-18 b {
+  font-weight: 700;
+}
+
+.emotion-19 {
   padding: 0 8px;
   overflow: hidden;
   padding: 10px 8px!important;
@@ -413,42 +565,54 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   color: var(--font-color-primary);
   overflow-wrap: anywhere;
   word-break: break-word;
+  -webkit-align-content: flex-start;
+  -ms-flex-line-pack: flex-start;
+  align-content: flex-start;
 }
 
-.emotion-18:focus-visible {
+.emotion-19:focus-visible {
   box-shadow: inset;
 }
 
-.emotion-18:last-child {
+.emotion-19:last-child {
   padding-right: 24px;
 }
 
-.emotion-18:first-child {
-  padding-left: 32px;
-}
-
-.emotion-18 * {
+.emotion-19 * {
   font-size: 13px!important;
   line-height: inherit;
 }
 
-.emotion-18>div {
+.emotion-19>div {
   height: unset;
   min-height: unset;
 }
 
-.emotion-18 *,
-.emotion-18 p,
-.emotion-18 a {
+.emotion-19>div {
+  min-height: unset;
+  max-height: unset;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.emotion-19 *,
+.emotion-19 p,
+.emotion-19 a {
   line-height: 20px;
 }
 
-.emotion-18>div>div>*,
-.emotion-18>div>div p {
+.emotion-19>div>*,
+.emotion-19>div>div p {
   margin: 0 0 12px;
 }
 
-.emotion-18>div>div>*:last-child {
+.emotion-19>div>div *:last-child,
+.emotion-19>div>*:last-child {
   margin-bottom: 0;
 }
 
@@ -467,437 +631,524 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
         >
           <th
             class="emotion-3"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                name
-              </div>
+              name
             </div>
           </th>
           <th
             class="emotion-5"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                quantity
-              </div>
+              quantity
             </div>
           </th>
           <th
             class="emotion-5"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                size
-              </div>
+              size
             </div>
           </th>
           <th
             class="emotion-5"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                status
-              </div>
+              status
             </div>
           </th>
           <th
             class="emotion-5"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                tags
-              </div>
+              tags
             </div>
           </th>
           <th
             class="emotion-5"
-            role="columnheader"
             scope="col"
           >
             <div
               class="emotion-4"
             >
-              <div>
-                rating
-              </div>
+              rating
             </div>
           </th>
         </tr>
       </thead>
       <tbody>
         <tr
+          aria-hidden="false"
           class="emotion-15"
+          data-selected="false"
+          id="lg-table-row-0"
         >
           <td
-            class="emotion-16"
+            class="body-cell emotion-16"
             role="rowheader"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 journal
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 25
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 14x21,cm
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 A
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 brown, lined
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 9
-              </div>
+              </p>
             </div>
           </td>
         </tr>
         <tr
+          aria-hidden="false"
           class="emotion-15"
+          data-selected="false"
+          id="lg-table-row-1"
         >
           <td
-            class="emotion-16"
+            class="body-cell emotion-16"
             role="rowheader"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 notebook
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 50
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 8.5x11,in
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 A
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 college-ruled,perforated
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 8
-              </div>
+              </p>
             </div>
           </td>
         </tr>
         <tr
+          aria-hidden="false"
           class="emotion-15"
+          data-selected="false"
+          id="lg-table-row-2"
         >
           <td
-            class="emotion-16"
+            class="body-cell emotion-16"
             role="rowheader"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 paper
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 100
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 8.5x11,in
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 D
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 watercolor
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 10
-              </div>
+              </p>
             </div>
           </td>
         </tr>
         <tr
+          aria-hidden="false"
           class="emotion-15"
+          data-selected="false"
+          id="lg-table-row-3"
         >
           <td
-            class="emotion-16"
+            class="body-cell emotion-16"
             role="rowheader"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 planner
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 75
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 22.85x30,cm
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 D
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 2019
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 10
-              </div>
+              </p>
             </div>
           </td>
         </tr>
         <tr
+          aria-hidden="false"
           class="emotion-15"
+          data-selected="false"
+          id="lg-table-row-4"
         >
           <td
-            class="emotion-16"
+            class="body-cell emotion-16"
             role="rowheader"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 postcard
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 45
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 10x,cm
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 D
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 double-sided,white
-              </div>
+              </p>
             </div>
           </td>
           <td
-            class="emotion-18"
+            class="body-cell emotion-19"
           >
             <div
               class="emotion-17"
+              data-state="entered"
             >
-              <div>
+              <p
+                class="emotion-18"
+              >
                 2
-              </div>
+              </p>
             </div>
           </td>
         </tr>

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -229,7 +229,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
           id="lg-table-row-0"
         >
           <td
-            class="body-cell emotion-3"
+            class="emotion-3"
           >
             <div
               class="emotion-4"
@@ -243,7 +243,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-6"
+            class="emotion-6"
           >
             <div
               class="emotion-4"
@@ -257,7 +257,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-6"
+            class="emotion-6"
           >
             <div
               class="emotion-4"
@@ -271,7 +271,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-6"
+            class="emotion-6"
           >
             <div
               class="emotion-4"
@@ -285,7 +285,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-6"
+            class="emotion-6"
           >
             <div
               class="emotion-4"
@@ -299,7 +299,7 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-6"
+            class="emotion-6"
           >
             <div
               class="emotion-4"
@@ -697,7 +697,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
           id="lg-table-row-0"
         >
           <td
-            class="body-cell emotion-16"
+            class="emotion-16"
             role="rowheader"
           >
             <div
@@ -712,7 +712,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -726,7 +726,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -740,7 +740,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -754,7 +754,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -768,7 +768,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -789,7 +789,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
           id="lg-table-row-1"
         >
           <td
-            class="body-cell emotion-16"
+            class="emotion-16"
             role="rowheader"
           >
             <div
@@ -804,7 +804,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -818,7 +818,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -832,7 +832,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -846,7 +846,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -860,7 +860,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -881,7 +881,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
           id="lg-table-row-2"
         >
           <td
-            class="body-cell emotion-16"
+            class="emotion-16"
             role="rowheader"
           >
             <div
@@ -896,7 +896,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -910,7 +910,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -924,7 +924,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -938,7 +938,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -952,7 +952,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -973,7 +973,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
           id="lg-table-row-3"
         >
           <td
-            class="body-cell emotion-16"
+            class="emotion-16"
             role="rowheader"
           >
             <div
@@ -988,7 +988,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1002,7 +1002,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1016,7 +1016,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1030,7 +1030,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1044,7 +1044,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1065,7 +1065,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
           id="lg-table-row-4"
         >
           <td
-            class="body-cell emotion-16"
+            class="emotion-16"
             role="rowheader"
           >
             <div
@@ -1080,7 +1080,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1094,7 +1094,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1108,7 +1108,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1122,7 +1122,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"
@@ -1136,7 +1136,7 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="body-cell emotion-19"
+            class="emotion-19"
           >
             <div
               class="emotion-17"

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -7,6 +7,9 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   width: 100%;
   position: relative;
   margin: 24px 0;
+}
+
+.emotion-0>table {
   table-layout: fixed;
 }
 
@@ -327,6 +330,9 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   width: 100%;
   position: relative;
   margin: 24px 0;
+}
+
+.emotion-0>table {
   table-layout: fixed;
 }
 

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -9,10 +9,6 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
   margin: 24px 0;
 }
 
-.emotion-0>table {
-  table-layout: fixed;
-}
-
 .emotion-1 {
   border-spacing: 0;
   border-collapse: collapse;
@@ -330,10 +326,6 @@ exports[`when rendering a list-table directive renders correctly 1`] = `
   width: 100%;
   position: relative;
   margin: 24px 0;
-}
-
-.emotion-0>table {
-  table-layout: fixed;
 }
 
 .emotion-1 {


### PR DESCRIPTION
### Stories/Links:

DOP-5124

### Current Behavior:

[test page for tables on main branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/seung.park/main/test-tables/index.html) - includes all of Atlas docs as well as the test page (sourced [here](https://github.com/rayangler/cloud-docs/blob/sandbox/source/test-tables.txt))

### Staging Links:
[test page for tables on branch](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5124-test-tables/cloud-docs/seung.park/DOP-5124/test-tables/index.html)



### Notes:
- This PR does not change the way tables are rendered, or how they should be used in ReST. This updates the logic for constructing table data on the front end, so that we can pass processed column/row data, enabling us to use farther features as [expanded content ](https://github.com/mongodb/leafygreen-ui/tree/main/packages/table#data--renderexpandedcontent) and/or nested tables.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
