### PR TITLE
DOP-5565: Add trailing slash to search results (monkey patch)

### DIFF
--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -11,6 +11,7 @@ import { palette } from '@leafygreen-ui/palette';
 import useScreenSize from '../../hooks/useScreenSize';
 import { theme } from '../../theme/docsTheme';
 import { reportAnalytics } from '../../utils/report-analytics';
+import { assertTrailingSlash } from '../../utils/assert-trailing-slash';
 import { escapeHtml } from '../../utils/escape-reserved-html-characters';
 import { searchParamsToMetaURL, searchParamsToURL } from '../../utils/search-params-to-url';
 import { requestHeaders } from '../../utils/search-facet-constants';
@@ -409,7 +410,8 @@ const SearchResults = () => {
     // fetch search results
     fetchSearchResults()
       .then((searchRes) => {
-        setSearchResults(searchRes || []);
+        const results = (searchRes || []).map((result) => ({ ...result, url: assertTrailingSlash(result.url) }));
+        setSearchResults(results);
       })
       .catch((e) => {
         console.error(`Error fetching search results: ${JSON.stringify(e)}`);


### PR DESCRIPTION
### Stories/Links:

DOP-5565

### Current Behavior:

[Searching "find"](https://www.mongodb.com/docs/search/?q=find)

### Staging Links:

[Searching "find"](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/collapse-expanded/landing/matt.meigs/DOP-5565-trailing-slash-search/search/index.html?q=find)

### Notes:

This is a monkey patch that we will keep in place for 3 months. The permanent solution is merged in mut.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
