### PR TITLE
DOP-6061: Icon for external links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -147,7 +147,7 @@ const Link = ({
     // For an external links, inside the unified toc
     if (!isRelativeUrl(to)) {
       const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
-      const isMDBLink = strippedUrl.includes('mongodb.com'); // For an symlinks
+      const isMDBLink = strippedUrl.includes('mongodb.com/docs'); // For an symlinks
 
       return (
         <LGLink


### PR DESCRIPTION
### Stories/Links:

DOP-6061

### Current Behavior:

<img width="441" height="430" alt="Screenshot 2025-08-11 at 2 44 19 PM" src="https://github.com/user-attachments/assets/3b495709-4684-4b41-9427-afa942b6b04d" />

https://mongodbcom-cdn.staging.corp.mongodb.com/docs/pricing/

### Staging Links:

N/A since caesar is working on staging links but below is a screenshot of my local host
<img width="383" height="370" alt="Screenshot 2025-08-11 at 2 48 11 PM" src="https://github.com/user-attachments/assets/cb9004a1-4f2d-4276-84c5-f2e82d2cec6f" />


### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
