### PR TITLE
DOP-6110: Legacy docs not showing up in version selector if not on the content site

### DIFF
--- a/src/components/VersionDropdown/index.tsx
+++ b/src/components/VersionDropdown/index.tsx
@@ -110,10 +110,12 @@ type VersionDropdownProps = {
 const VersionDropdown = ({ contentSite = null }: VersionDropdownProps) => {
   const { parserBranch } = useSiteMetadata();
   let { project, eol } = useSnootyMetadata();
-  const { availableVersions, availableGroups, onVersionSelect, showEol, activeVersions } = useContext(VersionContext);
+  const { availableVersions, availableGroups, onVersionSelect, docsets, activeVersions } = useContext(VersionContext);
   project = contentSite ? contentSite : project;
   let branches = availableVersions[project];
   let groups = availableGroups[project];
+  const docset = docsets.find((docset) => docset.project === project);
+  const showEol = docset?.branches?.some((b) => !b.active) || false;
 
   const onSelectChange = useCallback(
     (value: string) => {

--- a/src/context/version-context.tsx
+++ b/src/context/version-context.tsx
@@ -211,6 +211,7 @@ export type VersionContextType = {
   setActiveVersions: Dispatch<Partial<ActiveVersions>>;
   availableVersions: AvailableVersions;
   availableGroups: AvailableGroups;
+  docsets: DocsetSlice[];
   hasEmbeddedVersionDropdown: boolean;
   showEol: boolean;
   isAssociatedProduct: boolean;
@@ -223,6 +224,7 @@ const VersionContext = createContext<VersionContextType>({
   setActiveVersions: () => {},
   availableVersions: {},
   availableGroups: {},
+  docsets: [],
   hasEmbeddedVersionDropdown: false,
   showEol: false,
   isAssociatedProduct: false,
@@ -390,6 +392,7 @@ const VersionContextProvider = ({ repoBranches, slug, children }: VersionContext
         onVersionSelect,
         isAssociatedProduct,
         showEol,
+        docsets,
       }}
     >
       {children}


### PR DESCRIPTION
### Stories/Links:

DOP-6110: Legacy docs not showing up in version selector if not on the content site

Mellissa found bug - [bug report line 45](https://docs.google.com/spreadsheets/d/1Yw46uX0owcq8Velbv_bihO5curwlVT3PwRgs9_xFJsA/edit?gid=0#gid=0)

### Current Behavior:

<img width="404" height="358" alt="Screenshot 2025-08-13 at 10 46 23 AM" src="https://github.com/user-attachments/assets/71ecbb2d-35c6-4850-a8e6-a07569798748" />


### Staging Links:

<img width="445" height="460" alt="Screenshot 2025-08-13 at 10 56 56 AM" src="https://github.com/user-attachments/assets/5f514380-60a1-498f-8f08-d7b95ce01c89" />

https://preprd--mongodb-landing.netlify.app/docs/development/

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
