### PR TITLE
DOP-5806: collapsible item doesn't need link

### DIFF
--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -205,9 +205,9 @@ function CollapsibleNavItem({ items, label, url, slug, prefix, isAccordion, leve
   return (
     <>
       <SideNavItem
-        as={Link}
+        as={url ? Link : 'a'}
         prefix={prefix}
-        to={url}
+        to={url ? url : null}
         active={isActive}
         className={cx(l2ItemStyling({ level, isAccordion }), overwriteLinkStyle)}
         onClick={handleClick}

--- a/toc_data/toc.ts
+++ b/toc_data/toc.ts
@@ -18,6 +18,9 @@ export const tocData = (): TocItem[] => {
             {
               label: 'mongodump',
               url: '/docs/database-tools/mongodump/',
+            },
+            {
+              label: 'no link',
               collapsible: true,
               items: [
                 {


### PR DESCRIPTION
### Stories/Links:

DOP-5806

### Current Behavior:

no link, but collapsible items didnt work without a url 

### Staging Links:



### Notes:
* request from writers to not need a url for collapsible items

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
