### PR TITLE
DOP-6058: sidenav item scroll in view

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -124,6 +124,15 @@ const DefaultLayout = ({ children, data, pageContext: { slug, repoBranches, temp
         el.scrollIntoView({ behavior: 'smooth' });
       }
     }
+
+    // Scrolls selected sidenav item into view
+    const selectedLink = document.querySelector('a[aria-current="page"]');
+    if (selectedLink) {
+      selectedLink.scrollIntoView({
+        block: 'center',
+        behavior: 'instant',
+      });
+    }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (


### PR DESCRIPTION
### Stories/Links:

DOP-6058: TOC jumps to top after clicking a node below the fold

This happens when switching between sites and the new site is below the fold, doesn't load properly. Now added functionality so the selected item will always load into view

### Current Behavior:

[please watch melissa's video in line 15 of the bug report of current behavior ](https://docs.google.com/spreadsheets/d/1Yw46uX0owcq8Velbv_bihO5curwlVT3PwRgs9_xFJsA/edit?pli=1&gid=0#gid=0)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
