### PR TITLE
DOP-6986: Fix .md files on production using staging URLs

### DIFF
--- a/src/utils/snooty-ast-to-md/snooty-ast-to-md.js
+++ b/src/utils/snooty-ast-to-md/snooty-ast-to-md.js
@@ -6,7 +6,9 @@ let siteBasePrefix;
 const ENV_KEY = siteMetadata.snootyEnv || 'development';
 
 const baseURL =
-  ENV_KEY !== 'production' ? 'https://mongodbcom-cdn.staging.corp.mongodb.com' : 'https://www.mongodb.com';
+  ENV_KEY === 'production' || ENV_KEY === 'dotcomprd'
+    ? 'https://www.mongodb.com'
+    : 'https://mongodbcom-cdn.staging.corp.mongodb.com';
 
 const setSiteBasePrefix = (basePrefix) => (siteBasePrefix = basePrefix);
 


### PR DESCRIPTION
The baseURL check only handled 'production' but the dotcom production build uses SNOOTY_ENV=dotcomprd, causing all generated .md files to contain staging CDN links instead of www.mongodb.com links.

### Stories/Links:

DOP-NNNN

### Current Behavior:

_Put a link to current staging or production behavior, if applicable_

### Staging Links:

_Put a link to your staging environment(s), if applicable_

### Notes:

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
