### PR TITLE
Fix version dropdown navigate

### DIFF
--- a/src/context/version-context.tsx
+++ b/src/context/version-context.tsx
@@ -9,7 +9,8 @@ import React, {
   ReactNode,
   Dispatch,
 } from 'react';
-import { navigate } from 'gatsby';
+// @ts-ignore
+import { navigate } from '@gatsbyjs/reach-router';
 import { METADATA_COLLECTION } from '../build-constants';
 import { DocsetSlice, useAllDocsets } from '../hooks/useAllDocsets';
 import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';

--- a/tests/unit/VersionDropdown.test.js
+++ b/tests/unit/VersionDropdown.test.js
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { navigate } from 'gatsby';
+import { navigate } from '@gatsbyjs/reach-router';
 import userEvent from '@testing-library/user-event';
 import * as realm from '../../src/utils/realm';
 import VersionDropdown from '../../src/components/VersionDropdown';
@@ -17,7 +17,7 @@ jest.mock('../../src/utils/use-snooty-metadata', () => {
   return () => ({ project: 'node' });
 });
 
-jest.mock('gatsby', () => ({
+jest.mock('@gatsbyjs/reach-router', () => ({
   navigate: jest.fn(),
 }));
 


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Prod](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/) - Using the version dropdown appends the target URL to the current pathname.

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/node/raymund.rodriguez/fix-version-dropdown-navigate/index.html) - version dropdown should **replace** the pathname instead of add it onto the end.

### Notes:

* Seems like the behavior of `navigate` in `gatsby` and `@gatsby/reach-router` are different. The former seems to append to the current pathname while the latter replaces it as we currently use it. We can probably handle this without `navigate` (i.e. with `location` directly), but just reverting this change in the meantime.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
