### PR TITLE
DOP-5551: Fix capitalization on landing

### DIFF
--- a/src/components/Sidenav/IALinkedData.js
+++ b/src/components/Sidenav/IALinkedData.js
@@ -55,6 +55,7 @@ const liStyling = css`
     display: flex;
     align-items: center;
     gap: 8px;
+    text-transform: none;
 
     // Remove LG Link's existing underline pseudo-element
     :after {


### PR DESCRIPTION
### Stories/Links:

DOP-5551

### Current Behavior:

[Current](https://www.mongodb.com/docs/)

### Staging Links:

Staging

### Notes:

Node.js in the sidenav should be capitalized correctly in staging. LG has a style that accidentally capitalizes the J

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
