### PR TITLE
DOP-6161: Migrate `fetchSearchPropertyMapping`

### DIFF
--- a/src/hooks/use-marian-manifests.tsx
+++ b/src/hooks/use-marian-manifests.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { assertTrailingSlash } from '../utils/assert-trailing-slash';
 import { parseMarianManifests } from '../utils/parse-marian-manifests';
 import { MARIAN_URL } from '../constants';
-import { fetchSearchPropertyMapping } from '../utils/realm';
 import { requestHeaders } from '../utils/search-facet-constants';
+import { fetchSearchPropertyMapping } from '../utils/search-property-mapping';
 import { useSiteMetadata } from './use-site-metadata';
 
 export type SearchPropertyMapping = {

--- a/src/utils/realm.ts
+++ b/src/utils/realm.ts
@@ -2,7 +2,6 @@ import * as Realm from 'realm-web';
 import { Filter, FindOptions, Document } from 'mongodb';
 import { SNOOTY_REALM_APP_ID } from '../build-constants';
 import { Docset, MetadataDatabaseName, ReposDatabaseName, SnootyEnv } from '../types/data';
-import { SearchPropertyMapping } from '../hooks/use-marian-manifests';
 import { currentRealmUsersCleanup } from './realm-user-management';
 
 type Projection<T> = Pick<T, Extract<keyof T, string | number>> | Record<string, 0 | 1>;
@@ -59,10 +58,6 @@ export const fetchBanner = async (snootyEnv: SnootyEnv) => {
 
 export const fetchBreadcrumbs = async (database: MetadataDatabaseName, project: string) => {
   return callAuthenticatedFunction('fetchBreadcrumbs', database, project);
-};
-
-export const fetchSearchPropertyMapping = async (snootyEnv: SnootyEnv): Promise<SearchPropertyMapping> => {
-  return callAuthenticatedFunction('fetchSearchPropertyMapping', snootyEnv);
 };
 
 export const fetchOASFile = async (apiName: string, database: MetadataDatabaseName) => {

--- a/src/utils/search-property-mapping.ts
+++ b/src/utils/search-property-mapping.ts
@@ -1,0 +1,15 @@
+import { SearchPropertyMapping } from '../hooks/use-marian-manifests';
+
+/**
+ * Fetches SearchPropertyMapping
+ * {
+ *   [project: string]: {
+ *     categoryTitle: string;
+ *     versionSelectorLabel: string;
+ *   };
+ * }
+ */
+export const fetchSearchPropertyMapping = async (dbName: string): Promise<SearchPropertyMapping> => {
+  const res = await fetch(`${process.env.GATSBY_NEXT_API_BASE_URL}/search-mapping?dbName=${dbName}`);
+  return res.json();
+};

--- a/tests/unit/SearchResults.test.js
+++ b/tests/unit/SearchResults.test.js
@@ -10,7 +10,7 @@ import { tick, setMobile } from '../utils';
 import SearchResults from '../../src/components/SearchResults/SearchResults';
 import { SearchContextProvider } from '../../src/components/SearchResults/SearchContext';
 import mockStaticQuery from '../utils/mockStaticQuery';
-import * as RealmUtil from '../../src/utils/realm';
+import * as searchPropertyMappingApi from '../../src/utils/search-property-mapping';
 import mockInputData from '../utils/data/marian-manifests.json';
 import { FILTERED_RESULT, mockMarianFetch, UNFILTERED_RESULT } from './utils/mock-marian-fetch';
 
@@ -128,7 +128,9 @@ describe('Search Results Page', () => {
 
   beforeEach(() => {
     mockStaticQuery();
-    jest.spyOn(RealmUtil, 'fetchSearchPropertyMapping').mockImplementation(() => mockInputData.searchPropertyMapping);
+    jest
+      .spyOn(searchPropertyMappingApi, 'fetchSearchPropertyMapping')
+      .mockImplementation(() => mockInputData.searchPropertyMapping);
     navigateSpy = jest.spyOn(gatsby, 'navigate').mockImplementation((...args) => {});
   });
 


### PR DESCRIPTION
### Stories/Links:

DOP-6161

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

Depends on [this PR](https://github.com/10gen/docs-mongodb-internal/pull/14096) being merged

### Notes:

Migrates Snooty to use Nextjs API for fetching search property mappings.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
