### PR TITLE
DOP-5358: Add "MongoDB Docs" to page titles

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -23,7 +23,7 @@ const SEO = ({ pageTitle, siteTitle, showDocsLandingTitle, canonical, slug, noIn
       <title>
         {showDocsLandingTitle || (!siteTitle && !pageTitle)
           ? 'MongoDB Documentation'
-          : `${pageTitle ? `${pageTitle} - ` : ''}${siteTitle}`}
+          : `${pageTitle ? `${pageTitle} - ` : ''}${siteTitle} - MongoDB Docs`}
       </title>
       {hrefLangLinks}
       {/* Twitter Tags - default values, may be overwritten by Twitter component */}

--- a/tests/unit/Head.test.js
+++ b/tests/unit/Head.test.js
@@ -249,7 +249,7 @@ describe('Head', () => {
     it('correctly applies title, project name, and version', function () {
       const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
-      expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title} ${metadata.branch}`);
+      expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title} ${metadata.branch} - MongoDB Docs`);
     });
 
     it('defaults to project name and version if no page title', function () {
@@ -257,7 +257,7 @@ describe('Head', () => {
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
       const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
-      expect(title.innerHTML).toBe(`${metadata.title} ${metadata.branch}`);
+      expect(title.innerHTML).toBe(`${metadata.title} ${metadata.branch} - MongoDB Docs`);
     });
 
     it('only applies branch versions starting with a version number (v)', function () {
@@ -265,7 +265,7 @@ describe('Head', () => {
       useSnootyMetadata.mockImplementation(() => ({ ...metadata }));
       const { container } = render(<Head pageContext={pageContext} data={mockData} />);
       const title = container.querySelector('title');
-      expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title}`);
+      expect(title.innerHTML).toBe(`Get Started with  - ${metadata.title} - MongoDB Docs`);
     });
 
     // highly not likely to be missing project, title, and version


### PR DESCRIPTION
### Stories/Links:

DOP-5358

### Current Behavior:

[Current Cloud-docs](https://www.mongodb.com/docs/atlas/)

### Staging Links:

[Cloud-docs Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/matt.meigs/DOP-5358-title/index.html)

### Notes:

Sarah Lin asked us to append "- MongoDB Docs" to all page titles. I did not append it to the main landing page as it would then be "MongoDB Documentation - MongoDB Docs".

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
