### PR TITLE
DOP-5510: handle nested tabs

### DIFF
--- a/src/utils/head-scripts/offline-ui/tabs.js
+++ b/src/utils/head-scripts/offline-ui/tabs.js
@@ -5,12 +5,45 @@
  */
 
 function bindTabUI() {
+  /**
+   * Get all the tab panels (div [role=tabpanel]) within given snooty tab component
+   * Filters by the tab ids that are tied to the snooty tab (for handling nested tabs)
+   * @param   {Element}   snootyTab
+   * @returns {Element[]}
+   */
   function getTabPanels(snootyTab) {
-    return snootyTab.querySelectorAll(`[class*="lg-ui-tab-panels"] > div > [role=tabpanel]`);
+    // get the tab ids required from the snooty tab
+    const tabIds = (snootyTab.dataset.tabids ?? '').split('/');
+    const tabPanelsContainer = snootyTab.querySelector(`[class*="lg-ui-tab-panels"]`);
+
+    const res = [];
+    // get the tab content divs by tab ids
+    // return list of content divs' parent elms
+    for (const tabId of tabIds) {
+      const tabContentElm = tabPanelsContainer?.querySelector(`[data-tabid=${CSS.escape(tabId)}]`);
+      if (tabContentElm?.parentElement?.getAttribute('role') === 'tabpanel') {
+        res.push(tabContentElm.parentElement);
+      }
+    }
+    return res;
   }
 
+  /**
+   * Returns all the buttons associated with this snooty tab.
+   * Uses the tab ids associated with this tab
+   *
+   * @param   {Element}   snootyTab
+   * @returns {Element[]}
+   */
   function getTabButtons(snootyTab) {
-    return snootyTab.querySelectorAll(`[class*="lg-ui-tab-list"] > [role=tab]`);
+    // get first tab buttons list (vs nested tab buttons)
+    const tabList = snootyTab.querySelector(`[class*="lg-ui-tab-list"]`);
+    const tabIds = (snootyTab.dataset.tabids ?? '').split('/');
+    return tabList
+      ? Array.from(tabList.children).filter(
+          (elm) => elm.getAttribute('role') === 'tab' && tabIds.includes(elm?.dataset?.tabid)
+        )
+      : [];
   }
 
   function handleButtonClick(tabButton, parentSnootyTab) {
@@ -18,7 +51,6 @@ function bindTabUI() {
     const tabsetsName = parentSnootyTab.dataset.tabids;
     const selectedTabId = tabButton.dataset.tabid;
     const snootyTabsWithSameTabSets = document.querySelectorAll(`[data-tabids=${CSS.escape(tabsetsName)}]`);
-
     for (const snootyTab of snootyTabsWithSameTabSets) {
       // activate the buttons
       const tabButtons = getTabButtons(snootyTab);

--- a/src/utils/head-scripts/offline-ui/tabs.js
+++ b/src/utils/head-scripts/offline-ui/tabs.js
@@ -41,7 +41,7 @@ function bindTabUI() {
     const tabIds = (snootyTab.dataset.tabids ?? '').split('/');
     return tabList
       ? Array.from(tabList.children).filter(
-          (elm) => elm.getAttribute('role') === 'tab' && tabIds.includes(elm?.dataset?.tabid)
+          (elm) => elm.getAttribute('role') === 'tab' && tabIds.includes(elm.dataset.tabid)
         )
       : [];
   }


### PR DESCRIPTION
### Stories/Links:

DOP-5510

### Current Behavior:

Can test by [downloading this Offline Doc](http://mongodb.com/docs/offline/cloud-docs-master.tar.gz), and navigating to the configure-alerts page.
Can also find this in this S3 link: https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-dotcomprd?region=us-east-2&bucketType=general&prefix=docs/offline/cloud-docs-master.tar.gz

### Staging Links:
Offline pages of a snooty build have been uploaded to [this S3 path](https://us-east-2.console.aws.amazon.com/s3/buckets/docs-mongodb-org-stg?prefix=master%2Fcloud-docs%2Fseung.park%2FDOP-5510%2F&region=us-east-2&bucketType=general&tab=objects)
To replicate above behavior, see [this file](https://us-east-2.console.aws.amazon.com/s3/object/docs-mongodb-org-stg?region=us-east-2&bucketType=general&prefix=master/cloud-docs/seung.park/DOP-5510/configure-alerts/index.html) to see a fix. This is to demonstrate a fix for a nested tab ([RST here](https://github.com/10gen/cloud-docs/blob/master/source/configure-alerts.txt#L218-L227))

See below deploy preview for regression checks. This behavior is only changed with ENV flag `OFFLINE_DOCS = true`

### Notes:
- The behavior was that the script was collecting all Tab Buttons and Tab Panels within a snooty tab component, even when nested. Updated the queries so that they are returned based on 1) relative level and 2) part of the tab data set.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
