### PR TITLE
DOP-5259: interactive method selector for offline docs

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -8,7 +8,7 @@ import { cx } from '@leafygreen-ui/emotion';
 import { Body } from '@leafygreen-ui/typography';
 import { HeadingContextProvider } from '../../context/heading-context';
 import { findAllNestedAttribute } from '../../utils/find-all-nested-attribute';
-import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
+import { OFFLINE_COLLAPSIBLE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
 import { isBrowser } from '../../utils/is-browser';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 import { reportAnalytics } from '../../utils/report-analytics';
@@ -74,7 +74,7 @@ const Collapsible = ({ nodeData: { children, options }, sectionDepth, ...rest })
     <HeadingContextProvider ignoreNextHeading={true} heading={heading}>
       <Box
         aria-expanded={open}
-        className={cx('collapsible', collapsibleStyle, isOfflineDocsBuild ? OFFLINE_CLASSNAME : '')}
+        className={cx('collapsible', collapsibleStyle, isOfflineDocsBuild ? OFFLINE_COLLAPSIBLE_CLASSNAME : '')}
       >
         <Box className={cx(headerContainerStyle)}>
           <Box>

--- a/src/components/Collapsible/styles.js
+++ b/src/components/Collapsible/styles.js
@@ -1,7 +1,8 @@
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { theme } from '../../theme/docsTheme';
-import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
+import { OFFLINE_COLLAPSIBLE_CLASSNAME } from '../../utils/head-scripts/offline-ui/collapsible';
+import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 
 export const collapsibleStyle = css`
   border-bottom: 1px solid ${palette.gray.light2};
@@ -31,9 +32,10 @@ export const iconStyle = css`
   align-self: center;
   flex-shrink: 0;
 
-  .${OFFLINE_CLASSNAME}[aria-expanded=false] & {
+  ${isOfflineDocsBuild &&
+  `.${OFFLINE_COLLAPSIBLE_CLASSNAME}[aria-expanded=false] & {
     transform: rotate(-90deg);
-  }
+  }`}
 `;
 
 export const innerContentStyle = css`

--- a/src/components/MethodSelector/MethodOptionContent.js
+++ b/src/components/MethodSelector/MethodOptionContent.js
@@ -2,18 +2,27 @@ import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import ComponentFactory from '../ComponentFactory';
 import { theme } from '../../theme/docsTheme';
+import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
+import { OFFLINE_CONTENT_CLASSNAME } from '../../utils/head-scripts/offline-ui/method-selector';
 import MethodDescription from './MethodDescription';
 
 const METHOD_DESCRIPTION_NAME = 'method-description';
 
 const displayStyle = (isSelectedOption) => css`
-  ${!isSelectedOption && 'display: none;'}
+  ${!isSelectedOption && !isOfflineDocsBuild && 'display: none;'}
 `;
 
 export const getTestId = (optionId) => `method-option-content-${optionId}`;
 
 const containerStyle = css`
   margin-top: ${theme.size.default};
+
+  ${isOfflineDocsBuild &&
+  `
+    &[aria-expanded=false] {
+      display: none;
+    }
+  `}
 `;
 
 const MethodOptionContent = ({
@@ -27,7 +36,15 @@ const MethodOptionContent = ({
   const methodDescription = children.find(({ name }) => name === METHOD_DESCRIPTION_NAME);
 
   return (
-    <div className={cx(containerStyle, displayStyle(isSelectedOption))} data-testid={getTestId(id)}>
+    <div
+      aria-expanded={isSelectedOption}
+      className={cx(
+        containerStyle,
+        displayStyle(isSelectedOption),
+        isOfflineDocsBuild ? OFFLINE_CONTENT_CLASSNAME : ''
+      )}
+      data-testid={getTestId(id)}
+    >
       {methodDescription && <MethodDescription nodeData={methodDescription} />}
       {children.map((node, index) => {
         if (node.name === METHOD_DESCRIPTION_NAME) return null;

--- a/src/components/MethodSelector/MethodSelector.js
+++ b/src/components/MethodSelector/MethodSelector.js
@@ -6,6 +6,8 @@ import { theme } from '../../theme/docsTheme';
 import { getLocalValue, setLocalValue } from '../../utils/browser-storage';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { ContentsContext } from '../Contents/contents-context';
+import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
+import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/method-selector';
 import MethodOptionContent from './MethodOptionContent';
 
 const STORAGE_KEY = 'methodSelectorId';
@@ -129,7 +131,7 @@ const MethodSelector = ({ nodeData: { children } }) => {
 
   return (
     <>
-      <div className={optionsContainer}>
+      <div className={cx(optionsContainer, isOfflineDocsBuild ? OFFLINE_CLASSNAME : '')}>
         <RadioBoxGroup
           className={cx(radioBoxGroupStyle(children.length))}
           size={'full'}
@@ -146,17 +148,26 @@ const MethodSelector = ({ nodeData: { children } }) => {
         >
           {children.map(({ options: { title, id } }, index) => {
             return (
-              <RadioBox key={id} className={cx(radioBoxStyle)} value={`${id}-${index}`} checked={selectedMethod === id}>
+              <RadioBox
+                id={id}
+                key={id}
+                className={cx(radioBoxStyle)}
+                value={`${id}-${index}`}
+                checked={selectedMethod === id}
+              >
                 {title}
               </RadioBox>
             );
           })}
         </RadioBoxGroup>
         {/* Keep separate div for triangle to allow for relative positioning */}
-        <div className={cx(lineStyle)}>
-          <div className={cx(triangleStyle(optionCount, selectedIdx))} />
-          <hr className={cx(hrStyle)} />
-        </div>
+        {/* Offline docs will not have this triangle indicator */}
+        {!isOfflineDocsBuild && (
+          <div className={cx(lineStyle)}>
+            <div className={cx(triangleStyle(optionCount, selectedIdx))} />
+            <hr className={cx(hrStyle)} />
+          </div>
+        )}
       </div>
       {children.map((child, index) => {
         if (child.name !== 'method-option') return null;

--- a/src/components/MethodSelector/MethodSelector.js
+++ b/src/components/MethodSelector/MethodSelector.js
@@ -7,7 +7,7 @@ import { getLocalValue, setLocalValue } from '../../utils/browser-storage';
 import { reportAnalytics } from '../../utils/report-analytics';
 import { ContentsContext } from '../Contents/contents-context';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
-import { OFFLINE_CLASSNAME } from '../../utils/head-scripts/offline-ui/method-selector';
+import { OFFLINE_METHOD_SELECTOR_CLASSNAME } from '../../utils/head-scripts/offline-ui/method-selector';
 import MethodOptionContent from './MethodOptionContent';
 
 const STORAGE_KEY = 'methodSelectorId';
@@ -145,7 +145,7 @@ const MethodSelector = ({ nodeData: { children } }) => {
 
   return (
     <>
-      <div className={cx(optionsContainer, isOfflineDocsBuild ? OFFLINE_CLASSNAME : '')}>
+      <div className={cx(optionsContainer, isOfflineDocsBuild ? OFFLINE_METHOD_SELECTOR_CLASSNAME : '')}>
         <RadioBoxGroup
           className={cx(radioBoxGroupStyle(children.length))}
           size={'full'}

--- a/src/components/MethodSelector/MethodSelector.js
+++ b/src/components/MethodSelector/MethodSelector.js
@@ -52,7 +52,21 @@ const radioBoxStyle = css`
     padding: 14px 12px;
     background-color: inherit;
     color: inherit;
+
+    ${isOfflineDocsBuild &&
+    `
+      border-color: ${palette.gray.base};
+      box-shadow: none;
+    `}
   }
+
+  ${isOfflineDocsBuild &&
+  `
+    &[aria-selected=true] div {
+      border-color: transparent;
+      box-shadow: 0 0 0 3px ${palette.green.dark1};
+    }
+  `}
 
   :not(:last-of-type) {
     margin: 0;
@@ -154,6 +168,7 @@ const MethodSelector = ({ nodeData: { children } }) => {
                 className={cx(radioBoxStyle)}
                 value={`${id}-${index}`}
                 checked={selectedMethod === id}
+                aria-selected={isOfflineDocsBuild ? index === 0 : null}
               >
                 {title}
               </RadioBox>

--- a/src/components/MethodSelector/MethodSelector.js
+++ b/src/components/MethodSelector/MethodSelector.js
@@ -168,7 +168,7 @@ const MethodSelector = ({ nodeData: { children } }) => {
                 className={cx(radioBoxStyle)}
                 value={`${id}-${index}`}
                 checked={selectedMethod === id}
-                aria-selected={isOfflineDocsBuild ? index === 0 : null}
+                aria-selected={isOfflineDocsBuild ? selectedMethod === id : null}
               >
                 {title}
               </RadioBox>

--- a/src/utils/head-scripts/offline-ui/collapsible.js
+++ b/src/utils/head-scripts/offline-ui/collapsible.js
@@ -21,4 +21,4 @@ function bindCollapsibleUI() {
 
 export default bindCollapsibleUI;
 
-export const OFFLINE_CLASSNAME = `offline-collapsible`;
+export const OFFLINE_COLLAPSIBLE_CLASSNAME = `offline-collapsible`;

--- a/src/utils/head-scripts/offline-ui/index.js
+++ b/src/utils/head-scripts/offline-ui/index.js
@@ -2,6 +2,8 @@ import bindTabUI from './tabs';
 import bindCollapsibleUI from './collapsible';
 import updateSidenavHeight from './sidenav';
 import bindTabsSelectorsUI from './tabs-selectors';
+import bindMethodSelectorUI from './method-selector';
+
 const OFFLINE_UI_CLASSNAME = 'snooty-offline-ui';
 
 const getScript = ({ key, fn }) => (
@@ -13,6 +15,10 @@ const getScript = ({ key, fn }) => (
   />
 );
 
-export const OFFLINE_HEAD_SCRIPTS = [bindTabUI, updateSidenavHeight, bindTabsSelectorsUI, bindCollapsibleUI].map(
-  (fn, idx) => getScript({ key: `offline-docs-ui-${idx}`, fn })
-);
+export const OFFLINE_HEAD_SCRIPTS = [
+  bindTabUI,
+  updateSidenavHeight,
+  bindTabsSelectorsUI,
+  bindCollapsibleUI,
+  bindMethodSelectorUI,
+].map((fn, idx) => getScript({ key: `offline-docs-ui-${idx}`, fn }));

--- a/src/utils/head-scripts/offline-ui/method-selector.js
+++ b/src/utils/head-scripts/offline-ui/method-selector.js
@@ -18,7 +18,7 @@ function bindMethodSelectorUI() {
         const labels = methodSelectorComponent.querySelectorAll('label');
 
         // for each input, find value `{name}-{index}` ie.  `driver-0`
-        // find data-testid=[method-option-content-{name}] and show
+        // find content div with data-testid=[method-option-content-{name}] and show that content div
         for (let idx = 0; idx < buttons.length; idx++) {
           const button = buttons[idx];
           button.addEventListener('click', (e) => {
@@ -33,6 +33,9 @@ function bindMethodSelectorUI() {
             }
           });
         }
+
+        // on load, set first label as active
+        labels[0]?.setAttribute('aria-selected', true);
       }
     } catch (e) {
       console.error(e);

--- a/src/utils/head-scripts/offline-ui/method-selector.js
+++ b/src/utils/head-scripts/offline-ui/method-selector.js
@@ -47,5 +47,5 @@ function bindMethodSelectorUI() {
 
 export default bindMethodSelectorUI;
 
-export const OFFLINE_CLASSNAME = `offline-method-selector`;
+export const OFFLINE_METHOD_SELECTOR_CLASSNAME = `offline-method-selector`;
 export const OFFLINE_CONTENT_CLASSNAME = `offline-method-selector-content`;

--- a/src/utils/head-scripts/offline-ui/method-selector.js
+++ b/src/utils/head-scripts/offline-ui/method-selector.js
@@ -9,24 +9,27 @@ function bindMethodSelectorUI() {
 
         // find the radio box inputs within button group and bind action
         const buttons = buttonGroup?.querySelectorAll('input') ?? [];
-        console.log('buttons');
-        console.log(buttons);
 
         // find all the content within method selectors
         const contentDivs =
           methodSelectorComponent.parentElement?.querySelectorAll('.offline-method-selector-content') ?? [];
+
+        // find all the labels to style for selected
+        const labels = methodSelectorComponent.querySelectorAll('label');
 
         // for each input, find value `{name}-{index}` ie.  `driver-0`
         // find data-testid=[method-option-content-{name}] and show
         for (let idx = 0; idx < buttons.length; idx++) {
           const button = buttons[idx];
           button.addEventListener('click', (e) => {
-            console.log('click');
-            const id = (button.getAttribute('value') || '').split('-')[0];
-            console.log('id ', id);
+            const id = (e.currentTarget.getAttribute('value') || '').split('-')[0];
             const targetTestId = 'method-option-content-' + id;
+            const parentLabel = button.parentElement;
             for (const contentDiv of contentDivs) {
               contentDiv.setAttribute('aria-expanded', targetTestId === contentDiv.getAttribute('data-testid'));
+            }
+            for (const label of labels) {
+              label.setAttribute('aria-selected', label.isSameNode(parentLabel));
             }
           });
         }

--- a/src/utils/head-scripts/offline-ui/method-selector.js
+++ b/src/utils/head-scripts/offline-ui/method-selector.js
@@ -1,0 +1,45 @@
+function bindMethodSelectorUI() {
+  const onContentLoaded = () => {
+    try {
+      // find all method selectors
+      const methodSelectorComponents = document.querySelectorAll('.offline-method-selector');
+      for (const methodSelectorComponent of methodSelectorComponents) {
+        // find the button group role=group
+        const buttonGroup = methodSelectorComponent.querySelector('[role=group]');
+
+        // find the radio box inputs within button group and bind action
+        const buttons = buttonGroup?.querySelectorAll('input') ?? [];
+        console.log('buttons');
+        console.log(buttons);
+
+        // find all the content within method selectors
+        const contentDivs =
+          methodSelectorComponent.parentElement?.querySelectorAll('.offline-method-selector-content') ?? [];
+
+        // for each input, find value `{name}-{index}` ie.  `driver-0`
+        // find data-testid=[method-option-content-{name}] and show
+        for (let idx = 0; idx < buttons.length; idx++) {
+          const button = buttons[idx];
+          button.addEventListener('click', (e) => {
+            console.log('click');
+            const id = (button.getAttribute('value') || '').split('-')[0];
+            console.log('id ', id);
+            const targetTestId = 'method-option-content-' + id;
+            for (const contentDiv of contentDivs) {
+              contentDiv.setAttribute('aria-expanded', targetTestId === contentDiv.getAttribute('data-testid'));
+            }
+          });
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', onContentLoaded, false);
+}
+
+export default bindMethodSelectorUI;
+
+export const OFFLINE_CLASSNAME = `offline-method-selector`;
+export const OFFLINE_CONTENT_CLASSNAME = `offline-method-selector-content`;

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -160,13 +160,6 @@ exports[`collapsible component renders all the content in the options and childr
   background-color: rgba(61,79,88,0.1);
 }
 
-.offline-collapsible[aria-expanded=false] .emotion-8 {
-  -webkit-transform: rotate(-90deg);
-  -moz-transform: rotate(-90deg);
-  -ms-transform: rotate(-90deg);
-  transform: rotate(-90deg);
-}
-
 .emotion-9 {
   position: absolute;
   top: 0;


### PR DESCRIPTION
### Stories/Links:

DOP-5259


### Staging Links:

[S3 file to download and verify that method selector works offline](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=sandbox/cloud-docs/seung.park/DOP-5259/testing-method-selector/index.html)

[online docs without OFFLINE_DOCS env flag for regression check](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/offline-docs-false/sandbox/cloud-docs/seung.park/DOP-5259/testing-method-selector/index.html)

### Notes:
- The arrow indicator has been removed for offline method selectors as it needs some calculations based on selected index to get the position
- On this Page headings will be handled separately as the content values are hidden in a React context

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
