### PR TITLE
DOP-6188: show headings for none selection

### DIFF
--- a/src/components/Contents/index.tsx
+++ b/src/components/Contents/index.tsx
@@ -77,7 +77,10 @@ const isHeadingVisible = (
   const composableHeadingVisible = Object.keys(headingsComposableParent).reduce((res, key) => {
     if (!res) return res;
     const value = searchParams.get(key);
-    return (value && value === headingsComposableParent[key]) || (!value && headingsComposableParent[key] === 'None');
+    return (
+      (value && value === headingsComposableParent[key]) ||
+      (!value && headingsComposableParent[key]?.toLowerCase() === 'none')
+    );
   }, true);
   if (
     (headingsMethodParent && headingsMethodParent !== activeSelectorIds.methodSelector) ||


### PR DESCRIPTION
### Stories/Links:

DOP-6188

### Current Behavior:

These selections for a composable tutorial do not show any headings in the Right Column:
https://www.mongodb.com/docs/atlas/atlas-search/field-types/string-type/?deployment-type=atlas&interface=atlas-cli

### Staging Links:

_Put a link to your staging environment(s), if applicable_


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
