### PR TITLE
change favicon route

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withPrefix } from 'gatsby';
 
-const faviconUrl = `https://www.mongodb.com/docs/assets/favicon.ico`;
+const faviconUrl = withPrefix('/favicon.ico');
 
 const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyComponents, postBodyComponents }) => (
   <html lang="en" {...htmlAttributes}>

--- a/src/html.js
+++ b/src/html.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 
-const faviconUrl = withPrefix('/favicon.ico');
+const faviconUrl = withPrefix('assets/favicon.ico');
 
 const HTML = ({ body, bodyAttributes, headComponents, htmlAttributes, preBodyComponents, postBodyComponents }) => (
   <html lang="en" {...htmlAttributes}>


### PR DESCRIPTION
### Stories/Links:

https://www.mongodb.com/docs/assets/favicon.ico - fav icon not living at this route anymore 


https://deploy-preview-1610--docs-frontend-stg.netlify.app/docs/atlas/

now can see the fav icon

