### PR TITLE
DOP-6197: add ref/hash behavior

### DIFF
--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -243,7 +243,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
 
     // first verify if there is a hash
     // if there is a hash and it belongs to a composable option,
-    // set the current selections to the value of the hash
+    // set the current selections that composable option to show the content with hash id
     const hash = location.hash?.slice(1);
     if (hash) {
       const selection = refToSelection[hash];
@@ -253,7 +253,6 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
         isNavigatingRef.current = true;
         return navigatePreservingExternalQueryParams(`?${queryString}`, false, hash);
       }
-      // setCurrentSelections({ [hashValue]: hashValue });
     }
 
     // read query params

--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -192,6 +192,11 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
       const html_ids = findAllNestedAttribute(composableContent.children, 'html_id');
       const selection = composableContent.selections;
       for (const id of [...ids, ...html_ids]) {
+        // if multiple composable contents have the same id, this is a content issue.
+        // use the first composable content that has this id
+        if (res[id]) {
+          continue;
+        }
         res[id] = selection;
       }
     }


### PR DESCRIPTION
### Stories/Links:

DOP-6197

### Current Behavior:

This link contains a ref hash id (test in incognito window or clear local storage)
http://mongodb.com/docs/atlas/atlas-search/tutorial/#create-the--index.-18
This does not lead users to any significant portion of the page, just makes default selections.

### Staging Links:

This staging link takes users to the correct selections and to the ref on the page:
https://deploy-preview-1563--docs-frontend-stg.netlify.app/docs/atlas/atlas-search/tutorial/#create-the--index.-18

### Notes:
- This behavior is done by memoizing all the hashes included in each composable content at build time, and verifying if the hash in URL belongs to a selected content.
- **In the case that multiple composable content have the same ref**, this is a content issue and will result in the first composable content being returned.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
