### PR TITLE
DOP-5680: Get rid of Rating Component in app-services

### DIFF
--- a/src/templates/product-landing.js
+++ b/src/templates/product-landing.js
@@ -7,6 +7,7 @@ import { theme } from '../theme/docsTheme.js';
 import { findKeyValuePair } from '../utils/find-key-value-pair.js';
 import useSnootyMetadata from '../utils/use-snooty-metadata.js';
 import FeedbackRating from '../components/Widgets/FeedbackWidget';
+import { DEPRECATED_PROJECTS } from '../components/Contents/index';
 export const CONTENT_MAX_WIDTH = 1200;
 
 const formstyle = css`
@@ -253,10 +254,14 @@ const ProductLanding = ({ children, data: { page }, offlineBanner, pageContext: 
     >
       {offlineBanner}
       {children}
-      <hr className={cx(hrStyling)} />
-      <div className={cx(ratingStlying)}>
-        <FeedbackRating slug={slug} className={formstyle} classNameContainer={formContainer} />
-      </div>
+      {!DEPRECATED_PROJECTS.includes(project) && (
+        <>
+          <hr className={cx(hrStyling)} />
+          <div className={cx(ratingStlying)}>
+            <FeedbackRating slug={slug} className={formstyle} classNameContainer={formContainer} />
+          </div>
+        </>
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
### Stories/Links:

DOP-5680

### Current Behavior:

[current](https://www.mongodb.com/docs/atlas/app-services/)

### Staging Links:

[staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/realm/bianca.laube/DOP-5680/index.html)

### Notes:
* Just the homepage that i missed the deprecated project list, now fixed!
### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
