### PR TITLE
DOP-6219: Breadcrumbs use unified ToC structure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "10gen"
-REPO_NAME = "cloud-docs"
+REPO_NAME = "docs-csharp"
 BRANCH_NAME = "main"
-SITE_NAME = "atlas"
+SITE_NAME = "csharp"
 PARSER_VERSION = "v0.20.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "10gen"
-REPO_NAME = "docs-csharp"
+REPO_NAME = "cloud-docs"
 BRANCH_NAME = "main"
-SITE_NAME = "csharp"
+SITE_NAME = "atlas"
 PARSER_VERSION = "v0.20.11"

--- a/src/components/Breadcrumbs/IndividualBreadcrumb.tsx
+++ b/src/components/Breadcrumbs/IndividualBreadcrumb.tsx
@@ -94,7 +94,7 @@ const IndividualBreadcrumb = ({ crumb, setIsExcessivelyTruncated, onClick }: Ind
 
   let result = (
     <div className={cx(linkWrapperLayoutStyling, crumb.title.length > 21 ? ellipsisStyling : '')} ref={measuredRef}>
-      <Link className={cx(linkStyling)} to={crumb.path} onClick={onClick}>
+      <Link className={cx(linkStyling)} to={crumb.path} onClick={onClick} hideExternalIcon={true}>
         {formatText(crumb.title)}
       </Link>
     </div>

--- a/src/components/Breadcrumbs/UnifiedTocBreadCrumbs.ts
+++ b/src/components/Breadcrumbs/UnifiedTocBreadCrumbs.ts
@@ -7,9 +7,9 @@ export function createParentFromToc(tree: TocItem[] | undefined, breadcrumbs: Br
   return tree?.map((item) => {
     const newCrumbs = [...breadcrumbs];
 
-    if (item.url) {
+    if (item.newUrl) {
       const newBreadCrumb: BreadCrumb = {
-        path: assertLeadingSlash(removeTrailingSlash(item.url)),
+        path: assertLeadingSlash(removeTrailingSlash(item.newUrl)),
         title: item.label,
       };
       newCrumbs.push(newBreadCrumb);
@@ -29,8 +29,8 @@ export function createParentFromToc(tree: TocItem[] | undefined, breadcrumbs: Br
 export function findParentBreadCrumb(slug: string, tocTree: TocItem[]): BreadCrumb[] | undefined {
   for (const item of tocTree) {
     if (
-      item.url &&
-      assertLeadingSlash(removeTrailingSlash(item.url)) === assertLeadingSlash(removeTrailingSlash(slug))
+      item.newUrl &&
+      assertLeadingSlash(removeTrailingSlash(item.newUrl)) === assertLeadingSlash(removeTrailingSlash(slug))
     ) {
       return item.breadcrumbs?.slice(0, -1); // Removes last item which is the current item
     }

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -6,7 +6,7 @@ import { getCompleteBreadcrumbData } from '../../utils/get-complete-breadcrumb-d
 import { QueriedCrumbs, useBreadcrumbs } from '../../hooks/use-breadcrumbs';
 import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
-import { useUnifiedToc } from '../../hooks/use-unified-toc';
+import { useProcessedUnifiedToc } from '../../hooks/useProcessedUnifiedToc';
 import { getFeatureFlags } from '../../utils/feature-flags';
 import { usePageBreadcrumbs } from '../../hooks/useCreateBreadCrumbs';
 import BreadcrumbContainer, { BreadcrumbType } from './BreadcrumbContainer';
@@ -61,7 +61,7 @@ const Breadcrumbs = ({
   pageInfo,
 }: BreadcrumbsProps) => {
   const { isUnifiedToc } = getFeatureFlags();
-  const tocTree = useUnifiedToc();
+  const tocTree = useProcessedUnifiedToc();
   const queriedCrumbsHook = useBreadcrumbs();
   const queriedCrumbs = queriedCrumbsProp ?? queriedCrumbsHook;
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -230,7 +230,7 @@ const Link = ({
   }
 
   // Use Gatsby Link for internal links, and <a> for others
-  if (to && isRelativeUrl(to) && !anchor) {
+  if (to && isRelativeUrl(to) && !anchor && !to.startsWith('/docs')) {
     if (!to.startsWith('/')) to = `/${to}`;
 
     // Ensure trailing slash

--- a/src/components/StructuredData/BreadcrumbSchema.tsx
+++ b/src/components/StructuredData/BreadcrumbSchema.tsx
@@ -4,14 +4,14 @@ import useSnootyMetadata from '../../utils/use-snooty-metadata';
 import { BreadcrumbListSd, STRUCTURED_DATA_CLASSNAME } from '../../utils/structured-data';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { getFeatureFlags } from '../../utils/feature-flags';
-import { useUnifiedToc } from '../../hooks/use-unified-toc';
+import { useProcessedUnifiedToc } from '../../hooks/useProcessedUnifiedToc';
 import { usePageBreadcrumbs } from '../../hooks/useCreateBreadCrumbs';
 
 const BreadcrumbSchema = ({ slug }: { slug: string }) => {
   const { parentPaths, title: siteTitle } = useSnootyMetadata();
   const { siteUrl } = useSiteMetadata();
   const { isUnifiedToc } = getFeatureFlags();
-  const tocTree = useUnifiedToc();
+  const tocTree = useProcessedUnifiedToc();
 
   const parentPathsSlug = parentPaths[slug];
 

--- a/src/hooks/useCreateBreadCrumbs.ts
+++ b/src/hooks/useCreateBreadCrumbs.ts
@@ -1,15 +1,20 @@
 import { useMemo } from 'react';
 import { createParentFromToc, findParentBreadCrumb } from '../components/Breadcrumbs/UnifiedTocBreadCrumbs';
 import type { TocItem, BreadCrumb } from '../components/UnifiedSidenav/types';
+import { getFullSlug } from '../utils/get-full-slug';
+import { useSiteMetadata } from './use-site-metadata';
 
 export function usePageBreadcrumbs(tocTree: TocItem[], slug: string, isUnifiedToc: boolean): BreadCrumb[] | undefined {
+  const { pathPrefix } = useSiteMetadata();
+
   const unifiedTocParents = useMemo(() => {
     if (!isUnifiedToc) return undefined;
     const tree = createParentFromToc(tocTree, []);
     if (!tree) return undefined;
 
-    return findParentBreadCrumb(slug, tree);
-  }, [slug, tocTree, isUnifiedToc]);
+    const fullSlug = getFullSlug(slug, pathPrefix);
+    return findParentBreadCrumb(fullSlug, tree);
+  }, [slug, tocTree, isUnifiedToc, pathPrefix]);
 
   return unifiedTocParents;
 }

--- a/src/hooks/useProcessedUnifiedToc.ts
+++ b/src/hooks/useProcessedUnifiedToc.ts
@@ -1,0 +1,70 @@
+import { useMemo, useContext } from 'react';
+import useSnootyMetadata from '../utils/use-snooty-metadata';
+import { VersionContext } from '../context/version-context';
+import { TocItem } from '../components/UnifiedSidenav/types';
+import { ActiveVersions, AvailableVersions } from '../context/version-context';
+import { useUnifiedToc } from './use-unified-toc';
+
+interface UpdateURLsParams {
+  tree?: TocItem[];
+  contentSite?: string;
+  activeVersions: ActiveVersions;
+  versionsData: AvailableVersions;
+  project: string;
+}
+
+// Replace version variable in URL with current version
+const updateURLs = ({ tree, contentSite, activeVersions, versionsData, project }: UpdateURLsParams): TocItem[] => {
+  return (
+    tree?.map((item) => {
+      let newUrl = item.url ?? '';
+      const currentProject = item.contentSite ?? contentSite;
+
+      // Replace version variable with the true current version
+      if (item?.url?.includes(':version') && currentProject) {
+        const version = (versionsData[currentProject] || []).find(
+          (version) =>
+            version.gitBranchName === activeVersions[currentProject] ||
+            version.urlSlug === activeVersions[currentProject] ||
+            version?.urlAliases?.includes(activeVersions[currentProject])
+        );
+        // If no version found in local storage use 'current'
+        const currentVersion = version?.urlSlug ?? 'current';
+        newUrl = item.url!.replace(/:version/g, currentVersion);
+      }
+
+      const items = updateURLs({
+        tree: item.items,
+        contentSite: currentProject,
+        activeVersions,
+        versionsData,
+        project,
+      });
+
+      return {
+        ...item,
+        newUrl,
+        items,
+        contentSite: currentProject,
+      } as TocItem;
+    }) ?? []
+  );
+};
+
+// Hook that returns the processed unified TOC tree with updated URLs (version replacements)
+export const useProcessedUnifiedToc = () => {
+  const unifiedTocTree = useUnifiedToc();
+  const { project } = useSnootyMetadata();
+  const { activeVersions, availableVersions } = useContext(VersionContext);
+
+  const processedTree = useMemo(() => {
+    return updateURLs({
+      tree: unifiedTocTree,
+      activeVersions,
+      versionsData: availableVersions,
+      project,
+    });
+  }, [unifiedTocTree, activeVersions, availableVersions, project]);
+
+  return processedTree;
+};

--- a/src/utils/get-complete-breadcrumb-data.ts
+++ b/src/utils/get-complete-breadcrumb-data.ts
@@ -9,6 +9,7 @@ import { assertTrailingSlash } from './assert-trailing-slash';
 import { assertLeadingSlash } from './assert-leading-slash';
 import { isRelativeUrl } from './is-relative-url';
 import { getUrl, getCompleteUrl } from './url-utils';
+import { getFeatureFlags } from './feature-flags';
 
 const nodesToString = (titleNodes: string | Array<Node>) => {
   if (typeof titleNodes === 'string') {
@@ -75,6 +76,7 @@ export const getCompleteBreadcrumbData = ({
   unifiedTocParents,
 }: GetCompleteBreadcrumbDataProps) => {
   const isLanding = pageInfo?.project === 'landing';
+  const { isUnifiedToc } = getFeatureFlags();
 
   //get intermediate breadcrumbs
   const intermediateCrumbs = (queriedCrumbs?.breadcrumbs ?? []).map((crumb) => {
@@ -126,5 +128,7 @@ export const getCompleteBreadcrumbData = ({
     ? [homeCrumb, ...intermediateCrumbs, propertyCrumb, ...parents]
     : [homeCrumb, ...intermediateCrumbs, ...parents];
 
-  return selfCrumb ? [...almostFinalCrumbs, selfCrumb] : almostFinalCrumbs;
+  const unifiedTocCrumbs = [homeCrumb, ...parents];
+
+  return isUnifiedToc ? unifiedTocCrumbs : selfCrumb ? [...almostFinalCrumbs, selfCrumb] : almostFinalCrumbs;
 };

--- a/src/utils/get-full-slug.ts
+++ b/src/utils/get-full-slug.ts
@@ -1,0 +1,25 @@
+import { removeLeadingSlash } from './remove-leading-slash';
+import { removeTrailingSlash } from './remove-trailing-slash';
+import { isBrowser } from './is-browser';
+import { getAvailableLanguages } from './locale';
+
+// Getting a list of the available languages
+const langArray = getAvailableLanguages(true).map((lang) => lang.localeCode);
+
+// Get the full slug including the path prefix
+export const getFullSlug = (initialSlug: string, pathPrefix: string): string => {
+  const tempSlug = isBrowser ? removeLeadingSlash(removeTrailingSlash(window.location.pathname)) : initialSlug;
+  const hasLang = langArray.some(
+    (lang) =>
+      removeLeadingSlash(tempSlug)?.startsWith(lang + '/') || removeLeadingSlash(tempSlug)?.startsWith(lang + '/')
+  );
+
+  const fullSlug =
+    tempSlug?.startsWith('docs/') || hasLang
+      ? tempSlug
+      : tempSlug === '/' || tempSlug === ''
+      ? pathPrefix + tempSlug
+      : `${pathPrefix}/${tempSlug}/`;
+
+  return fullSlug;
+};


### PR DESCRIPTION
### Stories/Links:

DOP-6219: Breadcrumbs use unified ToC structure

Before this the breadcrumbs should've been using the unified ToC structure but, there was a bug with unified toc tree. It wasn't using the processed tree that changes the version. It also wasn't using the full path slug to find the corresponding breadcrumb. However there was a default of the old breadcrumbs if it couldn't find the new breadcrumbs which is why this bug wasn't caught before since most page structure has stayed the same. This fix however should address all issues. 

### Current Behavior:

https://www.mongodb.com/docs/atlas/security-vpc-peering/


### Staging Links:

https://68e4278ddbe84000088196e1--docs-frontend-stg.netlify.app/docs/atlas/security-vpc-peering/

https://68e429a62d700a0008ff32ff--docs-frontend-stg.netlify.app/docs/drivers/csharp/current/
^ versioned site 


### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
