### PR TITLE
DOP-5408 followup: make sure offline tabs selectors work

### DIFF
--- a/src/utils/head-scripts/offline-ui/tabs-selectors.js
+++ b/src/utils/head-scripts/offline-ui/tabs-selectors.js
@@ -19,13 +19,10 @@ function bindTabsSelectorsUI() {
     for (const tabsComponent of tabsComponents) {
       // find the tab within each tabsComponent
       // tabs are tied to data-tabid value
-      const tabContent = tabsComponent.querySelector(`[data-tabid=${tabName}`);
-      if (!tabContent) {
-        continue;
-      }
       // if it exists, hide all other tabs, and show this tab
       for (const tabPanel of tabsComponent.querySelectorAll('[role=tabpanel]')) {
-        tabPanel.style.display = tabPanel.contains(tabContent) ? 'block' : 'none';
+        const tabElmWithSameId = tabPanel.querySelector(`[data-tabid=${CSS.escape(tabName)}]`);
+        tabPanel.style.display = tabElmWithSameId ? 'block' : 'none';
       }
     }
     const buttonChildren = button.querySelectorAll('div');

--- a/src/utils/head-scripts/offline-ui/tabs-selectors.js
+++ b/src/utils/head-scripts/offline-ui/tabs-selectors.js
@@ -6,7 +6,7 @@
 
 function bindTabsSelectorsUI() {
   function onChoiceClick({ e, choices, tabsComponents, menu, button }) {
-    // get the data-value attribute
+    // get the data-value attribute from Select component
     const tabName = e.currentTarget.getAttribute('data-value');
 
     // set choice selected for styling css
@@ -18,7 +18,8 @@ function bindTabsSelectorsUI() {
     // handle the tabsComponents
     for (const tabsComponent of tabsComponents) {
       // find the tab within each tabsComponent
-      const tabContent = tabsComponent.querySelector(`[data-value=${tabName}`);
+      // tabs are tied to data-tabid value
+      const tabContent = tabsComponent.querySelector(`[data-tabid=${tabName}`);
       if (!tabContent) {
         continue;
       }


### PR DESCRIPTION
### Stories/Links:

DOP-5408
See first comment in issue.
The [previous change to make tabs work in sync](https://github.com/mongodb/snooty/pull/1355/files#diff-b0b2d09e76bfa9dfc8673f4b44f7525c7e1832cbfd7fa01933fddfa47fb89b0eL214) had a side effect of removing DOM attributes used by tabs selectors. This PR updates so that both offline modules look for the same DOM attribute

### Current Behavior:

Download this [offline doc](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/offline/cloud-docs-master.tar.gz). The page for /driver-connection which [correlates to this page in prod](https://www.mongodb.com/docs/atlas/driver-connection/), does not have the tabs selector working 

### Staging Links:

[Sample offline page upload to S3](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=master/cloud-docs/seung.park/DOP-5408-b/driver-connection/index.html) - download this page and verify the tabs selectors are working

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
