### PR TITLE
DOP-6726: Fix hashes in composable tutorials

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = ". ./build.sh $REPO_NAME $PARSER_VERSION"
 
 [build.environment]
 ORG_NAME = "10gen"
-REPO_NAME = "cloud-docs"
-BRANCH_NAME = "main"
-SITE_NAME = "atlas"
+REPO_NAME = "docs"
+BRANCH_NAME = "upcoming"
+SITE_NAME = "manual"
 PARSER_VERSION = "v0.20.18"

--- a/src/components/ComposableTutorial/ComposableTutorial.tsx
+++ b/src/components/ComposableTutorial/ComposableTutorial.tsx
@@ -175,7 +175,10 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
   // ie. if providing default selections, preserve the hash in url
   //    vs. if changing selections, do not preserve the hash
   const preserveHash = useRef(false);
-  const initialLoad = useRef(true);
+  // tracks whether the one-time query-param / local-storage defaults have been applied
+  const hasAppliedInitialDefaults = useRef(false);
+  // hash that needs to be scrolled to after selections update and DOM re-renders
+  const pendingHashScroll = useRef<string | null>(null);
 
   const validSelections = useMemo(() => {
     const res: Set<string> = new Set();
@@ -242,35 +245,36 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
         `${queryString.startsWith('?') ? '' : '?'}${queryString}${
           queryString.length > 0 && externalQueryParamsString.length > 0 ? '&' : ''
         }${externalQueryParamsString}${newHash ? newHash : ''}`,
-        { state: { ...state } }
+        // replace=true for URL corrections (initial defaults / hash-driven selection), which shouldn't
+        // add a history entry. replace=false (push) for explicit user dropdown changes so they can go back.
+        { state: { ...state }, replace: preserveHash.current }
       );
     },
     [externalQueryParamsString]
   );
 
-  // takes care of query param reading and rerouting on initial load
-  // if query params fulfill all selections, show the selections
-  // otherwise, fallback to getting default values from combination of local storage and node Data
+  // Handles hash-based selection on every hash change.
+  // On the first render without a matching hash, falls back to query params and local-storage defaults (runs once).
   useEffect(() => {
-    // do this only on initial load
-    if (!isBrowser || !initialLoad.current) {
-      return;
-    }
+    if (!isBrowser) return;
 
-    initialLoad.current = false;
-
-    // first verify if there is a hash
-    // if there is a hash and it belongs to a composable option,
-    // set the current selections that composable option to show the content with hash id
+    // If there is a hash that belongs to a composable option, set the selections so that content
+    // containing that hash id becomes visible, then queue a scroll once the DOM updates.
     if (hash) {
       const hashString = hash.slice(1);
       const selection = refToSelection[hashString];
       if (selection) {
         preserveHash.current = true;
+        pendingHashScroll.current = hash;
         setCurrentSelections(selection);
+        hasAppliedInitialDefaults.current = true;
         return;
       }
     }
+
+    // Query-param / local-storage fallback only runs once (initial load without a matching hash).
+    if (hasAppliedInitialDefaults.current) return;
+    hasAppliedInitialDefaults.current = true;
 
     // read query params
     const queryParams = parse(search);
@@ -293,6 +297,20 @@ const ComposableTutorialInternal = ({ nodeData, ...rest }: ComposableProps) => {
     preserveHash.current = true;
     setCurrentSelections(defaultParams);
   }, [hash, refToSelection, setCurrentSelections, search, composableOptions, validSelections]);
+
+  // After selections change, scroll to any pending hash once its element is in the DOM.
+  // The element is absent in the same render that setCurrentSelections is called, but present
+  // in the next render after the composable content re-renders with the new selections.
+  useEffect(() => {
+    if (!isBrowser || !pendingHashScroll.current) return;
+    const hashToScroll = pendingHashScroll.current;
+    const decodedHash = decodeURIComponent(hashToScroll.slice(1));
+    const el = document.querySelector('#' + CSS.escape(decodedHash));
+    if (el) {
+      pendingHashScroll.current = null;
+      el.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [currentSelections]);
 
   // when updating selection state, update the url and local storage with the new selections
   useEffect(() => {


### PR DESCRIPTION
### Stories/Links:

DOP-6726

### Current Behavior:

https://www.mongodb.com/docs/upcoming/reference/built-in-roles/?deployment-type=atlas#built-in-roles-and-inherited-privileges
select one of the links like `backup` that changes the deployment type and hash, you should see that it doesn't load the content unless you do a hard refresh

<img width="931" height="608" alt="Screenshot 2026-04-06 at 10 58 00 AM" src="https://github.com/user-attachments/assets/10ba8cdb-7aa2-4bb3-8e90-dbef6abcdf3d" />


### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
