### PR TITLE
DOP-5640: Collapsible item fix

### DIFF
--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
@@ -199,7 +199,8 @@ export function UnifiedTocNavItem({
 }
 
 function CollapsibleNavItem({ items, label, newUrl, slug, contentSite, isAccordion, level }) {
-  const [isOpen, setIsOpen] = useState(isActiveTocNode(slug, newUrl, items));
+  const isActiveCollapsible = isActiveTocNode(slug, newUrl, items);
+  const [isOpen, setIsOpen] = useState(isActiveCollapsible);
   const caretType = isOpen ? 'CaretDown' : 'CaretUp';
   const isActive = isSelectedTab(newUrl, slug);
 
@@ -214,6 +215,10 @@ function CollapsibleNavItem({ items, label, newUrl, slug, contentSite, isAccordi
       setIsOpen(!isOpen);
     }
   };
+
+  useEffect(() => {
+    setIsOpen(isActiveCollapsible);
+  }, [isActiveCollapsible]);
 
   return (
     <>


### PR DESCRIPTION
### Stories/Links:

DOP-5640
* if you open a collapsible item and then go open another one, both would stay open. We only want one open at a time.
 
### Current Behavior:

[before](https://687a96d4b45c513f42e9ab22--mongodb-database-tools-preprd.netlify.app/docs/database-tools/mongorestore/)

### Staging Links:

[after](https://687eb25b23c62c6a21f2b455--mongodb-database-tools-preprd.netlify.app/docs/database-tools/mongotop/)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
