### PR TITLE
DOP-5181: Upgrade Chatbot to 0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "lodash": "^4.6.0",
         "minimist": "^1.2.6",
         "mobx": "^6.1.5",
-        "mongodb-chatbot-ui": "^0.9.0",
+        "mongodb-chatbot-ui": "^0.10.2",
         "no-scroll": "^2.1.1",
         "node-fetch": "^3.3.2",
         "node-gyp": "^10.1.0",
@@ -3774,19 +3774,19 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@leafygreen-ui/a11y": {
-      "version": "1.4.13",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.13.tgz",
-      "integrity": "sha512-ufiO4B40jyqLORhD0mQIpd4aBGpeCnM0dp9BrYggp0vJKhJV5sNSOJb5ytmSPGYXut5yhUZe4smYN5b94YWygQ==",
+      "version": "1.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
+      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
+        "@leafygreen-ui/lib": "^13.6.1"
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@leafygreen-ui/lib": {
-      "version": "13.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+      "version": "13.8.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+      "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/@leafygreen-ui/a11y/node_modules/@storybook/csf": {
-      "version": "0.1.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
-      "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
+      "version": "0.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -4689,9 +4689,9 @@
       }
     },
     "node_modules/@leafygreen-ui/hooks": {
-      "version": "8.1.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
-      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+      "version": "8.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.2.1.tgz",
+      "integrity": "sha512-yozp+WfMo1aNzQJG4WOa4eoxEEMK3T7Q7D2AObRWEPR+jPeeocsBKSHoAkUsfJ/8AklQ+LIWM1SvtUm4iuLXtQ==",
       "dependencies": {
         "@leafygreen-ui/lib": "^13.3.0",
         "lodash": "^4.17.21"
@@ -4973,72 +4973,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator": {
-      "version": "2.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/loading-indicator/-/loading-indicator-2.0.12.tgz",
-      "integrity": "sha512-ZH2aOoiT4eF790PGe7yI0YLFU7Ts1vTZfc8LBPywbM5RJFJJZ243oFvPKKNAJ+aiSgYQn4Znj1Rt9B7Xj6GMFQ==",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "react-lottie-player": "^1.5.6"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/@leafygreen-ui/lib": {
-      "version": "13.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
-      "dependencies": {
-        "@storybook/csf": "^0.1.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
-      "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/@leafygreen-ui/typography": {
-      "version": "19.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.0.0.tgz",
-      "integrity": "sha512-RAzZOKGOEPRWfT2+oI6f14o3NP1v5+KWbEKS87YezlapjrQRPAu2/8TX1giTU0ELZ8r0vR7QkkPsr1j26qG2cg==",
-      "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/@storybook/csf": {
-      "version": "0.1.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.4.tgz",
-      "integrity": "sha512-B9UI/lsQMjF+oEfZCI6YXNoeuBcGZoOP5x8yKbe2tIEmsMjSztFKkpPzi5nLCnBk/MBtl6QJeI3ksJnbsWPkOw==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@leafygreen-ui/loading-indicator/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/@leafygreen-ui/logo": {
@@ -6514,18 +6448,19 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
-      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
+      "version": "2.11.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.11.0.tgz",
+      "integrity": "sha512-/0G+UaDpLBLLtEP1mjGjiDnqReHufUTUkteqNUsyTOz1bpfejoo1anu3f6dZDqNlxoKhHZEEngQ+HvP1l1RJVw==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.6.0",
-        "@leafygreen-ui/palette": "^4.0.9"
+        "@leafygreen-ui/lib": "^13.7.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "polished": "^4.2.2"
       }
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@leafygreen-ui/lib": {
-      "version": "13.6.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.1.tgz",
-      "integrity": "sha512-NaA0qmbY3QUg0GMpbaK0cdif2lRnGrzXMadi3ETRXHgMRljHi4y5I+v02bjggQ7vOW9VWhSooCF5HTtNd5j3fw==",
+      "version": "13.8.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+      "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -6541,9 +6476,9 @@
       "integrity": "sha512-D0eHY+wllK0Fyj2/xiHmiLtfsklTCjQXupZN6UrhveUK4BoNC2Wf9t0cnoFCP7W2rpBItvdPs4fthj9lxUOqDg=="
     },
     "node_modules/@leafygreen-ui/tokens/node_modules/@storybook/csf": {
-      "version": "0.1.11",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
-      "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
+      "version": "0.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -7002,23 +6937,23 @@
       }
     },
     "node_modules/@lg-chat/input-bar": {
-      "version": "4.0.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/input-bar/-/input-bar-4.0.3.tgz",
-      "integrity": "sha512-ajKLXqHun0bxHBHU4cNWfihCMWlXo26Qr4M/7pD7CQgxZW+K4sTAJRmqsaGzAOdQLFGoh4Jhr9EVMwFCiT3b8g==",
+      "version": "5.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/input-bar/-/input-bar-5.1.0.tgz",
+      "integrity": "sha512-qr5tYrtfg+zQyTwCQgHJ1vP1lDmmkybbeMz7Y8kvPaZ2KZdqJbCXvkTKBVXW+ogfodgBsPUaG5yMNxRnZpwgDw==",
       "dependencies": {
         "@leafygreen-ui/badge": "^8.1.2",
         "@leafygreen-ui/button": "^21.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/input-option": "^1.1.3",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/input-option": "^2.0.0",
+        "@leafygreen-ui/lib": "^13.6.1",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
         "@leafygreen-ui/popover": "^11.3.1",
-        "@leafygreen-ui/search-input": "^3.0.1",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
+        "@leafygreen-ui/search-input": "^3.1.2",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.1",
         "lodash": "^4.17.21",
         "react-keyed-flatten-children": "^1.3.0",
         "react-textarea-autosize": "^8.3.2"
@@ -7028,10 +6963,27 @@
         "@lg-chat/leafygreen-chat-provider": "^2.0.0"
       }
     },
+    "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/input-option": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-2.0.2.tgz",
+      "integrity": "sha512-GD3TX/5uF6NMdlcOt89jg7NXrN43ZAm+TEg/84NT9Mpdik9pw44Nznhv/BD/jXaWpxPXlDQzq7ReAOi7WtUujg==",
+      "dependencies": {
+        "@leafygreen-ui/a11y": "^1.5.0",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/lib": "^13.6.1",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.1"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
     "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/lib": {
-      "version": "13.4.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-      "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+      "version": "13.8.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+      "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -7042,20 +6994,29 @@
       }
     },
     "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.10",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
-      "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
+      "version": "4.1.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+      "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+    },
+    "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+      "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.6.0",
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/popover": {
-      "version": "11.3.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.3.1.tgz",
-      "integrity": "sha512-pkEGWOHSJ0HiRRaUEFLY42EZVGVlLVAe9ufr00QWOJ1tuu3Mr/al4yNRUSJqz9mZbUo1mAun9XXvVpwP5GfrSQ==",
+      "version": "11.4.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.4.0.tgz",
+      "integrity": "sha512-hSr3zbbWOCUuhByR5ncFJTkXxFfA7o2QjVjDXKLVPPn9Gh7+sYRLe87mTQWs9m8fbRx9O4Uk7Vq0R9U4A77dxw==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/lib": "^13.5.0",
         "@leafygreen-ui/portal": "^5.1.1",
-        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/tokens": "^2.8.0",
         "@types/react-transition-group": "^4.4.5",
         "react-transition-group": "^4.4.5"
       },
@@ -7076,22 +7037,22 @@
       }
     },
     "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/search-input": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-3.0.1.tgz",
-      "integrity": "sha512-D/JYpao5rhM/DnAB/g4QUoehCGfdupScgVXx4cjdvPJYYKZ9m/tgf7Mh2baVKyh0pzWOxj74ELx9N/o59VoGRQ==",
+      "version": "3.1.4",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-3.1.4.tgz",
+      "integrity": "sha512-pZKkBJ+R8KjNA+uwOUAwsCKy/8jDdE8/zEhO623dbMtDr83yL4lq4K07ZK6a0CSrooxOcf1+1uYGGzt8dgU1sg==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.13",
+        "@leafygreen-ui/a11y": "^1.5.0",
         "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.1.0",
+        "@leafygreen-ui/hooks": "^8.2.1",
+        "@leafygreen-ui/icon": "^12.5.4",
         "@leafygreen-ui/icon-button": "^15.0.21",
-        "@leafygreen-ui/input-option": "^1.1.3",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/input-option": "^2.0.0",
+        "@leafygreen-ui/lib": "^13.6.1",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/popover": "^11.3.1",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/popover": "^11.4.0",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.1",
         "lodash": "^4.17.21",
         "polished": "^4.2.2"
       },
@@ -7100,25 +7061,25 @@
       }
     },
     "node_modules/@lg-chat/input-bar/node_modules/@leafygreen-ui/typography": {
-      "version": "19.0.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.0.0.tgz",
-      "integrity": "sha512-RAzZOKGOEPRWfT2+oI6f14o3NP1v5+KWbEKS87YezlapjrQRPAu2/8TX1giTU0ELZ8r0vR7QkkPsr1j26qG2cg==",
+      "version": "19.3.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
+      "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/icon": "^12.6.0",
+        "@leafygreen-ui/lib": "^13.6.1",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
-        "@leafygreen-ui/tokens": "^2.5.2"
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
       },
       "peerDependencies": {
         "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@lg-chat/input-bar/node_modules/@storybook/csf": {
-      "version": "0.1.4",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.4.tgz",
-      "integrity": "sha512-B9UI/lsQMjF+oEfZCI6YXNoeuBcGZoOP5x8yKbe2tIEmsMjSztFKkpPzi5nLCnBk/MBtl6QJeI3ksJnbsWPkOw==",
+      "version": "0.1.12",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -7607,9 +7568,9 @@
       }
     },
     "node_modules/@lg-chat/rich-links": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/rich-links/-/rich-links-1.1.1.tgz",
-      "integrity": "sha512-He+wWQSrm7gt2EwQa+AuiawwXyA9t+l/8XNrizWaznI8j+aRtemRajUjKWexj7RHExvBu67lk3bVVs62rklZ+A==",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/rich-links/-/rich-links-1.2.0.tgz",
+      "integrity": "sha512-CzyW6kYLvFqmiEEUrtbMmg8Mann/7js1AyUJ/D0HmxC2SNEWbtgJb2plgduD1B6Y9ltnPBFvRHyvXKeiVjeQKA==",
       "dependencies": {
         "@leafygreen-ui/card": "^11.0.0",
         "@leafygreen-ui/emotion": "^4.0.7",
@@ -7618,7 +7579,7 @@
         "@leafygreen-ui/lib": "^12.0.0",
         "@leafygreen-ui/palette": "^4.1.0",
         "@leafygreen-ui/polymorphic": "^2.0.2",
-        "@leafygreen-ui/tokens": "^2.6.0",
+        "@leafygreen-ui/tokens": "^2.11.0",
         "@leafygreen-ui/typography": "^19.3.0"
       },
       "peerDependencies": {
@@ -22280,11 +22241,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lottie-web": {
-      "version": "5.12.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lottie-web/-/lottie-web-5.12.2.tgz",
-      "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "license": "MIT",
@@ -23305,9 +23261,9 @@
       }
     },
     "node_modules/mongodb-chatbot-ui": {
-      "version": "0.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.9.0.tgz",
-      "integrity": "sha512-IV3ltrTwfYVcy6Oj7ZXJ4aHIC/vZY4sOLRaKlPoAiU2oHuIKtUlHkVxfxyvwS+Uwk1pEpv/+jAC6EEKdn2wlBA==",
+      "version": "0.10.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.10.2.tgz",
+      "integrity": "sha512-fciCZLwcP+spx9QeOgA7fmYs0mcbTjiAm0YWbIeXc6gZVQiiSxoU2XSJDK4CN5pscgY/OqRdfFYa0kG2Z4R2tA==",
       "bundleDependencies": [
         "mongodb-rag-core"
       ],
@@ -23322,7 +23278,6 @@
         "@leafygreen-ui/icon": "^12.4.0",
         "@leafygreen-ui/icon-button": "^15.0.21",
         "@leafygreen-ui/leafygreen-provider": "^3.1.12",
-        "@leafygreen-ui/loading-indicator": "^2.0.12",
         "@leafygreen-ui/menu": "^22.0.9",
         "@leafygreen-ui/modal": "^16.0.7",
         "@leafygreen-ui/palette": "^4.0.10",
@@ -23334,14 +23289,14 @@
         "@lg-chat/chat-disclaimer": "^3.0.2",
         "@lg-chat/chat-window": "^2.0.1",
         "@lg-chat/fixed-chat-window": "^2.0.3",
-        "@lg-chat/input-bar": "^4.0.3",
+        "@lg-chat/input-bar": "^5.1.0",
         "@lg-chat/leafygreen-chat-provider": "^2.0.0",
         "@lg-chat/message": "^4.2.1",
         "@lg-chat/message-feed": "^3.0.1",
         "@lg-chat/message-feedback": "^2.1.0",
         "@lg-chat/message-prompts": "^2.0.2",
         "@lg-chat/message-rating": "^2.0.2",
-        "@lg-chat/rich-links": "^1.0.1",
+        "@lg-chat/rich-links": "^1.2.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "buffer": "^6.0.3",
         "esbuild": "^0.17.19",
@@ -26875,22 +26830,6 @@
         "react": "*"
       }
     },
-    "node_modules/react-lottie-player": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-lottie-player/-/react-lottie-player-1.5.6.tgz",
-      "integrity": "sha512-t0GdTYbml0Ihski8ZPx+1WjpjM/EQlTqTcuGm5yeZGJAgFXTmoqrHbSX8bcREIxrHjibWAyIWnLVUK/iHLcqAQ==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "lottie-web": "^5.7.6",
-        "rfdc": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-markdown": {
       "version": "8.0.7",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-markdown/-/react-markdown-8.0.7.tgz",
@@ -27060,9 +26999,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.5.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
-      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "version": "8.5.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-textarea-autosize/-/react-textarea-autosize-8.5.5.tgz",
+      "integrity": "sha512-CVA94zmfp8m4bSHtWwmANaBR8EPsKy2aZ7KwqhoS4Ftib87F9Kvi7XQhOixypPLMc6kVYgOXvKFuuzZDpHGRPg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -28240,6 +28179,7 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -33977,19 +33917,19 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "@leafygreen-ui/a11y": {
-      "version": "1.4.13",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.4.13.tgz",
-      "integrity": "sha512-ufiO4B40jyqLORhD0mQIpd4aBGpeCnM0dp9BrYggp0vJKhJV5sNSOJb5ytmSPGYXut5yhUZe4smYN5b94YWygQ==",
+      "version": "1.5.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
+      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/lib": "^13.3.0"
+        "@leafygreen-ui/lib": "^13.6.1"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "13.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+          "version": "13.8.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+          "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -33997,9 +33937,9 @@
           }
         },
         "@storybook/csf": {
-          "version": "0.1.3",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.3.tgz",
-          "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
+          "version": "0.1.12",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+          "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -34748,9 +34688,9 @@
       }
     },
     "@leafygreen-ui/hooks": {
-      "version": "8.1.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
-      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
+      "version": "8.2.1",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/hooks/-/hooks-8.2.1.tgz",
+      "integrity": "sha512-yozp+WfMo1aNzQJG4WOa4eoxEEMK3T7Q7D2AObRWEPR+jPeeocsBKSHoAkUsfJ/8AklQ+LIWM1SvtUm4iuLXtQ==",
       "requires": {
         "@leafygreen-ui/lib": "^13.3.0",
         "lodash": "^4.17.21"
@@ -34995,62 +34935,6 @@
       "version": "9.5.2",
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "@leafygreen-ui/loading-indicator": {
-      "version": "2.0.12",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/loading-indicator/-/loading-indicator-2.0.12.tgz",
-      "integrity": "sha512-ZH2aOoiT4eF790PGe7yI0YLFU7Ts1vTZfc8LBPywbM5RJFJJZ243oFvPKKNAJ+aiSgYQn4Znj1Rt9B7Xj6GMFQ==",
-      "requires": {
-        "@leafygreen-ui/emotion": "^4.0.8",
-        "@leafygreen-ui/lib": "^13.4.0",
-        "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
-        "react-lottie-player": "^1.5.6"
-      },
-      "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "13.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
-          "requires": {
-            "@storybook/csf": "^0.1.0",
-            "lodash": "^4.17.21",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@leafygreen-ui/palette": {
-          "version": "4.0.10",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
-          "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
-        },
-        "@leafygreen-ui/typography": {
-          "version": "19.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.0.0.tgz",
-          "integrity": "sha512-RAzZOKGOEPRWfT2+oI6f14o3NP1v5+KWbEKS87YezlapjrQRPAu2/8TX1giTU0ELZ8r0vR7QkkPsr1j26qG2cg==",
-          "requires": {
-            "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
-            "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
-          }
-        },
-        "@storybook/csf": {
-          "version": "0.1.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.4.tgz",
-          "integrity": "sha512-B9UI/lsQMjF+oEfZCI6YXNoeuBcGZoOP5x8yKbe2tIEmsMjSztFKkpPzi5nLCnBk/MBtl6QJeI3ksJnbsWPkOw==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@leafygreen-ui/logo": {
@@ -36332,18 +36216,19 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.9.0.tgz",
-      "integrity": "sha512-Ogn250aFFHylmkKZAtdyS6qhA3JiHra+Zx8tMK500kkWTo8lwh7bSiK6nVwKWzkkeReEr8Iq41a08RjaRaf4HQ==",
+      "version": "2.11.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/tokens/-/tokens-2.11.0.tgz",
+      "integrity": "sha512-/0G+UaDpLBLLtEP1mjGjiDnqReHufUTUkteqNUsyTOz1bpfejoo1anu3f6dZDqNlxoKhHZEEngQ+HvP1l1RJVw==",
       "requires": {
-        "@leafygreen-ui/lib": "^13.6.0",
-        "@leafygreen-ui/palette": "^4.0.9"
+        "@leafygreen-ui/lib": "^13.7.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "polished": "^4.2.2"
       },
       "dependencies": {
         "@leafygreen-ui/lib": {
-          "version": "13.6.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.6.1.tgz",
-          "integrity": "sha512-NaA0qmbY3QUg0GMpbaK0cdif2lRnGrzXMadi3ETRXHgMRljHi4y5I+v02bjggQ7vOW9VWhSooCF5HTtNd5j3fw==",
+          "version": "13.8.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+          "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -36356,9 +36241,9 @@
           "integrity": "sha512-D0eHY+wllK0Fyj2/xiHmiLtfsklTCjQXupZN6UrhveUK4BoNC2Wf9t0cnoFCP7W2rpBItvdPs4fthj9lxUOqDg=="
         },
         "@storybook/csf": {
-          "version": "0.1.11",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.11.tgz",
-          "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
+          "version": "0.1.12",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+          "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -36741,32 +36626,46 @@
       }
     },
     "@lg-chat/input-bar": {
-      "version": "4.0.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/input-bar/-/input-bar-4.0.3.tgz",
-      "integrity": "sha512-ajKLXqHun0bxHBHU4cNWfihCMWlXo26Qr4M/7pD7CQgxZW+K4sTAJRmqsaGzAOdQLFGoh4Jhr9EVMwFCiT3b8g==",
+      "version": "5.1.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/input-bar/-/input-bar-5.1.0.tgz",
+      "integrity": "sha512-qr5tYrtfg+zQyTwCQgHJ1vP1lDmmkybbeMz7Y8kvPaZ2KZdqJbCXvkTKBVXW+ogfodgBsPUaG5yMNxRnZpwgDw==",
       "requires": {
         "@leafygreen-ui/badge": "^8.1.2",
         "@leafygreen-ui/button": "^21.2.0",
         "@leafygreen-ui/emotion": "^4.0.8",
         "@leafygreen-ui/hooks": "^8.1.3",
-        "@leafygreen-ui/icon": "^12.1.0",
-        "@leafygreen-ui/input-option": "^1.1.3",
-        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/input-option": "^2.0.0",
+        "@leafygreen-ui/lib": "^13.6.1",
         "@leafygreen-ui/palette": "^4.0.10",
-        "@leafygreen-ui/polymorphic": "^1.3.7",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
         "@leafygreen-ui/popover": "^11.3.1",
-        "@leafygreen-ui/search-input": "^3.0.1",
-        "@leafygreen-ui/tokens": "^2.5.2",
-        "@leafygreen-ui/typography": "^19.0.0",
+        "@leafygreen-ui/search-input": "^3.1.2",
+        "@leafygreen-ui/tokens": "^2.9.0",
+        "@leafygreen-ui/typography": "^19.2.1",
         "lodash": "^4.17.21",
         "react-keyed-flatten-children": "^1.3.0",
         "react-textarea-autosize": "^8.3.2"
       },
       "dependencies": {
+        "@leafygreen-ui/input-option": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/input-option/-/input-option-2.0.2.tgz",
+          "integrity": "sha512-GD3TX/5uF6NMdlcOt89jg7NXrN43ZAm+TEg/84NT9Mpdik9pw44Nznhv/BD/jXaWpxPXlDQzq7ReAOi7WtUujg==",
+          "requires": {
+            "@leafygreen-ui/a11y": "^1.5.0",
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/lib": "^13.6.1",
+            "@leafygreen-ui/palette": "^4.0.9",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0",
+            "@leafygreen-ui/typography": "^19.2.1"
+          }
+        },
         "@leafygreen-ui/lib": {
-          "version": "13.4.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.4.0.tgz",
-          "integrity": "sha512-Ju+tHF6z3ttU9UD6EXmTtIExgj/ZXnjm48CRQ6jk65LnYuX19i3I35nkCZwb8n28WlxDH7UDoEumx/hvM05Z4w==",
+          "version": "13.8.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/lib/-/lib-13.8.0.tgz",
+          "integrity": "sha512-WHbs0ZKzMR/UU0XmlI7+PKDzayuynTXrEQ2GwL5WpPjRElxlajkDyjkzmxXkQLIKce+T+q8ucIVlRVInDG+Qlg==",
           "requires": {
             "@storybook/csf": "^0.1.0",
             "lodash": "^4.17.21",
@@ -36774,20 +36673,29 @@
           }
         },
         "@leafygreen-ui/palette": {
-          "version": "4.0.10",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.0.10.tgz",
-          "integrity": "sha512-0vhKwMfBv7eO9txSxkgxijjI8M9L8uLFge+JpbBXql37+rKJuiQl7wCb5OPIJM+aV2HaHElGMyf9nRliabk30w=="
+          "version": "4.1.1",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+          "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
+        },
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+          "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.6.0",
+            "lodash": "^4.17.21"
+          }
         },
         "@leafygreen-ui/popover": {
-          "version": "11.3.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.3.1.tgz",
-          "integrity": "sha512-pkEGWOHSJ0HiRRaUEFLY42EZVGVlLVAe9ufr00QWOJ1tuu3Mr/al4yNRUSJqz9mZbUo1mAun9XXvVpwP5GfrSQ==",
+          "version": "11.4.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/popover/-/popover-11.4.0.tgz",
+          "integrity": "sha512-hSr3zbbWOCUuhByR5ncFJTkXxFfA7o2QjVjDXKLVPPn9Gh7+sYRLe87mTQWs9m8fbRx9O4Uk7Vq0R9U4A77dxw==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
             "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/lib": "^13.3.0",
+            "@leafygreen-ui/lib": "^13.5.0",
             "@leafygreen-ui/portal": "^5.1.1",
-            "@leafygreen-ui/tokens": "^2.5.2",
+            "@leafygreen-ui/tokens": "^2.8.0",
             "@types/react-transition-group": "^4.4.5",
             "react-transition-group": "^4.4.5"
           }
@@ -36802,43 +36710,43 @@
           }
         },
         "@leafygreen-ui/search-input": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-3.0.1.tgz",
-          "integrity": "sha512-D/JYpao5rhM/DnAB/g4QUoehCGfdupScgVXx4cjdvPJYYKZ9m/tgf7Mh2baVKyh0pzWOxj74ELx9N/o59VoGRQ==",
+          "version": "3.1.4",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/search-input/-/search-input-3.1.4.tgz",
+          "integrity": "sha512-pZKkBJ+R8KjNA+uwOUAwsCKy/8jDdE8/zEhO623dbMtDr83yL4lq4K07ZK6a0CSrooxOcf1+1uYGGzt8dgU1sg==",
           "requires": {
-            "@leafygreen-ui/a11y": "^1.4.13",
+            "@leafygreen-ui/a11y": "^1.5.0",
             "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/hooks": "^8.1.3",
-            "@leafygreen-ui/icon": "^12.1.0",
+            "@leafygreen-ui/hooks": "^8.2.1",
+            "@leafygreen-ui/icon": "^12.5.4",
             "@leafygreen-ui/icon-button": "^15.0.21",
-            "@leafygreen-ui/input-option": "^1.1.3",
-            "@leafygreen-ui/lib": "^13.4.0",
+            "@leafygreen-ui/input-option": "^2.0.0",
+            "@leafygreen-ui/lib": "^13.6.1",
             "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/popover": "^11.3.1",
-            "@leafygreen-ui/tokens": "^2.5.2",
-            "@leafygreen-ui/typography": "^19.0.0",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/popover": "^11.4.0",
+            "@leafygreen-ui/tokens": "^2.9.0",
+            "@leafygreen-ui/typography": "^19.2.1",
             "lodash": "^4.17.21",
             "polished": "^4.2.2"
           }
         },
         "@leafygreen-ui/typography": {
-          "version": "19.0.0",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.0.0.tgz",
-          "integrity": "sha512-RAzZOKGOEPRWfT2+oI6f14o3NP1v5+KWbEKS87YezlapjrQRPAu2/8TX1giTU0ELZ8r0vR7QkkPsr1j26qG2cg==",
+          "version": "19.3.0",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/typography/-/typography-19.3.0.tgz",
+          "integrity": "sha512-pgTRcc4usW/S9nDDzkf5Ac/JPEybhWtOnDpmrp99mAJHM6tH48Pd1HjRNHWjn6bnh0nXWjwANXX1ZEe+8ggCNg==",
           "requires": {
             "@leafygreen-ui/emotion": "^4.0.8",
-            "@leafygreen-ui/icon": "^12.1.0",
-            "@leafygreen-ui/lib": "^13.4.0",
+            "@leafygreen-ui/icon": "^12.6.0",
+            "@leafygreen-ui/lib": "^13.6.1",
             "@leafygreen-ui/palette": "^4.0.10",
-            "@leafygreen-ui/polymorphic": "^1.3.7",
-            "@leafygreen-ui/tokens": "^2.5.2"
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
           }
         },
         "@storybook/csf": {
-          "version": "0.1.4",
-          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.4.tgz",
-          "integrity": "sha512-B9UI/lsQMjF+oEfZCI6YXNoeuBcGZoOP5x8yKbe2tIEmsMjSztFKkpPzi5nLCnBk/MBtl6QJeI3ksJnbsWPkOw==",
+          "version": "0.1.12",
+          "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@storybook/csf/-/csf-0.1.12.tgz",
+          "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
           "requires": {
             "type-fest": "^2.19.0"
           }
@@ -37252,9 +37160,9 @@
       }
     },
     "@lg-chat/rich-links": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/rich-links/-/rich-links-1.1.1.tgz",
-      "integrity": "sha512-He+wWQSrm7gt2EwQa+AuiawwXyA9t+l/8XNrizWaznI8j+aRtemRajUjKWexj7RHExvBu67lk3bVVs62rklZ+A==",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@lg-chat/rich-links/-/rich-links-1.2.0.tgz",
+      "integrity": "sha512-CzyW6kYLvFqmiEEUrtbMmg8Mann/7js1AyUJ/D0HmxC2SNEWbtgJb2plgduD1B6Y9ltnPBFvRHyvXKeiVjeQKA==",
       "requires": {
         "@leafygreen-ui/card": "^11.0.0",
         "@leafygreen-ui/emotion": "^4.0.7",
@@ -37263,7 +37171,7 @@
         "@leafygreen-ui/lib": "^12.0.0",
         "@leafygreen-ui/palette": "^4.1.0",
         "@leafygreen-ui/polymorphic": "^2.0.2",
-        "@leafygreen-ui/tokens": "^2.6.0",
+        "@leafygreen-ui/tokens": "^2.11.0",
         "@leafygreen-ui/typography": "^19.3.0"
       },
       "dependencies": {
@@ -46662,11 +46570,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lottie-web": {
-      "version": "5.12.2",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/lottie-web/-/lottie-web-5.12.2.tgz",
-      "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
-    },
     "lower-case": {
       "version": "2.0.2",
       "requires": {
@@ -47417,9 +47320,9 @@
       "version": "2.29.4"
     },
     "mongodb-chatbot-ui": {
-      "version": "0.9.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.9.0.tgz",
-      "integrity": "sha512-IV3ltrTwfYVcy6Oj7ZXJ4aHIC/vZY4sOLRaKlPoAiU2oHuIKtUlHkVxfxyvwS+Uwk1pEpv/+jAC6EEKdn2wlBA==",
+      "version": "0.10.2",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mongodb-chatbot-ui/-/mongodb-chatbot-ui-0.10.2.tgz",
+      "integrity": "sha512-fciCZLwcP+spx9QeOgA7fmYs0mcbTjiAm0YWbIeXc6gZVQiiSxoU2XSJDK4CN5pscgY/OqRdfFYa0kG2Z4R2tA==",
       "requires": {
         "@emotion/css": "^11.11.2",
         "@leafygreen-ui/badge": "^8.1.2",
@@ -47431,7 +47334,6 @@
         "@leafygreen-ui/icon": "^12.4.0",
         "@leafygreen-ui/icon-button": "^15.0.21",
         "@leafygreen-ui/leafygreen-provider": "^3.1.12",
-        "@leafygreen-ui/loading-indicator": "^2.0.12",
         "@leafygreen-ui/menu": "^22.0.9",
         "@leafygreen-ui/modal": "^16.0.7",
         "@leafygreen-ui/palette": "^4.0.10",
@@ -47443,14 +47345,14 @@
         "@lg-chat/chat-disclaimer": "^3.0.2",
         "@lg-chat/chat-window": "^2.0.1",
         "@lg-chat/fixed-chat-window": "^2.0.3",
-        "@lg-chat/input-bar": "^4.0.3",
+        "@lg-chat/input-bar": "^5.1.0",
         "@lg-chat/leafygreen-chat-provider": "^2.0.0",
         "@lg-chat/message": "^4.2.1",
         "@lg-chat/message-feed": "^3.0.1",
         "@lg-chat/message-feedback": "^2.1.0",
         "@lg-chat/message-prompts": "^2.0.2",
         "@lg-chat/message-rating": "^2.0.2",
-        "@lg-chat/rich-links": "^1.0.1",
+        "@lg-chat/rich-links": "^1.2.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "buffer": "^6.0.3",
         "esbuild": "^0.17.19",
@@ -49609,16 +49511,6 @@
         "prop-types": "^15.5.0"
       }
     },
-    "react-lottie-player": {
-      "version": "1.5.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-lottie-player/-/react-lottie-player-1.5.6.tgz",
-      "integrity": "sha512-t0GdTYbml0Ihski8ZPx+1WjpjM/EQlTqTcuGm5yeZGJAgFXTmoqrHbSX8bcREIxrHjibWAyIWnLVUK/iHLcqAQ==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3",
-        "lottie-web": "^5.7.6",
-        "rfdc": "^1.3.0"
-      }
-    },
     "react-markdown": {
       "version": "8.0.7",
       "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-markdown/-/react-markdown-8.0.7.tgz",
@@ -49722,9 +49614,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.5.3",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
-      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "version": "8.5.5",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-textarea-autosize/-/react-textarea-autosize-8.5.5.tgz",
+      "integrity": "sha512-CVA94zmfp8m4bSHtWwmANaBR8EPsKy2aZ7KwqhoS4Ftib87F9Kvi7XQhOixypPLMc6kVYgOXvKFuuzZDpHGRPg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -50450,7 +50342,8 @@
       "version": "1.0.4"
     },
     "rfdc": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "lodash": "^4.6.0",
     "minimist": "^1.2.6",
     "mobx": "^6.1.5",
-    "mongodb-chatbot-ui": "^0.9.0",
+    "mongodb-chatbot-ui": "^0.10.2",
     "no-scroll": "^2.1.1",
     "node-fetch": "^3.3.2",
     "node-gyp": "^10.1.0",

--- a/src/styles/mongodb-docs.css
+++ b/src/styles/mongodb-docs.css
@@ -385,7 +385,8 @@ q:before {
     max-width: 970px;
   }
 }
-label {
+/* :not negation used to disallow these styles from affecting chatbot modal like/dislike buttons */
+label:not([for*='-message-rating']) {
   margin-bottom: 5px;
   font-weight: 700;
 }


### PR DESCRIPTION
### Stories/Links:

DOP-5181

### Current Behavior:

[Landing](https://mongodb.com/docs/)

### Staging Links:

[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/collapse-expanded/landing/matt.meigs/DOP-5181-chatbot/index.html)

### Notes:

Updated Chatbot. Need to be on VPN to test on staging.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
