### PR TITLE
DOP-6046: fix styling for HL

### DIFF
--- a/src/components/HorizontalList.tsx
+++ b/src/components/HorizontalList.tsx
@@ -55,7 +55,7 @@ const HorizontalList = ({
       <tbody>
         <tr>
           {columnArray.map((col, colIndex) => (
-            <td className={cx(tableDataStyling, 'hlist-cell')} key={colIndex}>
+            <td className={cx(tableDataStyling)} key={colIndex}>
               <ListTag className="simple">
                 {col.map((child, index) => (
                   <ComponentFactory {...rest} key={index} nodeData={child} />

--- a/src/components/HorizontalList.tsx
+++ b/src/components/HorizontalList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { getNestedValue } from '../utils/get-nested-value';
 import { HorizontalListNode, ASTNode } from '../types/ast';
 import ComponentFactory from './ComponentFactory';
@@ -6,6 +7,15 @@ import ComponentFactory from './ComponentFactory';
 export type HorizontalListProps = {
   nodeData: HorizontalListNode;
 };
+
+const horizontalListStyling = css`
+  table-layout: fixed;
+  width: 100%;
+`;
+
+const tableDataStyling = css`
+  vertical-align: top;
+`;
 
 const HorizontalList = ({
   nodeData,
@@ -41,11 +51,11 @@ const HorizontalList = ({
   const columnArray = chunkArray(getNestedValue(['children', 0, 'children'], nodeData), columns);
   const ListTag = getNestedValue(['children', 0, 'ordered'], nodeData) ? 'ol' : 'ul';
   return (
-    <table className="hlist">
+    <table className={cx(horizontalListStyling, 'hlist')}>
       <tbody>
         <tr>
           {columnArray.map((col, colIndex) => (
-            <td key={colIndex}>
+            <td className={cx(tableDataStyling, 'hlist-cell')} key={colIndex}>
               <ListTag className="simple">
                 {col.map((child, index) => (
                   <ComponentFactory {...rest} key={index} nodeData={child} />


### PR DESCRIPTION
### Stories/Links:

DOP-6046

### Current Behavior:

[See this page for horizontal list item](https://www.mongodb.com/docs/atlas/unsupported-commands/)

### Staging Links:

[Staged above individual page via S3](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/preprd/cloud-docs/seung.park/DOP-6046/unsupported-commands/index.html)

### Notes:
- Verifying with Design team that this is the direction (vs scrollable table)
- Above has been verified, and we will tackle text wrapping with monospace as a separate mobile issue

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
