### PR TITLE
Update package lock for icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4765,9 +4765,9 @@
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.8.0.tgz",
-      "integrity": "sha512-LDYSFtdn+dX3/hyBJJw722grz98To+X9Nw/97F6MUk+D9eNdufzPFYQCd8iDsgUbfeSVJ/uw1PVr20QEJ7Xtcw==",
+      "version": "12.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
+      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
       "dependencies": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
@@ -35459,9 +35459,9 @@
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.8.0",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.8.0.tgz",
-      "integrity": "sha512-LDYSFtdn+dX3/hyBJJw722grz98To+X9Nw/97F6MUk+D9eNdufzPFYQCd8iDsgUbfeSVJ/uw1PVr20QEJ7Xtcw==",
+      "version": "12.9.0",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@leafygreen-ui/icon/-/icon-12.9.0.tgz",
+      "integrity": "sha512-TX5iObwOwOEZ1xI5YqABuIkzKcfiMN31FApGSDDvorq+uA4MNCo0whoJLnNkg/JkyJ0Wi+MSfstTEE9NYwlVDg==",
       "requires": {
         "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"


### PR DESCRIPTION
See slack thread [here](https://mongodb.slack.com/archives/CFFA5BS79/p1734448292356059)
Seems like the new releases for icon make it incompatible for the lock file