### PR TITLE
DOP-6043: update composable based on design feedback

### DIFF
--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -150,7 +150,6 @@ const containerStyling = css`
   justify-items: space-between;
   border-bottom: 1px solid ${palette.gray.light2};
   padding-bottom: ${theme.size.medium};
-  padding-top: ${theme.size.small};
   z-index: ${theme.zIndexes.content + 1};
 
   ${isOfflineDocsBuild && 'position: relative; top: unset;'}

--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -269,7 +269,11 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
           return null;
         })}
       </div>
-      <div>
+      <div
+        className={css`
+          margin-top: ${theme.size.medium};
+        `}
+      >
         {children.map((c, i) => {
           return <ComponentFactory nodeData={c} key={i} {...rest} />;
         })}

--- a/src/components/ComposableTutorial/ConfigurableOption.tsx
+++ b/src/components/ComposableTutorial/ConfigurableOption.tsx
@@ -20,17 +20,6 @@ const mainStyling = css`
     font-size: inherit;
   }
 
-  label {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
-
-  // for dark mode initial load
-  > label {
-    color: var(--font-color-primary);
-  }
-
   // overwriting lg style to apply to offline docs
   button {
     margin-top: 3px;
@@ -70,6 +59,9 @@ const selectStyling = css`
     margin-bottom: ${theme.size.tiny};
     text-transform: uppercase;
     color: var(--gray-dark1);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
   > button {
     margin-top: 0;

--- a/src/components/ComposableTutorial/ConfigurableOption.tsx
+++ b/src/components/ComposableTutorial/ConfigurableOption.tsx
@@ -13,6 +13,7 @@ const mainStyling = css`
   font-size: ${theme.fontSize.small};
   overflow: hidden;
   z-index: ${theme.zIndexes.actionBar};
+  max-width: 200px;
 
   label,
   button {
@@ -64,6 +65,18 @@ interface ConfigurationOptionProps {
   optionIndex: number;
 }
 
+const selectStyling = css`
+  > label {
+    margin-bottom: ${theme.size.tiny};
+    text-transform: uppercase;
+    color: var(--gray-dark1);
+  }
+  > button {
+    margin-top: 0;
+    height: 22px;
+  }
+`;
+
 const ConfigurableOption = ({
   option,
   selections,
@@ -92,6 +105,7 @@ const ConfigurableOption = ({
   return (
     <div className={cx('configurable-option', mainStyling)}>
       <Select
+        className={cx(selectStyling)}
         popoverZIndex={theme.zIndexes.actionBar - 1}
         label={option.text}
         allowDeselect={false}

--- a/tests/unit/__snapshots__/ComposableTutorial.test.tsx.snap
+++ b/tests/unit/__snapshots__/ComposableTutorial.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`Composable Tutorial component prioritizes query params over local stora
   font-size: 13px;
   overflow: hidden;
   z-index: 800;
+  max-width: 200px;
 }
 
 .emotion-1 label,
@@ -84,6 +85,17 @@ exports[`Composable Tutorial component prioritizes query params over local stora
 .emotion-2>label+button,
 .emotion-2>p+button {
   margin-top: 3px;
+}
+
+.emotion-2>label {
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  color: var(--gray-dark1);
+}
+
+.emotion-2>button {
+  margin-top: 0;
+  height: 22px;
 }
 
 .emotion-3 {
@@ -272,11 +284,15 @@ exports[`Composable Tutorial component prioritizes query params over local stora
   justify-self: left;
 }
 
-.emotion-37>*:first-child:not(script):not(style) {
+.emotion-37 {
   margin-top: 24px;
 }
 
-.emotion-38 {
+.emotion-38>*:first-child:not(script):not(style) {
+  margin-top: 24px;
+}
+
+.emotion-39 {
   margin: unset;
   font-family: 'Euclid Circular A','Helvetica Neue',Helvetica,Arial,sans-serif;
   color: #001E2B;
@@ -288,8 +304,8 @@ exports[`Composable Tutorial component prioritizes query params over local stora
   color: var(--font-color-primary);
 }
 
-.emotion-38 strong,
-.emotion-38 b {
+.emotion-39 strong,
+.emotion-39 b {
   font-weight: 700;
 }
 
@@ -544,12 +560,14 @@ exports[`Composable Tutorial component prioritizes query params over local stora
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="emotion-37"
+    >
       <div
-        class="emotion-37"
+        class="emotion-38"
       >
         <p
-          class="emotion-38"
+          class="emotion-39"
         >
           This content will only be shown when the selections are as follows:
 * Interface - Drivers

--- a/tests/unit/__snapshots__/ComposableTutorial.test.tsx.snap
+++ b/tests/unit/__snapshots__/ComposableTutorial.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Composable Tutorial component prioritizes query params over local stora
   justify-items: space-between;
   border-bottom: 1px solid #E8EDEB;
   padding-bottom: 24px;
-  padding-top: 8px;
   z-index: 2;
 }
 
@@ -43,16 +42,6 @@ exports[`Composable Tutorial component prioritizes query params over local stora
 .emotion-1 label,
 .emotion-1 button {
   font-size: inherit;
-}
-
-.emotion-1 label {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.emotion-1>label {
-  color: var(--font-color-primary);
 }
 
 .emotion-1 button {
@@ -91,6 +80,9 @@ exports[`Composable Tutorial component prioritizes query params over local stora
   margin-bottom: 4px;
   text-transform: uppercase;
   color: var(--gray-dark1);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .emotion-2>button {


### PR DESCRIPTION
### Stories/Links:

DOP-6043

### Current Behavior:

[Current page](https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/?deployment-type=atlas&interface=driver&language=python)

### Staging Links:

[Composable with content before](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5920/landing/seung.park/DOP-6043/vector-search-quick-start-2/index.html) - content  is located [here](https://github.com/10gen/docs-mongodb-internal/blob/DOP-5920/content/landing/source/vector-search-quick-start-2.txt)

[Composable with repeated content within](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5920/landing/seung.park/DOP-6043/vector-search-quick-start/index.html) - content is located [here](https://github.com/10gen/docs-mongodb-internal/blob/DOP-5920/content/landing/source/vector-search-quick-start.txt)


### Notes:
- Addresses Component to have a max width of 200px
- Selector be of XS size (shrink height to 22px)
- Label font color and uppercase
- `be underneath the title` was not addressed, as this is a content driven. However, DOP-5920 should allow for content to be placed inside composable tutorials, whereas previously it wasnt

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
