### PR TITLE
DOP-5258: make collapsibles interactive offline

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -28,7 +28,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
   }, [children]);
 
   const [open, setOpen] = useState(() => {
-    if (isOfflineDocsBuild || expanded) return true;
+    if (isOfflineDocsBuild) return true;
     return expanded ?? true;
   });
   const headingNodeData = {

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -8,7 +8,9 @@ import { cx } from '@leafygreen-ui/emotion';
 import { Body } from '@leafygreen-ui/typography';
 import { HeadingContextProvider } from '../../context/heading-context';
 import { findAllNestedAttribute } from '../../utils/find-all-nested-attribute';
+import { CLASSNAME, CONTENT_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
 import { isBrowser } from '../../utils/is-browser';
+import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 import { reportAnalytics } from '../../utils/report-analytics';
 import ComponentFactory from '../ComponentFactory';
 import Heading from '../Heading';
@@ -25,7 +27,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(expanded ?? true);
+  const [open, setOpen] = useState(() => expanded ?? true);
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],
@@ -67,7 +69,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
 
   return (
     <HeadingContextProvider ignoreNextHeading={true} heading={heading}>
-      <Box className={cx('collapsible', collapsibleStyle)}>
+      <Box aria-expanded={open} className={cx('collapsible', collapsibleStyle, isOfflineDocsBuild ? CLASSNAME : '')}>
         <Box className={cx(headerContainerStyle)}>
           <Box>
             {/* Adding 1 to reflect logic in parser, but want to show up as H2 for SEO reasons */}
@@ -76,11 +78,16 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
             </Heading>
             <Body baseFontSize={13}>{subHeading}</Body>
           </Box>
-          <IconButton className={iconStyle} aria-labelledby={'Expand the collapsed content'} onClick={onIconClick}>
-            <Icon glyph={open ? 'ChevronDown' : 'ChevronRight'} />
+          <IconButton
+            className={iconStyle}
+            aria-labelledby={'Expand the collapsed content'}
+            aria-expanded={open}
+            onClick={onIconClick}
+          >
+            <Icon glyph={open || isOfflineDocsBuild ? 'ChevronDown' : 'ChevronRight'} />
           </IconButton>
         </Box>
-        <Box className={cx(innerContentStyle(open))}>
+        <Box className={cx(innerContentStyle, isOfflineDocsBuild ? CONTENT_CLASSNAME : '')}>
           {children.map((c, i) => (
             <ComponentFactory nodeData={c} key={i} sectionDepth={sectionDepth} {...rest}></ComponentFactory>
           ))}

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -27,7 +27,10 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(() => (expanded || isOfflineDocsBuild) ?? true);
+  const [open, setOpen] = useState(() => {
+    if (isOfflineDocsBuild || expanded) return true;
+    return expanded ?? true;
+  });
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -27,7 +27,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     return findAllNestedAttribute(children, 'id');
   }, [children]);
 
-  const [open, setOpen] = useState(() => expanded ?? true);
+  const [open, setOpen] = useState(() => (expanded || isOfflineDocsBuild) ?? true);
   const headingNodeData = {
     id,
     children: [{ type: 'text', value: heading }],
@@ -84,7 +84,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
             aria-expanded={open}
             onClick={onIconClick}
           >
-            <Icon glyph={open || isOfflineDocsBuild ? 'ChevronDown' : 'ChevronRight'} />
+            <Icon glyph={open ? 'ChevronDown' : 'ChevronRight'} />
           </IconButton>
         </Box>
         <Box className={cx(innerContentStyle, isOfflineDocsBuild ? CONTENT_CLASSNAME : '')}>

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -8,7 +8,7 @@ import { cx } from '@leafygreen-ui/emotion';
 import { Body } from '@leafygreen-ui/typography';
 import { HeadingContextProvider } from '../../context/heading-context';
 import { findAllNestedAttribute } from '../../utils/find-all-nested-attribute';
-import { CLASSNAME, CONTENT_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
+import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
 import { isBrowser } from '../../utils/is-browser';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 import { reportAnalytics } from '../../utils/report-analytics';
@@ -72,7 +72,10 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
 
   return (
     <HeadingContextProvider ignoreNextHeading={true} heading={heading}>
-      <Box aria-expanded={open} className={cx('collapsible', collapsibleStyle, isOfflineDocsBuild ? CLASSNAME : '')}>
+      <Box
+        aria-expanded={open}
+        className={cx('collapsible', collapsibleStyle, isOfflineDocsBuild ? OFFLINE_CLASSNAME : '')}
+      >
         <Box className={cx(headerContainerStyle)}>
           <Box>
             {/* Adding 1 to reflect logic in parser, but want to show up as H2 for SEO reasons */}
@@ -90,7 +93,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
             <Icon glyph={open ? 'ChevronDown' : 'ChevronRight'} />
           </IconButton>
         </Box>
-        <Box className={cx(innerContentStyle, isOfflineDocsBuild ? CONTENT_CLASSNAME : '')}>
+        <Box className={cx(innerContentStyle)}>
           {children.map((c, i) => (
             <ComponentFactory nodeData={c} key={i} sectionDepth={sectionDepth} {...rest}></ComponentFactory>
           ))}

--- a/src/components/Collapsible/styles.js
+++ b/src/components/Collapsible/styles.js
@@ -1,6 +1,7 @@
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
+import { CLASSNAME as OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
 
 export const collapsibleStyle = css`
   border-bottom: 1px solid ${palette.gray.light2};
@@ -29,13 +30,18 @@ export const headerStyle = css`
 export const iconStyle = css`
   align-self: center;
   flex-shrink: 0;
+
+  .${OFFLINE_CLASSNAME}[aria-expanded=false] & {
+    transform: rotate(-90deg);
+  }
 `;
 
-export const innerContentStyle = (open) => css`
+export const innerContentStyle = css`
   overflow: hidden;
   height: 0;
   color: --font-color-primary;
 
-  ${open && `height: auto;`}
-  ${open && `visibility: visible;`}
+  [aria-expanded='true'] & {
+    height: auto;
+  }
 `;

--- a/src/components/Collapsible/styles.js
+++ b/src/components/Collapsible/styles.js
@@ -1,7 +1,7 @@
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
-import { CLASSNAME as OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
+import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
 
 export const collapsibleStyle = css`
   border-bottom: 1px solid ${palette.gray.light2};

--- a/src/components/ComponentFactoryLazy.js
+++ b/src/components/ComponentFactoryLazy.js
@@ -12,7 +12,7 @@ const ComponentMap = {
 };
 
 export const LAZY_COMPONENTS = Object.keys(ComponentMap).reduce((res, key) => {
-  if (isOfflineDocsBuild && key === 'instruqt') {
+  if (isOfflineDocsBuild && ['video', 'instruqt'].includes(key)) {
     res[key] = (props) => (!props.nodeData?.options?.drawer ? <OfflineNotAvailable assetKey={key} /> : null);
   } else {
     const LazyComponent = ComponentMap[key];

--- a/src/utils/head-scripts/offline-ui/collapsible.js
+++ b/src/utils/head-scripts/offline-ui/collapsible.js
@@ -1,0 +1,26 @@
+function bindCollapsibleUI() {
+  const onContentLoaded = () => {
+    try {
+      const collapsibleComponents = document.querySelectorAll('.offline-collapsible');
+      for (const collapsible of collapsibleComponents) {
+        // bind event to button
+        const button = collapsible.querySelector('button');
+        button?.addEventListener('click', () => {
+          console.log('click');
+          const newVal = button.getAttribute('aria-expanded') === 'false' ? true : false;
+          button.setAttribute('aria-expanded', newVal);
+          collapsible.setAttribute('aria-expanded', newVal);
+        });
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', onContentLoaded, false);
+}
+
+export default bindCollapsibleUI;
+
+export const CLASSNAME = `offline-collapsible`;
+export const CONTENT_CLASSNAME = `offline-collapsible-content`;

--- a/src/utils/head-scripts/offline-ui/collapsible.js
+++ b/src/utils/head-scripts/offline-ui/collapsible.js
@@ -6,8 +6,7 @@ function bindCollapsibleUI() {
         // bind event to button
         const button = collapsible.querySelector('button');
         button?.addEventListener('click', () => {
-          console.log('click');
-          const newVal = button.getAttribute('aria-expanded') === 'false' ? true : false;
+          const newVal = button.getAttribute('aria-expanded') === 'false';
           button.setAttribute('aria-expanded', newVal);
           collapsible.setAttribute('aria-expanded', newVal);
         });
@@ -22,5 +21,4 @@ function bindCollapsibleUI() {
 
 export default bindCollapsibleUI;
 
-export const CLASSNAME = `offline-collapsible`;
-export const CONTENT_CLASSNAME = `offline-collapsible-content`;
+export const OFFLINE_CLASSNAME = `offline-collapsible`;

--- a/src/utils/head-scripts/offline-ui/index.js
+++ b/src/utils/head-scripts/offline-ui/index.js
@@ -1,4 +1,5 @@
 import bindTabUI from './tabs';
+import bindCollapsibleUI from './collapsible';
 import updateSidenavHeight from './sidenav';
 import bindTabsSelectorsUI from './tabs-selectors';
 const OFFLINE_UI_CLASSNAME = 'snooty-offline-ui';
@@ -12,6 +13,6 @@ const getScript = ({ key, fn }) => (
   />
 );
 
-export const OFFLINE_HEAD_SCRIPTS = [bindTabUI, updateSidenavHeight, bindTabsSelectorsUI].map((fn, idx) =>
-  getScript({ key: `offline-docs-ui-${idx}`, fn })
+export const OFFLINE_HEAD_SCRIPTS = [bindTabUI, updateSidenavHeight, bindTabsSelectorsUI, bindCollapsibleUI].map(
+  (fn, idx) => getScript({ key: `offline-docs-ui-${idx}`, fn })
 );

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -193,7 +193,7 @@ exports[`collapsible component renders all the content in the options and childr
   color: --font-color-primary;
 }
 
-[aria-expanded=true] .emotion-10 {
+[aria-expanded='true'] .emotion-10 {
   height: auto;
 }
 

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -160,6 +160,13 @@ exports[`collapsible component renders all the content in the options and childr
   background-color: rgba(61,79,88,0.1);
 }
 
+.offline-collapsible[aria-expanded=false] .emotion-8 {
+  -webkit-transform: rotate(-90deg);
+  -moz-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+
 .emotion-9 {
   position: absolute;
   top: 0;
@@ -184,6 +191,10 @@ exports[`collapsible component renders all the content in the options and childr
   overflow: hidden;
   height: 0;
   color: --font-color-primary;
+}
+
+[aria-expanded=true] .emotion-10 {
+  height: auto;
 }
 
 .emotion-11 {
@@ -509,6 +520,7 @@ exports[`collapsible component renders all the content in the options and childr
 }
 
 <div
+    aria-expanded="false"
     class="collapsible emotion-0"
   >
     <div
@@ -557,6 +569,7 @@ exports[`collapsible component renders all the content in the options and childr
       </div>
       <button
         aria-disabled="false"
+        aria-expanded="false"
         aria-labelledby="Expand the collapsed content"
         class="emotion-8"
         tabindex="0"


### PR DESCRIPTION
### Stories/Links:

DOP-5258

### Staging Links:

[Sample S3 file that has collapsibles enabled on offline page](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=DOP-5124-test-tables/cloud-docs/seung.park/DOP-5258/tutorial/prometheus-integration/index.html) (append #mongo-metrics.json to URL or search for `mongo-metrics.json`

[Regression check for online collapsibles](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/offline-docs-false/DOP-5124-test-tables/cloud-docs/seung.park/DOP-5258/tutorial/prometheus-integration/index.html)


### Notes:
- Made a minor change to allow videos to be covered by `OfflineNotAvailable` component.
- Minor improvement to add `aria-expanded` to collapsibles and their button

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
