### PR TITLE
DOP-5517: disable download for mobile/tablet

### DIFF
--- a/src/components/OfflineDownloadModal/DownloadButton.tsx
+++ b/src/components/OfflineDownloadModal/DownloadButton.tsx
@@ -3,6 +3,8 @@ import Button, { Size } from '@leafygreen-ui/button';
 import { css } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import { reportAnalytics } from '../../utils/report-analytics';
+import { displayNone } from '../../utils/display-none';
+import useScreenSize from '../../hooks/useScreenSize';
 import { useOfflineDownloadContext } from './DownloadContext';
 
 const downloadIconStyling = css`
@@ -13,12 +15,16 @@ const downloadIconStyling = css`
     color: var(--white);
     background-color: var(--gray-dark2);
   }
+
+  ${displayNone.onMobileAndTablet};
 `;
 
 const DownloadButton = () => {
   const { setModalOpen } = useOfflineDownloadContext();
+  const { isTabletOrMobile } = useScreenSize();
 
   const openDownloadModal = () => {
+    if (isTabletOrMobile) return;
     reportAnalytics('Offline docs download button clicked');
     setModalOpen(true);
   };

--- a/src/components/OfflineDownloadModal/DownloadContext.tsx
+++ b/src/components/OfflineDownloadModal/DownloadContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, 
 import { useAllDocsets } from '../../hooks/useAllDocsets';
 import { getAllRepos, type Repo } from '../../utils/snooty-data-api';
 import assertLeadingBrand from '../../utils/assert-leading-brand';
+import useScreenSize from '../../hooks/useScreenSize';
 import DownloadModal from './DownloadModal';
 
 export type OfflineVersion = {
@@ -83,12 +84,7 @@ function processRepos(repos: Repo[]) {
         if (branch.offlineUrl) {
           offlineRepo.versions.push({
             displayName: lintVersionLabel(branch.label),
-            // url: branch.offlineUrl,
-            // TODO: revert testing code
-            url: branch.offlineUrl.replace(
-              'https://www.mongodb.com/docs/offline',
-              'https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/offline'
-            ),
+            url: branch.offlineUrl,
           });
         }
       }
@@ -116,14 +112,17 @@ const OfflineDownloadProvider = ({ children }: ProviderProps) => {
   const [offlineRepos, setOfflineRepos] = useState<OfflineRepo[]>(() => processDocsets(allDocsets));
   const [modalOpen, setModalOpen] = useState(() => false);
   const promise = useRef<Promise<void>>();
+  const { isTabletOrMobile } = useScreenSize();
 
   useEffect(() => {
     if (promise.current || !modalOpen) {
       return;
     }
 
+    let isMounted = true;
     promise.current = getAllRepos()
       .then((res) => {
+        if (!isMounted) return;
         setOfflineRepos(processRepos(res));
       })
       .catch((e) => {
@@ -132,12 +131,16 @@ const OfflineDownloadProvider = ({ children }: ProviderProps) => {
       .finally(() => {
         promise.current = undefined;
       });
+
+    return () => {
+      isMounted = false;
+    };
   }, [modalOpen]);
 
   return (
     <OfflineDownloadContext.Provider value={{ repos: offlineRepos, modalOpen, setModalOpen }}>
       {children}
-      <DownloadModal open={modalOpen} setOpen={setModalOpen} />
+      {!isTabletOrMobile && <DownloadModal open={modalOpen} setOpen={setModalOpen} />}
     </OfflineDownloadContext.Provider>
   );
 };

--- a/src/components/OfflineDownloadModal/DownloadContext.tsx
+++ b/src/components/OfflineDownloadModal/DownloadContext.tsx
@@ -83,7 +83,12 @@ function processRepos(repos: Repo[]) {
         if (branch.offlineUrl) {
           offlineRepo.versions.push({
             displayName: lintVersionLabel(branch.label),
-            url: branch.offlineUrl,
+            // url: branch.offlineUrl,
+            // TODO: revert testing code
+            url: branch.offlineUrl.replace(
+              'https://www.mongodb.com/docs/offline',
+              'https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/offline'
+            ),
           });
         }
       }

--- a/src/components/OfflineDownloadModal/DownloadModal.tsx
+++ b/src/components/OfflineDownloadModal/DownloadModal.tsx
@@ -320,7 +320,9 @@ const DownloadModal = ({ open, setOpen }: ModalProps) => {
 
       {/* REMOVE TESTING CODE */}
       <div>
-        CHECK STATUS HERE
+        CHECK STATUS HERE:
+      </div>
+      <div>
         {status}
       </div>
       <Box className={footerStyling}>

--- a/src/components/OfflineDownloadModal/DownloadModal.tsx
+++ b/src/components/OfflineDownloadModal/DownloadModal.tsx
@@ -109,8 +109,6 @@ const DownloadModal = ({ open, setOpen }: ModalProps) => {
   const selectedVersions = useRef<Record<OfflineRepo['displayName'], OfflineVersion>>({});
   const { pushToast } = useToast();
   const { isMobile } = useScreenSize();
-  // TODO: remove testing code
-  const [status, setStatus] = useState('');
 
   useEffect(() => {
     // reset row selection when modal is opened/closed
@@ -247,10 +245,8 @@ const DownloadModal = ({ open, setOpen }: ModalProps) => {
         })
       );
       setOpen(false);
-      setStatus(`Downloaded ${urlsToRequest.map((u) => u.url)}`)
     } catch (e) {
       console.error(`Error downloading, `, e);
-      setStatus(JSON.stringify(e));
     } finally {
       setResultsLoading(false);
     }
@@ -318,13 +314,6 @@ const DownloadModal = ({ open, setOpen }: ModalProps) => {
         </TableBody>
       </LeafyTable>
 
-      {/* REMOVE TESTING CODE */}
-      <div>
-        CHECK STATUS HERE:
-      </div>
-      <div>
-        {status}
-      </div>
       <Box className={footerStyling}>
         <Button onClick={() => setOpen(false)}>Cancel</Button>
         <Button

--- a/src/components/Sidenav/Sidenav.js
+++ b/src/components/Sidenav/Sidenav.js
@@ -24,6 +24,7 @@ import { SIDE_NAV_CONTAINER_ID } from '../../constants';
 import { DownloadButton } from '../OfflineDownloadModal';
 import { useOfflineDownloadContext } from '../OfflineDownloadModal/DownloadContext';
 import { reportAnalytics } from '../../utils/report-analytics';
+import { displayNone } from '../../utils/display-none';
 import GuidesLandingTree from './GuidesLandingTree';
 import GuidesTOCTree from './GuidesTOCTree';
 import IA from './IA';
@@ -341,7 +342,11 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, slug, eol })
                       reportAnalytics('Offline docs download button clicked');
                       setModalOpen(true);
                     }}
-                    className={cx(sideNavItemBasePadding, sideNavItemFontSize)}
+                    className={cx(
+                      sideNavItemBasePadding,
+                      sideNavItemFontSize,
+                      LeafyCSS`${displayNone.onMobileAndTablet}`
+                    )}
                     glyph={<Icon glyph={'Download'} />}
                   >
                     Download Documentation


### PR DESCRIPTION
### Stories/Links:

DOP-5517

### Current Behavior:

[Atlas docs in mobile/tablet can access download button via sidenav](https://www.mongodb.com/docs/atlas/)
[Landing docs show as bottom Sidenav Item in mobile](https://www.mongodb.com/docs/)

### Staging Links:

Netlify Atlas docs
Netlify Landing docs

### Notes:
See comment in ticket - Discussed with Product that we will be removing the download modal on mobile/tablet as offline docs are not meant for mobile users.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
