### PR TITLE
DOP-6125: preserve external query params on composable tutorials

### DIFF
--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -198,7 +198,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
     (queryString: string, preserveScroll = false) => {
       navigate(
         `${queryString.startsWith('?') ? '' : '?'}${queryString}${
-          queryString.length > 0 ? '&' : ''
+          queryString.length > 0 && externalQueryParamsString.length > 0 ? '&' : ''
         }${externalQueryParamsString}`,
         { state: { preserveScroll } }
       );

--- a/tests/unit/ComposableTutorial.test.tsx
+++ b/tests/unit/ComposableTutorial.test.tsx
@@ -24,7 +24,8 @@ describe('Composable Tutorial component', () => {
   it('navigates to default selections without local storage or url query params', async () => {
     renderComposable();
     expect(mockedNavigate).toHaveBeenCalledWith(
-      '?interface=driver&language=nodejs&deployment-type=atlas&operator=queryString'
+      '?interface=driver&language=nodejs&deployment-type=atlas&operator=queryString',
+      { state: { preserveScroll: false } }
     );
   });
 
@@ -39,7 +40,8 @@ describe('Composable Tutorial component', () => {
     });
     renderComposable();
     expect(mockedNavigate).toHaveBeenCalledWith(
-      '?deployment-type=self&interface=atlas-admin-api&operator=autocomplete'
+      '?deployment-type=self&interface=atlas-admin-api&operator=autocomplete',
+      { state: { preserveScroll: false } }
     );
   });
 
@@ -81,7 +83,8 @@ describe('Composable Tutorial component', () => {
 
     // removed bad selection of language
     expect(mockedNavigate).toHaveBeenCalledWith(
-      '?deployment-type=self&interface=atlas-admin-api&operator=autocomplete'
+      '?deployment-type=self&interface=atlas-admin-api&operator=autocomplete',
+      { state: { preserveScroll: false } }
     );
   });
 });


### PR DESCRIPTION
### Stories/Links:

DOP-6125

### Current Behavior:

Follow this link and notice the marketing query params being dropped
https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/?utm_source=testSource&utm_medium=testMedium&utm_campaign=testCampaign 

### Staging Links:

Same query parameters but on staging deploy preview:
https://deploy-preview-14008--mongodb-cloud-docs.netlify.app/docs/atlas/atlas-vector-search/tutorials/vector-search-quick-start/?utm_source=testSource&utm_medium=testMedium&utm_campaign=testCampaign

Note the original query params are preserved

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
