### PR TITLE
DOP-5937: Allow for symlinks in unified toc

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -146,12 +146,15 @@ const Link = ({
   if (contentSite) {
     // For an external links, inside the unified toc
     if (!isRelativeUrl(to)) {
+      const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
+      const isMDBLink = strippedUrl.includes('mongodb.com'); // For an symlinks
+
       return (
         <LGLink
           className={joinClassNames(lgLinkStyling, className)}
           href={to}
-          hideExternalIcon={false}
-          target={'_blank'}
+          hideExternalIcon={isMDBLink ? true : false}
+          target={isMDBLink ? '_self' : '_blank'}
           style={{ fill: palette.gray.base }}
           {...anchorProps}
         >

--- a/src/components/UnifiedSidenav/UnifiedSidenav.js
+++ b/src/components/UnifiedSidenav/UnifiedSidenav.js
@@ -212,7 +212,6 @@ export function UnifiedSidenav({ slug }) {
   // listen for scrolls for mobile and tablet menu
   const viewport = useViewport(false);
 
-  console.log('bah', currentL1, currentL2s, tree, showDriverBackBtn);
   // Hide the Sidenav with css while keeping state as open/not collapsed.
   // This prevents LG's SideNav component from being seen in its collapsed state on mobile
   return (

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -273,7 +273,6 @@ export function StaticNavItem({
       as={isUnifiedTOCInDevMode ? null : Link}
       to={newUrl}
       onClick={() => {
-        console.log('hello i am under the water');
         setCurrentL1({ items, newUrl, versionDropdown, label });
         setShowDriverBackBtn(false);
       }}


### PR DESCRIPTION
### Stories/Links:

DOP-5937
* I didnt account for symlinks in the unified toc since I didnt realize they exist. However the functionality was already partly accounted for so to create a symlink in the unified toc you just need to put the full url path. So for example

how the toc node should look for where the page lives:
```
{
    label: "database-tools",
    url: "/docs/databse-tools/",
    contentSite: "database-tools".
}
```

how a symlink would work
```
{
    label: "database-tools",
    url: "https://www.mongodb.com/docs/database-tools/",
    contentSite: "database-tools".
}
```

### Current Behavior:

N/A

### Staging Links:

Its a lil difficult to do staging links right now do to using preprd for UAT and frontend-stg not being updated but i recorded a video 


https://github.com/user-attachments/assets/ba7c0939-a1aa-4be8-a115-f1cfeeea7f82



### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
