### PR TITLE
DOP-5362: Fix missing search and hash from lang redirects

### DIFF
--- a/src/utils/head-scripts/redirect-based-on-lang.js
+++ b/src/utils/head-scripts/redirect-based-on-lang.js
@@ -40,7 +40,8 @@ function redirectBasedOnLang() {
       // Check to see if browser's language is one that is already translated
       const matchedLocale = supportedLocaleCodes.find((localeCode) => localeCode.startsWith(lang));
       if (matchedLocale) {
-        const targetPath = '/' + matchedLocale + window.location.pathname;
+        const targetPath =
+          '/' + matchedLocale + window.location.pathname + window.location.search + window.location.hash;
         window.location.href = targetPath;
       }
     }

--- a/src/utils/head-scripts/redirect-based-on-lang.js
+++ b/src/utils/head-scripts/redirect-based-on-lang.js
@@ -40,9 +40,8 @@ function redirectBasedOnLang() {
       // Check to see if browser's language is one that is already translated
       const matchedLocale = supportedLocaleCodes.find((localeCode) => localeCode.startsWith(lang));
       if (matchedLocale) {
-        const targetPath =
-          '/' + matchedLocale + window.location.pathname + window.location.search + window.location.hash;
-        window.location.href = targetPath;
+        const targetPath = '/' + matchedLocale + window.location.pathname;
+        window.location.pathname = targetPath;
       }
     }
   } catch (e) {

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -187,7 +187,7 @@ export const onSelectLocale = (locale) => {
   const location = window.location;
   setLocalValue(STORAGE_KEY_PREF_LOCALE, locale);
   const localizedPath = localizePath(location.pathname, locale);
-  window.location.href = localizedPath;
+  window.location.pathname = localizedPath;
 };
 
 /**

--- a/tests/unit/utils/head-scripts/redirect-based-on-lang.test.js
+++ b/tests/unit/utils/head-scripts/redirect-based-on-lang.test.js
@@ -13,10 +13,14 @@ const defineWindowLocation = (value = {}) => {
 };
 
 const runFuncTest = (originalPathname, expectedPathname) => {
+  const { hash, search, pathname } = new URL(originalPathname, 'https://mongodb.com');
   defineWindowLocation({
-    pathname: originalPathname,
     // Implementation detail: window.location.href should be defined since it won't be set if no redirect occurs
+    // For testing purposes, we don't care about the base url, so we just use whatever the original pathname was
     href: originalPathname,
+    pathname,
+    hash,
+    search,
   });
 
   redirectBasedOnLang();
@@ -81,5 +85,12 @@ describe('redirectBasedOnLang', () => {
     // "en" should take precedence over "ko" here
     mockedBrowserLangs.mockReturnValue(['en-uk', 'ko-kr']);
     runFuncTest(DEFAULT_SLUG, DEFAULT_SLUG);
+  });
+
+  it('includes the query string and/or hash', () => {
+    mockedBrowserLangs.mockReturnValue(['zh-cn', 'en']);
+    runFuncTest('/docs/bar?a=b#c', '/zh-cn/docs/bar?a=b#c');
+    runFuncTest('/docs/bar?a=b', '/zh-cn/docs/bar?a=b');
+    runFuncTest('/docs/bar#c', '/zh-cn/docs/bar#c');
   });
 });

--- a/tests/unit/utils/head-scripts/redirect-based-on-lang.test.js
+++ b/tests/unit/utils/head-scripts/redirect-based-on-lang.test.js
@@ -12,19 +12,20 @@ const defineWindowLocation = (value = {}) => {
   });
 };
 
-const runFuncTest = (originalPathname, expectedPathname) => {
-  const { hash, search, pathname } = new URL(originalPathname, 'https://mongodb.com');
+const runFuncTest = (originalHref, expectedHref) => {
+  // Destructure URL parts to help mock location
+  const { hash, search, pathname } = new URL(originalHref, 'https://mongodb.com');
   defineWindowLocation({
-    // Implementation detail: window.location.href should be defined since it won't be set if no redirect occurs
+    // Implementation detail: window.location.pathname should be defined since it won't be set if no redirect occurs
     // For testing purposes, we don't care about the base url, so we just use whatever the original pathname was
-    href: originalPathname,
     pathname,
     hash,
     search,
   });
 
   redirectBasedOnLang();
-  expect(window.location.href).toBe(expectedPathname);
+  const resultingHref = window.location.pathname + window.location.search + window.location.hash;
+  expect(resultingHref).toBe(expectedHref);
 };
 
 describe('redirectBasedOnLang', () => {


### PR DESCRIPTION
### Stories/Links:

DOP-5362

### Current Behavior:

* [English prod](https://www.mongodb.com/docs/atlas/)

### Staging Links:

* [English staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/sandbox/cloud-docs/raymund.rodriguez/DOP-5362-query-lang/index.html)
* [Chinese staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/zh-cn/sandbox/cloud-docs/raymund.rodriguez/DOP-5362-query-lang/index.html)

### Notes:

The approach is to change the `location.pathname` instead of `location.href` so that we only need to modify the pathname, automatically keeping the search query strings and hashes the same.

To test (best done in incognito window. Otherwise, delete site's local storage):

1. Set your browser's primary language to Simplified Chinese. Make sure it's the top language (i.e. about English).
2. Add a query search query string and/or a hash to a site URL. This should result in a redirect to the Chinese site.
3. On prod, the redirected URL should have no query string nor hash. On the staging links, the redirected URL should have the search query string and hash.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
