### PR TITLE
DOP-5568: Prevent browser lang redirects on writers staging

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -13,6 +13,7 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
   if (isOfflineDocsBuild) {
     return setHeadComponents([...OFFLINE_HEAD_SCRIPTS]);
   }
+
   const headComponents = [
     // GTM Pathway
     <script
@@ -20,15 +21,6 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
       type="text/javascript"
       dangerouslySetInnerHTML={{
         __html: `!function(e,n){var t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),window.segment=o})}();`,
-      }}
-    />,
-    // Client-side redirect based on browser's language settings
-    <script
-      key="browser-lang-redirect"
-      type="text/javascript"
-      dangerouslySetInnerHTML={{
-        // Call function immediately on load
-        __html: `!${redirectBasedOnLang}()`,
       }}
     />,
     <link
@@ -57,6 +49,7 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
       rel="stylesheet"
     ></link>,
   ];
+
   if (process.env['GATSBY_ENABLE_DARK_MODE'] === 'true') {
     // Detect dark mode
     // before document body
@@ -90,6 +83,22 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
       />
     );
   }
+
+  if (process.env.SNOOTY_ENV !== 'prd') {
+    // Client-side redirect based on browser's language settings.
+    // We want to exclude writers' staging
+    headComponents.push(
+      <script
+        key="browser-lang-redirect"
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          // Call function immediately on load
+          __html: `!${redirectBasedOnLang}()`,
+        }}
+      />
+    );
+  }
+
   setHtmlAttributes({
     // Help work with translated content locally; Smartling should handle rewriting the lang
     lang: process.env.GATSBY_LOCALE ? getHtmlLangFormat(process.env.GATSBY_LOCALE) : 'en',


### PR DESCRIPTION
### Stories/Links:

DOP-5568

### Current Behavior:

* [Writers' staging](https://deploy-preview-11568--docs-mongodb-internal.netlify.app) (redirects based on browser lang)
* [Server docs prod](https://www.mongodb.com/docs/manual/) (redirects based on browser lang)

### Staging Links:

* [With prd SNOOTY_ENV](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/raymund.rodriguez/DOP-5568-redirects/index.html) (mimics the env for Netlify deploy previews. Ideally, this shouldn't redirect based on browser lang)
* [With dotcomprd SNOOTY_ENV](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dotcomprd/master/docs/raymund.rodriguez/DOP-5568-redirects/index.html) (ideally, this continue to redirect based on browser lang)

### Notes:

**To test:**

1. Set browser's primary language to Korean, Simplified Chinese, Portuguese, or Japanese. Ensure it's the topmost one on the list.
2. Go to the staging link built with `prd` and notice that it doesn't redirect.
3. Go to the staging link built with `dotcomprd` and notice that it does redirect. The 404 here is expected. If nothing happens, try in an incognito window, remove local storage for the site, or check your browser language again.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
