### PR TITLE
DOP-6162: Migrate `getBanner`

### DIFF
--- a/plugins/gatsby-source-snooty-prod/gatsby-node.js
+++ b/plugins/gatsby-source-snooty-prod/gatsby-node.js
@@ -217,7 +217,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, getNo
 
   await createBreadcrumbNodes({ db, createNode, createNodeId, createContentDigest });
 
-  await createBannerNode({ db, createNode, createNodeId, createContentDigest });
+  await createBannerNode({ createNode, createNodeId, createContentDigest });
 
   if (process.env['OFFLINE_DOCS'] !== 'true') {
     const umbrellaProduct = await db.realmInterface.getMetadata(

--- a/plugins/utils/banner.js
+++ b/plugins/utils/banner.js
@@ -1,9 +1,18 @@
 const { siteMetadata } = require('../../src/utils/site-metadata');
 
-const createBannerNode = async ({ createNode, createNodeId, createContentDigest }) => {
+const fetchBanner = async () => {
   const isStaging = ['staging', 'development', 'dotcomstg'].includes(siteMetadata.snootyEnv);
-  const res = await fetch(`${process.env.GATSBY_NEXT_API_BASE_URL}/banners/${isStaging ? '?staging=true' : ''}`);
-  const banner = await res.json();
+  try {
+    const res = await fetch(`${process.env.GATSBY_NEXT_API_BASE_URL}/banners/${isStaging ? '?staging=true' : ''}`);
+    return await res.json();
+  } catch (e) {
+    console.error(`Error while fetching banner data from Nextjs: ${e}`);
+    return null;
+  }
+};
+
+const createBannerNode = async ({ createNode, createNodeId, createContentDigest }) => {
+  const banner = await fetchBanner();
 
   createNode({
     children: [],
@@ -26,4 +35,5 @@ const createBannerNode = async ({ createNode, createNodeId, createContentDigest 
 
 module.exports = {
   createBannerNode,
+  fetchBanner,
 };

--- a/plugins/utils/banner.js
+++ b/plugins/utils/banner.js
@@ -1,7 +1,9 @@
 const { siteMetadata } = require('../../src/utils/site-metadata');
 
-const createBannerNode = async ({ db, createNode, createNodeId, createContentDigest }) => {
-  const banner = await db.realmInterface.fetchBanner(siteMetadata.snootyEnv === 'development');
+const createBannerNode = async ({ createNode, createNodeId, createContentDigest }) => {
+  const isStaging = ['staging', 'development', 'dotcomstg'].includes(siteMetadata.snootyEnv);
+  const res = await fetch(`${process.env.GATSBY_NEXT_API_BASE_URL}/banners/${isStaging ? '?staging=true' : ''}`);
+  const banner = await res.json();
 
   createNode({
     children: [],

--- a/src/init/DocumentDatabase.js
+++ b/src/init/DocumentDatabase.js
@@ -59,10 +59,6 @@ class RealmInterface {
   async fetchBreadcrumbs(database, project) {
     return this.realmClient.callFunction('fetchBreadcrumbs', database, project);
   }
-
-  async fetchBanner(isDevBuild) {
-    return this.realmClient.callFunction('getBanner', isDevBuild);
-  }
 }
 
 class ManifestDocumentDatabase {

--- a/src/utils/realm.ts
+++ b/src/utils/realm.ts
@@ -53,10 +53,6 @@ const callAuthenticatedFunction = async (funcName: string, ...argsList: unknown[
   }
 };
 
-export const fetchBanner = async (snootyEnv: SnootyEnv) => {
-  return callAuthenticatedFunction('getBanner', snootyEnv === 'development');
-};
-
 export const fetchBreadcrumbs = async (database: MetadataDatabaseName, project: string) => {
   return callAuthenticatedFunction('fetchBreadcrumbs', database, project);
 };

--- a/tests/unit/SiteBanner.test.tsx
+++ b/tests/unit/SiteBanner.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import * as Gatsby from 'gatsby';
 import { palette } from '@leafygreen-ui/palette';
-import * as RealmUtil from '../../src/utils/realm';
+import * as BannerUtil from '../../plugins/utils/banner';
 import SiteBanner from '../../src/components/Banner/SiteBanner';
 import { HeaderContext } from '../../src/components/Header/header-context';
 import { tick } from '../utils';
@@ -40,7 +40,7 @@ describe('Banner component', () => {
 
   it('renders with a banner image', async () => {
     jest.useFakeTimers();
-    jest.spyOn(RealmUtil, 'fetchBanner').mockResolvedValueOnce(() => mockBannerContent);
+    jest.spyOn(BannerUtil, 'fetchBanner').mockResolvedValueOnce(() => mockBannerContent);
     const wrapper = render(
       <HeaderContext.Provider value={{ hasBanner: true, totalHeaderHeight: '' }}>
         <SiteBanner />
@@ -60,7 +60,7 @@ describe('Banner component', () => {
       pillText: 'DOP',
       url: mockBannerContent.url,
     };
-    jest.spyOn(RealmUtil, 'fetchBanner').mockResolvedValueOnce(() => bannerContent);
+    jest.spyOn(BannerUtil, 'fetchBanner').mockResolvedValueOnce(() => bannerContent);
     const wrapper = render(
       <HeaderContext.Provider value={{ hasBanner: true, totalHeaderHeight: '' }}>
         <SiteBanner />

--- a/tests/unit/SiteBanner.test.tsx
+++ b/tests/unit/SiteBanner.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import * as Gatsby from 'gatsby';
 import { palette } from '@leafygreen-ui/palette';
-import * as BannerUtil from '../../plugins/utils/banner';
 import SiteBanner from '../../src/components/Banner/SiteBanner';
 import { HeaderContext } from '../../src/components/Header/header-context';
 import { tick } from '../utils';
@@ -32,6 +31,11 @@ describe('Banner component', () => {
     mockSnootyEnv('development');
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
   it('renders without a banner image', () => {
     // bannerContent state should remain null
     const wrapper = render(<SiteBanner />);
@@ -40,6 +44,7 @@ describe('Banner component', () => {
 
   it('renders with a banner image', async () => {
     jest.useFakeTimers();
+    const BannerUtil = require('../../plugins/utils/banner');
     jest.spyOn(BannerUtil, 'fetchBanner').mockResolvedValueOnce(() => mockBannerContent);
     const wrapper = render(
       <HeaderContext.Provider value={{ hasBanner: true, totalHeaderHeight: '' }}>
@@ -60,6 +65,7 @@ describe('Banner component', () => {
       pillText: 'DOP',
       url: mockBannerContent.url,
     };
+    const BannerUtil = require('../../plugins/utils/banner');
     jest.spyOn(BannerUtil, 'fetchBanner').mockResolvedValueOnce(() => bannerContent);
     const wrapper = render(
       <HeaderContext.Provider value={{ hasBanner: true, totalHeaderHeight: '' }}>


### PR DESCRIPTION
### Stories/Links:

DOP-6162

### Current Behavior:

https://www.mongodb.com/docs/

### Staging Links:

Below see that the banner pill says "MongoDB Jokes" and when clicked it takes you to a Dad jokes site :) 
[Staging](https://deploy-preview-1552--docs-frontend-stg.netlify.app/docs/manual/)

### Notes:

MIgrate getBanner

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
