### PR TITLE
Add tracking to DismissibleSkillsCard

### DIFF
--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -75,7 +75,6 @@ const DismissibleSkillsCard = ({ skill, url, slug }: { skill: string; url: strin
   const shownClassname = useMemo(() => `${slug.split('/').join('-')}-${DISMISSIBLE_SKILLS_CARD_SHOWN}`, [slug]);
 
   const onLinkClick = () => {
-    console.log('onLinkClick');
     reportAnalytics('DismissibleSkillsCardLinkClicked', {
       skill,
       url,

--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -76,16 +76,16 @@ const DismissibleSkillsCard = ({ skill, url, slug }: { skill: string; url: strin
 
   const onLinkClick = () => {
     reportAnalytics('DismissibleSkillsCardLinkClicked', {
-      skill,
-      url,
+      cardSkill: skill,
+      cardUrl: url,
     });
   };
 
   const onClose = () => {
     if (isBrowser) {
       reportAnalytics('DismissibleSkillsCardClosed', {
-        skill,
-        url,
+        cardSkill: skill,
+        cardUrl: url,
       });
       // Add to document classnames
       const docClassList = window.document.documentElement.classList;

--- a/src/components/DismissibleSkillsCard.tsx
+++ b/src/components/DismissibleSkillsCard.tsx
@@ -10,6 +10,7 @@ import { displayNone } from '../utils/display-none';
 import { getSessionValue, setSessionValue } from '../utils/browser-storage';
 import { isBrowser } from '../utils/is-browser';
 import { theme } from '../theme/docsTheme';
+import { reportAnalytics } from '../utils/report-analytics';
 import CloseButton from './Widgets/FeedbackWidget/components/CloseButton';
 import SkillsBadgeIcon from './SVGs/SkillsBadgeIcon';
 
@@ -73,8 +74,20 @@ const hrStyles = css`
 const DismissibleSkillsCard = ({ skill, url, slug }: { skill: string; url: string; slug: string }) => {
   const shownClassname = useMemo(() => `${slug.split('/').join('-')}-${DISMISSIBLE_SKILLS_CARD_SHOWN}`, [slug]);
 
+  const onLinkClick = () => {
+    console.log('onLinkClick');
+    reportAnalytics('DismissibleSkillsCardLinkClicked', {
+      skill,
+      url,
+    });
+  };
+
   const onClose = () => {
     if (isBrowser) {
+      reportAnalytics('DismissibleSkillsCardClosed', {
+        skill,
+        url,
+      });
       // Add to document classnames
       const docClassList = window.document.documentElement.classList;
       docClassList.add(shownClassname);
@@ -109,7 +122,7 @@ const DismissibleSkillsCard = ({ skill, url, slug }: { skill: string; url: strin
         </Box>
         <CloseButton onClick={onClose} />
         <Body>Master "{skill}" for free!</Body>
-        <Link arrowAppearance={'persist'} baseFontSize={13} href={url} hideExternalIcon>
+        <Link arrowAppearance={'persist'} baseFontSize={13} href={url} onClick={onLinkClick} hideExternalIcon>
           Learn more
         </Link>
       </Card>


### PR DESCRIPTION
### Stories/Links:

DOP-5732

### Current Behavior:

[Current Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/fix-dismiss/data-modeling/design-antipatterns/index.html)

### Staging Links:

[New Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/docs/matt.meigs/DOP-5732-tracking/data-modeling/design-antipatterns/index.html)

### Notes:

Adds tracking analytics to the two types of clicks available on the DismissibleSkillsCard. Titles and state of analytics discussed with Sarah Lin.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
