### PR TITLE
DOP-5938: `showSubNav` inside collapsible

### DIFF
--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -175,6 +175,8 @@ export function UnifiedTocNavItem({
         newUrl={newUrl}
         level={level}
         isAccordion={isAccordion}
+        setShowDriverBackBtn={setShowDriverBackBtn}
+        setCurrentL2s={setCurrentL2s}
         slug={slug}
         contentSite={contentSite}
         className={cx(l2ItemStyling({ level, isAccordion }))}
@@ -196,7 +198,17 @@ export function UnifiedTocNavItem({
   );
 }
 
-function CollapsibleNavItem({ items, label, newUrl, slug, contentSite, isAccordion, level }) {
+function CollapsibleNavItem({
+  items,
+  label,
+  newUrl,
+  slug,
+  contentSite,
+  setShowDriverBackBtn,
+  setCurrentL2s,
+  isAccordion,
+  level,
+}) {
   const isActiveCollapsible = isActiveTocNode(slug, newUrl, items);
   const [isOpen, setIsOpen] = useState(isActiveCollapsible);
   const caretType = isOpen ? 'CaretDown' : 'CaretUp';
@@ -244,6 +256,8 @@ function CollapsibleNavItem({ items, label, newUrl, slug, contentSite, isAccordi
             level={level + 1}
             key={item.newUrl + item.label}
             slug={slug}
+            setShowDriverBackBtn={setShowDriverBackBtn}
+            setCurrentL2s={setCurrentL2s}
             isAccordion={isAccordion}
           />
         ))}


### PR DESCRIPTION
### Stories/Links:

DOP-5938
* Micheal pointed out that showsubnav wasnt working for sidenav items inside collapsibles so made that fix in this pr
### Current Behavior:

N/A

### Staging Links:

N/A
<img width="522" height="335" alt="Screenshot 2025-07-24 at 2 33 44 PM" src="https://github.com/user-attachments/assets/1682e0f6-0e77-44a1-a125-80da2a717e37" />

* if you would like to test locally i have a toc.json i can send you. But it was just a bug that i wasnt passing some variables to the collapsible component. 
* 
### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
