### PR TITLE
DOP-5322 🆕  introduces the language callout user flow

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { palette } from '@leafygreen-ui/palette';
 import LeafyBanner, { Variant as LeafyVariant } from '@leafygreen-ui/banner';
 import { css, cx } from '@leafygreen-ui/emotion';
+import { getCurrLocale } from '../../utils/locale';
 import ComponentFactory from '../ComponentFactory';
 import type { BannerNode } from '../../types/ast';
 import { baseBannerStyle } from './styles/bannerItemStyle';
@@ -110,6 +111,14 @@ interface BannerProps {
 }
 
 const Banner = ({ nodeData: { children, options }, ...rest }: BannerProps) => {
+  // Get the current locale (language + region) i.e. es-US, fr-FR
+  const locale = getCurrLocale();
+
+  // if banner has option locale, then only render the banner for said translated page.
+  if (options?.locale && !options.locale.includes(locale)) {
+    return <div />;
+  }
+
   return (
     <LeafyBanner className={cx(bannerStyle({ variant: alertMap[options?.variant] || LeafyVariant.Info }))}>
       {children.map((child, i) => (

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { UnifiedFooter } from '@mdb/consistent-nav';
-import { getAvailableLanguages, getCurrLocale, onSelectLocale } from '../utils/locale';
+import { getCurrLocale, onSelectLocale } from '../utils/locale';
+import { LocaleContext } from '../context/locale';
 
 const Footer = () => {
-  const enabledLocales = getAvailableLanguages().map((language) => language.localeCode);
+  const { enabledLocalesData } = useContext(LocaleContext);
+  const enabledLocales = enabledLocalesData.map((language) => language.localeCode);
   return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} enabledLocales={enabledLocales} />;
 };
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -4,8 +4,9 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import { UnifiedNav } from '@mdb/consistent-nav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
-import { getAvailableLanguages, getCurrLocale, onSelectLocale } from '../../utils/locale';
+import { getCurrLocale, onSelectLocale } from '../../utils/locale';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
+import { LocaleContext } from '../../context/locale';
 import { HeaderContext } from './header-context';
 
 interface StyledHeaderProps {
@@ -44,7 +45,9 @@ type HeaderProps = {
 
 const Header = ({ eol }: HeaderProps) => {
   const unifiedNavProperty = 'DOCS';
-  const enabledLocales = getAvailableLanguages().map((language) => language.localeCode);
+  const { enabledLocalesData } = useContext(LocaleContext);
+  const enabledLocales = enabledLocalesData.map((language) => language.localeCode);
+  const locale = getCurrLocale();
   const { hasBanner } = useContext(HeaderContext);
 
   return (
@@ -63,7 +66,7 @@ const Header = ({ eol }: HeaderProps) => {
                 showLanguageSelector={true}
                 onSelectLocale={onSelectLocale}
                 // @ts-ignore
-                locale={getCurrLocale()}
+                locale={locale}
                 enabledLocales={enabledLocales}
                 darkMode={false}
                 className={cx('nav-light', isOfflineDocsBuild ? offlineClass : '')}
@@ -76,7 +79,7 @@ const Header = ({ eol }: HeaderProps) => {
                 showLanguageSelector={true}
                 onSelectLocale={onSelectLocale}
                 // @ts-ignore
-                locale={getCurrLocale()}
+                locale={locale}
                 enabledLocales={enabledLocales}
                 darkMode={true}
                 className={cx('nav-dark', isOfflineDocsBuild ? offlineClass : '')}

--- a/src/components/RootProvider.tsx
+++ b/src/components/RootProvider.tsx
@@ -4,6 +4,7 @@ import { TocContextProvider } from '../context/toc-context';
 import { DarkModeContextProvider } from '../context/dark-mode-context';
 import { PageContextRepoBranches, RemoteMetadata } from '../types/data';
 import { HeadingNode } from '../types/ast';
+import { LocaleProvider } from '../context/locale';
 import { HeaderContextProvider } from './Header/header-context';
 import { SidenavContextProvider } from './Sidenav';
 import { ContentsProvider } from './Contents/contents-context';
@@ -20,13 +21,15 @@ const RootProvider = ({ children, headingNodes, slug, repoBranches, remoteMetada
   return (
     <DarkModeContextProvider slug={slug}>
       <ContentsProvider headingNodes={headingNodes}>
-        <HeaderContextProvider>
-          <VersionContextProvider repoBranches={repoBranches} slug={slug}>
-            <TocContextProvider remoteMetadata={remoteMetadata}>
-              <SidenavContextProvider>{children}</SidenavContextProvider>
-            </TocContextProvider>
-          </VersionContextProvider>
-        </HeaderContextProvider>
+        <LocaleProvider>
+          <HeaderContextProvider>
+            <VersionContextProvider repoBranches={repoBranches} slug={slug}>
+              <TocContextProvider remoteMetadata={remoteMetadata}>
+                <SidenavContextProvider>{children}</SidenavContextProvider>
+              </TocContextProvider>
+            </VersionContextProvider>
+          </HeaderContextProvider>
+        </LocaleProvider>
       </ContentsProvider>
     </DarkModeContextProvider>
   );

--- a/src/context/locale.tsx
+++ b/src/context/locale.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, PropsWithChildren, useEffect, useState } from 'react';
+import {
+  AvailableLanguageData,
+  AvailableLocaleType,
+  BETA_LOCALE,
+  getAvailableLanguages,
+  getCurrLocale,
+} from '../utils/locale';
+
+type LocaleContextType = {
+  enabledLocalesData: AvailableLanguageData[];
+  updateAvailableLocales?: (locale: AvailableLocaleType) => void;
+};
+
+const LocaleContext = createContext<LocaleContextType>({
+  enabledLocalesData: getAvailableLanguages(),
+});
+
+const LocaleProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [enabledLocalesData, setEnableLocalesData] = useState<AvailableLanguageData[]>([]);
+  const locale = getCurrLocale();
+
+  const betaLocale = BETA_LOCALE[locale];
+
+  useEffect(() => {
+    const betaLocals = ['es'];
+    /**
+     * Grab the available languages and if the current locale is included in the
+     * beta list of locale, add it to the enable locales data which will be used by the
+     * unified header and footer.
+     * If not then just use the default available languages
+     */
+    const data = getAvailableLanguages();
+    if (betaLocals.includes(locale) && betaLocale) {
+      setEnableLocalesData([...data, betaLocale]);
+    } else {
+      setEnableLocalesData(data);
+    }
+  }, [locale, betaLocale]);
+
+  return <LocaleContext.Provider value={{ enabledLocalesData }}>{children}</LocaleContext.Provider>;
+};
+
+export { LocaleContext, LocaleProvider };

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -621,6 +621,7 @@ interface TocTreeDirective extends Directive<TocTreeOptions> {
 
 type BannerOptions = {
   variant: 'info' | 'warning' | 'danger';
+  locale?: string[];
 };
 
 interface BannerNode extends Directive<BannerOptions> {

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -7,7 +7,7 @@ import { removeLeadingSlash } from './remove-leading-slash';
 
 export type AvailableLocaleType = 'en-us' | 'pt-br' | 'es' | 'ko-kr' | 'ja-jp' | 'it-it' | 'de-de' | 'fr-fr' | 'zh-cn';
 
-type AvailableLanguageData = {
+export type AvailableLanguageData = {
   language: string;
   localeCode: AvailableLocaleType;
   fontFamily?: string;
@@ -35,8 +35,16 @@ const AVAILABLE_LANGUAGES: AvailableLanguageData[] = [
   { language: '日本語', localeCode: 'ja-jp', fontFamily: 'Noto Sans JP' },
 ];
 
+// GTM locale
+export const BETA_LOCALE: { [key: string]: AvailableLanguageData } = {
+  es: {
+    language: 'Español',
+    localeCode: 'es',
+  },
+};
+
 // Languages in current development that we do not want displayed publicly yet
-const HIDDEN_LANGUAGES: AvailableLanguageData[] = [];
+const HIDDEN_LANGUAGES: AvailableLanguageData[] = [BETA_LOCALE['es']];
 
 /**
  * @param {boolean} forceAll - Bypasses feature flag requirements if necessary
@@ -127,7 +135,7 @@ export const getAllLocaleCssStrings = () => {
 /**
  * Returns the locale code based on the current location pathname of the page.
  */
-export const getCurrLocale = () => {
+export const getCurrLocale = (): AvailableLocaleType => {
   const defaultLang = 'en-us';
 
   if (!isBrowser) {
@@ -146,7 +154,7 @@ export const getCurrLocale = () => {
   }
 
   const slugMatchesCode = validateLocaleCode(firstPathSlug);
-  return slugMatchesCode ? firstPathSlug : defaultLang;
+  return slugMatchesCode ? (firstPathSlug as AvailableLocaleType) : defaultLang;
 };
 
 /**

--- a/tests/unit/Banner.test.js
+++ b/tests/unit/Banner.test.js
@@ -4,14 +4,44 @@ import Banner from '../../src/components/Banner/Banner';
 import OfflineBanner from '../../src/components/Banner/OfflineBanner';
 
 // data for this component
+import { getCurrLocale } from '../../src/utils/locale';
 import mockData from './data/Banner.test.json';
+// locale data for this component
+import mockDataWithLocale from './data/BannerLocale.test.json';
 
-it('renders a Banner correctly', () => {
-  const wrapper = render(<Banner nodeData={mockData} />);
-  expect(wrapper.asFragment()).toMatchSnapshot();
+jest.mock('../../src/utils/locale', () => ({
+  getCurrLocale: jest.fn().mockReturnValue('en-US'),
+}));
+
+describe('Snapshots', () => {
+  it('renders a Banner correctly', () => {
+    const wrapper = render(<Banner nodeData={mockData} />);
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it('renders a Banner correctly for a beta locale', () => {
+    const wrapper = render(<Banner nodeData={mockDataWithLocale} />);
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it('renders an offline banner correctly', () => {
+    const wrapper = render(<OfflineBanner />);
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
 });
 
-it('renders an offline banner correctly', () => {
-  const wrapper = render(<OfflineBanner />);
-  expect(wrapper.asFragment()).toMatchSnapshot();
+describe('Conditionally rendering banner as language callout', () => {
+  it('Should NOT render banner if locale is not within the beta locale', () => {
+    const { queryByRole } = render(<Banner nodeData={mockDataWithLocale} />);
+    const banner = queryByRole('alert');
+    expect(banner).not.toBeInTheDocument();
+  });
+
+  it('Should render banner if locale is a beta locale', () => {
+    // Mock one of the beta locales
+    getCurrLocale.mockReturnValue('es');
+    const { getByRole } = render(<Banner nodeData={mockDataWithLocale} />);
+    const banner = getByRole('alert');
+    expect(banner).toBeVisible();
+  });
 });

--- a/tests/unit/__snapshots__/Banner.test.js.snap
+++ b/tests/unit/__snapshots__/Banner.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a Banner correctly 1`] = `
+exports[`Snapshots renders a Banner correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   position: relative;
@@ -207,7 +207,13 @@ exports[`renders a Banner correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`renders an offline banner correctly 1`] = `
+exports[`Snapshots renders a Banner correctly for a beta locale 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
+
+exports[`Snapshots renders an offline banner correctly 1`] = `
 <DocumentFragment>
   .emotion-1 {
   position: relative;

--- a/tests/unit/data/BannerLocale.test.json
+++ b/tests/unit/data/BannerLocale.test.json
@@ -1,0 +1,42 @@
+{
+  "type": "directive",
+  "children": [
+    {
+      "type": "text",
+      "value": "This page and the following pages are translated in Spanish:"
+    },
+    {
+      "type": "list",
+      "children": [
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "text",
+              "value": "/atlas-search/view-query-analytics"
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "text",
+              "value": "/atlas-search/tracking"
+            }
+          ]
+        }
+      ],
+      "enumtype": "unordered"
+    }
+  ],
+  "domain": "mongodb",
+  "name": "banner",
+  "argument": [],
+  "options": {
+    "variant": "info",
+    "locale": [
+      "es"
+    ]
+  }
+}


### PR DESCRIPTION
### Stories/Links:

DOP-5322

### Current Behavior:

[Log in with Atlas](https://www.mongodb.com/docs/relational-migrator/getting-started/atlas-log-in/)

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

This PR introduces the language callout flow, which is a banner that will appear on pages within the targets array of the banner directive from the [snooty.toml](https://github.com/10gen/docs-mongodb-internal/blob/9ef44c815a62a0b1e29ef54ad5af8c1213d56e6f/content/atlas/snooty.toml#L737-L738). These banners carry the locale option that the writers can use to determine which languages they want to slowly introduce users too, and when a user hits that page that match that locale, the banner will show for that page with a list of pages that are supported in this language. 

The reason for this flow is to slowly introduce users to new languages. The localization team wanted a way to slowly introduce new pages, and this language callout flow was what they decided on. 


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
