### PR TITLE
DOP-5468 🐛  Fixes Tabs in procedures are not fully visible in mobile view issue.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
-ORG_NAME = "10gen"
-REPO_NAME = "cloud-docs"
-BRANCH_NAME = "master"
+ORG_NAME = "mongodb"
+REPO_NAME = "docs"
+BRANCH_NAME = "v8.0"
 PARSER_VERSION = "0.18.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
-ORG_NAME = "mongodb"
-REPO_NAME = "docs"
-BRANCH_NAME = "v8.0"
+ORG_NAME = "10gen"
+REPO_NAME = "cloud-docs"
+BRANCH_NAME = "master"
 PARSER_VERSION = "0.18.11"

--- a/src/components/Procedure/Step.js
+++ b/src/components/Procedure/Step.js
@@ -88,7 +88,10 @@ const StepBlock = styled('div')`
   min-height: 59px;
 `;
 
-const Content = 'div';
+const Content = styled('div')`
+  flex: 1;
+  min-width: 0;
+`;
 
 const contentStyles = {
   connected: css`

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -90,6 +90,10 @@ exports[`renders correctly 1`] = `
 }
 
 .emotion-8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
   padding-bottom: 64px;
 }
 
@@ -105,7 +109,7 @@ exports[`renders correctly 1`] = `
   }
 }
 
-.emotion-9 {
+.emotion-10 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -117,12 +121,12 @@ exports[`renders correctly 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-9 strong,
-.emotion-9 b {
+.emotion-10 strong,
+.emotion-10 b {
   font-weight: 700;
 }
 
-.emotion-11 {
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -137,13 +141,13 @@ exports[`renders correctly 1`] = `
   font-weight: var(--link-font-weight);
 }
 
-.emotion-11>code {
+.emotion-12>code {
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 }
 
-.emotion-11:focus,
-.emotion-11:hover {
+.emotion-12:focus,
+.emotion-12:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -151,12 +155,12 @@ exports[`renders correctly 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-11:focus {
+.emotion-12:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-11:hover {
+.emotion-12:hover {
   text-decoration-color: #E8EDEB;
 }
 
@@ -176,18 +180,18 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           Connect to a MongoDB deployment hosted on MongoDB Atlas, or a deployment hosted locally on your own machine.
         </p>
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           <a
-            class="emotion-11"
+            class="emotion-12"
             href="/connect/#std-label-connect-run-compass"
           >
             To learn more, see Connect to MongoDB
@@ -208,18 +212,18 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           Import data from CSV or JSON files into your MongoDB database.
         </p>
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           <a
-            class="emotion-11"
+            class="emotion-12"
             href="/import-export/#std-label-compass-import-export"
           >
             To learn more, see Import and Export Data
@@ -315,6 +319,10 @@ exports[`renders steps nested in include nodes 1`] = `
 }
 
 .emotion-8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
   padding-bottom: 64px;
 }
 
@@ -330,7 +338,7 @@ exports[`renders steps nested in include nodes 1`] = `
   }
 }
 
-.emotion-9 {
+.emotion-10 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -346,7 +354,7 @@ exports[`renders steps nested in include nodes 1`] = `
   margin-bottom: 24px;
 }
 
-.emotion-10 {
+.emotion-11 {
   position: absolute;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
@@ -355,13 +363,13 @@ exports[`renders steps nested in include nodes 1`] = `
   visibility: hidden;
 }
 
-.emotion-11 {
+.emotion-12 {
   color: #889397;
   vertical-align: middle;
   margin-top: -2px;
 }
 
-.emotion-12 {
+.emotion-13 {
   display: inline;
   left: 0;
   top: 0;
@@ -370,7 +378,7 @@ exports[`renders steps nested in include nodes 1`] = `
   padding-bottom: 2px;
 }
 
-.emotion-14 {
+.emotion-15 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -382,8 +390,8 @@ exports[`renders steps nested in include nodes 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-14 strong,
-.emotion-14 b {
+.emotion-15 strong,
+.emotion-15 b {
   font-weight: 700;
 }
 
@@ -403,22 +411,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 1
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-1"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -436,13 +444,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-1"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 1
           </p>
@@ -462,22 +470,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 2
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-2"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -495,13 +503,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-2"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 2
           </p>
@@ -521,22 +529,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 3
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-3"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -554,13 +562,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-3"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 3
           </p>
@@ -580,22 +588,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 4
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-4"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -613,13 +621,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-4"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 4
           </p>
@@ -639,22 +647,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 5
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-5"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -672,13 +680,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-5"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 5
           </p>
@@ -698,22 +706,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 6
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-6"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -731,13 +739,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-6"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 6
           </p>
@@ -757,22 +765,22 @@ exports[`renders steps nested in include nodes 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <section>
           <h1
-            class="contains-headerlink emotion-9"
+            class="contains-headerlink emotion-10"
             weight="medium"
           >
             Step 7
             <a
-              class="headerlink emotion-10"
+              class="headerlink emotion-11"
               href="#step-7"
               title="Permalink to this heading"
             >
               <svg
                 aria-label="Link Icon"
-                class="emotion-11"
+                class="emotion-12"
                 fill="none"
                 height="12"
                 role="img"
@@ -790,13 +798,13 @@ exports[`renders steps nested in include nodes 1`] = `
                 />
               </svg>
               <div
-                class="emotion-12 emotion-13"
+                class="emotion-13 emotion-14"
                 id="step-7"
               />
             </a>
           </h1>
           <p
-            class="emotion-14"
+            class="emotion-15"
           >
             Content for step 7
           </p>
@@ -866,13 +874,20 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   width: 27px;
 }
 
+.emotion-8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-8 section>*,
 .emotion-8 ol p,
 .emotion-8 ul p {
   margin-bottom: 16px;
 }
 
-.emotion-9 {
+.emotion-10 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -884,12 +899,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-9 strong,
-.emotion-9 b {
+.emotion-10 strong,
+.emotion-10 b {
   font-weight: 700;
 }
 
-.emotion-11 {
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -904,13 +919,13 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   font-weight: var(--link-font-weight);
 }
 
-.emotion-11>code {
+.emotion-12>code {
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 }
 
-.emotion-11:focus,
-.emotion-11:hover {
+.emotion-12:focus,
+.emotion-12:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -918,12 +933,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-11:focus {
+.emotion-12:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-11:hover {
+.emotion-12:hover {
   text-decoration-color: #E8EDEB;
 }
 
@@ -943,18 +958,18 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           Connect to a MongoDB deployment hosted on MongoDB Atlas, or a deployment hosted locally on your own machine.
         </p>
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           <a
-            class="emotion-11"
+            class="emotion-12"
             href="/connect/#std-label-connect-run-compass"
           >
             To learn more, see Connect to MongoDB
@@ -975,18 +990,18 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
         </div>
       </div>
       <div
-        class="emotion-8"
+        class="emotion-8 emotion-9"
       >
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           Import data from CSV or JSON files into your MongoDB database.
         </p>
         <p
-          class="emotion-9"
+          class="emotion-10"
         >
           <a
-            class="emotion-11"
+            class="emotion-12"
             href="/import-export/#std-label-compass-import-export"
           >
             To learn more, see Import and Export Data

--- a/tests/unit/__snapshots__/Step.test.js.snap
+++ b/tests/unit/__snapshots__/Step.test.js.snap
@@ -63,6 +63,10 @@ exports[`renders with "connected" styling 1`] = `
 }
 
 .emotion-6 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
   padding-bottom: 64px;
 }
 
@@ -78,7 +82,7 @@ exports[`renders with "connected" styling 1`] = `
   }
 }
 
-.emotion-7 {
+.emotion-8 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -90,12 +94,12 @@ exports[`renders with "connected" styling 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-7 strong,
-.emotion-7 b {
+.emotion-8 strong,
+.emotion-8 b {
   font-weight: 700;
 }
 
-.emotion-9 {
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -110,13 +114,13 @@ exports[`renders with "connected" styling 1`] = `
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9>code {
+.emotion-10>code {
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9:focus,
-.emotion-9:hover {
+.emotion-10:focus,
+.emotion-10:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -124,12 +128,12 @@ exports[`renders with "connected" styling 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-9:focus {
+.emotion-10:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-9:hover {
+.emotion-10:hover {
   text-decoration-color: #E8EDEB;
 }
 
@@ -146,18 +150,18 @@ exports[`renders with "connected" styling 1`] = `
       </div>
     </div>
     <div
-      class="emotion-6"
+      class="emotion-6 emotion-7"
     >
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         Import data from CSV or JSON files into your MongoDB database.
       </p>
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         <a
-          class="emotion-9"
+          class="emotion-10"
           href="/import-export/#std-label-compass-import-export"
         >
           To learn more, see Import and Export Data
@@ -231,6 +235,10 @@ exports[`renders with "connected" styling by default 1`] = `
 }
 
 .emotion-6 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
   padding-bottom: 64px;
 }
 
@@ -246,7 +254,7 @@ exports[`renders with "connected" styling by default 1`] = `
   }
 }
 
-.emotion-7 {
+.emotion-8 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -258,12 +266,12 @@ exports[`renders with "connected" styling by default 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-7 strong,
-.emotion-7 b {
+.emotion-8 strong,
+.emotion-8 b {
   font-weight: 700;
 }
 
-.emotion-9 {
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -278,13 +286,13 @@ exports[`renders with "connected" styling by default 1`] = `
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9>code {
+.emotion-10>code {
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9:focus,
-.emotion-9:hover {
+.emotion-10:focus,
+.emotion-10:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -292,12 +300,12 @@ exports[`renders with "connected" styling by default 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-9:focus {
+.emotion-10:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-9:hover {
+.emotion-10:hover {
   text-decoration-color: #E8EDEB;
 }
 
@@ -314,18 +322,18 @@ exports[`renders with "connected" styling by default 1`] = `
       </div>
     </div>
     <div
-      class="emotion-6"
+      class="emotion-6 emotion-7"
     >
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         Import data from CSV or JSON files into your MongoDB database.
       </p>
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         <a
-          class="emotion-9"
+          class="emotion-10"
           href="/import-export/#std-label-compass-import-export"
         >
           To learn more, see Import and Export Data
@@ -386,13 +394,20 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   width: 27px;
 }
 
+.emotion-6 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 0;
+}
+
 .emotion-6 section>*,
 .emotion-6 ol p,
 .emotion-6 ul p {
   margin-bottom: 16px;
 }
 
-.emotion-7 {
+.emotion-8 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -404,12 +419,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   color: var(--font-color-primary);
 }
 
-.emotion-7 strong,
-.emotion-7 b {
+.emotion-8 strong,
+.emotion-8 b {
   font-weight: 700;
 }
 
-.emotion-9 {
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -424,13 +439,13 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9>code {
+.emotion-10>code {
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
 }
 
-.emotion-9:focus,
-.emotion-9:hover {
+.emotion-10:focus,
+.emotion-10:hover {
   text-decoration-line: underline;
   -webkit-transition: text-decoration 150ms ease-in-out;
   transition: text-decoration 150ms ease-in-out;
@@ -438,12 +453,12 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
   text-decoration-thickness: 2px;
 }
 
-.emotion-9:focus {
+.emotion-10:focus {
   text-decoration-color: #016BF8;
   outline: none;
 }
 
-.emotion-9:hover {
+.emotion-10:hover {
   text-decoration-color: #E8EDEB;
 }
 
@@ -460,18 +475,18 @@ exports[`renders with "normal" or YAML steps styling 1`] = `
       </div>
     </div>
     <div
-      class="emotion-6"
+      class="emotion-6 emotion-7"
     >
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         Import data from CSV or JSON files into your MongoDB database.
       </p>
       <p
-        class="emotion-7"
+        class="emotion-8"
       >
         <a
-          class="emotion-9"
+          class="emotion-10"
           href="/import-export/#std-label-compass-import-export"
         >
           To learn more, see Import and Export Data


### PR DESCRIPTION
### Stories/Links:

DOP-5468

### Current Behavior:

[Production](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-windows/)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

The tabs are now visible and scrollable horizontally, which also prevents the content from being cutoff. 

The fix solution: 

Allow the content to shrink properly in a flex container. 

Adding the following

```css
flex: 1; 
min-width: 0;
```

does two things. First, it allows the child to grow and shrink to fill the available space in the flex container, and second tells the browser it's okay for this flex item to shrink below its content's intrinsic width.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
