### PR TITLE
DOP-5273: add console warning for column out of index and continue

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -213,7 +213,12 @@ const generateRowsData = (bodyRowNodes, columns) => {
   const rowNodes = bodyRowNodes.map((node) => node?.children[0]?.children ?? []);
   const rows = rowNodes.map((rowNode) => {
     return rowNode.reduce((res, columnNode, colIndex) => {
-      res[columns[colIndex].accessorKey] = (
+      const column = columns[colIndex];
+      if (!column) {
+        console.warn(`Row has too many items (index ${colIndex}) for table with ${columns.length} columns`);
+        return res;
+      }
+      res[column?.accessorKey ?? colIndex] = (
         <>
           {columnNode.children.map((cellNode, index) => (
             <ComponentFactory key={index} nodeData={cellNode} />


### PR DESCRIPTION
### Stories/Links:

DOP-5273

### Current Behavior:

On the main branch, building a wrongly structured ListTable can produce an error in the build step for ListTables.
See [this build log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=6764665504ba9f49246c5ea5) and search for `ListTable`. This resulted in the front end throwing an error at build time.

[An example of badly structured ListTable](https://github.com/mongodb/docs-pymongo/blob/960ea6688e47334a09d3a77a84b75a6512de37f0/source/includes/mongodb-compatibility-table-pymongo.rst?plain=1#L16-L27)). This row has too many columns (12) even though the table only has 9 columns.

### Staging Links:

[Staging link with test RST with too many items in row
](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/HEAD/pymongo/seung.park/DOP-5273/compatibility/index.html)
Above link shows a console warning `ListTable.js:218 Row has too many items (index 9) for table with 9 columns` if too many items are included for that row. This is being tested with the above example RST

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
