### PR TITLE
Remove fetching remote TOC in writers' staging

### DIFF
--- a/plugins/gatsby-source-snooty-prod/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-prod/gatsby-node.js
@@ -203,7 +203,11 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, getNo
       { associated_products: 1 }
     );
     await createAssociatedProductNodes({ createNode, createNodeId, createContentDigest }, umbrellaProduct);
-    await createRemoteMetadataNode({ createNode, createNodeId, createContentDigest }, umbrellaProduct);
+
+    // Disable fetching remote toctree data for writers' staging
+    if (siteMetadata.database !== 'snooty_prod') {
+      await createRemoteMetadataNode({ createNode, createNodeId, createContentDigest }, umbrellaProduct);
+    }
   }
 
   if (siteMetadata.project === 'cloud-docs' && hasOpenAPIChangelog)

--- a/src/context/toc-context.js
+++ b/src/context/toc-context.js
@@ -81,11 +81,15 @@ const TocContextProvider = ({ children, remoteMetadata }) => {
     if (!Object.keys(activeVersions).length || isLoaded) {
       return;
     }
-    getTocMetadata().then((tocTreeResponse) => {
-      setInitVersion(tocTreeResponse);
-      setActiveToc(tocTreeResponse);
-      setIsLoaded(true);
-    });
+
+    // Disable fetching remote toctree data for writers' staging
+    if (database !== 'snooty_prod') {
+      getTocMetadata().then((tocTreeResponse) => {
+        setInitVersion(tocTreeResponse);
+        setActiveToc(tocTreeResponse);
+        setIsLoaded(true);
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeVersions]);
 


### PR DESCRIPTION
### Stories/Links:

N/A for now

### Current Behavior:

[Manual writers' staging](https://deploy-preview-12119--mongodb-manual.netlify.app/docs/upcoming/) - Notice how the TOC shows "Atlas Search" and "Atlas Vector Search"
[Atlas prod deploy](https://www.mongodb.com/docs/atlas/) - Show Atlas CLI and other embedded TOCs

### Staging Links:

[Manual staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/upcoming/docs/raymund.rodriguez/remove-remote-toc/index.html) (using writers' staging db) - Notice how the TOC shows "Search" and "Vector Search" as expected
[Atlas staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/cloud-docs/raymund.rodriguez/remove-remote-toc/index.html) (using prod deployments db) - Still shows Atlas CLI and other 

### Notes:

* This PR removes the ability for writers' staging to fetch remote metadata for embedded TOC. With the new monorepo setup, writers can overwrite one another's remote metadata documents since the directories are used within the page IDs instead of the working git branch name.
* We disable the feature both at build time and client-side to ensure there aren't any race conditions between different writers' builds at build time.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
