### PR TITLE
DOP-5250: Support .ast filenames as pages

### DIFF
--- a/plugins/gatsby-source-snooty-prod/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-prod/gatsby-node.js
@@ -155,7 +155,9 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, getNo
 
     currentPageComponents.forEach((componentName) => projectComponents.add(componentName));
 
-    if (filename.endsWith('.txt') && !manifestMetadata.openapi_pages?.[key]) {
+    const validPageExtensions = ['.txt', '.ast'];
+    const isValidPageExtension = validPageExtensions.some((ext) => filename.endsWith(ext));
+    if (isValidPageExtension && !manifestMetadata.openapi_pages?.[key]) {
       createNode({
         id: key,
         page_id: key,


### PR DESCRIPTION
### Stories/Links:

DOP-5250

### Current Behavior:

N/A

### Staging Links:

[Java staging - .ast file](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/java/raymund.rodriguez/DOP-5250-page-extensions/api/example/index.html)
[Java staging - .txt file (regression check)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/java/raymund.rodriguez/DOP-5250-page-extensions/index.html)

### Notes:

* `.ast` filenames should be treated as full pages too

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
