### PR TITLE
fix: Only use `toctree` if has associated products

### DIFF
--- a/src/context/toc-context.tsx
+++ b/src/context/toc-context.tsx
@@ -41,13 +41,17 @@ const TocContextProvider = ({ children, remoteMetadata }: TocContextProviderProp
 
       if (associatedProducts?.length || hasEmbeddedVersionDropdown) {
         filter['is_merged_toc'] = true;
+        const metadata = await fetchDocument(database, METADATA_COLLECTION, filter, { toctree: 1 });
+        return metadata?.toctree ?? toctree;
       }
-      const metadata = await fetchDocument(database, METADATA_COLLECTION, filter, { toctree: 1 });
-      return metadata?.toctree ?? toctree;
+      return toctree;
     } catch (e) {
       // fallback to toctree from build time
       console.error(e);
-      return remoteMetadata?.toctree || toctree;
+      if (associatedProducts?.length || hasEmbeddedVersionDropdown) {
+        return remoteMetadata?.toctree || toctree;
+      }
+      return toctree;
     }
     // below dependents are server constants
   }, [


### PR DESCRIPTION
### Stories/Links:

[Slack thread](https://mongodb.slack.com/archives/GGPUBUMLN/p1751475239731669)

### Current Behavior:

[Current](https://www.mongodb.com/docs/atlas/architecture/current/)

### Staging Links:

[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/atlas-architecture/matt.meigs/fix-toctree/index.html)

### Notes:

Disallows fetching possibly stale toctree information (only if not an associatedProduct or umbrellaProduct)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
