### PR TITLE
DOP-6045: Correct Spacing between Static Header and L1 in Accordion 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "10gen"
-REPO_NAME = "docs"
+REPO_NAME = "docs-landing"
 BRANCH_NAME = "unified-toc-mvp"
-SITE_NAME = "manual"
+SITE_NAME = "landing"
 PARSER_VERSION = "v0.20.6"

--- a/src/components/UnifiedSidenav/styles/SideNavItem.tsx
+++ b/src/components/UnifiedSidenav/styles/SideNavItem.tsx
@@ -17,7 +17,7 @@ export const l1ItemStyling = ({ isActive, isAccordion }: { isActive: boolean; is
   padding-left: ${theme.size.medium};
   padding-right: ${theme.size.medium};
   padding-top: ${theme.size.default};
-  padding-bottom: ${theme.size.default};
+  padding-bottom: ${isActive ? theme.size.small : theme.size.default};
   font-weight: 500;
   font-size: 12px;
   line-height: 16px;


### PR DESCRIPTION
### Stories/Links:

DOP-6045

### Current Behavior:
<img width="282" height="231" alt="Screenshot 2025-08-12 at 10 55 47 AM" src="https://github.com/user-attachments/assets/ffaa14c8-959b-4868-a3cf-2a4c00133db6" />

###  Staging Links:
<img width="318" height="312" alt="Screenshot 2025-08-12 at 10 56 04 AM" src="https://github.com/user-attachments/assets/6b63e59d-24fb-4a45-8e80-5c0af166bfaf" />

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
