### PR TITLE
DOP-6105: Adding icon for internal toc node symlinks

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -6,6 +6,7 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { palette } from '@leafygreen-ui/palette';
 // @ts-ignore
 import ArrowRightIcon from '@leafygreen-ui/icon/dist/ArrowRight';
+import Icon from '@leafygreen-ui/icon';
 import { isRelativeUrl } from '../utils/is-relative-url';
 import { joinClassNames } from '../utils/join-class-names';
 import { validateHTMAttributes } from '../utils/validate-element-attributes';
@@ -44,6 +45,15 @@ const THEME_STYLES: LinkThemeStyles = {
 export const sharedDarkModeOverwriteStyles = `
   color: var(--link-color-primary);
   font-weight: var(--link-font-weight);
+`;
+
+const symLinkStyling = css`
+  display: inline;
+  svg {
+    transform: rotate(-45deg);
+    margin-left: 8px;
+    margin-bottom: -5px;
+  }
 `;
 
 /**
@@ -85,7 +95,7 @@ const lgLinkStyling = css`
   ${sharedDarkModeOverwriteStyles}
   svg {
     margin-left: 8px;
-    margin-bottom: -6px;
+    margin-bottom: -10px;
     color: ${palette.gray.base};
   }
 
@@ -96,7 +106,7 @@ const lgLinkStyling = css`
 `;
 
 export type LinkProps = {
-  children: ReactNode;
+  children?: ReactNode;
   to?: string;
   activeClassName?: string;
   className?: string;
@@ -148,6 +158,22 @@ const Link = ({
     if (!isRelativeUrl(to)) {
       const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
       const isMDBLink = strippedUrl.includes('mongodb.com/docs'); // For an symlinks
+
+      if (isMDBLink) {
+        return (
+          <LGLink
+            className={joinClassNames(symLinkStyling, className)}
+            href={to}
+            hideExternalIcon={true}
+            target={'_self'}
+            {...anchorProps}
+          >
+            {children}
+            {decoration}
+            <Icon glyph={'ArrowRight'} fill={palette.gray.base} />
+          </LGLink>
+        );
+      }
 
       return (
         <LGLink
@@ -223,14 +249,14 @@ const Link = ({
   const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
   const isMDBLink = strippedUrl.includes('mongodb.com');
   const showExtIcon = showExternalIcon ?? (!anchor && !isMDBLink && !hideExternalIconProp);
-  const target = !showExtIcon ? '_self' : undefined;
+  const target = !showExtIcon || !openInNewTab ? '_self' : 'blank';
 
   return (
     <LGLink
       className={joinClassNames(lgLinkStyling, className)}
       href={to}
       hideExternalIcon={!showExtIcon}
-      target={openInNewTab ? '_blank' : target}
+      target={target}
       onClick={onClick}
       {...anchorProps}
     >

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -51,8 +51,19 @@ const symLinkStyling = css`
   display: inline;
   svg {
     transform: rotate(-45deg);
+    margin-left: 7px;
+    margin-bottom: -3px;
+    width: 13px;
+    height: 13px;
+    opacity: 1;
+  }
+`;
+
+const externalNavLinks = css`
+  svg {
     margin-left: 8px;
-    margin-bottom: -5px;
+    margin-bottom: -10px;
+    color: ${palette.gray.base};
   }
 `;
 
@@ -93,11 +104,6 @@ const gatsbyLinkStyling = (linkThemeStyle: LinkThemeStyle) => css`
 const lgLinkStyling = css`
   display: inline;
   ${sharedDarkModeOverwriteStyles}
-  svg {
-    margin-left: 8px;
-    margin-bottom: -10px;
-    color: ${palette.gray.base};
-  }
 
   > span > code,
   > code {
@@ -177,7 +183,7 @@ const Link = ({
 
       return (
         <LGLink
-          className={joinClassNames(lgLinkStyling, className)}
+          className={joinClassNames(lgLinkStyling, externalNavLinks, className)}
           href={to}
           hideExternalIcon={isMDBLink ? true : false}
           target={isMDBLink ? '_self' : '_blank'}
@@ -249,7 +255,7 @@ const Link = ({
   const strippedUrl = to?.replace(/(^https:\/\/)|(www\.)/g, '');
   const isMDBLink = strippedUrl.includes('mongodb.com');
   const showExtIcon = showExternalIcon ?? (!anchor && !isMDBLink && !hideExternalIconProp);
-  const target = !showExtIcon || !openInNewTab ? '_self' : 'blank';
+  const target = !showExtIcon ? '_self' : undefined;
 
   return (
     <LGLink

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -262,7 +262,7 @@ const Link = ({
       className={joinClassNames(lgLinkStyling, className)}
       href={to}
       hideExternalIcon={!showExtIcon}
-      target={target}
+      target={openInNewTab ? '_blank' : target}
       onClick={onClick}
       {...anchorProps}
     >

--- a/src/components/Sidenav/DocsHomeButton.tsx
+++ b/src/components/Sidenav/DocsHomeButton.tsx
@@ -4,13 +4,14 @@ import Icon from '@leafygreen-ui/icon';
 import { css as LeafyCSS, cx } from '@leafygreen-ui/emotion';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { MongoDBLogoMark } from '@leafygreen-ui/logo';
-import { Body, Link } from '@leafygreen-ui/typography';
+import { Body } from '@leafygreen-ui/typography';
 import { palette } from '@leafygreen-ui/palette';
 import useViewport from '../../hooks/useViewport';
 import { baseUrl } from '../../utils/base-url';
 import { theme } from '../../theme/docsTheme';
 import useScreenSize from '../../hooks/useScreenSize';
 import { getFeatureFlags } from '../../utils/feature-flags';
+import Link from '../Link';
 import { sideNavItemBasePadding } from './styles/sideNavItem';
 import { titleStyle, logoLinkStyling } from './styles/sideNavItem';
 


### PR DESCRIPTION
### Stories/Links:

DOP-6105: Adding the icon for internal nav links, ie symlinks

** Also found small bug of clicking the `Docs Home` button at the top of the side nav opens in new tab instead of same tab so made that fix 

[slack thread ](https://mongodb.slack.com/archives/C088QVAUS2Z/p1755008760361089)

[figma link](https://www.figma.com/proto/KEtaPAkucUDw2Fdr1k6U7v/TOC-WORK?page-id=3565%3A23307&node-id=4316-36888&viewport=-10679%2C769%2C0.85&t=H6PVLKU2bSLKB3SS-1&scaling=scale-down-width&content-scaling=fixed&starting-point-node-id=4072%3A5949&show-proto-sidebar=1)

### Current Behavior:

<img width="457" height="274" alt="Screenshot 2025-08-12 at 1 09 23 PM" src="https://github.com/user-attachments/assets/973737ca-71d7-4327-9b93-e4e7deabb8cd" />


### Staging Links:

<img width="434" height="296" alt="Screenshot 2025-08-12 at 1 09 38 PM" src="https://github.com/user-attachments/assets/82ca497d-75ef-4fb8-913a-06c073f55f13" />

* Staging link N/A until [DOP-6105](https://jira.mongodb.org/browse/DOP-6105) is complete
* Also made sure regular external icon svg looks as it should
    * <img width="237" height="198" alt="Screenshot 2025-08-12 at 1 13 19 PM" src="https://github.com/user-attachments/assets/5bcb89c0-5ceb-40bb-b96d-b4fc1f05aa8b" />


### Notes:
Adding the icon 
### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
