### PR TITLE
DOP-5452: fixes anchor tag wrapping for longer text headings.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,5 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 [build.environment]
 ORG_NAME = "mongodb"
 REPO_NAME = "docs-atlas-architecture"
-BRANCH_NAME = "master"
+BRANCH_NAME = "main"
 PARSER_VERSION = "0.18.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-landing"
+REPO_NAME = "docs-atlas-architecture"
 BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "docs-atlas-architecture"
-BRANCH_NAME = "main"
+REPO_NAME = "docs-landing"
+BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.11"

--- a/src/components/Permalink.js
+++ b/src/components/Permalink.js
@@ -32,7 +32,7 @@ const HeaderBuffer = styled.div`
 
 const headingStyle = (copied) => css`
   ${!!copied && 'visibility: visible !important;'}
-  position:relative;
+  position:absolute;
   align-self: center;
   padding: 0 5px;
   visibility: hidden;

--- a/src/components/Permalink.js
+++ b/src/components/Permalink.js
@@ -34,7 +34,7 @@ const headingStyle = (copied) => css`
   ${!!copied && 'visibility: visible !important;'}
   position:relative;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 `;
 

--- a/src/components/Permalink.js
+++ b/src/components/Permalink.js
@@ -32,7 +32,7 @@ const HeaderBuffer = styled.div`
 
 const headingStyle = (copied) => css`
   ${!!copied && 'visibility: visible !important;'}
-  position:absolute;
+  position: absolute;
   align-self: center;
   padding: 0 10px;
   visibility: hidden;

--- a/src/components/Permalink.js
+++ b/src/components/Permalink.js
@@ -34,7 +34,7 @@ const headingStyle = (copied) => css`
   ${!!copied && 'visibility: visible !important;'}
   position:absolute;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 `;
 

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -52,7 +52,7 @@ exports[`collapsible component renders all the content in the options and childr
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -52,7 +52,7 @@ exports[`collapsible component renders all the content in the options and childr
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Collapsible.test.js.snap
+++ b/tests/unit/__snapshots__/Collapsible.test.js.snap
@@ -48,7 +48,7 @@ exports[`collapsible component renders all the content in the options and childr
 }
 
 .emotion-3 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-1 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -93,7 +93,7 @@ exports[`renders correctly in dark mode 1`] = `
 }
 
 .emotion-1 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -20,7 +20,7 @@ exports[`renders correctly 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 
@@ -97,7 +97,7 @@ exports[`renders correctly in dark mode 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -20,7 +20,7 @@ exports[`renders correctly 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 
@@ -97,7 +97,7 @@ exports[`renders correctly in dark mode 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -351,7 +351,7 @@ exports[`renders steps nested in include nodes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -351,7 +351,7 @@ exports[`renders steps nested in include nodes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -347,7 +347,7 @@ exports[`renders steps nested in include nodes 1`] = `
 }
 
 .emotion-10 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -19,7 +19,7 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-1 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -23,7 +23,7 @@ exports[`renders correctly 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -23,7 +23,7 @@ exports[`renders correctly 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -43,7 +43,7 @@ a .emotion-0 {
 }
 
 .emotion-1 {
-  position: relative;
+  position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -47,7 +47,7 @@ a .emotion-0 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 10px;
+  padding: 0 5px;
   visibility: hidden;
 }
 

--- a/tests/unit/__snapshots__/Target.test.js.snap
+++ b/tests/unit/__snapshots__/Target.test.js.snap
@@ -47,7 +47,7 @@ a .emotion-0 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
-  padding: 0 5px;
+  padding: 0 10px;
   visibility: hidden;
 }
 


### PR DESCRIPTION
### Stories/Links:

DOP-5452

### Current Behavior:

[Getting Started with the Atlas Architecture Center](https://www.mongodb.com/docs/atlas/architecture/current/getting-started/)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

~~One approach is to reduce the padding from `0 10px` to `0 5px`, which seems like the simplest solution with the design team's approval, of course. We can also consider using flex styling on the header and inline-block or inline-flex on the anchor tag.~~

~~There is also a `max-content` method we can explore, but this will disrupt the current responsiveness, requiring us to introduce some media query breakpoints.~~

~~I am completely open to other options and approaches.~~

Setting `position: absolute` around the Permalink so it doesn't need to take up any extra whitespace.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
