### PR TITLE
Add LocalizedLinkProvider and upgrade consistent-nav package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@leafygreen-ui/tooltip": "^11.0.4",
         "@leafygreen-ui/typography": "^18.3.0",
         "@loadable/component": "^5.14.1",
-        "@mdb/consistent-nav": "^2.4.6",
+        "@mdb/consistent-nav": "^2.6.3",
         "@mdb/flora": "1.14.2",
         "@mdx-js/react": "^2.2.1",
         "@types/react-resizable": "^3.0.8",
@@ -9932,17 +9932,17 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@mdb/consistent-nav": {
-      "version": "2.4.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.4.6.tgz",
-      "integrity": "sha512-2vAhZ1WtzLY6ZwIy07F5dSbXyaYIwyksA+o2ODjoMvG1po4Gi5LRLhAFi62GVRvkjtA8h/Ds4+GP8SrtpD52Kw==",
+      "version": "2.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.6.3.tgz",
+      "integrity": "sha512-tHK+dm7LC7uhg6jz9+mI3I+G85TKxcYwHKwvWFnjUUXHdWXHUYaXoHkKme5sU0RZsAuCVosZuTr+9zCPTBoRPw==",
       "peerDependencies": {
         "@emotion/react": ">= 11.6.0",
         "@emotion/styled": ">= 11.6.0",
-        "@mdb/flora": "^1.20.0",
+        "@mdb/flora": "^1.21.10",
         "@mdx-js/react": "^1.6.22",
         "react": ">= 16.8",
         "react-dom": ">= 16.8",
-        "theme-ui": ">= 0.16.0"
+        "theme-ui": ">= 0.16.1"
       }
     },
     "node_modules/@mdb/flora": {
@@ -42583,9 +42583,9 @@
       }
     },
     "@mdb/consistent-nav": {
-      "version": "2.4.6",
-      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.4.6.tgz",
-      "integrity": "sha512-2vAhZ1WtzLY6ZwIy07F5dSbXyaYIwyksA+o2ODjoMvG1po4Gi5LRLhAFi62GVRvkjtA8h/Ds4+GP8SrtpD52Kw=="
+      "version": "2.6.3",
+      "resolved": "https://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@mdb/consistent-nav/-/@mdb/consistent-nav-2.6.3.tgz",
+      "integrity": "sha512-tHK+dm7LC7uhg6jz9+mI3I+G85TKxcYwHKwvWFnjUUXHdWXHUYaXoHkKme5sU0RZsAuCVosZuTr+9zCPTBoRPw=="
     },
     "@mdb/flora": {
       "version": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@leafygreen-ui/tooltip": "^11.0.4",
     "@leafygreen-ui/typography": "^18.3.0",
     "@loadable/component": "^5.14.1",
-    "@mdb/consistent-nav": "^2.4.6",
+    "@mdb/consistent-nav": "^2.6.3",
     "@mdb/flora": "1.14.2",
     "@mdx-js/react": "^2.2.1",
     "@types/react-resizable": "^3.0.8",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,11 +1,21 @@
 import React from 'react';
-import { UnifiedFooter } from '@mdb/consistent-nav';
-import { getCurrLocale, onSelectLocale } from '../utils/locale';
+import { LocalizedLinkProvider, UnifiedFooter } from '@mdb/consistent-nav';
+import { getCurrLocale, onSelectLocale, stripLocale } from '../utils/locale';
 import { useLocale } from '../context/locale';
+import { isBrowser } from '../utils/is-browser';
 
 const Footer = () => {
   const { enabledLocales } = useLocale();
-  return <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} enabledLocales={enabledLocales} />;
+  const pageUrl = (() => {
+    if (isBrowser) return stripLocale(window.location.pathname);
+    else return '';
+  })();
+
+  return (
+    <LocalizedLinkProvider origin="https://www.mongodb.com/docs" pageUrl={pageUrl}>
+      <UnifiedFooter onSelectLocale={onSelectLocale} locale={getCurrLocale()} enabledLocales={enabledLocales} />
+    </LocalizedLinkProvider>
+  );
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { LocalizedLinkProvider, UnifiedFooter } from '@mdb/consistent-nav';
-import { getCurrLocale, onSelectLocale, stripLocale } from '../utils/locale';
+import { getCurrLocale, onSelectLocale } from '../utils/locale';
 import { useLocale } from '../context/locale';
-import { isBrowser } from '../utils/is-browser';
+import { getPageUrl } from '../utils/get-page-url';
 
 const Footer = () => {
   const { enabledLocales } = useLocale();
-  const pageUrl = (() => {
-    if (isBrowser) return stripLocale(window.location.pathname);
-    else return '';
-  })();
+  const pageUrl = getPageUrl();
 
   return (
     <LocalizedLinkProvider origin="https://www.mongodb.com/docs" pageUrl={pageUrl}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,12 +1,13 @@
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { css, cx } from '@leafygreen-ui/emotion';
-import { UnifiedNav } from '@mdb/consistent-nav';
+import { LocalizedLinkProvider, UnifiedNav } from '@mdb/consistent-nav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
-import { getCurrLocale, onSelectLocale } from '../../utils/locale';
+import { getCurrLocale, onSelectLocale, stripLocale } from '../../utils/locale';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 import { useLocale } from '../../context/locale';
+import { isBrowser } from '../../utils/is-browser';
 import { HeaderContext } from './header-context';
 
 interface StyledHeaderProps {
@@ -49,6 +50,11 @@ const Header = ({ eol }: HeaderProps) => {
   const locale = getCurrLocale();
   const { hasBanner } = useContext(HeaderContext);
 
+  const pageUrl = (() => {
+    if (isBrowser) return stripLocale(window.location.pathname);
+    else return '';
+  })();
+
   return (
     <>
       <SiteBanner />
@@ -56,7 +62,7 @@ const Header = ({ eol }: HeaderProps) => {
         <>
           {/* Two navs used intentionally: one for light mode, one for dark mode */}
           {!eol && (
-            <>
+            <LocalizedLinkProvider origin="https://www.mongodb.com/docs" pageUrl={pageUrl}>
               <UnifiedNav
                 fullWidth={true}
                 hideSearch={true}
@@ -83,7 +89,7 @@ const Header = ({ eol }: HeaderProps) => {
                 darkMode={true}
                 className={cx('nav-dark', isOfflineDocsBuild ? offlineClass : '')}
               />
-            </>
+            </LocalizedLinkProvider>
           )}
         </>
       </StyledHeaderContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -4,10 +4,10 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import { LocalizedLinkProvider, UnifiedNav } from '@mdb/consistent-nav';
 import SiteBanner from '../Banner/SiteBanner';
 import { theme } from '../../theme/docsTheme';
-import { getCurrLocale, onSelectLocale, stripLocale } from '../../utils/locale';
+import { getCurrLocale, onSelectLocale } from '../../utils/locale';
 import { isOfflineDocsBuild } from '../../utils/is-offline-docs-build';
 import { useLocale } from '../../context/locale';
-import { isBrowser } from '../../utils/is-browser';
+import { getPageUrl } from '../../utils/get-page-url';
 import { HeaderContext } from './header-context';
 
 interface StyledHeaderProps {
@@ -50,10 +50,7 @@ const Header = ({ eol }: HeaderProps) => {
   const locale = getCurrLocale();
   const { hasBanner } = useContext(HeaderContext);
 
-  const pageUrl = (() => {
-    if (isBrowser) return stripLocale(window.location.pathname);
-    else return '';
-  })();
+  const pageUrl = getPageUrl();
 
   return (
     <>

--- a/src/utils/get-page-url.ts
+++ b/src/utils/get-page-url.ts
@@ -1,0 +1,7 @@
+import { isBrowser } from './is-browser';
+import { stripLocale } from './locale';
+
+export const getPageUrl = () => {
+  if (isBrowser) return stripLocale(window.location.pathname);
+  else return '';
+};

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -66,7 +66,7 @@ const validateLocaleCode = (potentialCode: string) =>
  * @param {string} slug
  * @returns {string}
  */
-const stripLocale = (slug: string) => {
+export const stripLocale = (slug: string) => {
   // Smartling has extensive replace logic for URLs and slugs that follow the pattern of "https://www.mongodb.com/docs". However,
   // there are instances where we can't rely on them for certain components
   if (!slug) {

--- a/tests/unit/__snapshots__/Presentation.test.js.snap
+++ b/tests/unit/__snapshots__/Presentation.test.js.snap
@@ -207,7 +207,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 .emotion-10 {
   font-family: Akzidenz-Grotesk Std,Noto Sans KR,Noto Sans SC,Noto Sans JP;
   font-size: 16px;
-  line-height: 16px;
+  line-height: 20px;
   color: #ffffff;
   padding-left: 16px;
   width: -webkit-min-content;
@@ -277,9 +277,22 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   border-radius: 2px;
   background-color: #3d4f58;
   color: #0ad05b;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.emotion-22 {
+.emotion-16:hover>a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-17 {
+  color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-28 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -291,12 +304,12 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-22 {
+  .emotion-28 {
     display: block;
   }
 }
 
-.emotion-23 {
+.emotion-29 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -308,19 +321,19 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 460px) {
-  .emotion-23 {
+  .emotion-29 {
     min-width: unset;
   }
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-23 {
+  .emotion-29 {
     margin-top: 0px;
     min-width: unset;
   }
 }
 
-.emotion-24 {
+.emotion-30 {
   font-family: Akzidenz-Grotesk Std,Noto Sans KR,Noto Sans SC,Noto Sans JP;
   font-weight: 500;
   font-size: 16px;
@@ -330,23 +343,23 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-24 {
+  .emotion-30 {
     margin-top: initial;
   }
 }
 
-.emotion-25 {
+.emotion-31 {
   list-style: none;
   margin: 0;
   padding: 0;
   display: block;
 }
 
-.emotion-26 {
+.emotion-32 {
   margin-bottom: 24px;
 }
 
-.emotion-27 {
+.emotion-33 {
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -358,13 +371,33 @@ exports[`DocumentBody renders the necessary elements 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-62 {
+.emotion-65 {
+  margin-right: 5px;
+}
+
+.emotion-66 {
+  fill: #fff;
+}
+
+.emotion-67 {
+  fill: #0066FF;
+}
+
+.emotion-68 {
+  fill: white;
+}
+
+.emotion-79 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -376,19 +409,19 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 460px) {
-  .emotion-62 {
+  .emotion-79 {
     min-width: 100%;
   }
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-62 {
+  .emotion-79 {
     margin-top: 0px;
     min-width: unset;
   }
 }
 
-.emotion-64 {
+.emotion-81 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -397,18 +430,18 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 460px) {
-  .emotion-64 {
+  .emotion-81 {
     display: grid;
   }
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-64 {
+  .emotion-81 {
     display: block;
   }
 }
 
-.emotion-79 {
+.emotion-96 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -423,7 +456,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
 }
 
 @media screen and (min-width: 768px) {
-  .emotion-79 {
+  .emotion-96 {
     display: none;
   }
 }
@@ -519,42 +552,72 @@ exports[`DocumentBody renders the necessary elements 1`] = `
                     role="option"
                     tabindex="0"
                   >
-                    English
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs"
+                    >
+                      English
+                    </a>
                   </li>
                   <li
                     class="emotion-16"
                     role="option"
                     tabindex="0"
                   >
-                    Português
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs/pt-br"
+                    >
+                      Português
+                    </a>
                   </li>
                   <li
                     class="emotion-16"
                     role="option"
                     tabindex="0"
                   >
-                    Español
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs/es"
+                    >
+                      Español
+                    </a>
                   </li>
                   <li
                     class="emotion-16"
                     role="option"
                     tabindex="0"
                   >
-                    한국어
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs/ko-kr"
+                    >
+                      한국어
+                    </a>
                   </li>
                   <li
                     class="emotion-16"
                     role="option"
                     tabindex="0"
                   >
-                    日本語
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs/ja-jp"
+                    >
+                      日本語
+                    </a>
                   </li>
                   <li
                     class="emotion-16"
                     role="option"
                     tabindex="0"
                   >
-                    简体中文
+                    <a
+                      class="emotion-17"
+                      href="https://www.mongodb.com/docs/zh-cn"
+                    >
+                      简体中文
+                    </a>
                   </li>
                 </ul>
               </div>
@@ -562,28 +625,28 @@ exports[`DocumentBody renders the necessary elements 1`] = `
           </div>
         </div>
         <div
-          class="emotion-22"
+          class="emotion-28"
         >
           © 2026 MongoDB, Inc.
         </div>
       </div>
       <div
-        class="emotion-23"
+        class="emotion-29"
       >
         <p
-          class="emotion-24"
+          class="emotion-30"
         >
           About
         </p>
         <ul
-          class="emotion-25"
+          class="emotion-31"
         >
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
-              href="https://www.mongodb.com/careers"
+              class=" emotion-33"
+              href="https://www.mongodb.com/company/careers"
               rel="noreferrer noopener"
               target="_self"
             >
@@ -591,10 +654,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://investors.mongodb.com"
               rel="noreferrer noopener"
               target="_self"
@@ -603,10 +666,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/legal"
               rel="noreferrer noopener"
               target="_self"
@@ -615,10 +678,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/legal/privacy/privacy-policy"
               rel="noreferrer noopener"
               target="_self"
@@ -627,22 +690,22 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://github.com/mongodb"
-              rel="noreferrer noopener"
+              rel="noreferrer noopener nofollow"
               target="_self"
             >
               GitHub
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/company/contact/mongodb-vulnerability-disclosure-policy"
               rel="noreferrer noopener"
               target="_self"
@@ -651,10 +714,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/products/platform/trust"
               rel="noreferrer noopener"
               target="_self"
@@ -663,35 +726,35 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/company/contact/social-media-hub"
               rel="noreferrer noopener"
               target="_self"
             >
-              Connect with Us
+              Follow Us
             </a>
           </li>
         </ul>
       </div>
       <div
-        class="emotion-23"
+        class="emotion-29"
       >
         <p
-          class="emotion-24"
+          class="emotion-30"
         >
           Support
         </p>
         <ul
-          class="emotion-25"
+          class="emotion-31"
         >
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/company/contact"
               rel="noreferrer noopener"
               target="_self"
@@ -700,11 +763,11 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
-              href="https://support.mongodb.com/welcome"
+              class=" emotion-33"
+              href="https://support.mongodb.com/"
               rel="noreferrer noopener"
               target="_self"
             >
@@ -712,10 +775,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://status.mongodb.com/"
               rel="noreferrer noopener"
               target="_self"
@@ -724,10 +787,22 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
+              href="https://www.mongodb.com/products/updates/"
+              rel="noreferrer noopener"
+              target="_self"
+            >
+              Product Updates
+            </a>
+          </li>
+          <li
+            class="emotion-32"
+          >
+            <a
+              class=" emotion-33"
               href="https://www.mongodb.com/services/support"
               rel="noreferrer noopener"
               target="_self"
@@ -735,24 +810,83 @@ exports[`DocumentBody renders the necessary elements 1`] = `
               Customer Support
             </a>
           </li>
+          <li
+            class="emotion-32"
+          >
+            <a
+              class="manage-cookies emotion-33"
+              href="#"
+              rel="noreferrer noopener"
+              target="_self"
+            >
+              Manage Cookies
+            </a>
+          </li>
+          <li
+            class="emotion-32"
+          >
+            <a
+              class="privacy-choices emotion-33"
+              href="#"
+              rel="noreferrer noopener"
+              target="_self"
+            >
+              <svg
+                aria-label="California Consumer Privacy Act (CCPA) Opt-Out Icon"
+                class="emotion-65"
+                version="1.1"
+                viewBox="0 0 30 14"
+                width="30"
+                x="0px"
+                xmlns="http://www.w3.org/2000/svg"
+                y="0px"
+              >
+                <g
+                  transform="translate(-1275.000000, -200.000000)"
+                >
+                  <g
+                    transform="translate(1275.000000, 200.000000)"
+                  >
+                    <path
+                      class="emotion-66"
+                      d="M7.4,12.8h6.8l3.1-11.6H7.4C4.2,1.2,1.6,3.8,1.6,7S4.2,12.8,7.4,12.8z"
+                    />
+                    <path
+                      class="emotion-67"
+                      d="M22.6,0H7.4c-3.9,0-7,3.1-7,7s3.1,7,7,7h15.2c3.9,0,7-3.1,7-7S26.4,0,22.6,0z M1.6,7c0-3.2,2.6-5.8,5.8-5.8h9.9l-3.1,11.6H7.4C4.2,12.8,1.6,10.2,1.6,7z"
+                    />
+                    <path
+                      class="emotion-68"
+                      d="M24.6,4c0.2,0.2,0.2,0.6,0,0.8l0,0L22.5,7l2.2,2.2c0.2,0.2,0.2,0.6,0,0.8c-0.2,0.2-0.6,0.2-0.8,0l0,0l-2.2-2.2L19.5,10c-0.2,0.2-0.6,0.2-0.8,0c-0.2-0.2-0.2-0.6,0-0.8l0,0L20.8,7l-2.2-2.2c-0.2-0.2-0.2-0.6,0-0.8c0.2-0.2,0.6-0.2,0.8,0l0,0l2.2,2.2L23.8,4C24,3.8,24.4,3.8,24.6,4z"
+                    />
+                    <path
+                      class="emotion-67"
+                      d="M12.7,4.1c0.2,0.2,0.3,0.6,0.1,0.8l0,0L8.6,9.8C8.5,9.9,8.4,10,8.3,10c-0.2,0.1-0.5,0.1-0.7-0.1l0,0L5.4,7.7c-0.2-0.2-0.2-0.6,0-0.8c0.2-0.2,0.6-0.2,0.8,0l0,0L8,8.6l3.8-4.5C12,3.9,12.4,3.9,12.7,4.1z"
+                    />
+                  </g>
+                </g>
+              </svg>
+              Your Privacy Choices
+            </a>
+          </li>
         </ul>
       </div>
       <div
-        class="emotion-23"
+        class="emotion-29"
       >
         <p
-          class="emotion-24"
+          class="emotion-30"
         >
           Deployment Options
         </p>
         <ul
-          class="emotion-25"
+          class="emotion-31"
         >
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/cloud/atlas/register"
               rel="noreferrer noopener"
               target="_self"
@@ -761,10 +895,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/try/download/enterprise"
               rel="noreferrer noopener"
               target="_self"
@@ -773,10 +907,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href=" https://www.mongodb.com/try/download/community"
               rel="noreferrer noopener"
               target="_self"
@@ -787,21 +921,21 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-62"
+        class="emotion-79"
       >
         <p
-          class="emotion-24"
+          class="emotion-30"
         >
           Data Basics
         </p>
         <ul
-          class="emotion-64"
+          class="emotion-81"
         >
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/basics/databases/vector-databases"
               rel="noreferrer noopener"
               target="_self"
@@ -810,10 +944,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/basics/databases/nosql-explained"
               rel="noreferrer noopener"
               target="_self"
@@ -822,10 +956,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/basics/databases/document-databases"
               rel="noreferrer noopener"
               target="_self"
@@ -834,10 +968,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/basics/artificial-intelligence/retrieval-augmented-generation"
               rel="noreferrer noopener"
               target="_self"
@@ -846,10 +980,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/basics/databases/acid-transactions"
               rel="noreferrer noopener"
               target="_self"
@@ -858,10 +992,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href="https://www.mongodb.com/resources/languages/mern-stack"
               rel="noreferrer noopener"
               target="_self"
@@ -870,10 +1004,10 @@ exports[`DocumentBody renders the necessary elements 1`] = `
             </a>
           </li>
           <li
-            class="emotion-26"
+            class="emotion-32"
           >
             <a
-              class=" emotion-27"
+              class=" emotion-33"
               href=" https://www.mongodb.com/resources/languages/mean-stack"
               rel="noreferrer noopener"
               target="_self"
@@ -884,7 +1018,7 @@ exports[`DocumentBody renders the necessary elements 1`] = `
         </ul>
       </div>
       <div
-        class="emotion-79"
+        class="emotion-96"
       >
         © 2026 MongoDB, Inc.
       </div>


### PR DESCRIPTION
### Stories/Links:

DOP-6631

### Current Behavior:

https://www.mongodb.com/docs/atlas/

### Staging Links:

https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/main/cloud-docs/matt.meigs/DOP-6631-nav/index.html

### Notes:

Updated `consistent-nav` package to latest.
This required adding their new `LocalizedLinkProvider`. We will want to test this in preprd before release. This is a breaking change that they added without any guidance. I looked through their implementation and it seems simple, but we want to make sure it works with smartling and our system.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
