### PR TITLE
DOP-6063: Collapsible item should open on close on Click of Active item

### DIFF
--- a/src/components/UnifiedSidenav/UnifiedTocNavItems.js
+++ b/src/components/UnifiedSidenav/UnifiedTocNavItems.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
 import { palette } from '@leafygreen-ui/palette';
@@ -214,17 +214,21 @@ function CollapsibleNavItem({
   const [isOpen, setIsOpen] = useState(isActiveCollapsible);
   const caretType = isOpen ? 'CaretDown' : 'CaretUp';
   const isActive = isSelectedTab(newUrl, slug);
+  const openedByCaret = useRef(false);
 
   const onCaretClick = (event) => {
     event.preventDefault();
-    setIsOpen(!isOpen);
+    event.stopPropagation();
+    openedByCaret.current = !isOpen;
+    setIsOpen((open) => !open);
   };
 
   const handleClick = () => {
-    // Allows the collapsed item if the caret was selected first before
-    if (!(newUrl !== `/${slug}` && isOpen)) {
-      setIsOpen(!isOpen);
+    if (isOpen && openedByCaret.current) {
+      openedByCaret.current = false; // Was opened by caret, keep it open and reset
+      return;
     }
+    setIsOpen((open) => !open);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Stories/Links:

DOP-6063

* Drawer pages don't collapse on click: [bug report line 22](https://docs.google.com/spreadsheets/d/1Yw46uX0owcq8Velbv_bihO5curwlVT3PwRgs9_xFJsA/edit?gid=0#gid=0)

### Current Behavior:

- example of the current bug, when an active item is selected that has collapsible it doesn't toggle between open and close on click 
https://mongodbcom-cdn.staging.corp.mongodb.com/docs/spark-connector/upcoming/batch-mode/

### Staging Links:

Released these changes on `bi-connector` in preprd since frontend-stg doesnt work for unified toc for now 

https://mongodbcom-cdn.staging.corp.mongodb.com/docs/bi-connector/current/client-applications/
### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
