### PR TITLE
DOP-5855: Changing internal nav links to be based on Unified TOC

### DIFF
--- a/src/components/InternalPageNav/InternalPageNav.js
+++ b/src/components/InternalPageNav/InternalPageNav.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { glyphs } from '@leafygreen-ui/icon';
 import { css, cx } from '@leafygreen-ui/emotion';
@@ -6,6 +6,12 @@ import { theme } from '../../theme/docsTheme';
 import { getPageTitle } from '../../utils/get-page-title';
 import { useActiveMpTutorial } from '../MultiPageTutorials';
 import { reportAnalytics } from '../../utils/report-analytics';
+import { getFeatureFlags } from '../../utils/feature-flags';
+import { useUnifiedToc } from '../../hooks/use-unified-toc';
+import { useSiteMetadata } from '../../hooks/use-site-metadata';
+import { VersionContext } from '../../context/version-context';
+import { removeTrailingSlash } from '../../utils/remove-trailing-slash';
+import { assertTrailingSlash } from '../../utils/assert-trailing-slash';
 import NextPrevLink from './NextPrevLink';
 
 const containerStyling = css`
@@ -69,11 +75,137 @@ const getNext = (activeTutorial, toctreeOrder, slugTitleMapping, slugIndex) => {
   return getTocPage(nextSlug, slugTitleMapping, 'Next Section');
 };
 
+// Replacing the version in the pathPrefix with `:version` to match toc.json urls
+function replaceVersionInPath(pathPrefix, versions) {
+  if (!versions) return pathPrefix;
+
+  const segments = pathPrefix.split('/');
+  const lastSegment = segments[segments.length - 1] || segments[segments.length - 2];
+  const matchesVersion = versions.find(
+    (version) => version.urlSlug === lastSegment || (version.urlAliases && version.urlAliases.includes(lastSegment))
+  );
+
+  if (matchesVersion) {
+    segments[segments.length - 1] = ':version/';
+    if (segments[segments.length - 1] === '') {
+      segments[segments.length - 2] = ':version/'; // If the last was empty due to trailing slash
+      segments.pop();
+    }
+    return segments.join('/');
+  }
+
+  return pathPrefix;
+}
+
+function groupContainsUrl(items, currentUrl) {
+  for (const item of items) {
+    if (removeTrailingSlash(item.url) === removeTrailingSlash(currentUrl)) return true;
+    if (item.items && groupContainsUrl(item.items, currentUrl)) return true;
+  }
+  return false;
+}
+
+function findGroupForUrl(toc, currentUrl) {
+  for (const topLevelItem of toc) {
+    if (!topLevelItem.items) continue;
+
+    for (const item of topLevelItem.items) {
+      if (item.group) {
+        if (groupContainsUrl(item.items || [], currentUrl)) {
+          return item;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function flattenGroupItems(items, flat = []) {
+  for (const item of items) {
+    if (item.isExternal) {
+      // Skips external links
+      continue;
+    }
+
+    if (item.url) {
+      flat.push({
+        label: item.label,
+        url: item.url,
+        contentSite: item.contentSite,
+      });
+    }
+    if (item.items) {
+      flattenGroupItems(item.items, flat);
+    }
+  }
+  return flat;
+}
+
+// Allows InternalNavLinks to be between different contentSites if needed
+function getTargetSlug(fullUrl, contentSite, activeVersions, availableVersions) {
+  if (!fullUrl.includes(':version')) {
+    return fullUrl;
+  } else {
+    const version = (availableVersions[contentSite] || []).find(
+      (version) => version.gitBranchName === activeVersions[contentSite]
+    );
+    // If no version use first version.urlSlug in the list, or if no version loads, set as current
+    const defaultVersion = availableVersions[contentSite]?.[0].urlSlug ?? 'current';
+    const currentVersion = version?.urlSlug ?? defaultVersion;
+    return fullUrl.replace(/:version/g, currentVersion);
+  }
+}
+
+function getPrevUnified(toc, currentUrl, activeVersions, availableVersions) {
+  const group = findGroupForUrl(toc, currentUrl);
+  if (!group) return null;
+
+  const flat = flattenGroupItems(group.items || []);
+  const index = flat.findIndex((item) => removeTrailingSlash(item.url) === removeTrailingSlash(currentUrl));
+
+  const node = index > 0 ? flat[index - 1] : null;
+
+  return {
+    targetSlug: node ? getTargetSlug(node.url, node.contentSite, activeVersions, availableVersions) : null,
+    pageTitle: node ? node.label : null,
+    contentSite: node ? node.contentSite : null,
+    linkTitle: 'Previous Section',
+  };
+}
+
+function getNextUnified(toc, currentUrl, activeVersions, availableVersions) {
+  const group = findGroupForUrl(toc, currentUrl);
+  if (!group) return null;
+
+  const flat = flattenGroupItems(group.items || []);
+  const index = flat.findIndex((item) => removeTrailingSlash(item.url) === removeTrailingSlash(currentUrl));
+
+  const node = index >= 0 && index < flat.length - 1 ? flat[index + 1] : null;
+
+  return {
+    targetSlug: node ? getTargetSlug(node.url, node.contentSite, activeVersions, availableVersions) : null,
+    pageTitle: node ? node.label : null,
+    contentSite: node ? node.contentSite : null,
+    linkTitle: 'Next Section',
+  };
+}
+
 const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
+  const { isUnifiedToc } = getFeatureFlags();
+  const tocTree = useUnifiedToc();
+  const { pathPrefix, project } = useSiteMetadata();
+  const { availableVersions, activeVersions } = useContext(VersionContext);
+  const noVersionPathPrefix = replaceVersionInPath(pathPrefix, availableVersions[project]);
+  const fullSlug = slug === '/' ? noVersionPathPrefix : assertTrailingSlash(noVersionPathPrefix) + slug;
   const activeTutorial = useActiveMpTutorial();
   const slugIndex = toctreeOrder.indexOf(slug);
-  const prevPage = getPrev(activeTutorial, toctreeOrder, slugTitleMapping, slugIndex);
-  const nextPage = getNext(activeTutorial, toctreeOrder, slugTitleMapping, slugIndex);
+
+  const prevPage = isUnifiedToc
+    ? getPrevUnified(tocTree, fullSlug, activeVersions, availableVersions)
+    : getPrev(activeTutorial, toctreeOrder, slugTitleMapping, slugIndex);
+  const nextPage = isUnifiedToc
+    ? getNextUnified(tocTree, fullSlug, activeVersions, availableVersions)
+    : getNext(activeTutorial, toctreeOrder, slugTitleMapping, slugIndex);
 
   const handleClick = (direction, targetSlug) => {
     reportAnalytics('InternalPageNavClicked', {
@@ -92,6 +224,7 @@ const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
           targetSlug={prevPage.targetSlug}
           pageTitle={prevPage.pageTitle}
           title={prevPage.linkTitle}
+          contentSite={prevPage?.contentSite}
           onClick={handleClick}
         />
       )}
@@ -103,6 +236,7 @@ const InternalPageNav = ({ slug, slugTitleMapping, toctreeOrder }) => {
           targetSlug={nextPage.targetSlug}
           pageTitle={nextPage.pageTitle}
           title={nextPage.linkTitle}
+          contentSite={nextPage?.contentSite}
           onClick={handleClick}
         />
       )}

--- a/src/components/InternalPageNav/InternalPageNav.js
+++ b/src/components/InternalPageNav/InternalPageNav.js
@@ -106,10 +106,8 @@ function groupContainsUrl(items, currentUrl) {
 }
 
 function findGroupForUrl(toc, currentUrl) {
-  for (const topLevelItem of toc) {
-    if (!topLevelItem.items) continue;
-
-    for (const item of topLevelItem.items) {
+  for (const L1Item of toc) {
+    for (const item of L1Item.items) {
       if (item.group) {
         if (groupContainsUrl(item.items || [], currentUrl)) {
           return item;

--- a/src/components/InternalPageNav/NextPrevLink.js
+++ b/src/components/InternalPageNav/NextPrevLink.js
@@ -62,13 +62,13 @@ const baseButtonStyle = css`
   }
 `;
 
-const NextPrevLink = ({ className, icon, direction, pageTitle, targetSlug, title, onClick }) => {
+const NextPrevLink = ({ className, icon, direction, pageTitle, targetSlug, title, contentSite, onClick }) => {
   const isNext = direction?.toLowerCase() === 'next';
   const isPrev = direction?.toLowerCase() === 'back';
 
   return (
     <div className={className} onClick={() => onClick(direction, targetSlug)}>
-      <Link to={targetSlug} title={title}>
+      <Link to={targetSlug} title={title} contentSite={contentSite}>
         <div className={cx({ [nextLinkContainerStyling]: isNext, [prevLinkContainerStyling]: isPrev })}>
           <Button className={cx(baseButtonStyle, navLinkButtonStyle)}>
             <Icon glyph={icon} />


### PR DESCRIPTION
### Stories/Links:

DOP-5855

**ASSUMPTIONS** Im _only_ flattening out page links within the same group. That was the only idea that made sense in my head but please let me know if you think otherwise.

### Current Behavior:

based on tocTree

### Staging Links:

[released on database-tools link](https://687f13a4d75ca7d7c3af3db5--mongodb-database-tools-preprd.netlify.app/docs/database-tools/)

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
