### PR TITLE
DOP-5504: Remove version dropdown filter for active versions

### DIFF
--- a/src/components/AssociatedVersionSelector/index.js
+++ b/src/components/AssociatedVersionSelector/index.js
@@ -29,7 +29,7 @@ const StyledSelect = styled(Select)`
 
 const AssociatedVersionSelector = () => {
   const { project } = useSnootyMetadata();
-  const { activeVersions, availableVersions, showVersionDropdown, onVersionSelect } = useContext(VersionContext);
+  const { activeVersions, availableVersions, hasEmbeddedVersionDropdown, onVersionSelect } = useContext(VersionContext);
 
   const onSelectChange = useCallback(
     ({ value }) => {
@@ -40,7 +40,7 @@ const AssociatedVersionSelector = () => {
 
   return (
     <>
-      {showVersionDropdown &&
+      {hasEmbeddedVersionDropdown &&
         activeVersions[project] &&
         availableVersions[project] &&
         availableVersions[project].length > 0 && (

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -188,10 +188,10 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, slug, eol })
   // CSS top property values for sticky side nav based on header height
   const topValues = useStickyTopValues(false, true, !!bannerContent);
 
-  let showVersions = repoBranches?.branches?.filter((b) => b.active)?.length > 1;
+  let showVersions = repoBranches?.branches?.length > 1;
 
-  const { showVersionDropdown } = useContext(VersionContext);
-  if (showVersionDropdown) {
+  const { hasEmbeddedVersionDropdown } = useContext(VersionContext);
+  if (hasEmbeddedVersionDropdown) {
     showVersions = false;
   }
 

--- a/src/components/VersionDropdown/index.js
+++ b/src/components/VersionDropdown/index.js
@@ -121,8 +121,8 @@ const VersionDropdown = ({ eol }) => {
   // Used to ensure that the value of the select is set to the urlSlug if the urlSlug is present and differs from the gitBranchName
   const currentUrlSlug = useCurrentUrlSlug(parserBranch, branches);
 
-  if ((branches?.length ?? 0) < 2) {
-    console.warn('Insufficient branches supplied to VersionDropdown; expected 2 or more');
+  if ((branches?.length ?? 0) < 1) {
+    console.warn('Insufficient branches supplied to VersionDropdown; expected 1 or more');
     return null;
   }
 

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -13,7 +13,8 @@ const TocContext = createContext({
 // ToC context that provides ToC content in form of *above*
 // filters all available ToC by currently selected version via VersionContext
 const TocContextProvider = ({ children, remoteMetadata }) => {
-  const { activeVersions, setActiveVersions, availableVersions, showVersionDropdown } = useContext(VersionContext);
+  const { activeVersions, setActiveVersions, availableVersions, hasEmbeddedVersionDropdown } =
+    useContext(VersionContext);
   const { project, branch, toctree, associated_products: associatedProducts } = useSnootyMetadata();
   const { database } = useSiteMetadata();
   const [activeToc, setActiveToc] = useState(remoteMetadata?.toctree || toctree);
@@ -29,7 +30,7 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
         sort: { build_id: -1 },
       };
 
-      if (associatedProducts?.length || showVersionDropdown) {
+      if (associatedProducts?.length || hasEmbeddedVersionDropdown) {
         filter['is_merged_toc'] = true;
       }
       const metadata = await fetchDocument(database, METADATA_COLLECTION, filter, { toctree: 1 }, findOptions);
@@ -40,7 +41,15 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
       return remoteMetadata?.toctree || toctree;
     }
     // below dependents are server constants
-  }, [toctree, project, branch, associatedProducts?.length, showVersionDropdown, database, remoteMetadata?.toctree]);
+  }, [
+    toctree,
+    project,
+    branch,
+    associatedProducts?.length,
+    hasEmbeddedVersionDropdown,
+    database,
+    remoteMetadata?.toctree,
+  ]);
 
   const setInitVersion = useCallback(
     (tocNode) => {

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -139,7 +139,7 @@ const VersionContext = createContext({
   availableVersions: {},
   availableGroups: {},
   setAvailableVersions: () => {},
-  showVersionDropdown: false,
+  hasEmbeddedVersionDropdown: false,
   showEol: false,
   isAssociatedProduct: false,
   onVersionSelect: () => {},
@@ -210,13 +210,13 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [showVersionDropdown, setShowVersionDropdown] = useState(isAssociatedProduct);
+  const [hasEmbeddedVersionDropdown, setHasEmbeddedVersionDropdown] = useState(isAssociatedProduct);
   useEffect(() => {
     getUmbrellaProject(metadata.project, metadata.database).then((umbrellaMetadata) => {
       if (!mountRef.current) {
         return;
       }
-      setShowVersionDropdown(!!umbrellaMetadata);
+      setHasEmbeddedVersionDropdown(!!umbrellaMetadata);
     });
   }, [metadata.project, metadata.database]);
 
@@ -289,7 +289,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
         setActiveVersions,
         availableVersions,
         availableGroups,
-        showVersionDropdown,
+        hasEmbeddedVersionDropdown,
         onVersionSelect,
         isAssociatedProduct,
         showEol,


### PR DESCRIPTION
### Stories/Links:

DOP-5504

### Current Behavior:

* https://www.mongodb.com/docs/bi-connector/current/
* https://www.mongodb.com/docs/atlas/architecture/current/

### Staging Links:

* https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/bi-connector/raymund.rodriguez/DOP-5504-version-dropdown/index.html
* https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/atlas-architecture/raymund.rodriguez/DOP-5504-version-dropdown/index.html

### Notes:

* Bonus: Also renamed a variable to accommodate confusion around embedded versioning variables.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
