### PR TITLE
DOP-5821 handles styling issue along with Safari blocking clipboard behavior

### DIFF
--- a/src/components/Widgets/MarkdownWidget/index.tsx
+++ b/src/components/Widgets/MarkdownWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { SplitButton } from '@leafygreen-ui/split-button';
 import { Size } from '@leafygreen-ui/button';
@@ -24,11 +24,13 @@ const splitButtonStyles = css`
   [data-theme] {
     width: 310px;
   }
-  min-width: 145px;
+  min-width: 175px; /* Increase min-width to account for Copy Page in diff langs */
+  justify-content: end; /* Ensures it stays flush to the right */
 `;
 
 const CopyPageMarkdownButton = ({ className }: CopyPageMarkdownButtonProps) => {
   const [toastOpen, setToastOpen] = useState<ToastOpen>({ open: false, variant: Variant.Success });
+  const [markdownText, getMarkdownText] = useState<string | null>(null);
   const { href } = useLocation();
 
   // First removing the search and then the trailing slash, since we expect the URL to be available in markdown
@@ -39,15 +41,37 @@ const CopyPageMarkdownButton = ({ className }: CopyPageMarkdownButtonProps) => {
   const urlWithoutTrailingSlash = removeTrailingSlash(markdownPath);
   const markdownAddress = `${urlWithoutTrailingSlash}.md`;
 
+  useEffect(() => {
+    // Introducing aborting to handling bounce behavior
+    // (someone hits a page and immediately hits the back button or leaves the page)
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    // prefetch the markdown
+    const fetchMarkDown = async () => {
+      const response = await fetch(markdownAddress, { signal });
+      if (response.ok) {
+        const text = await response.text();
+        getMarkdownText(text);
+      }
+    };
+
+    fetchMarkDown();
+
+    return () => {
+      // When called sends a signal to the fetch
+      // to cancel the request
+      controller.abort();
+    };
+  }, [markdownAddress]);
+
   const copyMarkdown = async () => {
     try {
-      const response = await fetch(markdownAddress);
-      if (!response.ok) {
-        throw new Error('Failed to fetch Markdown');
+      if (!markdownText) {
+        throw new Error(`Failed to fetch markdown from ${markdownAddress}`);
       }
 
-      const text = await response.text();
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(markdownText);
 
       setToastOpen({
         open: true,

--- a/src/components/Widgets/MarkdownWidget/index.tsx
+++ b/src/components/Widgets/MarkdownWidget/index.tsx
@@ -50,7 +50,7 @@ const CopyPageMarkdownButton = ({ className }: CopyPageMarkdownButtonProps) => {
     // prefetch the markdown
     const fetchMarkDown = async () => {
       const response = await fetch(markdownAddress, { signal });
-      if (response.ok) {
+      if (response?.ok) {
         const text = await response.text();
         getMarkdownText(text);
       }

--- a/tests/unit/CopyPageMarkdownButton.test.tsx
+++ b/tests/unit/CopyPageMarkdownButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import * as Gatsby from 'gatsby';
 import * as ReachRouter from '@gatsbyjs/reach-router';
 import CopyPageMarkdownButton from '../../src/components/Widgets/MarkdownWidget';
@@ -10,6 +10,8 @@ const mockedNavigate = jest.spyOn(Gatsby, 'navigate');
 const mockedUseLocation = jest.spyOn(ReachRouter, 'useLocation') as jest.SpyInstance<Partial<Location>>;
 const mockedConsoleError = jest.spyOn(console, 'error');
 const mockedFetch = jest.spyOn(global, 'fetch') as jest.Mock;
+
+const TEST_URL = 'http://localhost:8000/tutorial/foo/';
 
 // Mock clipboard
 Object.defineProperty(global.navigator, 'clipboard', {
@@ -22,8 +24,8 @@ Object.defineProperty(global.navigator, 'clipboard', {
 describe('Copy markdown button', () => {
   beforeEach(() => {
     // Mock location
-    mockedUseLocation.mockReturnValueOnce({
-      href: 'http://localhost:8000/tutorial/foo/',
+    mockedUseLocation.mockReturnValue({
+      href: TEST_URL,
     });
 
     mockedNavigate.mockReset();
@@ -33,22 +35,36 @@ describe('Copy markdown button', () => {
 
   it('copies markdown to the clipboard when button is clicked', async () => {
     // Mock fetch response
-    mockedFetch.mockResolvedValueOnce({
+    mockedFetch.mockResolvedValue({
       ok: true,
       text: () => Promise.resolve('# Markdown content'),
     });
 
     // Render component
-    const { getByText } = renderCopyMarkdownButton();
+    let getByText: any;
+    await act(async () => {
+      const result = renderCopyMarkdownButton();
+      getByText = result.getByText;
+    });
+
+    // Wait for the initial fetch to complete
+    await waitFor(() => {
+      // Verify fetch was called with correct URL
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'http://localhost:8000/tutorial/foo.md',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
+
+    // await new Promise(resolve => setTimeout(resolve, 100));
 
     // Click the button
-    fireEvent.click(getByText('Copy page'));
+    act(() => fireEvent.click(getByText('Copy page')));
 
     // Wait for the async operations to complete
     await waitFor(() => {
-      // Verify fetch was called with correct URL
-      expect(mockedFetch).toHaveBeenCalledWith('http://localhost:8000/tutorial/foo.md');
-
       // Verify clipboard was called with fetched markdown
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('# Markdown content');
     });
@@ -56,22 +72,34 @@ describe('Copy markdown button', () => {
 
   it('triggers error when hitting a 404 page', async () => {
     // Mock fetch response
-    mockedFetch.mockResolvedValueOnce({
+    mockedFetch.mockResolvedValue({
       ok: false,
       statusCode: 404,
     });
 
     // Render component
-    const { getByText } = renderCopyMarkdownButton();
+    let getByText: any;
+    await act(async () => {
+      const result = renderCopyMarkdownButton();
+      getByText = result.getByText;
+    });
+
+    // Wait for the initial fetch to complete
+    await waitFor(() => {
+      // Verify fetch was called with correct URL
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'http://localhost:8000/tutorial/foo.md',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
 
     // Click the button
-    fireEvent.click(getByText('Copy page'));
+    act(() => fireEvent.click(getByText('Copy page')));
 
     // Wait for the async operations to complete
     await waitFor(() => {
-      // Verify fetch was called with correct URL
-      expect(mockedFetch).toHaveBeenCalledWith('http://localhost:8000/tutorial/foo.md');
-
       // Verify clipboard was called with fetched markdown
       expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
       expect(mockedConsoleError).toHaveBeenCalled();

--- a/tests/unit/__snapshots__/Procedure.test.js.snap
+++ b/tests/unit/__snapshots__/Procedure.test.js.snap
@@ -425,7 +425,11 @@ exports[`renders steps nested in include nodes 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  min-width: 145px;
+  min-width: 175px;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: end;
+  justify-content: end;
 }
 
 .emotion-13 [data-theme] {

--- a/tests/unit/__snapshots__/Section.test.js.snap
+++ b/tests/unit/__snapshots__/Section.test.js.snap
@@ -70,7 +70,11 @@ exports[`renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  min-width: 145px;
+  min-width: 175px;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: end;
+  justify-content: end;
 }
 
 .emotion-5 [data-theme] {


### PR DESCRIPTION
### Stories/Links:

DOP-5821

### Current Behavior:

[Query Atlas with Natural Language Using LangChain and LangGraph](https://www.mongodb.com/docs/atlas/ai-integrations/langchain/natural-language-to-mql/)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

This handles styling issues in the copy page button (mainly found when changing the language) - a new line was created and you would get this odd stacking of the words. 

Also, on Safari, the copy to clipboard behavior was being rejected with the following message; (It works find in Chrome).

```bash
NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
writeText
(anonymous function) — index.tsx:49
```

Which led me to believe in Safari, the user gesture is being lost by the time the call to writeText was made (due to the awaiting of a network fetch first).

Also, it was probably better for performance to prefetch the markdown.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
