### PR TITLE
DOP-6123: allow for legacy docs to link

### DIFF
--- a/src/components/VersionDropdown/index.tsx
+++ b/src/components/VersionDropdown/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext } from 'react';
 import { cx, css as LeafyCSS } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { Option, OptionGroup, Select } from '@leafygreen-ui/select';
+import { navigate } from 'gatsby';
 import { VersionContext } from '../../context/version-context';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { theme } from '../../theme/docsTheme';
@@ -121,7 +122,11 @@ const VersionDropdown = ({ contentSite = null }: VersionDropdownProps) => {
 
   const onSelectChange = useCallback(
     (value: string) => {
-      onVersionSelect(project, value);
+      if (value === 'legacy') {
+        navigate(`https://www.mongodb.com/docs/legacy/?site=${project}`);
+      } else {
+        onVersionSelect(project, value);
+      }
     },
     [onVersionSelect, project]
   );


### PR DESCRIPTION
### Stories/Links:

DOP-6123
* Mellisa noticed when you are on a content site and loading a different a version dropdown on a different site the legacy docs option in the dropdown wont take you to the legacy docs page. Need to fix the behavior so when ever you select legacy docs it will link you to the correct page
* [bug report line 52](https://docs.google.com/spreadsheets/d/1Yw46uX0owcq8Velbv_bihO5curwlVT3PwRgs9_xFJsA/edit?gid=0#gid=0)

### Current Behavior:

https://mongodbcom-cdn.staging.corp.mongodb.com/docs/development/

### Staging Links:

https://deploy-preview-1519--docs-frontend-stg.netlify.app/docs/

click on `Development` L1 to see the version selector

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
