### PR TITLE
DOP-6087: L1's don't need items/children anymore

### DIFF
--- a/src/components/UnifiedSidenav/DoublePannedNav.js
+++ b/src/components/UnifiedSidenav/DoublePannedNav.js
@@ -80,7 +80,11 @@ export const DoublePannedNav = ({
   const { isTabletOrMobile } = useScreenSize();
 
   return (
-    <SideNav widthOverride={currentL1 ? 426 : 161} className={cx(sideNavStyle)} aria-label="Side navigation Panel">
+    <SideNav
+      widthOverride={currentL2s?.items ? 426 : 161}
+      className={cx(sideNavStyle)}
+      aria-label="Side navigation Panel"
+    >
       <div className={cx(NavTopContainer(isTabletOrMobile))}>
         <ArtificialPadding />
         <DocsHomeButton />
@@ -101,7 +105,7 @@ export const DoublePannedNav = ({
           ))}
         </div>
         {currentL1?.versionDropdown && <UnifiedVersionDropdown />}
-        {currentL2s && (
+        {currentL2s?.items && (
           <div className={cx(rightPane)}>
             {showDriverBackBtn && (
               <BackLink

--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -100,7 +100,7 @@ export function UnifiedTocNavItem({
                 setShowDriverBackBtn={setShowDriverBackBtn}
               />
             ))}
-          {newUrl === currentL2s?.newUrl && <Border />}
+          {items && newUrl === currentL2s?.newUrl && <Border />}
         </>
       );
     }


### PR DESCRIPTION
### Stories/Links:

DOP-6087: The "Get Started" L1 won't have any children/items so no second nav should display when the l1 is selected

### Current Behavior:

<img width="425" height="575" alt="image" src="https://github.com/user-attachments/assets/40b8d472-f1fa-4941-87f3-0f73e829fab5" />


### Staging Links:

<img width="343" height="550" alt="Screenshot 2025-08-08 at 1 16 28 PM" src="https://github.com/user-attachments/assets/ff4d6ba6-81cd-4471-9bb2-393ed33feff2" />

https://mongodbcom-cdn.staging.corp.mongodb.com/docs/get-started/

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
