### PR TITLE
DOP-5411: hide style on code outputs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-landing"
+REPO_NAME = "docs-pymongo"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-pymongo"
+REPO_NAME = "docs-landing"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.11"

--- a/src/components/Code/Output.js
+++ b/src/components/Code/Output.js
@@ -12,6 +12,9 @@ const OutputContainer = styled.div`
   > div > * {
     display: inline !important;
   }
+  style {
+    display: none !important;
+  }
   * {
     border-top-right-radius: 0px;
     border-top-left-radius: 0px;

--- a/tests/unit/__snapshots__/CodeIO.test.js.snap
+++ b/tests/unit/__snapshots__/CodeIO.test.js.snap
@@ -508,6 +508,10 @@ exports[`CodeIO renders correctly 1`] = `
   display: inline!important;
 }
 
+.emotion-22 style {
+  display: none!important;
+}
+
 .emotion-22 * {
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;


### PR DESCRIPTION
### Stories/Links:

DOP-5411
This PR fixes the problem where we see the styling as plain text on offline docs. This can be seen on the offline docs, as well as pre-hydration on live production sites. This was due to a small `display: inline !important` styling done in code components that also mistakenly captured style elements

### Current Behavior:

[This page shows a flash of styling text on top of the code output](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/data-formats/custom-types/) - original page from issue description

[Another page where flash of styling text on page from atlas docs](https://www.mongodb.com/docs/atlas/atlas-search/aggregation-stages/search/#troubleshooting)

The problem can be seen on the offline doc [here](http://mongodb.com/docs/offline/pymongo-master.tar.gz) (navigate to the `data-formats/custom-types` page) - this one is persistent because there is no hydration.

### Staging Links:

[netlify staging link](https://67b88d93d9292100087909df--docs-frontend-stg.netlify.app/data-formats/custom-types/) (no styling text pre hydration)

[S3 HTML output](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=HEAD/pymongo/seung.park/DOP-5411/data-formats/custom-types/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
