### PR TITLE
DOP-5447: Gatsby Link vs LG Link difference in font-weight

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -81,6 +81,10 @@ const gatsbyLinkStyling = (linkThemeStyle: LinkThemeStyle) => css`
 const lgLinkStyling = css`
   display: inline;
   ${sharedDarkModeOverwriteStyles}
+
+  > span > code {
+    ${sharedDarkModeOverwriteStyles}
+  }
 `;
 
 export type LinkProps = {


### PR DESCRIPTION
### Stories/Links:

DOP-5447

### Current Behavior:

[Current (look at difference between `$first` and `$bucket`)](https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/)

### Staging Links:

[Staging (same `$first` vs `$bucket`)](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/docs/matt.meigs/DOP-5447-link-weight/reference/operator/aggregation/first/index.html)

### Notes:

Correctly target all code elements within LG and Gatsby links with the desired font-weight.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
