### PR TITLE
DOP-5925: On Version Dropdown Change ToC should Persist

### DIFF
--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -80,6 +80,7 @@ export const AccordionNavPanel = ({
 }) => {
   const { isTabletOrMobile } = useScreenSize();
   const viewportSize = useViewportSize();
+
   return (
     <SideNav
       widthOverride={isTabletOrMobile ? viewportSize.width : 290}

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -96,9 +96,9 @@ export const AccordionNavPanel = ({
             <BackLink
               className={cx(backLinkStyling)}
               onClick={() => setShowDriverBackBtn(false)}
-              href={currentL1.newUrl}
+              href={currentL1?.newUrl}
             >
-              Back to {currentL1.label}
+              Back to {currentL1?.label}
             </BackLink>
           )}
           {displayedItems?.map((navItems) => (

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -19,6 +19,7 @@ export const leftPane = () => LeafyCSS`
 
 const panelStyling = LeafyCSS`
     position: fixed;
+    overflow-y: auto;
     top: 50px;
     height: calc(100% - 120px);
     padding-top: 10px;
@@ -71,6 +72,7 @@ export const AccordionNavPanel = ({
   setShowDriverBackBtn,
   displayedItems,
   slug,
+  currentL1,
   currentL2s,
   setCurrentL1,
   setCurrentL2s,
@@ -94,9 +96,9 @@ export const AccordionNavPanel = ({
             <BackLink
               className={cx(backLinkStyling)}
               onClick={() => setShowDriverBackBtn(false)}
-              href="/docs/kafka-connector/current/whats-new/"
+              href={currentL1.newUrl}
             >
-              Back to Client Libraries
+              Back to {currentL1.label}
             </BackLink>
           )}
           {displayedItems.map((navItems) => (

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -70,18 +70,16 @@ const backLinkStyling = LeafyCSS`
 export const AccordionNavPanel = ({
   showDriverBackBtn,
   setShowDriverBackBtn,
-  displayedItems,
   slug,
   currentL1,
   currentL2s,
   setCurrentL1,
   setCurrentL2s,
+  tree,
   hideMobile,
 }) => {
   const { isTabletOrMobile } = useScreenSize();
   const viewportSize = useViewportSize();
-
-  console.log('HELLO earthling', displayedItems);
 
   return (
     <SideNav
@@ -95,30 +93,50 @@ export const AccordionNavPanel = ({
       </div>
       <div className={cx(panelStyling)}>
         <div className={cx(leftPane)}>
-          {showDriverBackBtn && (
-            <BackLink
-              className={cx(backLinkStyling)}
-              onClick={() => setShowDriverBackBtn(false)}
-              href={currentL1?.newUrl}
-            >
-              Back to {currentL1?.label}
-            </BackLink>
+          {showDriverBackBtn ? (
+            <>
+              <BackLink
+                className={cx(backLinkStyling)}
+                onClick={() => setShowDriverBackBtn(false)}
+                href={currentL1?.newUrl}
+              >
+                Back to {currentL1?.label}
+              </BackLink>
+              {currentL2s.items?.map((navItem) => (
+                <UnifiedTocNavItem
+                  {...navItem}
+                  level={1}
+                  key={navItem.newUrl + navItem.label}
+                  group={true}
+                  isStatic={false}
+                  slug={slug}
+                  currentL2s={currentL2s}
+                  isAccordion={true}
+                  setCurrentL1={setCurrentL1}
+                  setCurrentL2s={setCurrentL2s}
+                  setShowDriverBackBtn={setShowDriverBackBtn}
+                />
+              ))}
+            </>
+          ) : (
+            <>
+              {tree.map((navItems) => (
+                <UnifiedTocNavItem
+                  {...navItems}
+                  level={1}
+                  key={navItems.newUrl + navItems.label}
+                  group={true}
+                  isStatic={true}
+                  slug={slug}
+                  currentL2s={currentL2s}
+                  isAccordion={true}
+                  setCurrentL1={setCurrentL1}
+                  setCurrentL2s={setCurrentL2s}
+                  setShowDriverBackBtn={setShowDriverBackBtn}
+                />
+              ))}
+            </>
           )}
-          {displayedItems?.map((navItems) => (
-            <UnifiedTocNavItem
-              {...navItems}
-              level={1}
-              key={navItems.newUrl + navItems.label}
-              group={true}
-              isStatic={!showDriverBackBtn}
-              slug={slug}
-              currentL2s={currentL2s}
-              isAccordion={true}
-              setCurrentL1={setCurrentL1}
-              setCurrentL2s={setCurrentL2s}
-              setShowDriverBackBtn={setShowDriverBackBtn}
-            />
-          ))}
         </div>
       </div>
       <div className={cx(downloadButtonStlying)}>

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -81,6 +81,8 @@ export const AccordionNavPanel = ({
   const { isTabletOrMobile } = useScreenSize();
   const viewportSize = useViewportSize();
 
+  console.log('HELLO earthling', displayedItems);
+
   return (
     <SideNav
       widthOverride={isTabletOrMobile ? viewportSize.width : 290}

--- a/src/components/UnifiedSidenav/AccordionNav.js
+++ b/src/components/UnifiedSidenav/AccordionNav.js
@@ -101,7 +101,7 @@ export const AccordionNavPanel = ({
               Back to {currentL1.label}
             </BackLink>
           )}
-          {displayedItems.map((navItems) => (
+          {displayedItems?.map((navItems) => (
             <UnifiedTocNavItem
               {...navItems}
               level={1}

--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -106,9 +106,9 @@ export const DoublePannedNav = ({
               <BackLink
                 className={cx(backLinkStyling)}
                 onClick={() => setShowDriverBackBtn(false)}
-                href="/docs/kafka-connector/current/whats-new/"
+                href={currentL1.newUrl}
               >
-                Back to Client Libraries
+                Back to {currentL1.label}
               </BackLink>
             )}
             {currentL2s.items?.map((navItems) => (

--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -106,9 +106,9 @@ export const DoublePannedNav = ({
               <BackLink
                 className={cx(backLinkStyling)}
                 onClick={() => setShowDriverBackBtn(false)}
-                href={currentL1.newUrl}
+                href={currentL1?.newUrl}
               >
-                Back to {currentL1.label}
+                Back to {currentL1?.label}
               </BackLink>
             )}
             {currentL2s.items?.map((navItems) => (

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -180,17 +180,17 @@ export function UnifiedSidenav({ slug }) {
     });
   });
 
-  const [currentL2s, setCurrentL2s] = useState(() => {
-    return currentL2List;
-  });
+  const [currentL2s, setCurrentL2s] = useState(currentL2List);
 
-  console.log('cocomelon', currentL1, currentL2s);
+  console.log('cocomelon', currentL1, currentL2s, slug);
 
   useEffect(() => {
     const [isDriver, updatedL2s] = findPageParent(tree, slug);
     const updatedL1s = tree.find((staticTocItem) => {
       return isActiveTocNode(slug, staticTocItem.newUrl, staticTocItem.items);
     });
+
+    console.log('temp values', isDriver, updatedL2s);
 
     setShowDriverBackBtn(isDriver);
     setCurrentL1(updatedL1s);
@@ -200,6 +200,7 @@ export function UnifiedSidenav({ slug }) {
   // Changes if L1 is selected/changed, but doesnt change on inital load
   useEffect(() => {
     if (!showDriverBackBtn) setCurrentL2s(currentL1);
+    console.log('i am in l1 change use effect', currentL1);
   }, [currentL1, showDriverBackBtn]);
 
   // close navigation panel on mobile screen, but leaves open if they click on a twisty

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -219,9 +219,9 @@ export function UnifiedSidenav({ slug }) {
   // listen for scrolls for mobile and tablet menu
   const viewport = useViewport(false);
 
-  const displayedItems = showDriverBackBtn ? currentL2s?.items : tree;
+  // const displayedItems = showDriverBackBtn ? currentL2s?.items : tree;
 
-  console.log('please', displayedItems, currentL1, currentL2s);
+  // console.log('please', displayedItems, currentL1, currentL2s);
 
   // Hide the Sidenav with css while keeping state as open/not collapsed.
   // This prevents LG's SideNav component from being seen in its collapsed state on mobile
@@ -235,13 +235,13 @@ export function UnifiedSidenav({ slug }) {
         <AccordionNavPanel
           showDriverBackBtn={showDriverBackBtn}
           setShowDriverBackBtn={setShowDriverBackBtn}
-          displayedItems={displayedItems}
           slug={slug}
           currentL2s={currentL2s}
           setCurrentL1={setCurrentL1}
           setCurrentL2s={setCurrentL2s}
           hideMobile={hideMobile}
           currentL1={currentL1}
+          tree={tree}
         />
         <DoublePannedNav
           showDriverBackBtn={showDriverBackBtn}

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -184,6 +184,8 @@ export function UnifiedSidenav({ slug }) {
     return currentL2List;
   });
 
+  console.log('cocomelon', currentL1, currentL2s);
+
   useEffect(() => {
     const [isDriver, updatedL2s] = findPageParent(tree, slug);
     const updatedL1s = tree.find((staticTocItem) => {
@@ -209,6 +211,8 @@ export function UnifiedSidenav({ slug }) {
   const viewport = useViewport(false);
 
   const displayedItems = showDriverBackBtn ? currentL2s?.items : tree;
+
+  console.log('please', displayedItems, currentL1, currentL2s);
 
   // Hide the Sidenav with css while keeping state as open/not collapsed.
   // This prevents LG's SideNav component from being seen in its collapsed state on mobile

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -160,16 +160,12 @@ export function UnifiedSidenav({ slug }) {
   const { bannerContent } = useContext(HeaderContext);
   const topValues = useStickyTopValues(false, true, !!bannerContent);
   const { pathname } = useLocation();
-  console.log('slug before', slug, isBrowser && window.location.pathname);
   const tempSlug = isBrowser ? removeLeadingSlash(removeTrailingSlash(window.location.pathname)) : slug;
-
   slug = tempSlug?.startsWith('docs/')
     ? tempSlug
     : tempSlug === '/'
     ? pathPrefix + tempSlug
     : `${pathPrefix}/${tempSlug}/`;
-
-  console.log('slug after', slug, isBrowser && window.location.pathname);
 
   const tree = useMemo(() => {
     return updateURLs({
@@ -178,7 +174,7 @@ export function UnifiedSidenav({ slug }) {
       versionsData: availableVersions,
       project,
     });
-  }, [unifiedTocTree, activeVersions, availableVersions, project]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [unifiedTocTree, activeVersions, availableVersions, project]);
 
   const [isDriver, currentL2List] = findPageParent(tree, slug);
   const [showDriverBackBtn, setShowDriverBackBtn] = useState(isDriver);
@@ -190,16 +186,12 @@ export function UnifiedSidenav({ slug }) {
   });
 
   const [currentL2s, setCurrentL2s] = useState(currentL2List);
-  // console.log("bah", tree);
-  console.log('cocomelon', currentL1, currentL2s);
 
   useEffect(() => {
     const [isDriver, updatedL2s] = findPageParent(tree, slug);
     const updatedL1s = tree.find((staticTocItem) => {
       return isActiveTocNode(slug, staticTocItem.newUrl, staticTocItem.items);
     });
-
-    console.log('temp values', isDriver, updatedL2s);
 
     setShowDriverBackBtn(isDriver);
     setCurrentL1(updatedL1s);
@@ -218,10 +210,6 @@ export function UnifiedSidenav({ slug }) {
 
   // listen for scrolls for mobile and tablet menu
   const viewport = useViewport(false);
-
-  // const displayedItems = showDriverBackBtn ? currentL2s?.items : tree;
-
-  // console.log('please', displayedItems, currentL1, currentL2s);
 
   // Hide the Sidenav with css while keeping state as open/not collapsed.
   // This prevents LG's SideNav component from being seen in its collapsed state on mobile

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -15,6 +15,7 @@ import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { assertLeadingSlash } from '../../utils/assert-leading-slash';
 import { removeTrailingSlash } from '../../utils/remove-trailing-slash';
 // import { isActiveTocNode } from '../../utils/is-active-toc-node';
+import { removeLeadingSlash } from '../../utils/remove-leading-slash';
 import { isActiveTocNode } from './UnifiedTocNavItems';
 import { DoublePannedNav } from './DoublePannedNav';
 import { AccordionNavPanel } from './AccordionNav';
@@ -79,7 +80,7 @@ const SidenavContainer = ({ topLarge, topMedium, topSmall }) => LeafyCSS`
 `;
 
 // Function that adds the current version
-const updateURLs = ({ tree, contentSite, activeVersions, versionsData, project, snootyEnv }) => {
+const updateURLs = ({ tree, contentSite, activeVersions, versionsData, project }) => {
   return tree?.map((item) => {
     let newUrl = item.url ?? '';
     const currentProject = item.contentSite ?? contentSite;
@@ -101,7 +102,6 @@ const updateURLs = ({ tree, contentSite, activeVersions, versionsData, project, 
       activeVersions,
       versionsData,
       project,
-      snootyEnv,
     });
 
     return {
@@ -153,13 +153,17 @@ const findPageParent = (tree, targetUrl) => {
 export function UnifiedSidenav({ slug }) {
   const unifiedTocTree = useUnifiedToc();
   const { project } = useSnootyMetadata();
-  const { snootyEnv, pathPrefix } = useSiteMetadata();
+  const { pathPrefix } = useSiteMetadata();
   const { activeVersions, availableVersions } = useContext(VersionContext);
   const { hideMobile, setHideMobile } = useContext(SidenavContext);
   const { bannerContent } = useContext(HeaderContext);
   const topValues = useStickyTopValues(false, true, !!bannerContent);
   const { pathname } = useLocation();
-  slug = slug === '/' ? pathPrefix + slug : `${pathPrefix}/${slug}/`;
+  const currentPathname = removeLeadingSlash(removeTrailingSlash(window.location.pathname)) || slug;
+  // const currentPathname = slug;
+
+  console.log('slug vs window path', slug, window.location.pathname);
+  slug = currentPathname === '/' ? pathPrefix + currentPathname : `${pathPrefix}/${currentPathname}/`;
 
   const tree = useMemo(() => {
     return updateURLs({
@@ -167,9 +171,8 @@ export function UnifiedSidenav({ slug }) {
       activeVersions,
       versionsData: availableVersions,
       project,
-      snootyEnv,
     });
-  }, [unifiedTocTree, activeVersions, availableVersions, project, snootyEnv]);
+  }, [unifiedTocTree, activeVersions, availableVersions, project]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [isDriver, currentL2List] = findPageParent(tree, slug);
   const [showDriverBackBtn, setShowDriverBackBtn] = useState(isDriver);
@@ -195,12 +198,11 @@ export function UnifiedSidenav({ slug }) {
     setShowDriverBackBtn(isDriver);
     setCurrentL1(updatedL1s);
     setCurrentL2s(updatedL2s);
-  }, [tree, slug]);
+  }, [tree]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Changes if L1 is selected/changed, but doesnt change on inital load
   useEffect(() => {
     if (!showDriverBackBtn) setCurrentL2s(currentL1);
-    console.log('i am in l1 change use effect', currentL1);
   }, [currentL1, showDriverBackBtn]);
 
   // close navigation panel on mobile screen, but leaves open if they click on a twisty
@@ -232,7 +234,6 @@ export function UnifiedSidenav({ slug }) {
           currentL2s={currentL2s}
           setCurrentL1={setCurrentL1}
           setCurrentL2s={setCurrentL2s}
-          currentL1={currentL1}
           hideMobile={hideMobile}
         />
         <DoublePannedNav

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -160,13 +160,16 @@ export function UnifiedSidenav({ slug }) {
   const { bannerContent } = useContext(HeaderContext);
   const topValues = useStickyTopValues(false, true, !!bannerContent);
   const { pathname } = useLocation();
-  const currentPathname = isBrowser
-    ? removeLeadingSlash(removeTrailingSlash(window.location.pathname.replace(pathPrefix, '')))
-    : slug;
-  // const currentPathname = slug;
+  console.log('slug before', slug, isBrowser && window.location.pathname);
+  const tempSlug = isBrowser ? removeLeadingSlash(removeTrailingSlash(window.location.pathname)) : slug;
 
-  console.log('slug vs window path', slug, isBrowser && window.location.pathname, currentPathname);
-  slug = currentPathname === '/' ? pathPrefix + currentPathname : `${pathPrefix}/${currentPathname}/`;
+  slug = tempSlug?.startsWith('docs/')
+    ? tempSlug
+    : tempSlug === '/'
+    ? pathPrefix + tempSlug
+    : `${pathPrefix}/${tempSlug}/`;
+
+  console.log('slug after', slug, isBrowser && window.location.pathname);
 
   const tree = useMemo(() => {
     return updateURLs({
@@ -187,8 +190,8 @@ export function UnifiedSidenav({ slug }) {
   });
 
   const [currentL2s, setCurrentL2s] = useState(currentL2List);
-
-  console.log('cocomelon', currentL1, currentL2s, slug);
+  // console.log("bah", tree);
+  console.log('cocomelon', currentL1, currentL2s);
 
   useEffect(() => {
     const [isDriver, updatedL2s] = findPageParent(tree, slug);

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -208,7 +208,7 @@ export function UnifiedSidenav({ slug }) {
   // listen for scrolls for mobile and tablet menu
   const viewport = useViewport(false);
 
-  const displayedItems = showDriverBackBtn ? currentL2s.items : tree;
+  const displayedItems = showDriverBackBtn ? currentL2s?.items : tree;
 
   // Hide the Sidenav with css while keeping state as open/not collapsed.
   // This prevents LG's SideNav component from being seen in its collapsed state on mobile

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -16,6 +16,7 @@ import { assertLeadingSlash } from '../../utils/assert-leading-slash';
 import { removeTrailingSlash } from '../../utils/remove-trailing-slash';
 // import { isActiveTocNode } from '../../utils/is-active-toc-node';
 import { removeLeadingSlash } from '../../utils/remove-leading-slash';
+import { isBrowser } from '../../utils/is-browser';
 import { isActiveTocNode } from './UnifiedTocNavItems';
 import { DoublePannedNav } from './DoublePannedNav';
 import { AccordionNavPanel } from './AccordionNav';
@@ -159,10 +160,12 @@ export function UnifiedSidenav({ slug }) {
   const { bannerContent } = useContext(HeaderContext);
   const topValues = useStickyTopValues(false, true, !!bannerContent);
   const { pathname } = useLocation();
-  const currentPathname = removeLeadingSlash(removeTrailingSlash(window.location.pathname)) || slug;
+  const currentPathname = isBrowser
+    ? removeLeadingSlash(removeTrailingSlash(window.location.pathname.replace(pathPrefix, '')))
+    : slug;
   // const currentPathname = slug;
 
-  console.log('slug vs window path', slug, window.location.pathname);
+  console.log('slug vs window path', slug, isBrowser && window.location.pathname, currentPathname);
   slug = currentPathname === '/' ? pathPrefix + currentPathname : `${pathPrefix}/${currentPathname}/`;
 
   const tree = useMemo(() => {

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -227,6 +227,7 @@ export function UnifiedSidenav({ slug }) {
           currentL2s={currentL2s}
           setCurrentL1={setCurrentL1}
           setCurrentL2s={setCurrentL2s}
+          currentL1={currentL1}
           hideMobile={hideMobile}
         />
         <DoublePannedNav

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -241,6 +241,7 @@ export function UnifiedSidenav({ slug }) {
           setCurrentL1={setCurrentL1}
           setCurrentL2s={setCurrentL2s}
           hideMobile={hideMobile}
+          currentL1={currentL1}
         />
         <DoublePannedNav
           showDriverBackBtn={showDriverBackBtn}

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -86,7 +86,6 @@ export function UnifiedTocNavItem({
             isAccordion={isAccordion}
           />
           {versionDropdown && newUrl === currentL2s?.newUrl && <UnifiedVersionDropdown contentSite={contentSite} />}
-          {console.log('peanut butter', newUrl, currentL2s, items)}
           {newUrl === currentL2s?.newUrl &&
             items?.map((tocItem) => (
               <UnifiedTocNavItem

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -86,6 +86,7 @@ export function UnifiedTocNavItem({
             isAccordion={isAccordion}
           />
           {versionDropdown && newUrl === currentL2s?.newUrl && <UnifiedVersionDropdown contentSite={contentSite} />}
+          {console.log('peanut butter', newUrl, currentL2s, items)}
           {newUrl === currentL2s?.newUrl &&
             items?.map((tocItem) => (
               <UnifiedTocNavItem

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -268,7 +268,7 @@ export function StaticNavItem({
       as={isUnifiedTOCInDevMode ? null : Link}
       to={newUrl}
       onClick={() => {
-        setCurrentL1({ items, newUrl, versionDropdown });
+        setCurrentL1({ items, newUrl, versionDropdown, label });
         setShowDriverBackBtn(false);
       }}
       className={cx(l1ItemStyling({ isActive, isAccordion }))}

--- a/src/components/UnifiedSidenav/UnifiedVersionDropdown.js
+++ b/src/components/UnifiedSidenav/UnifiedVersionDropdown.js
@@ -1,16 +1,14 @@
 import React from 'react';
-// import VersionDropdown from '../VersionDropdown';
+import VersionDropdown from '../VersionDropdown';
 import VersionSelector from '../Sidenav/VersionSelector';
-// import useSnootyMetadata from '../../utils/use-snooty-metadata';
+import useSnootyMetadata from '../../utils/use-snooty-metadata';
 
 export function UnifiedVersionDropdown({ contentSite }) {
-  // const { project } = useSnootyMetadata();
+  const { project } = useSnootyMetadata();
 
-  return <VersionSelector versionedProject={contentSite} />;
-
-  // if (contentSite === project) {
-  //   return <VersionDropdown />;
-  // } else {
-
-  // }
+  if (contentSite === project) {
+    return <VersionDropdown />;
+  } else {
+    return <VersionSelector versionedProject={contentSite} />;
+  }
 }

--- a/src/components/UnifiedSidenav/UnifiedVersionDropdown.js
+++ b/src/components/UnifiedSidenav/UnifiedVersionDropdown.js
@@ -1,14 +1,16 @@
 import React from 'react';
-import VersionDropdown from '../VersionDropdown';
+// import VersionDropdown from '../VersionDropdown';
 import VersionSelector from '../Sidenav/VersionSelector';
-import useSnootyMetadata from '../../utils/use-snooty-metadata';
+// import useSnootyMetadata from '../../utils/use-snooty-metadata';
 
 export function UnifiedVersionDropdown({ contentSite }) {
-  const { project } = useSnootyMetadata();
+  // const { project } = useSnootyMetadata();
 
-  if (contentSite === project) {
-    return <VersionDropdown />;
-  } else {
-    return <VersionSelector versionedProject={contentSite} />;
-  }
+  return <VersionSelector versionedProject={contentSite} />;
+
+  // if (contentSite === project) {
+  //   return <VersionDropdown />;
+  // } else {
+
+  // }
 }

--- a/src/components/UnifiedSidenav/styles/SideNavItem.tsx
+++ b/src/components/UnifiedSidenav/styles/SideNavItem.tsx
@@ -31,6 +31,7 @@ export const l1ItemStyling = ({ isActive, isAccordion }: { isActive: boolean; is
           // Hides the left tab on Active Selection
           &[aria-current='page'] {
             background-color: unset;
+            color: unset;
             :hover {
               background-color: var(--sidenav-hover-bg-color);
             }

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -224,6 +224,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
   // handler for selecting version on multiple dropdowns
   const onVersionSelect = useCallback(
     (targetProject, gitBranchName) => {
+      console.log('hello bitch', targetProject, getInitBranchName);
       const updatedVersion = {};
       updatedVersion[targetProject] = gitBranchName;
       setActiveVersions(updatedVersion);

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -9,6 +9,7 @@ import { getLocalValue, setLocalValue } from '../utils/browser-storage';
 import { fetchDocset, fetchDocument } from '../utils/realm';
 import { getUrl } from '../utils/url-utils';
 import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { getFeatureFlags } from '../utils/feature-flags';
 
 // <-------------- begin helper functions -------------->
 const STORAGE_KEY = 'activeVersions';
@@ -149,6 +150,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
   const associatedProductNames = useAllAssociatedProducts();
   const docsets = useAllDocsets();
   const { project } = useSnootyMetadata();
+  const { isUnifiedToc } = getFeatureFlags();
   const associatedReposInfo = useMemo(
     () =>
       associatedProductNames.reduce((res, productName) => {
@@ -277,14 +279,13 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
       console.error(`url <${currentUrlSlug}> does not correspond to any current branch`);
       return;
     }
-    // DOP-5812 : MAYBE NEED TO CHANGE THIS, TEST HOW THIS WORKS IN PREPROD
-    // if (activeVersions[metadata.project] !== currentBranch.gitBranchName) {
-    //   const newState = { ...activeVersions };
-    //   newState[metadata.project] = currentBranch.gitBranchName;
-    //   console.log('i shouldnt be here', newState, currentBranch.gitBranchName, activeVersions[metadata.project]);
-    //   setActiveVersions(newState);
-    // }
-  }, [activeVersions, currentUrlSlug, findBranchByAlias, metadata.project, setActiveVersions]);
+
+    if (!isUnifiedToc && activeVersions[metadata.project] !== currentBranch.gitBranchName) {
+      const newState = { ...activeVersions };
+      newState[metadata.project] = currentBranch.gitBranchName;
+      setActiveVersions(newState);
+    }
+  }, [activeVersions, currentUrlSlug, findBranchByAlias, metadata.project, setActiveVersions, isUnifiedToc]);
 
   return (
     <VersionContext.Provider

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -226,7 +226,6 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
   // handler for selecting version on multiple dropdowns
   const onVersionSelect = useCallback(
     (targetProject, gitBranchName) => {
-      console.log('hello', targetProject, getInitBranchName);
       const updatedVersion = {};
       updatedVersion[targetProject] = gitBranchName;
       setActiveVersions(updatedVersion);

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer, useEffect, useState, useCallback, useRef, useMemo } from 'react';
-import { navigate } from '@gatsbyjs/reach-router';
+// import { navigate } from '@gatsbyjs/reach-router';
 import { METADATA_COLLECTION } from '../build-constants';
 import { useAllDocsets } from '../hooks/useAllDocsets';
 import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';
@@ -224,7 +224,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
   // handler for selecting version on multiple dropdowns
   const onVersionSelect = useCallback(
     (targetProject, gitBranchName) => {
-      console.log('hello bitch', targetProject, getInitBranchName);
+      console.log('hello', targetProject, getInitBranchName);
       const updatedVersion = {};
       updatedVersion[targetProject] = gitBranchName;
       setActiveVersions(updatedVersion);
@@ -244,7 +244,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
           ? gitBranchName
           : targetBranch.urlSlug || targetBranch.urlAliases[0] || targetBranch.gitBranchName;
       const urlTarget = getUrl(target, metadata.project, repoBranches?.siteBasePrefix, slug);
-      navigate(urlTarget);
+      window.location.href = urlTarget;
     },
     [availableVersions, metadata, repoBranches, slug]
   );
@@ -278,12 +278,12 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
       return;
     }
     // DOP-5812 : MAYBE NEED TO CHANGE THIS, TEST HOW THIS WORKS IN PREPROD
-    if (activeVersions[metadata.project] !== currentBranch.gitBranchName) {
-      const newState = { ...activeVersions };
-      newState[metadata.project] = currentBranch.gitBranchName;
-      console.log('i shouldnt be here', newState, currentBranch.gitBranchName, activeVersions[metadata.project]);
-      setActiveVersions(newState);
-    }
+    // if (activeVersions[metadata.project] !== currentBranch.gitBranchName) {
+    //   const newState = { ...activeVersions };
+    //   newState[metadata.project] = currentBranch.gitBranchName;
+    //   console.log('i shouldnt be here', newState, currentBranch.gitBranchName, activeVersions[metadata.project]);
+    //   setActiveVersions(newState);
+    // }
   }, [activeVersions, currentUrlSlug, findBranchByAlias, metadata.project, setActiveVersions]);
 
   return (

--- a/src/context/version-context.js
+++ b/src/context/version-context.js
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer, useEffect, useState, useCallback, useRef, useMemo } from 'react';
-// import { navigate } from '@gatsbyjs/reach-router';
+import { navigate } from '@gatsbyjs/reach-router';
 import { METADATA_COLLECTION } from '../build-constants';
 import { useAllDocsets } from '../hooks/useAllDocsets';
 import { useAllAssociatedProducts } from '../hooks/useAssociatedProducts';
@@ -244,7 +244,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }) => {
           ? gitBranchName
           : targetBranch.urlSlug || targetBranch.urlAliases[0] || targetBranch.gitBranchName;
       const urlTarget = getUrl(target, metadata.project, repoBranches?.siteBasePrefix, slug);
-      window.location.href = urlTarget;
+      navigate(urlTarget);
     },
     [availableVersions, metadata, repoBranches, slug]
   );


### PR DESCRIPTION
### Stories/Links:

DOP-5925

### Current Behavior:

There was a bug where the page would flash white when changing versions of the site youre on. Now the flash of white shouldnt be there
[before](https://687dc778b820d0da05b22e14--mongodb-kafka-connector-preprd.netlify.app/docs/kafka-connector/v1.13/source-connector/)

### Staging Links:

[after](https://687ea8b53fed6098900770a0--mongodb-kafka-connector-preprd.netlify.app/docs/kafka-connector/upcoming/introduction/)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
