### PR TITLE
DOP-6197: preserve hash when hash not within composable

### DIFF
--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -216,7 +216,15 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
   }, [composableOptions, location.search]);
 
   const navigatePreservingExternalQueryParams = useCallback(
-    (queryString: string, preserveScroll = false, hash = '') => {
+    ({
+      queryString,
+      preserveScroll = false,
+      hash = '',
+    }: {
+      queryString: string;
+      preserveScroll?: boolean;
+      hash?: string;
+    }) => {
       navigate(
         `${queryString.startsWith('?') ? '' : '?'}${queryString}${
           queryString.length > 0 && externalQueryParamsString.length > 0 ? '&' : ''
@@ -251,7 +259,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
         setCurrentSelections(selection);
         const queryString = new URLSearchParams(selection).toString();
         isNavigatingRef.current = true;
-        return navigatePreservingExternalQueryParams(`?${queryString}`, false, hash);
+        return navigatePreservingExternalQueryParams({ queryString: `?${queryString}`, preserveScroll: false, hash });
       }
     }
 
@@ -275,7 +283,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
     const localStorage: Record<string, string> = getLocalValue(LOCAL_STORAGE_KEY) ?? {};
     const [defaultParams] = filterValidQueryParams(localStorage, composableOptions, validSelections, true);
     const queryString = new URLSearchParams(defaultParams).toString();
-    navigatePreservingExternalQueryParams(`?${queryString}`);
+    navigatePreservingExternalQueryParams({ queryString: `?${queryString}`, hash });
   }, [
     composableOptions,
     location.pathname,
@@ -296,7 +304,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
       if (validSelections.has(joinKeyValuesAsString(correctedParams))) {
         setCurrentSelections(correctedParams);
         const queryString = new URLSearchParams(correctedParams).toString();
-        return navigatePreservingExternalQueryParams(`?${queryString}`, true);
+        return navigatePreservingExternalQueryParams({ queryString: `?${queryString}`, preserveScroll: true });
       }
 
       // need to correct preceding options
@@ -314,7 +322,7 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
 
       const [defaultParams] = filterValidQueryParams(persistSelections, composableOptions, validSelections, true);
       const queryString = new URLSearchParams(defaultParams).toString();
-      return navigatePreservingExternalQueryParams(`?${queryString}`);
+      return navigatePreservingExternalQueryParams({ queryString: `?${queryString}` });
     },
     [composableOptions, currentSelections, validSelections, setCurrentSelections, navigatePreservingExternalQueryParams]
   );


### PR DESCRIPTION
### Stories/Links:

This is part 2 of the fix applied to DOP-6197
Previous PR addressed when hash was within the composable, but original case was for a hash below the composable tutorial. (see [content here](https://github.com/10gen/docs-mongodb-internal/blob/main/content/atlas/source/atlas-search/about/feature-compatibility.txt#L37))

### Current Behavior:

Behavior in prod (note stripped hash and not landing correctly):
https://www.mongodb.com/docs/atlas/atlas-search/about/feature-compatibility/#supported-clients

Testing link in staging / qa (same result):
https://mongodbcom-cdn.staging.corp.mongodb.com/docs/atlas/atlas-search/about/feature-compatibility/#supported-clients

Previous fix applied in staging/prod - this only applied to content with composable tutorials:
http://mongodb.com/docs/atlas/atlas-search/tutorial/#create-the--index.-18
https://mongodbcom-cdn.staging.corp.mongodb.com//docs/atlas/atlas-search/tutorial/#create-the--index.-18


### Staging Links:

Testing link on my branch

_Put a link to your staging environment(s), if applicable_

### Notes:

- [Previous fix](https://github.com/mongodb/snooty/pull/1563) addressed when hash was found within the composable. This change fixes for outside of composable, but on same page.
- Change was to preserve hash when redirecting


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
