### PR TITLE
DOP-5539: add min height to download modal

### DIFF
--- a/src/components/OfflineDownloadModal/DownloadModal.tsx
+++ b/src/components/OfflineDownloadModal/DownloadModal.tsx
@@ -57,6 +57,7 @@ const searchInputStyle = css`
 
 const tableStyling = css`
   margin-top: ${theme.size.tiny};
+  min-height: 200px;
   th:first-of-type,
   td:first-of-type {
     padding-left: 8px;

--- a/tests/unit/__snapshots__/OfflineDownloadModal.test.tsx.snap
+++ b/tests/unit/__snapshots__/OfflineDownloadModal.test.tsx.snap
@@ -488,6 +488,7 @@ exports[`Offline download button opens the offline modal when clicked 1`] = `
   width: 100%;
   position: relative;
   margin-top: 4px;
+  min-height: 200px;
 }
 
 .emotion-14 th:first-of-type,


### PR DESCRIPTION
### Stories/Links:

DOP-5539

### Current Behavior:
[Current behavior cuts off the download modal (and makes version selector hard to see) when filtering projects:
](https://www.mongodb.com/docs/atlas/)![image](https://github.com/user-attachments/assets/01b59727-4c54-4912-8137-8a8cf30e4aaa)


### Staging Links:

See Staging link below

### Notes:
- Min height kicks in when using the filter and there are only few projects to download:
![image](https://github.com/user-attachments/assets/435d1990-a7e7-461c-bf70-988f0953ef77)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
