### PR TITLE
bugfix. Dismissible Skills Card allowed without Contents directive

### DIFF
--- a/src/components/ComponentFactory.tsx
+++ b/src/components/ComponentFactory.tsx
@@ -89,6 +89,7 @@ import { ComposableTutorial } from './ComposableTutorial';
 const IGNORED_NAMES = new Set([
   'contents',
   'default-domain',
+  'dismissible-skills-card',
   'entry',
   'ia',
   'raw',

--- a/src/components/Contents/index.tsx
+++ b/src/components/Contents/index.tsx
@@ -9,7 +9,6 @@ import { HeadingNodeSelectorIds } from '../../types/ast';
 import { theme } from '../../theme/docsTheme';
 import useScreenSize from '../../hooks/useScreenSize';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
-import DismissibleSkillsCard from '../DismissibleSkillsCard';
 import ContentsList from './ContentsList';
 import ContentsListItem from './ContentsListItem';
 import { type ActiveSelectorIds, ContentsContext } from './contents-context';
@@ -89,15 +88,7 @@ const isHeadingVisible = (
   return isHeadingVisible(headingSelectorIds.children ?? {}, activeSelectorIds, searchParams);
 };
 
-const Contents = ({
-  className,
-  slug,
-  dismissibleSkillsCard,
-}: {
-  className: string;
-  slug: string;
-  dismissibleSkillsCard?: { skill: string; url: string };
-}) => {
+const Contents = ({ className, slug }: { className: string; slug: string }) => {
   const { activeHeadingId, headingNodes, showContentsComponent, activeSelectorIds } = useContext(ContentsContext);
   const { isTabletOrMobile } = useScreenSize();
   const metadata = useSnootyMetadata();
@@ -111,9 +102,6 @@ const Contents = ({
   if (filteredNodes.length === 0 || !showContentsComponent) {
     return (
       <div className={className}>
-        {!!dismissibleSkillsCard && (
-          <DismissibleSkillsCard skill={dismissibleSkillsCard.skill} url={dismissibleSkillsCard.url} slug={slug} />
-        )}
         <FeedbackRating slug={slug} className={formStyle} />
       </div>
     );
@@ -123,15 +111,8 @@ const Contents = ({
 
   return (
     <>
-      {!isTabletOrMobile && (
-        <>
-          {!!dismissibleSkillsCard && (
-            <DismissibleSkillsCard skill={dismissibleSkillsCard.skill} url={dismissibleSkillsCard.url} slug={slug} />
-          )}
-          {!DEPRECATED_PROJECTS.includes(metadata.project) && (
-            <FeedbackRating slug={slug} className={formStyle} classNameContainer={formContainer} />
-          )}
-        </>
+      {!isTabletOrMobile && !DEPRECATED_PROJECTS.includes(metadata.project) && (
+        <FeedbackRating slug={slug} className={formStyle} classNameContainer={formContainer} />
       )}
       <div className={cx(className, styledContentList)}>
         <ContentsList label={label}>

--- a/src/components/Contents/index.tsx
+++ b/src/components/Contents/index.tsx
@@ -111,6 +111,9 @@ const Contents = ({
   if (filteredNodes.length === 0 || !showContentsComponent) {
     return (
       <div className={className}>
+        {!!dismissibleSkillsCard && (
+          <DismissibleSkillsCard skill={dismissibleSkillsCard.skill} url={dismissibleSkillsCard.url} slug={slug} />
+        )}
         <FeedbackRating slug={slug} className={formStyle} />
       </div>
     );

--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -28,6 +28,7 @@ const containerStyles = css`
 const cardStyles = css`
   padding: ${theme.fontSize.default};
   border-radius: 12px;
+  box-shadow: none;
 
   p {
     line-height: 20px;

--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -29,6 +29,12 @@ const cardStyles = css`
   padding: ${theme.fontSize.default};
   border-radius: 12px;
   box-shadow: none;
+  background-color: var(--background-color-primary);
+  border-color: ${palette.gray.light2};
+
+  .dark-theme & {
+    border-color: ${palette.gray.dark2};
+  }
 
   p {
     line-height: 20px;
@@ -41,7 +47,7 @@ const cardStyles = css`
   }
 `;
 
-const titleStyles = css`
+const titleBoxStyles = css`
   display: flex;
   align-items: center;
   gap: ${theme.size.small};
@@ -52,6 +58,10 @@ const titleStyles = css`
       fill: ${palette.white};
     }
   }
+`;
+
+const titleStyles = css`
+  color: var(--font-color-primary);
 `;
 
 const hrStyles = css`
@@ -93,9 +103,9 @@ const DismissibleSkillsCard = ({ skill, url, slug }: { skill: string; url: strin
       )}
     >
       <Card className={cx(cardStyles)}>
-        <Box className={cx(titleStyles)}>
+        <Box className={cx(titleBoxStyles)}>
           <SkillsBadgeIcon />
-          <Subtitle>Earn a Skill Badge</Subtitle>
+          <Subtitle className={titleStyles}>Earn a Skill Badge</Subtitle>
         </Box>
         <CloseButton onClick={onClose} />
         <Body>Master "{skill}" for free!</Body>

--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -30,6 +30,7 @@ const cardStyles = css`
   border-radius: 12px;
 
   p {
+    line-height: 20px;
     font-size: ${theme.fontSize.small};
     color: ${palette.gray.dark1};
 

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -17,7 +17,7 @@ const RightColumn = ({
   return (
     <div
       className={cx(css`
-        margin: 70px ${theme.size.medium} 40px 5px;
+        margin: 50px ${theme.size.medium} 70px 5px;
         min-width: ${hasDismissibleSkillsCard ? '250px' : '180px'};
         max-width: 250px;
         z-index: ${theme.zIndexes.content + 2};
@@ -34,7 +34,7 @@ const RightColumn = ({
 
           & > *:not(.${DISMISSIBLE_SKILLS_CARD_CLASSNAME}) {
             margin-bottom: 30px;
-            margin-right: 24px;
+            ${!hasDismissibleSkillsCard ? 'margin-right: 24px;' : ''}
           }
         `)}
       >

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -17,7 +17,7 @@ const RightColumn = ({
   return (
     <div
       className={cx(css`
-        margin: 50px ${theme.size.medium} 70px 5px;
+        margin: 70px ${theme.size.medium} 40px 5px;
         min-width: ${hasDismissibleSkillsCard ? '250px' : '180px'};
         max-width: 250px;
         z-index: ${theme.zIndexes.content + 2};

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -34,7 +34,7 @@ const RightColumn = ({
 
           & > *:not(.${DISMISSIBLE_SKILLS_CARD_CLASSNAME}) {
             margin-bottom: 30px;
-            ${!hasDismissibleSkillsCard ? 'margin-right: 24px;' : ''}
+            margin-right: 24px;
           }
         `)}
       >

--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -12,6 +12,7 @@ import useSnootyMetadata from '../utils/use-snooty-metadata';
 import AssociatedVersionSelector from '../components/AssociatedVersionSelector';
 import { theme } from '../theme/docsTheme';
 import { usePageContext } from '../context/page-context';
+import DismissibleSkillsCard from '../components/DismissibleSkillsCard';
 
 const MAX_ON_THIS_PAGE_WIDTH = '200px';
 const MAX_CONTENT_WIDTH = '775px';
@@ -71,9 +72,12 @@ const Document = ({ children, data: { page }, pageContext: { slug, isAssociatedP
         </div>
       </StyledMainColumn>
       <StyledRightColumn hasDismissibleSkillsCard={!!dismissibleSkillsCard}>
+        {!!dismissibleSkillsCard && (
+          <DismissibleSkillsCard skill={dismissibleSkillsCard.skill} url={dismissibleSkillsCard.url} slug={slug} />
+        )}
         {isAssociatedProduct && <AssociatedVersionSelector />}
         {!hasMethodSelector && !tabsMainColumn && <TabSelectors rightColumn={true} />}
-        <Contents slug={slug} dismissibleSkillsCard={dismissibleSkillsCard} />
+        <Contents slug={slug} />
       </StyledRightColumn>
     </DocumentContainer>
   );


### PR DESCRIPTION
### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/fix-dismiss/data-modeling/design-patterns/index.html)

Regression testing staged pages 

[Staging page with Contents list and Card](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/fix-dismiss/data-modeling/design-antipatterns/index.html)

[Staging page that also was not showing a Card in last iteration that now is](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/fix-dismiss/tutorial/authenticate-a-user/index.html)

[Staging page with no Card](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/fix-dismiss/data-modeling/design-patterns/group-data/bucket-pattern/index.html)

### Notes:

Dismissible Skills Cards would not render if there wasn't a Contents directive. Also, fixes line height and removes box-shadow after talking to design.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
