### PR TITLE
DOP-5474: Move lab button outside of h1 element

### DIFF
--- a/src/components/DeprecatedVersionSelector.js
+++ b/src/components/DeprecatedVersionSelector.js
@@ -4,13 +4,13 @@ import { keyBy, isEmpty } from 'lodash';
 import Button from '@leafygreen-ui/button';
 import Icon from '@leafygreen-ui/icon';
 import { css, cx } from '@leafygreen-ui/emotion';
-import { palette } from '@leafygreen-ui/palette';
 import { isBrowser } from '../utils/is-browser';
 import { theme } from '../theme/docsTheme';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useAllDocsets } from '../hooks/useAllDocsets';
 import { fetchDocsets } from '../utils/realm';
 import { sortVersions } from '../utils/sort-versioned-branches';
+import { disabledStyle } from '../styles/button';
 import Select from './Select';
 
 const SELECT_WIDTH = '336px';
@@ -21,41 +21,6 @@ const selectStyle = css`
 
   @media ${theme.screenSize.upToSmall} {
     width: 100%;
-  }
-`;
-
-const focusBoxShadow = (color) => `
-    0 0 0 2px ${color}, 
-    0 0 0 ${theme.size.tiny} ${palette.blue.light1};
-`;
-
-const disabledStyles = css`
-  &[aria-disabled='true'] {
-    background-color: ${palette.gray.light2};
-    border-color: ${palette.gray.light1};
-    color: ${palette.gray.base};
-    box-shadow: none;
-    cursor: not-allowed;
-
-    &:focus-visible,
-    &[data-focus='true'] {
-      color: ${palette.gray.base};
-      box-shadow: ${focusBoxShadow(palette.white)};
-    }
-
-    .dark-theme & {
-      background-color: ${palette.gray.dark3};
-      border-color: ${palette.gray.dark2};
-      color: ${palette.gray.dark1};
-      box-shadow: none;
-      cursor: not-allowed;
-
-      &:focus-visible,
-      &[data-focus='true'] {
-        color: ${palette.gray.dark1};
-        box-shadow: ${focusBoxShadow(palette.black)};
-      }
-    }
   }
 `;
 
@@ -211,7 +176,7 @@ const DeprecatedVersionSelector = () => {
         rightGlyph={versionChoicesMap[version]?.icon}
         href={generateUrl(versionChoicesMap[version])}
         disabled={buttonDisabled}
-        className={cx(disabledStyles)}
+        className={cx(disabledStyle)}
       >
         {versionChoicesMap[version]?.icon ? 'Download Documentation' : 'View Documentation'}
       </Button>

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -21,25 +21,22 @@ import Permalink from './Permalink';
 import { TimeRequired } from './MultiPageTutorials';
 
 const titleMarginStyle = css`
-  margin-top: 16px;
-  margin-bottom: 24px;
+  margin-top: ${theme.size.default};
+  margin-bottom: ${theme.size.medium};
 `;
 
 const headingStyles = (sectionDepth, shouldShowLabButton) => css`
-  ${shouldShowLabButton
-    ? `
-      display: inline-block;
-    `
-    : `
-      margin-top: 24px;
-      margin-bottom: 8px;
-    `}
+  ${!shouldShowLabButton &&
+  `
+    margin-top: ${theme.size.medium};
+    margin-bottom: ${theme.size.small};
+  `}
   color: ${sectionDepth < 2 ? `var(--heading-color-primary)` : `var(--font-color-primary)`};
 `;
 
 const labWrapperStyle = css`
   display: flex;
-  gap: 18px;
+  gap: ${theme.size.default} ${theme.size.large};
   flex-wrap: wrap;
 `;
 

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -5,6 +5,7 @@ import { cx, css } from '@leafygreen-ui/emotion';
 import { H2, H3, Subtitle, Body } from '@leafygreen-ui/typography';
 import Button from '@leafygreen-ui/button';
 import Icon from '@leafygreen-ui/icon';
+import { palette } from '@leafygreen-ui/palette';
 import useScreenSize from '../hooks/useScreenSize';
 import { usePageContext } from '../context/page-context';
 import { theme } from '../theme/docsTheme';
@@ -23,14 +24,24 @@ const h2Styling = css`
   margin-bottom: 24px;
 `;
 
-const headingStyles = (sectionDepth) => css`
+const headingStyles = (sectionDepth, shouldShowLabButton) => css`
   margin-top: 24px;
   margin-bottom: 8px;
   color: ${sectionDepth < 2 ? `var(--heading-color-primary)` : `var(--font-color-primary)`};
+  ${shouldShowLabButton && 'display: inline-block;'}
 `;
 
 const labButtonStyling = css`
   margin-left: 18px;
+  background-color: ${palette.gray.light3};
+  border-color: ${palette.gray.base};
+  color: ${palette.black};
+
+  .dark-theme & {
+    background-color: ${palette.gray.dark2};
+    border-color: ${palette.gray.base};
+    color: ${palette.white};
+  }
 `;
 
 const contentsStyle = css`
@@ -78,32 +89,40 @@ const Heading = ({ sectionDepth, nodeData, className, as, ...rest }) => {
           </HeadingContainer>
         )}
       >
-        <HeadingTag
-          className={cx(
-            headingStyles(sectionDepth),
-            'contains-headerlink',
-            sectionDepth === 1 ? h2Styling : '',
-            className
+        {/* Wrapper for Instruqt drawer button */}
+        <ConditionalWrapper
+          condition={shouldShowLabButton}
+          wrapper={(children) => (
+            <div>
+              {children}
+              <Button
+                role="button"
+                className={cx(labButtonStyling)}
+                disabled={isOfflineDocsBuild || isOpen}
+                onClick={() => setIsOpen(true)}
+                leftGlyph={<Icon glyph="Code" />}
+              >
+                {'Open Interactive Tutorial'}
+              </Button>
+            </div>
           )}
-          as={asHeading}
-          weight="medium"
         >
-          {nodeData.children.map((element, index) => {
-            return <ComponentFactory {...rest} nodeData={element} key={index} />;
-          })}
-          <Permalink id={id} description="heading" />
-          {shouldShowLabButton && (
-            <Button
-              role="button"
-              className={cx(labButtonStyling)}
-              disabled={isOfflineDocsBuild || isOpen}
-              onClick={() => setIsOpen(true)}
-              leftGlyph={<Icon glyph="Code" />}
-            >
-              {'Open Interactive Tutorial'}
-            </Button>
-          )}
-        </HeadingTag>
+          <HeadingTag
+            className={cx(
+              headingStyles(sectionDepth, shouldShowLabButton),
+              'contains-headerlink',
+              sectionDepth === 1 ? h2Styling : '',
+              className
+            )}
+            as={asHeading}
+            weight="medium"
+          >
+            {nodeData.children.map((element, index) => {
+              return <ComponentFactory {...rest} nodeData={element} key={index} />;
+            })}
+            <Permalink id={id} description="heading" />
+          </HeadingTag>
+        </ConditionalWrapper>
       </ConditionalWrapper>
       {isPageTitle && (
         <>

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -10,6 +10,7 @@ import useScreenSize from '../hooks/useScreenSize';
 import { usePageContext } from '../context/page-context';
 import { theme } from '../theme/docsTheme';
 import { isOfflineDocsBuild } from '../utils/is-offline-docs-build';
+import { disabledStyle } from '../styles/button';
 import ComponentFactory from './ComponentFactory';
 import TabSelectors from './Tabs/TabSelectors';
 import { TabContext } from './Tabs/tab-context';
@@ -31,6 +32,7 @@ const headingStyles = (sectionDepth, shouldShowLabButton) => css`
   ${shouldShowLabButton && 'display: inline-block;'}
 `;
 
+// Theme-specific styles were copied from the original Button component
 const labButtonStyling = css`
   margin-left: 18px;
   background-color: ${palette.gray.light3};
@@ -97,7 +99,7 @@ const Heading = ({ sectionDepth, nodeData, className, as, ...rest }) => {
               {children}
               <Button
                 role="button"
-                className={cx(labButtonStyling)}
+                className={cx(labButtonStyling, disabledStyle)}
                 disabled={isOfflineDocsBuild || isOpen}
                 onClick={() => setIsOpen(true)}
                 leftGlyph={<Icon glyph="Code" />}

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -20,21 +20,32 @@ import Contents from './Contents';
 import Permalink from './Permalink';
 import { TimeRequired } from './MultiPageTutorials';
 
-const h2Styling = css`
+const titleMarginStyle = css`
   margin-top: 16px;
   margin-bottom: 24px;
 `;
 
 const headingStyles = (sectionDepth, shouldShowLabButton) => css`
-  margin-top: 24px;
-  margin-bottom: 8px;
+  ${shouldShowLabButton
+    ? `
+      display: inline-block;
+    `
+    : `
+      margin-top: 24px;
+      margin-bottom: 8px;
+    `}
   color: ${sectionDepth < 2 ? `var(--heading-color-primary)` : `var(--font-color-primary)`};
-  ${shouldShowLabButton && 'display: inline-block;'}
+`;
+
+const labWrapperStyle = css`
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
 `;
 
 // Theme-specific styles were copied from the original Button component
 const labButtonStyling = css`
-  margin-left: 18px;
+  align-self: center;
   background-color: ${palette.gray.light3};
   border-color: ${palette.gray.base};
   color: ${palette.black};
@@ -95,7 +106,7 @@ const Heading = ({ sectionDepth, nodeData, className, as, ...rest }) => {
         <ConditionalWrapper
           condition={shouldShowLabButton}
           wrapper={(children) => (
-            <div>
+            <div className={cx(titleMarginStyle, labWrapperStyle)}>
               {children}
               <Button
                 role="button"
@@ -113,7 +124,7 @@ const Heading = ({ sectionDepth, nodeData, className, as, ...rest }) => {
             className={cx(
               headingStyles(sectionDepth, shouldShowLabButton),
               'contains-headerlink',
-              sectionDepth === 1 ? h2Styling : '',
+              isPageTitle && !hasDrawer ? titleMarginStyle : '',
               className
             )}
             as={asHeading}

--- a/src/styles/button.ts
+++ b/src/styles/button.ts
@@ -1,5 +1,5 @@
-import { css } from "@leafygreen-ui/emotion";
-import { palette } from "@leafygreen-ui/palette";
+import { css } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
 
 const focusBoxShadow = (color: string) => `
   0 0 0 2px ${color}, 
@@ -10,8 +10,10 @@ const focusBoxShadow = (color: string) => `
 export const disabledStyle = css`
   &[aria-disabled='true'] {
     &,
-    &:hover, &[data-hover="true"],
-    &:active, &[data-active="true"] {
+    &:hover,
+    &[data-hover='true'],
+    &:active,
+    &[data-active='true'] {
       background-color: ${palette.gray.light2};
       border-color: ${palette.gray.light1};
       color: ${palette.gray.base};
@@ -19,7 +21,8 @@ export const disabledStyle = css`
       cursor: not-allowed;
     }
 
-    &:focus-visible, &[data-focus="true"] {
+    &:focus-visible,
+    &[data-focus='true'] {
       color: ${palette.gray.base};
       box-shadow: ${focusBoxShadow(palette.white)};
     }
@@ -27,8 +30,10 @@ export const disabledStyle = css`
     // Needs to be nested here to ensure proper cascading
     .dark-theme & {
       &,
-      &:hover, &[data-hover="true"],
-      &:active, &[data-active="true"] {
+      &:hover,
+      &[data-hover='true'],
+      &:active,
+      &[data-active='true'] {
         background-color: ${palette.gray.dark3};
         border-color: ${palette.gray.dark2};
         color: ${palette.gray.dark1};
@@ -36,7 +41,8 @@ export const disabledStyle = css`
         cursor: not-allowed;
       }
 
-      &:focus-visible, &[data-focus="true"] {
+      &:focus-visible,
+      &[data-focus='true'] {
         color: ${palette.gray.dark1};
         box-shadow: ${focusBoxShadow(palette.black)};
       }

--- a/src/styles/button.ts
+++ b/src/styles/button.ts
@@ -7,6 +7,7 @@ const focusBoxShadow = (color: string) => `
 `;
 
 // Theme-specific styles were copied from the original Button component
+// to allow pre-rendering for dark mode
 export const disabledStyle = css`
   &[aria-disabled='true'] {
     &,

--- a/src/styles/button.ts
+++ b/src/styles/button.ts
@@ -1,0 +1,45 @@
+import { css } from "@leafygreen-ui/emotion";
+import { palette } from "@leafygreen-ui/palette";
+
+const focusBoxShadow = (color: string) => `
+  0 0 0 2px ${color}, 
+  0 0 0 4px ${palette.blue.light1};
+`;
+
+// Theme-specific styles were copied from the original Button component
+export const disabledStyle = css`
+  &[aria-disabled='true'] {
+    &,
+    &:hover, &[data-hover="true"],
+    &:active, &[data-active="true"] {
+      background-color: ${palette.gray.light2};
+      border-color: ${palette.gray.light1};
+      color: ${palette.gray.base};
+      box-shadow: none;
+      cursor: not-allowed;
+    }
+
+    &:focus-visible, &[data-focus="true"] {
+      color: ${palette.gray.base};
+      box-shadow: ${focusBoxShadow(palette.white)};
+    }
+
+    // Needs to be nested here to ensure proper cascading
+    .dark-theme & {
+      &,
+      &:hover, &[data-hover="true"],
+      &:active, &[data-active="true"] {
+        background-color: ${palette.gray.dark3};
+        border-color: ${palette.gray.dark2};
+        color: ${palette.gray.dark1};
+        box-shadow: none;
+        cursor: not-allowed;
+      }
+
+      &:focus-visible, &[data-focus="true"] {
+        color: ${palette.gray.dark1};
+        box-shadow: ${focusBoxShadow(palette.black)};
+      }
+    }
+  }
+`;


### PR DESCRIPTION
### Stories/Links:

DOP-5474

### Current Behavior:

* [Server docs](https://www.mongodb.com/docs/manual/reference/method/db.collection.find/)
* [Csharp](https://www.mongodb.com/docs/drivers/csharp/current/fundamentals/crud/write-operations/insert/)
* [Legacy](https://www.mongodb.com/docs/legacy/)

### Staging Links:

* [Server docs](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-5474-lab-button/reference/method/db.collection.find/index.html)
* [Csharp](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/csharp/raymund.rodriguez/DOP-5474-lab-button/fundamentals/crud/write-operations/insert/index.html)
* [Legacy](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/landing/raymund.rodriguez/DOP-5474-lab-button/legacy/index.html) (control for disabled button change)

### Notes:

* The solution was to move the lab button outside of the h1 element to ensure the lab button text is not mistakenly included as text within the heading. A conditional wrapper was used to wrap the h1 and button in a div to ensure layout persisted.
* **Bonus change:** Included CSS changes to ensure the lab button was the proper theme on initial load of the page. This involved making some existing button CSS for the /legacy page reusable. Happy to move it out if it seems undesired.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
