### PR TITLE
DOP-5752: re add scrolly to style

### DIFF
--- a/src/components/Sidenav/Sidenav.tsx
+++ b/src/components/Sidenav/Sidenav.tsx
@@ -86,8 +86,8 @@ const disableScroll = (shouldDisableScroll: boolean) => css`
 
 const getTopAndHeight = (topValue: string, scrollY: string) => {
   return css`
-    top: max(min(calc(${topValue} - var(${scrollY}))), ${theme.header.actionBarMobileHeight});
-    height: calc(100vh - max(min(calc(${topValue} - var(${scrollY}))), ${theme.header.actionBarMobileHeight}));
+    top: max(min(calc(${topValue} - ${scrollY})), ${theme.header.actionBarMobileHeight});
+    height: calc(100vh - max(min(calc(${topValue} - ${scrollY})), ${theme.header.actionBarMobileHeight}));
   `;
 };
 
@@ -100,7 +100,7 @@ const SidenavContainer = styled.div(
     top: 0px;
     height: calc(
       100vh + ${theme.header.actionBarMobileHeight} - ${topLarge} +
-        min(calc(${topLarge} - ${theme.header.actionBarMobileHeight}), var(--scroll-y))
+        min(calc(${topLarge} - ${theme.header.actionBarMobileHeight}), ${scrollY})
     );
 
     @media ${theme.screenSize.upToLarge} {
@@ -266,13 +266,7 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, slug, eol }:
           ${disableScroll(!hideMobile)}
         `}
       />
-      <SidenavContainer
-        {...topValues}
-        // @ts-expect-error
-        style={{ '--scroll-y': `${viewport.scrollY}px` }}
-        scrollY={`${viewport.scrollY}px`}
-        id={SIDE_NAV_CONTAINER_ID}
-      >
+      <SidenavContainer {...topValues} scrollY={`${viewport.scrollY}px`} id={SIDE_NAV_CONTAINER_ID}>
         <SidenavMobileTransition hideMobile={hideMobile} isMobile={isTabletOrMobile}>
           <LeafygreenSideNav
             aria-label="Side navigation"

--- a/src/components/Sidenav/Sidenav.tsx
+++ b/src/components/Sidenav/Sidenav.tsx
@@ -100,7 +100,7 @@ const SidenavContainer = styled.div(
     top: 0px;
     height: calc(
       100vh + ${theme.header.actionBarMobileHeight} - ${topLarge} +
-        min(calc(${topLarge} - ${theme.header.actionBarMobileHeight}), var(${scrollY}))
+        min(calc(${topLarge} - ${theme.header.actionBarMobileHeight}), var(--scroll-y))
     );
 
     @media ${theme.screenSize.upToLarge} {
@@ -266,7 +266,13 @@ const Sidenav = ({ chapters, guides, page, pageTitle, repoBranches, slug, eol }:
           ${disableScroll(!hideMobile)}
         `}
       />
-      <SidenavContainer {...topValues} scrollY={`${viewport.scrollY}px`} id={SIDE_NAV_CONTAINER_ID}>
+      <SidenavContainer
+        {...topValues}
+        // @ts-expect-error
+        style={{ '--scroll-y': `${viewport.scrollY}px` }}
+        scrollY={`${viewport.scrollY}px`}
+        id={SIDE_NAV_CONTAINER_ID}
+      >
         <SidenavMobileTransition hideMobile={hideMobile} isMobile={isTabletOrMobile}>
           <LeafygreenSideNav
             aria-label="Side navigation"


### PR DESCRIPTION
### Stories/Links:

DOP-5752 follow up. Seems like we introduced a bug in the height of sidenav.

### Current Behavior:

Current behavior in [preprd on cloud manager docs](https://mongodb-cloud-manager-preprd.netlify.app/docs/cloud-manager/)

### Staging Links:

[Staging link on pymongo](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/pymongo/seung.park/DOP-5752-follow-up/index.html) (same behavior with sidenav)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
