### PR TITLE
Fix version dropdown value

### DIFF
--- a/src/components/VersionDropdown/index.tsx
+++ b/src/components/VersionDropdown/index.tsx
@@ -161,11 +161,10 @@ const VersionDropdown = ({ eol }: VersionDropdownProps) => {
       allowDeselect={false}
       className={cx(selectStyling, eol ? eolVersionFlipperStyle : '')}
       aria-labelledby="View a different version of documentation."
-      defaultValue="master"
       onChange={onSelectChange}
       placeholder={'Select a version'}
       popoverZIndex={3}
-      defaultChecked={Boolean(activeVersions[project])}
+      value={activeVersions[project]}
       usePortal={false}
       disabled={isOfflineDocsBuild || eol}
     >


### PR DESCRIPTION
### Stories/Links:

N/A

### Current Behavior:

[Mongocli](https://mongodbcom-cdn.staging.corp.mongodb.com/docs/mongocli/current/) (no version selected)

Screenshot for posterity:

<img width="754" alt="Screenshot 2025-06-26 at 2 53 32 PM" src="https://github.com/user-attachments/assets/5ddd7050-530b-474f-b1a5-e710af6749a1" />


### Staging Links:

[Mongocli](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/current/mongocli/raymund.rodriguez/fix-version-dropdown-value/index.html) (from monorepo build)
[Node driver](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/node/raymund.rodriguez/fix-version-dropdown-value/index.html) (not from monorepo build)

### Notes:

Fixes missing `value` field for version dropdown.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
