### PR TITLE
DOP-5808: Adding special icons for link styling to the Unified ToC

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
-ORG_NAME = "10gen"
-REPO_NAME = "cloud-docs"
+ORG_NAME = "mongodb"
+REPO_NAME = "database-tools"
 BRANCH_NAME = "master"
 PARSER_VERSION = "v0.20.2"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "mongodb"
-REPO_NAME = "database-tools"
+REPO_NAME = "docs-commandline-tools"
 BRANCH_NAME = "master"
 PARSER_VERSION = "v0.20.2"

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -133,7 +133,7 @@ const Link = ({
 
   // If prefix, that means we are coming from the UnifiedSideNav and not the old SideNav
   if (prefix) {
-    // For an external link insides the unified toc
+    // For an external links, inside the unified toc
     if (!isRelativeUrl(to)) {
       return (
         <LGLink
@@ -174,12 +174,14 @@ const Link = ({
       );
     }
 
+    console.log(hideExternalIconProp, 'pepsi', !hideExternalIconProp, l1List?.indexOf(to) !== -1, to);
     // On the Unified SideNav but linking to a different site
     return (
       <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), l1LinkStyling, className)} href={to}>
         {children}
         {decoration}
-        {!hideExternalIconProp && l1List && l1List.indexOf(to) !== -1 && (
+        {/* Adds icon if we are in the L2 panel and linking to an L1 tab */}
+        {((hideExternalIconProp && !hideExternalIconProp) || (l1List && l1List.indexOf(to) !== -1)) && (
           <Icon glyph={'ArrowRight'} fill={palette.gray.base} />
         )}
       </a>
@@ -205,8 +207,6 @@ const Link = ({
       </GatsbyLink>
     );
   }
-
-  console.log('hey', to);
 
   const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
   const isMDBLink = strippedUrl.includes('mongodb.com');

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -174,8 +174,7 @@ const Link = ({
       );
     }
 
-    console.log(hideExternalIconProp, 'pepsi', !hideExternalIconProp, l1List?.indexOf(to) !== -1, to);
-    // On the Unified SideNav but linking to a different site
+    // On the Unified SideNav but linking to a different content site
     return (
       <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), l1LinkStyling, className)} href={to}>
         {children}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -46,6 +46,13 @@ export const sharedDarkModeOverwriteStyles = `
   font-weight: var(--link-font-weight);
 `;
 
+const l1LinkStyling = css`
+  svg {
+    transform: rotate(-45deg);
+    margin-left: 4px;
+  }
+`;
+
 /**
  * CSS purloined from LG Link definition (source: https://bit.ly/3JpiPIt)
  * @param {ThemeStyle} linkThemeStyle
@@ -83,6 +90,11 @@ const gatsbyLinkStyling = (linkThemeStyle) => css`
 const lgLinkStyling = css`
   display: inline;
   ${sharedDarkModeOverwriteStyles}
+  svg {
+    margin-left: 4px;
+    margin-bottom: -6px;
+    color: ${palette.gray.base};
+  }
 `;
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,
@@ -119,10 +131,25 @@ const Link = ({
     ''
   );
 
-  console.log('l1 list is ', l1List);
-
   // If prefix, that means we are coming from the UnifiedSideNav and not the old SideNav
-  if (prefix && isRelativeUrl(to)) {
+  if (prefix) {
+    // For an external link insides the unified toc
+    if (!isRelativeUrl(to)) {
+      return (
+        <LGLink
+          className={joinClassNames(lgLinkStyling, className)}
+          href={to}
+          hideExternalIcon={false}
+          target={'_blank'}
+          fill={palette.gray.base}
+          {...anchorProps}
+        >
+          {children}
+          {decoration}
+        </LGLink>
+      );
+    }
+
     if (!to.startsWith('/')) to = `/${to}`;
 
     // Ensure trailing slash
@@ -149,18 +176,13 @@ const Link = ({
 
     // On the Unified SideNav but linking to a different site
     return (
-      <>
-        <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), className)} href={to}>
-          {children}
-          {decoration}
-        </a>
-        <Icon
-          // className={cx(caretStyle)}
-          glyph={'ArrowRight'}
-          // fill={isActive ? 'inherit' : palette.gray.base}
-          // onClick={onCaretClick}
-        />
-      </>
+      <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), l1LinkStyling, className)} href={to}>
+        {children}
+        {decoration}
+        {!hideExternalIconProp && l1List && l1List.indexOf(to) !== -1 && (
+          <Icon glyph={'ArrowRight'} fill={palette.gray.base} />
+        )}
+      </a>
     );
   }
 
@@ -186,9 +208,9 @@ const Link = ({
 
   console.log('hey', to);
 
-  // const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
-  // const isMDBLink = strippedUrl.includes('mongodb.com');
-  const showExtIcon = showExternalIcon ?? (!anchor && !hideExternalIconProp);
+  const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
+  const isMDBLink = strippedUrl.includes('mongodb.com');
+  const showExtIcon = showExternalIcon ?? (!anchor && !isMDBLink && !hideExternalIconProp);
   const target = !showExtIcon ? '_self' : undefined;
 
   return (

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -6,6 +6,7 @@ import { Link as LGLink } from '@leafygreen-ui/typography';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 import ArrowRightIcon from '@leafygreen-ui/icon/dist/ArrowRight';
+import Icon from '@leafygreen-ui/icon';
 import { isRelativeUrl } from '../utils/is-relative-url';
 import { joinClassNames } from '../utils/join-class-names';
 import { validateHTMAttributes } from '../utils/validate-element-attributes';
@@ -91,6 +92,7 @@ const Link = ({
   to,
   activeClassName,
   className,
+  l1List,
   partiallyActive,
   showLinkArrow,
   hideExternalIcon: hideExternalIconProp,
@@ -117,8 +119,10 @@ const Link = ({
     ''
   );
 
+  console.log('l1 list is ', l1List);
+
   // If prefix, that means we are coming from the UnifiedSideNav and not the old SideNav
-  if (prefix) {
+  if (prefix && isRelativeUrl(to)) {
     if (!to.startsWith('/')) to = `/${to}`;
 
     // Ensure trailing slash
@@ -145,10 +149,18 @@ const Link = ({
 
     // On the Unified SideNav but linking to a different site
     return (
-      <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), className)} href={to}>
-        {children}
-        {decoration}
-      </a>
+      <>
+        <a className={cx(gatsbyLinkStyling(THEME_STYLES[siteTheme]), className)} href={to}>
+          {children}
+          {decoration}
+        </a>
+        <Icon
+          // className={cx(caretStyle)}
+          glyph={'ArrowRight'}
+          // fill={isActive ? 'inherit' : palette.gray.base}
+          // onClick={onCaretClick}
+        />
+      </>
     );
   }
 
@@ -172,9 +184,11 @@ const Link = ({
     );
   }
 
-  const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
-  const isMDBLink = strippedUrl.includes('mongodb.com');
-  const showExtIcon = showExternalIcon ?? (!anchor && !isMDBLink && !hideExternalIconProp);
+  console.log('hey', to);
+
+  // const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
+  // const isMDBLink = strippedUrl.includes('mongodb.com');
+  const showExtIcon = showExternalIcon ?? (!anchor && !hideExternalIconProp);
   const target = !showExtIcon ? '_self' : undefined;
 
   return (

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -75,6 +75,7 @@ export const AccordionNavPanel = ({
   currentL2s,
   setCurrentL1,
   setCurrentL2s,
+  l1List,
   hideMobile,
 }) => {
   const { isTabletOrMobile } = useScreenSize();
@@ -112,6 +113,7 @@ export const AccordionNavPanel = ({
               isAccordion={true}
               setCurrentL1={setCurrentL1}
               setCurrentL2s={setCurrentL2s}
+              l1List={l1List}
               setShowDriverBackBtn={setShowDriverBackBtn}
             />
           ))}

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -28,12 +28,6 @@ const panelStyling = LeafyCSS`
     ul {
       display: block;
       width: 100%;
-
-      li {
-        a {
-          justify-content: space-between !important;
-        }
-      }
     }
 
 `;

--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -56,12 +56,6 @@ const panelStyling = LeafyCSS`
     ul {
       display: block;
       width: 100%;
-
-      li {
-        a {
-          justify-content: space-between !important;
-        }
-      }
     }
 
 `;

--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -74,6 +74,7 @@ export const DoublePannedNav = ({
   currentL2s,
   setCurrentL1,
   setCurrentL2s,
+  l1List,
   currentL1,
 }) => {
   const { isTabletOrMobile } = useScreenSize();
@@ -118,6 +119,7 @@ export const DoublePannedNav = ({
                 slug={slug}
                 isAccordion={false}
                 setCurrentL2s={setCurrentL2s}
+                l1List={l1List}
                 setShowDriverBackBtn={setShowDriverBackBtn}
               />
             ))}

--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -87,6 +87,7 @@ export const DoublePannedNav = ({
               slug={slug}
               key={staticTocItem.newUrl + staticTocItem.label}
               isStatic={true}
+              l1List={l1List}
               setCurrentL1={setCurrentL1}
               setShowDriverBackBtn={setShowDriverBackBtn}
               isAccordion={false}

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -195,7 +195,11 @@ export function UnifiedSidenav({ slug, versionsData }) {
     });
   }, [unifiedTocTree, activeVersions, versionsData, project, snootyEnv]);
 
-  console.log('The edited toctree with prefixes is:', tree);
+  const l1List = useMemo(() => {
+    return tree.map((item) => item.newUrl);
+  }, [tree]);
+
+  console.log('The edited toctree with prefixes is:', tree, l1List);
   console.log(unifiedTocTree);
 
   const [isDriver, currentL2List] = findPageParent(tree, slug);
@@ -242,6 +246,7 @@ export function UnifiedSidenav({ slug, versionsData }) {
           slug={slug}
           currentL2s={currentL2s}
           setCurrentL1={setCurrentL1}
+          l1List={l1List}
           setCurrentL2s={setCurrentL2s}
           hideMobile={hideMobile}
         />
@@ -253,6 +258,7 @@ export function UnifiedSidenav({ slug, versionsData }) {
           currentL2s={currentL2s}
           setCurrentL1={setCurrentL1}
           setCurrentL2s={setCurrentL2s}
+          l1List={l1List}
           currentL1={currentL1}
         />
       </div>

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -25,6 +25,7 @@ const overwriteLinkStyle = LeafyCSS`
   span {
     display: flex;
   }
+  justify-content: space-between;
 `;
 
 const caretStyle = LeafyCSS`
@@ -263,6 +264,7 @@ export function StaticNavItem({
       active={isActive}
       aria-label={label}
       prefix={prefix}
+      hideExtLernalIcon={true}
       as={Link}
       to={url}
       onClick={() => {

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -59,6 +59,7 @@ export function UnifiedTocNavItem({
   isAccordion,
   setCurrentL1,
   setCurrentL2s,
+  l1List,
   setShowDriverBackBtn,
   level,
 }) {
@@ -89,6 +90,7 @@ export function UnifiedTocNavItem({
                 isStatic={false}
                 isAccordion={isAccordion}
                 setCurrentL2s={setCurrentL2s}
+                l1List={l1List}
                 setShowDriverBackBtn={setShowDriverBackBtn}
               />
             ))}
@@ -108,6 +110,7 @@ export function UnifiedTocNavItem({
             isStatic={false}
             isAccordion={isAccordion}
             setCurrentL2s={setCurrentL2s}
+            l1List={l1List}
             setShowDriverBackBtn={setShowDriverBackBtn}
           />
         ))}
@@ -127,6 +130,7 @@ export function UnifiedTocNavItem({
             slug={slug}
             isAccordion={isAccordion}
             setCurrentL2s={setCurrentL2s}
+            l1List={l1List}
             setShowDriverBackBtn={setShowDriverBackBtn}
           />
         ))}
@@ -147,6 +151,7 @@ export function UnifiedTocNavItem({
         as={Link}
         prefix={prefix}
         to={url}
+        l1List={l1List}
         onClick={handleClick}
         className={cx(l2ItemStyling({ level, isAccordion }))}
       >
@@ -166,6 +171,7 @@ export function UnifiedTocNavItem({
         isAccordion={isAccordion}
         slug={slug}
         prefix={prefix}
+        l1List={l1List}
         className={cx(l2ItemStyling({ level, isAccordion }))}
       />
     );
@@ -178,6 +184,7 @@ export function UnifiedTocNavItem({
       as={Link}
       prefix={prefix}
       to={url}
+      l1List={l1List}
       className={cx(l2ItemStyling({ level, isAccordion }))}
     >
       {label}
@@ -185,7 +192,7 @@ export function UnifiedTocNavItem({
   );
 }
 
-function CollapsibleNavItem({ items, label, url, slug, prefix, isAccordion, level }) {
+function CollapsibleNavItem({ items, label, url, slug, l1List, prefix, isAccordion, level }) {
   const [isOpen, setIsOpen] = useState(isActiveTocNode(slug, url, items));
   const caretType = isOpen ? 'CaretDown' : 'CaretUp';
   const isActive = isSelectedTab(url, slug);
@@ -208,6 +215,7 @@ function CollapsibleNavItem({ items, label, url, slug, prefix, isAccordion, leve
         as={Link}
         prefix={prefix}
         to={url}
+        l1List={l1List}
         active={isActive}
         className={cx(l2ItemStyling({ level, isAccordion }), overwriteLinkStyle)}
         onClick={handleClick}
@@ -228,6 +236,7 @@ function CollapsibleNavItem({ items, label, url, slug, prefix, isAccordion, leve
             level={level + 1}
             key={item.newUrl + item.label}
             slug={slug}
+            l1List={l1List}
             isAccordion={isAccordion}
           />
         ))}

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -264,7 +264,7 @@ export function StaticNavItem({
       active={isActive}
       aria-label={label}
       prefix={prefix}
-      hideExtLernalIcon={true}
+      hideExternalIcon={true}
       as={Link}
       to={url}
       onClick={() => {

--- a/toc_data/toc.ts
+++ b/toc_data/toc.ts
@@ -34,6 +34,14 @@ export const tocData = (): TocItem[] => {
                 },
               ],
             },
+            {
+              label: 'external link',
+              url: 'https://www.mongodb.com/pricing',
+            },
+            {
+              label: 'l1 link',
+              url: '/docs/atlas/getting-started/',
+            },
           ],
         },
       ],

--- a/toc_data/toc.ts
+++ b/toc_data/toc.ts
@@ -40,7 +40,13 @@ export const tocData = (): TocItem[] => {
             },
             {
               label: 'l1 link',
+              prefix: CLOUD_DOCS,
               url: '/docs/atlas/getting-started/',
+            },
+            {
+              label: 'just a dif link',
+              prefix: CLOUD_DOCS,
+              url: '/docs/atlas/getting-started/meow',
             },
           ],
         },


### PR DESCRIPTION
### Stories/Links:

DOP-5808

### Current Behavior:

n/a

### Staging Links:

https://dop-5808--docs-frontend-stg.netlify.app/mongodump/

### Notes:

following the [figma](https://www.figma.com/proto/KEtaPAkucUDw2Fdr1k6U7v/TOC-WORK?node-id=4316-36888&t=DZIpGafDFyLnH476-0&scaling=min-zoom&content-scaling=fixed&page-id=3565%3A23307&starting-point-node-id=4072%3A5949&show-proto-sidebar=1) 
![Screenshot 2025-06-24 at 9 40 38 AM](https://github.com/user-attachments/assets/a8039bc8-5511-4fe5-88c7-967e413c0cab)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
